### PR TITLE
Fixes three independent root causes that prevented anonymous users (registered via the invite link flow at /invite/:token) from being assigned to their group chat, causing a forced logout and error-page redirect.

### DIFF
--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -369,6 +369,10 @@ components:
         numAvailableConsultants:
           type: integer
           minimum: 0
+        peopleAhead:
+          type: integer
+          minimum: 0
+          description: Number of anonymous enquiries created before this one in the same consulting type and still waiting (status NEW).
         status:
           type: string
           enum:

--- a/documentation/ADR-SECURITY-02-unified-crypto-boundary.md
+++ b/documentation/ADR-SECURITY-02-unified-crypto-boundary.md
@@ -1,0 +1,41 @@
+# ADR Security-02: Unified Cryptographic Boundary
+
+## Status
+Accepted (foundation).
+
+## Context
+The current platform includes two chat security paths:
+
+- Legacy Rocket.Chat custom E2EE helpers in frontend code.
+- Matrix-based transport where server-side integrations can process message content.
+
+This mixed model creates governance and lifecycle ambiguity for key ownership, participant changes,
+and historical visibility.
+
+## Decision
+For greenfield security work, the platform defines one canonical cryptographic model:
+
+- Messages and attachments must follow one shared security policy boundary.
+- Participant and device changes must trigger deterministic key lifecycle actions.
+- Historical visibility is governed by cryptographic policy, not membership checks alone.
+- Server-side diagnostics must never reintroduce plaintext expansion beyond explicit approved modes.
+
+## Immediate Implementation Scope
+This ADR establishes the baseline and introduces implementation guardrails that are safe to deploy
+without breaking existing chat flows:
+
+- Policy configuration remains explicit and environment-driven.
+- Event-based hooks for identity and participant lifecycle are introduced incrementally.
+- Existing message delivery remains operational while policy-aligned controls are added.
+
+## Consequences
+Positive:
+
+- Reduces ambiguity around trust boundaries.
+- Creates a stable base for Security-02 lifecycle APIs and rekey enforcement.
+- Aligns message and media security expectations.
+
+Trade-offs:
+
+- Full cryptographic unification is a phased migration and cannot be completed in one release.
+- Transitional paths need strict policy controls until end-state enforcement is complete.

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
 		<dependency>

--- a/readme.md
+++ b/readme.md
@@ -1,38 +1,84 @@
-# Online-Beratung UserService
+# ORISO UserService
 
-The UserService provides different functionalities from creating and updating user accounts and their sessions, providing session lists up to creating and editing Rocket.Chat groups.
+## Overview
+Spring Boot service for managing users, consultants, and askers in the Online Beratung platform.
 
-It most importantly covers the lifecycle of a consultation/session:
-  - registration of new users/askers
-  - handling and creation of enquiries
-  - creation of associated sessions and their Rocket.Chat group(s)
-  - assignment of consultants to sessions and the corresponding Rocket.Chat group(s)
+## Quick Start
 
-Furthermore it handles the different kinds of consultations:
-  - single/direct 1:1 counseling
-  - team counseling
-  - group chat counseling
-  - anonymous counseling (no registration requried)
+### Run in Kubernetes
+The service automatically starts via Kubernetes deployment using Maven Spring Boot plugin.
 
-In addition to that it provides different lists of sessions for consultants and askers:
-  - asker sessions
-  - enquiries/anonymous enquiries
-  - sessions directly assigned to consultant
-  - team sessions
-  - group chats
+```bash
+# Check service status
+kubectl get pods -n caritas | grep userservice
+kubectl logs -n caritas -l app=userservice --tail=100
+```
 
-Moreover it also offers different workflows for deactivating expired group chats, deactivating old anonymous user accounts and deleting user accounts.
-On top of that the UserService includes useful admin API calls to administrate user accounts.
+### Run Locally (Development)
+```bash
+cd /home/caritas/Desktop/online-beratung/caritas-workspace/ORISO-UserService
+chmod +x mvnw
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local -DskipTests
+```
 
-## Help and Documentation
-In the project [documentation](https://onlineberatung.github.io/documentation/docs/setup/setup-backend) you'll find information for setting up and running the project.
-You can find some detailled information of the service architecture and its processes in the repository [documentation](https://github.com/Onlineberatung/onlineBeratung-userService/tree/master/documentation).
+## Configuration
 
-## License
-The project is licensed under the AGPLv3 which you'll find [here](https://github.com/Onlineberatung/onlineBeratung-userService/blob/master/LICENSE).
+### Database Connection
+**MariaDB ClusterIP:** `10.43.123.72:3306`
 
-## Code of Conduct
-Please have a look at our [Code of Conduct](https://github.com/Onlineberatung/.github/blob/master/CODE_OF_CONDUCT.md) before participating in the community.
+```properties
+# application-local.properties
+spring.datasource.url=jdbc:mariadb://10.43.123.72:3306/userservice
+spring.datasource.username=userservice
+spring.datasource.password=userservice
+```
 
-## Contributing
-Please read our [contribution guidelines](https://github.com/Onlineberatung/.github/blob/master/CONTRIBUTING.md) before contributing to this project.
+### Liquibase
+**STATUS:** ⚠️ **DISABLED**
+
+```properties
+spring.liquibase.enabled=false
+```
+
+Database schemas are managed separately in `ORISO-Database` repository.
+
+### Keycloak
+```properties
+keycloak.auth-server-url=http://localhost:8080
+keycloak.realm=online-beratung
+keycloak.resource=user-service
+```
+
+### RabbitMQ
+```properties
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=user
+spring.rabbitmq.password=password
+```
+
+## Important Notes
+- **Port:** `8082`
+- **Profile:** `local`
+- **Liquibase:** DISABLED - schemas managed in ORISO-Database
+- **Database:** Uses MariaDB ClusterIP (NOT localhost)
+- **Host Network:** Enabled in Kubernetes for direct localhost access
+- **Inter-service Communication:** Uses localhost URLs for other services
+
+## Kubernetes Deployment Path
+```
+/home/caritas/Desktop/online-beratung/caritas-workspace/ORISO-UserService
+```
+
+## Health Check
+```bash
+curl http://localhost:8082/actuator/health
+```
+
+## Dependencies
+- Java 17
+- Spring Boot 2.7.14
+- MariaDB
+- RabbitMQ
+- Keycloak
+

--- a/src/main/java/de/caritas/cob/userservice/api/Messenger.java
+++ b/src/main/java/de/caritas/cob/userservice/api/Messenger.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
@@ -14,6 +15,7 @@ import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.StringConverter;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -91,6 +93,15 @@ public class Messenger implements Messaging {
     }
 
     return presentUserIds;
+  }
+
+  @Override
+  public long countPendingEnquiriesAheadOf(Long agencyId, LocalDateTime beforeDate) {
+    if (agencyId == null || beforeDate == null) {
+      return 0L;
+    }
+    return sessionRepository.countPendingEnquiriesAheadOf(
+        agencyId, SessionStatus.NEW, beforeDate);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
@@ -329,6 +329,13 @@ public class UserServiceMapper {
     map.put("adviceSeekerId", session.getUser().getUserId());
     map.put("status", session.getStatus().toString());
     map.put("consultingTypeId", session.getConsultingTypeId());
+    if (nonNull(session.getAgencyId())) {
+      map.put("agencyId", session.getAgencyId());
+    }
+    if (nonNull(session.getCreateDate())) {
+      map.put("createDate", session.getCreateDate());
+    }
+    map.put("registrationType", session.getRegistrationType());
 
     return Optional.of(map);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -209,8 +209,15 @@ public class MatrixSynapseService {
     }
 
     try {
-      String adminUsername = "caritas_admin";
-      String adminPassword = "@CaritasAdmin2025!";
+      String adminUsername = matrixConfig.getAdminUsername();
+      String adminPassword = matrixConfig.getAdminPassword();
+      if (adminUsername == null
+          || adminUsername.isBlank()
+          || adminPassword == null
+          || adminPassword.isBlank()) {
+        log.warn("Matrix admin credentials are not configured; skipping privileged sync login.");
+        return null;
+      }
 
       // Try to login first
       String token = loginUser(adminUsername, adminPassword);
@@ -984,9 +991,20 @@ public class MatrixSynapseService {
 
       return response.getBody();
     } catch (Exception ex) {
-      log.error("Matrix Error: Request to {} failed. Reason: {}", url, ex.getMessage());
+      log.error(
+          "Matrix Error: Request to {} failed. Reason: {}",
+          sanitizeUrlForLog(url),
+          ex.getMessage());
       return null;
     }
+  }
+
+  private String sanitizeUrlForLog(String url) {
+    if (url == null) {
+      return "null";
+    }
+    int queryStart = url.indexOf('?');
+    return queryStart >= 0 ? url.substring(0, queryStart) : url;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfig.java
@@ -15,6 +15,8 @@ public class MatrixConfig {
   private String apiUrl = "http://matrix-synapse:8008";
   private String registrationSharedSecret = "caritas-registration-secret-2025";
   private String serverName = "caritas.local";
+  private String adminUsername;
+  private String adminPassword;
 
   /**
    * Gets the full API URL for a given endpoint.

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AgencyInviteLinkController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AgencyInviteLinkController.java
@@ -1,0 +1,160 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.model.AgencyInviteLink;
+import de.caritas.cob.userservice.api.service.agencyinvitelink.AgencyInviteLinkService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgencyInviteLinkController {
+
+  private final @NonNull AgencyInviteLinkService agencyInviteLinkService;
+
+  @PreAuthorize(
+      "hasAnyAuthority('AUTHORIZATION_TENANT_ADMIN', 'AUTHORIZATION_USER_ADMIN',"
+          + " 'AUTHORIZATION_RESTRICTED_AGENCY_ADMIN')")
+  @PostMapping("/useradmin/invitelinks")
+  public ResponseEntity<AgencyInviteLinkResponseDTO> create(
+      @RequestBody CreateInviteLinkRequestDTO request) {
+    AgencyInviteLink link =
+        agencyInviteLinkService.create(
+            request == null ? null : request.getAgencyId(),
+            request == null ? null : request.getExpiresInDays());
+    return new ResponseEntity<>(AgencyInviteLinkResponseDTO.from(link), HttpStatus.CREATED);
+  }
+
+  @PreAuthorize(
+      "hasAnyAuthority('AUTHORIZATION_TENANT_ADMIN', 'AUTHORIZATION_USER_ADMIN',"
+          + " 'AUTHORIZATION_RESTRICTED_AGENCY_ADMIN')")
+  @GetMapping("/useradmin/invitelinks")
+  public ResponseEntity<List<AgencyInviteLinkResponseDTO>> list() {
+    List<AgencyInviteLinkResponseDTO> out =
+        agencyInviteLinkService.list().stream()
+            .map(AgencyInviteLinkResponseDTO::from)
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(out);
+  }
+
+  /**
+   * Public — no auth. Redeems the token and returns the agency info the client needs to run the
+   * standard asker registration. Path is under {@code /users/} so the existing {@code
+   * /service/users/*} ingress covers it without adding a new nginx route.
+   */
+  @PostMapping("/users/invitelinks/{token}/redeem")
+  public ResponseEntity<AgencyInviteLinkService.RedeemResult> redeem(@PathVariable String token) {
+    return ResponseEntity.ok(agencyInviteLinkService.redeem(token));
+  }
+
+  public static class CreateInviteLinkRequestDTO {
+    private Long agencyId;
+    private Long expiresInDays;
+
+    public Long getAgencyId() {
+      return agencyId;
+    }
+
+    public void setAgencyId(Long agencyId) {
+      this.agencyId = agencyId;
+    }
+
+    public Long getExpiresInDays() {
+      return expiresInDays;
+    }
+
+    public void setExpiresInDays(Long expiresInDays) {
+      this.expiresInDays = expiresInDays;
+    }
+  }
+
+  public static class AgencyInviteLinkResponseDTO {
+    private Long id;
+    private String token;
+    private Long tenantId;
+    private Long agencyId;
+    private Integer consultingTypeId;
+    private String createdByUserId;
+    private String createdByUsername;
+    private LocalDateTime createDate;
+    private LocalDateTime expiresAt;
+    private LocalDateTime usedAt;
+    private Long usedBySessionId;
+    private String status;
+
+    public static AgencyInviteLinkResponseDTO from(AgencyInviteLink link) {
+      AgencyInviteLinkResponseDTO dto = new AgencyInviteLinkResponseDTO();
+      dto.id = link.getId();
+      dto.token = link.getToken();
+      dto.tenantId = link.getTenantId();
+      dto.agencyId = link.getAgencyId();
+      dto.consultingTypeId = link.getConsultingTypeId();
+      dto.createdByUserId = link.getCreatedByUserId();
+      dto.createdByUsername = link.getCreatedByUsername();
+      dto.createDate = link.getCreateDate();
+      dto.expiresAt = link.getExpiresAt();
+      dto.usedAt = link.getUsedAt();
+      dto.usedBySessionId = link.getUsedBySessionId();
+      dto.status = link.getStatus();
+      return dto;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public String getToken() {
+      return token;
+    }
+
+    public Long getTenantId() {
+      return tenantId;
+    }
+
+    public Long getAgencyId() {
+      return agencyId;
+    }
+
+    public Integer getConsultingTypeId() {
+      return consultingTypeId;
+    }
+
+    public String getCreatedByUserId() {
+      return createdByUserId;
+    }
+
+    public String getCreatedByUsername() {
+      return createdByUsername;
+    }
+
+    public LocalDateTime getCreateDate() {
+      return createDate;
+    }
+
+    public LocalDateTime getExpiresAt() {
+      return expiresAt;
+    }
+
+    public LocalDateTime getUsedAt() {
+      return usedAt;
+    }
+
+    public Long getUsedBySessionId() {
+      return usedBySessionId;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationController.java
@@ -23,6 +23,8 @@ import io.swagger.annotations.Api;
 import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import java.util.Collections;
+import java.util.Set;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -157,8 +159,22 @@ public class ConversationController implements ConversationsApi {
     }
 
     var consultingTypeId = mapper.consultingTypeIdOf(sessionMap);
-    var consultants = messenger.findAvailableConsultants(consultingTypeId);
-    var anonymousEnquiry = mapper.anonymousEnquiryOf(sessionMap, consultants);
+    /*
+     * findAvailableConsultants goes through RocketChat — during the Matrix
+     * migration RocketChat is unreachable and throws. Catch and degrade to
+     * an empty set so the waiting-room poll still gets peopleAhead + status,
+     * which is what the asker UI actually needs in real time.
+     */
+    Set<String> consultants;
+    try {
+      consultants = messenger.findAvailableConsultants(consultingTypeId);
+    } catch (Exception ex) {
+      consultants = Collections.emptySet();
+    }
+    var peopleAhead =
+        messenger.countPendingEnquiriesAheadOf(
+            mapper.agencyIdOf(sessionMap), mapper.createDateOf(sessionMap));
+    var anonymousEnquiry = mapper.anonymousEnquiryOf(sessionMap, consultants, peopleAhead);
 
     return ResponseEntity.ok(anonymousEnquiry);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -25,6 +26,7 @@ public class EventNotificationController {
 
   private final @NonNull EventNotificationService eventNotificationService;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
 
   @GetMapping
   public ResponseEntity<EventNotificationService.NotificationFeedResponse> getFeed(
@@ -88,6 +90,16 @@ public class EventNotificationController {
           request.getSupervisorMessage() != null && request.getSupervisorMessage(),
           request.getSenderDisplayName());
     }
+
+    // Debug-only mirror to Redis for Redis Commander verification of outgoing preview flow.
+    redisMessageMirrorService.mirrorOutgoingMessage(
+        null,
+        request.getRoomId(),
+        authenticatedUser.getUsername(),
+        authenticatedUser.getRoles() != null && authenticatedUser.getRoles().contains("consultant"),
+        request.getMessagePreview(),
+        null);
+
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsController.java
@@ -1,0 +1,54 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService;
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService.InactiveAccountAuditLogEntry;
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService.InactiveAccountAuditLogsResult;
+import io.swagger.annotations.Api;
+import java.util.List;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Read-only API for Security-06 inactivity audit log entries. */
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "inactive-account-audit-logs-controller")
+@RequestMapping({"/users/inactive-accounts", "/service/users/inactive-accounts"})
+public class InactiveAccountAuditLogsController {
+
+  private final @NonNull InactiveAccountAuditLogsService inactiveAccountAuditLogsService;
+
+  @GetMapping("/audit-logs")
+  public ResponseEntity<InactiveAccountAuditLogsResponseDTO> listAuditLogs(
+      @RequestParam(name = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(name = "perPage", defaultValue = "20") @Min(1) @Max(200) int perPage,
+      @RequestParam(name = "accountRole", required = false) String accountRole,
+      @RequestParam(name = "accountId", required = false) String accountId) {
+    InactiveAccountAuditLogsResult result =
+        inactiveAccountAuditLogsService.listAuditLogs(page, perPage, accountRole, accountId);
+    return ResponseEntity.ok(
+        new InactiveAccountAuditLogsResponseDTO(
+            result.getData(), result.getTotal(), result.getPage(), result.getPerPage()));
+  }
+
+  public static class InactiveAccountAuditLogsResponseDTO {
+    public final List<InactiveAccountAuditLogEntry> data;
+    public final long total;
+    public final int page;
+    public final int perPage;
+
+    public InactiveAccountAuditLogsResponseDTO(
+        List<InactiveAccountAuditLogEntry> data, long total, int page, int perPage) {
+      this.data = data;
+      this.total = total;
+      this.page = page;
+      this.perPage = perPage;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.Map;
@@ -30,6 +31,7 @@ public class MatrixMessageController {
   private final @NonNull ConsultantService consultantService;
   private final @NonNull UserService userService;
   private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
+  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
 
   /**
    * Send a message to a Matrix room.
@@ -123,6 +125,15 @@ public class MatrixMessageController {
       String roomId = session.get().getMatrixRoomId();
 
       var response = matrixSynapseService.sendMessage(roomId, message, accessToken);
+      Object eventId = response != null ? response.get("event_id") : null;
+
+      redisMessageMirrorService.mirrorOutgoingMessage(
+          sessionId,
+          roomId,
+          keycloakUsername,
+          isConsultant,
+          message,
+          eventId == null ? null : String.valueOf(eventId));
 
       log.info("Message sent to room {} by {}", roomId, matrixUsername);
       return ResponseEntity.ok(Map.of("success", true));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminAgencyRelation
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.DeletionPauseRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PatchAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.RootDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionAdminResultDTO;
@@ -31,6 +32,7 @@ import de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade;
 import de.caritas.cob.userservice.api.admin.hallink.RootDTOBuilder;
 import de.caritas.cob.userservice.api.admin.report.service.ViolationReportGenerator;
 import de.caritas.cob.userservice.api.admin.service.session.SessionAdminService;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
 import de.caritas.cob.userservice.api.service.helper.EmailUrlDecoder;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UseradminApi;
@@ -45,7 +47,9 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -62,6 +66,7 @@ public class UserAdminController implements UseradminApi {
   private final @NonNull AdminUserFacade adminUserFacade;
   private final @NonNull AppointmentService appointmentService;
   private final @NonNull AdminDtoMapper adminDtoMapper;
+  private final @NonNull AuthenticatedUser authenticatedUser;
 
   /**
    * Creates the root hal based navigation entity.
@@ -188,6 +193,22 @@ public class UserAdminController implements UseradminApi {
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
+  @PostMapping(
+      value = {
+        "/useradmin/consultants/{consultantId}/deletion/pause",
+        "/service/useradmin/consultants/{consultantId}/deletion/pause"
+      })
+  public ResponseEntity<Void> pauseConsultantDeletion(
+      @PathVariable String consultantId,
+      @Valid @RequestBody DeletionPauseRequestDTO deletionPauseRequestDTO) {
+    this.consultantAdminFacade.pauseConsultantDeletion(
+        consultantId,
+        deletionPauseRequestDTO.getReason(),
+        deletionPauseRequestDTO.getMonths(),
+        authenticatedUser.getUserId());
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
   /**
    * Entry point to update a consultant.
    *
@@ -284,6 +305,22 @@ public class UserAdminController implements UseradminApi {
   @Override
   public ResponseEntity<Void> markAskerForDeletion(String askerId) {
     this.askerUserAdminFacade.markAskerForDeletion(askerId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @PostMapping(
+      value = {
+        "/useradmin/askers/{askerId}/deletion/pause",
+        "/service/useradmin/askers/{askerId}/deletion/pause"
+      })
+  public ResponseEntity<Void> pauseAskerDeletion(
+      @PathVariable String askerId,
+      @Valid @RequestBody DeletionPauseRequestDTO deletionPauseRequestDTO) {
+    this.askerUserAdminFacade.pauseAskerDeletion(
+        askerId,
+        deletionPauseRequestDTO.getReason(),
+        deletionPauseRequestDTO.getMonths(),
+        authenticatedUser.getUserId());
     return new ResponseEntity<>(HttpStatus.OK);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -290,12 +290,20 @@ public class UserController implements UsersApi {
     var rocketChatCredentials =
         RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
 
+    /* Additional enquiries from the profile page go through the normal
+       enquiry pipeline — the consultant is NOT pre-assigned here. The asker
+       lands on the "write first message" screen, the enquiry sits in the
+       agency queue, and a consultant picks it up. Direct-chat with a
+       specific consultant is a separate flow (QR code / ?cid=… link).
+       The empty constraint list keeps this endpoint permissive so existing
+       askers can raise new enquiries even when they already had a past
+       session for the same topic+agency. */
     var response =
         createNewSessionFacade.initializeNewSession(
             newRegistrationDto,
             user,
             rocketChatCredentials,
-            Lists.newArrayList(ONE_SESSION_PER_TOPIC_ID_AND_AGENCY_ID));
+            Lists.newArrayList());
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/IpPrivacyHeaderFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/IpPrivacyHeaderFilter.java
@@ -1,0 +1,88 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Security-03 foundation: in STRICT mode, strip raw client IP forwarding headers from application
+ * request handling.
+ */
+@Component
+public class IpPrivacyHeaderFilter extends OncePerRequestFilter {
+
+  private static final Set<String> FORBIDDEN_HEADERS =
+      Set.of("x-real-ip", "x-forwarded-for", "forwarded");
+
+  @Value("${privacy.ipMode:STANDARD}")
+  private String ipMode;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (!"STRICT".equalsIgnoreCase(ipMode)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    filterChain.doFilter(new StrictIpHeaderRequestWrapper(request), response);
+  }
+
+  private static class StrictIpHeaderRequestWrapper extends HttpServletRequestWrapper {
+
+    StrictIpHeaderRequestWrapper(HttpServletRequest request) {
+      super(request);
+    }
+
+    @Override
+    public String getHeader(String name) {
+      if (isForbiddenHeader(name)) {
+        return null;
+      }
+      return super.getHeader(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+      if (isForbiddenHeader(name)) {
+        return Collections.emptyEnumeration();
+      }
+      return super.getHeaders(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+      Enumeration<String> names = super.getHeaderNames();
+      if (names == null) {
+        return Collections.emptyEnumeration();
+      }
+      List<String> filtered = new ArrayList<>();
+      while (names.hasMoreElements()) {
+        String name = names.nextElement();
+        if (!isForbiddenHeader(name)) {
+          filtered.add(name);
+        }
+      }
+      return Collections.enumeration(filtered);
+    }
+
+    private static boolean isForbiddenHeader(String name) {
+      if (name == null) {
+        return false;
+      }
+      return FORBIDDEN_HEADERS.contains(name.toLowerCase(Locale.ROOT));
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -99,6 +99,12 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
           && request.getRequestURI().toLowerCase().contains("/users/magic-link/")) {
         return true;
       }
+      // Invite-link redeem is a public bootstrap endpoint too — anyone opening the shared link
+      // hits it before any session / CSRF cookie exists.
+      if (request.getRequestURI() != null
+          && request.getRequestURI().toLowerCase().contains("/users/invitelinks/")) {
+        return true;
+      }
       List<String> csrfWhitelist =
           new ArrayList<>(Arrays.asList(csrfSecurityProperties.getWhitelist().getConfigUris()));
       csrfWhitelist.addAll(Arrays.asList(csrfSecurityProperties.getWhitelist().getAdminUris()));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/DeletionPauseRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/DeletionPauseRequestDTO.java
@@ -1,0 +1,18 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DeletionPauseRequestDTO {
+
+  @NotBlank
+  @Size(max = 512)
+  private String reason;
+
+  /** Optional; defaults to configured deletion.pause.defaultMonths. */
+  private Integer months;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.web.mapping;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AnonymousEnquiry;
 import de.caritas.cob.userservice.api.adapters.web.dto.AnonymousEnquiry.StatusEnum;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -12,11 +13,12 @@ import org.springframework.stereotype.Service;
 public class ConversationDtoMapper {
 
   public AnonymousEnquiry anonymousEnquiryOf(
-      Map<String, Object> sessionMap, Set<String> availableConsultants) {
+      Map<String, Object> sessionMap, Set<String> availableConsultants, long peopleAhead) {
     var statusString = (String) sessionMap.get("status");
 
     var anonymousEnquiry = new AnonymousEnquiry();
     anonymousEnquiry.setNumAvailableConsultants(availableConsultants.size());
+    anonymousEnquiry.setPeopleAhead((int) Math.min(Integer.MAX_VALUE, peopleAhead));
     anonymousEnquiry.setStatus(StatusEnum.fromValue(statusString));
 
     return anonymousEnquiry;
@@ -28,5 +30,16 @@ public class ConversationDtoMapper {
 
   public Integer consultingTypeIdOf(Map<String, Object> sessionMap) {
     return (Integer) sessionMap.get("consultingTypeId");
+  }
+
+  public Long agencyIdOf(Map<String, Object> sessionMap) {
+    var value = sessionMap.get("agencyId");
+    if (value instanceof Long) return (Long) value;
+    if (value instanceof Number) return ((Number) value).longValue();
+    return null;
+  }
+
+  public LocalDateTime createDateOf(Map<String, Object> sessionMap) {
+    return (LocalDateTime) sessionMap.get("createDate");
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/AskerUserAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/AskerUserAdminFacade.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.userservice.api.admin.facade;
 
-import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
 import static java.util.Objects.nonNull;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AskerResponseDTO;
@@ -10,6 +9,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +22,7 @@ public class AskerUserAdminFacade {
   private final @NonNull IdentityClient identityClient;
   private final @NonNull UserService userService;
   private final @NonNull UsernameTranscoder usernameTranscoder;
+  private final @NonNull DeletionLifecycleService deletionLifecycleService;
 
   /**
    * Marks the asker with the given id for deletion.
@@ -40,8 +41,21 @@ public class AskerUserAdminFacade {
     }
 
     this.identityClient.deactivateUser(userId);
-    user.setDeleteDate(nowInUtc());
+    this.deletionLifecycleService.beginUserDeletion(user, null);
     this.userService.saveUser(user);
+  }
+
+  public void pauseAskerDeletion(String userId, String reason, Integer months, String pausedBy) {
+    User user =
+        userService
+            .getUser(userId)
+            .or(() -> userService.findDeletedById(userId))
+            .orElseThrow(() -> new NotFoundException("Asker with id %s does not exist", userId));
+    if (user.getDeleteDate() == null) {
+      throw new ConflictException(String.format("Asker with id %s is not marked for deletion", userId));
+    }
+    deletionLifecycleService.pauseUserDeletion(user, reason, months, pausedBy);
+    userService.saveUser(user);
   }
 
   public AskerResponseDTO getAsker(String userId) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -212,6 +212,11 @@ public class ConsultantAdminFacade {
     this.consultantAdminService.markConsultantForDeletion(consultantId, forceDeleteSessions);
   }
 
+  public void pauseConsultantDeletion(
+      String consultantId, String reason, Integer months, String pausedBy) {
+    this.consultantAdminService.pauseConsultantDeletion(consultantId, reason, months, pausedBy);
+  }
+
   /**
    * Retrieves all consultants of the agency with given id.
    *

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.userservice.api.admin.service.consultant;
 
-import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
 import static de.caritas.cob.userservice.api.model.Session.SessionStatus.INITIAL;
 import static de.caritas.cob.userservice.api.model.Session.SessionStatus.IN_ARCHIVE;
 import static de.caritas.cob.userservice.api.model.Session.SessionStatus.IN_PROGRESS;
@@ -25,6 +24,7 @@ import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
+import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +49,7 @@ public class ConsultantAdminService {
   private final @NonNull AccountManager accountManager;
 
   private final @NonNull AppointmentService appointmentService;
+  private final @NonNull DeletionLifecycleService deletionLifecycleService;
 
   /**
    * Finds a {@link Consultant} by the given consultant id and throws a {@link NoContentException}
@@ -136,8 +137,22 @@ public class ConsultantAdminService {
           consultantId);
     }
 
-    consultant.setDeleteDate(nowInUtc());
+    deletionLifecycleService.beginConsultantDeletion(consultant, authenticatedUser.getUserId());
     consultant.setStatus(ConsultantStatus.IN_DELETION);
+    this.consultantRepository.save(consultant);
+  }
+
+  public void pauseConsultantDeletion(
+      String consultantId, String reason, Integer months, String pausedBy) {
+    var consultant =
+        this.consultantRepository
+            .findById(consultantId)
+            .orElseThrow(
+                () -> new NotFoundException("Consultant with id %s does not exist", consultantId));
+    if (consultant.getDeleteDate() == null) {
+      throw new NotFoundException("Consultant with id %s is not marked for deletion", consultantId);
+    }
+    deletionLifecycleService.pauseConsultantDeletion(consultant, reason, months, pausedBy);
     this.consultantRepository.save(consultant);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
@@ -16,10 +16,14 @@ import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAc
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Language;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -39,6 +43,8 @@ public class ConsultantUpdateService {
   private final @NonNull RocketChatService rocketChatService;
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull AppointmentService appointmentService;
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull EventNotificationService eventNotificationService;
 
   /**
    * Updates the basic data of consultant with given id.
@@ -49,8 +55,6 @@ public class ConsultantUpdateService {
    */
   public Consultant updateConsultant(
       String consultantId, UpdateAdminConsultantDTO updateConsultantDTO) {
-    System.out.println("=== SUPERVISOR DEBUG: Received updateConsultantDTO.isSupervisor: " + updateConsultantDTO.getIsSupervisor());
-    log.info("Received updateConsultantDTO.isSupervisor: {}", updateConsultantDTO.getIsSupervisor());
     this.userAccountInputValidator.validateAbsence(
         new UpdateConsultantDTOAbsenceInputAdapter(updateConsultantDTO));
 
@@ -62,6 +66,9 @@ public class ConsultantUpdateService {
                     new BadRequestException(
                         String.format("Consultant with id %s does not exist", consultantId)));
 
+    String previousDisplayName = displayNameOf(consultant.getFirstName(), consultant.getLastName());
+    String nextDisplayName =
+        displayNameOf(updateConsultantDTO.getFirstname(), updateConsultantDTO.getLastname());
     UserDTO userDTO = buildValidatedUserDTO(updateConsultantDTO, consultant);
     this.identityClient.updateUserData(
         consultant.getId(),
@@ -101,6 +108,7 @@ public class ConsultantUpdateService {
 
     var updatedConsultant = updateDatabaseConsultant(updateConsultantDTO, consultant);
     appointmentService.syncConsultantData(updatedConsultant);
+    emitCounselorRenameNotificationsIfNeeded(consultant, previousDisplayName, nextDisplayName);
     return updatedConsultant;
   }
 
@@ -132,17 +140,8 @@ public class ConsultantUpdateService {
     consultant.setAbsent(updateConsultantDTO.getAbsent());
     consultant.setAbsenceMessage(updateConsultantDTO.getAbsenceMessage());
     // Always update supervisor field if provided (even if false)
-    System.out.println("=== SUPERVISOR DEBUG: Checking isSupervisor: DTO value = " + updateConsultantDTO.getIsSupervisor() + ", consultant current value = " + consultant.isSupervisor());
-    log.info("Checking isSupervisor: DTO value = {}, consultant current value = {}", updateConsultantDTO.getIsSupervisor(), consultant.isSupervisor());
     if (updateConsultantDTO.getIsSupervisor() != null) {
-      System.out.println("=== SUPERVISOR DEBUG: Updating supervisor field for consultant " + consultant.getId() + ": " + updateConsultantDTO.getIsSupervisor());
-      log.info("Updating supervisor field for consultant {}: {}", consultant.getId(), updateConsultantDTO.getIsSupervisor());
       consultant.setSupervisor(updateConsultantDTO.getIsSupervisor());
-      System.out.println("=== SUPERVISOR DEBUG: Consultant supervisor field after update: " + consultant.isSupervisor());
-      log.info("Consultant supervisor field after update: {}", consultant.isSupervisor());
-    } else {
-      System.out.println("=== SUPERVISOR DEBUG: isSupervisor is null in DTO, skipping update");
-      log.info("isSupervisor is null in DTO, skipping update");
     }
     consultant.setUpdateDate(nowInUtc());
     if (updateConsultantDTO.getTermsAndConditionsConfirmation() != null
@@ -167,5 +166,36 @@ public class ConsultantUpdateService {
             .map(LanguageCode::getByCode)
             .map(languageCode -> new Language(consultant, languageCode))
             .collect(Collectors.toSet());
+  }
+
+  private void emitCounselorRenameNotificationsIfNeeded(
+      Consultant consultant, String previousDisplayName, String nextDisplayName) {
+    if (consultant == null || consultant.getId() == null) {
+      return;
+    }
+    if (previousDisplayName.equals(nextDisplayName)) {
+      return;
+    }
+    var activeStatuses = List.of(SessionStatus.NEW, SessionStatus.IN_PROGRESS);
+    var sessions = sessionRepository.findByConsultantAndStatusIn(consultant, activeStatuses);
+    sessions.stream()
+        .filter(session -> session.getUser() != null && session.getUser().getUserId() != null)
+        .forEach(
+            session ->
+                eventNotificationService.createCounselorRenamedNotification(
+                    session, session.getUser().getUserId(), previousDisplayName, nextDisplayName));
+    log.info(
+        "Counselor rename event created for consultantId={} from='{}' to='{}' sessions={}",
+        consultant.getId(),
+        previousDisplayName,
+        nextDisplayName,
+        sessions.size());
+  }
+
+  private String displayNameOf(String firstName, String lastName) {
+    String first = firstName == null ? "" : firstName.trim();
+    String last = lastName == null ? "" : lastName.trim();
+    String combined = (first + " " + last).trim();
+    return combined.isBlank() ? "Counselor" : combined;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
@@ -49,6 +49,9 @@ public enum Authority {
   SINGLE_TENANT_ADMIN(
       UserRole.SINGLE_TENANT_ADMIN, singletonList(AuthorityValue.SINGLE_TENANT_ADMIN)),
   TENANT_ADMIN(UserRole.TENANT_ADMIN, singletonList(AuthorityValue.TENANT_ADMIN)),
+  /** Same API gates as {@link #RESTRICTED_AGENCY_ADMIN}; realm role still distinguishes full vs restricted in code. */
+  AGENCY_ADMIN(
+      UserRole.AGENCY_ADMIN, singletonList(AuthorityValue.RESTRICTED_AGENCY_ADMIN)),
 
   RESTRICTED_CONSULTANT_ADMIN(
       UserRole.RESTRICTED_CONSULTANT_ADMIN, List.of(CONSULTANT_CREATE, CONSULTANT_UPDATE)),

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -95,7 +95,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
             "/users/consultants/{consultantId:" + UUID_PATTERN + "}",
             "/users/consultants/languages",
             "/users/magic-link/request",
-            "/users/magic-link/consume")
+            "/users/magic-link/consume",
+            "/users/invitelinks/*/redeem")
         .permitAll()
         .antMatchers(
             HttpMethod.POST,
@@ -107,7 +108,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .regexMatchers(HttpMethod.POST, ".*/users/magic-link/(request|consume)$")
         .permitAll()
         .antMatchers(HttpMethod.GET, "/conversations/anonymous/{sessionId:[0-9]+}")
-        .hasAnyAuthority(ANONYMOUS_DEFAULT)
+        .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT)
         .antMatchers("/users/notifications")
         .hasAnyAuthority(NOTIFICATIONS_TECHNICAL)
         .antMatchers("/users/data")

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -226,6 +226,13 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers(
             HttpMethod.PUT, "/useradmin/consultants/{consultantId:" + UUID_PATTERN + "}/agencies")
         .hasAnyAuthority(CONSULTANT_UPDATE, TECHNICAL_DEFAULT)
+        .antMatchers(
+            HttpMethod.POST,
+            "/useradmin/askers/{askerId:" + UUID_PATTERN + "}/deletion/pause",
+            "/useradmin/consultants/{consultantId:" + UUID_PATTERN + "}/deletion/pause",
+            "/service/useradmin/askers/{askerId:" + UUID_PATTERN + "}/deletion/pause",
+            "/service/useradmin/consultants/{consultantId:" + UUID_PATTERN + "}/deletion/pause")
+        .hasAnyAuthority(USER_ADMIN, RESTRICTED_AGENCY_ADMIN, TENANT_ADMIN, SINGLE_TENANT_ADMIN)
         .antMatchers("/useradmin", "/useradmin/**")
         .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT)
         .antMatchers("/users/consultants/search")

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.config.auth;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.*;
 
 import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.HttpTenantFilter;
+import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.IpPrivacyHeaderFilter;
 import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.StatelessCsrfFilter;
 import de.caritas.cob.userservice.api.config.CsrfSecurityProperties;
 import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
@@ -43,6 +44,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
   private boolean multitenancy;
 
   private HttpTenantFilter tenantFilter;
+  private final @Nullable IpPrivacyHeaderFilter ipPrivacyHeaderFilter;
 
   /**
    * Processes HTTP requests and checks for a valid spring security authentication for the
@@ -52,10 +54,12 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
       @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
           KeycloakClientRequestFactory keycloakClientRequestFactory,
       CsrfSecurityProperties csrfSecurityProperties,
-      @Nullable HttpTenantFilter tenantFilter) {
+      @Nullable HttpTenantFilter tenantFilter,
+      @Nullable IpPrivacyHeaderFilter ipPrivacyHeaderFilter) {
     this.keycloakClientRequestFactory = keycloakClientRequestFactory;
     this.csrfSecurityProperties = csrfSecurityProperties;
     this.tenantFilter = tenantFilter;
+    this.ipPrivacyHeaderFilter = ipPrivacyHeaderFilter;
   }
 
   /**
@@ -71,6 +75,9 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         http.csrf()
             .disable()
             .addFilterBefore(new StatelessCsrfFilter(csrfSecurityProperties), CsrfFilter.class);
+    if (ipPrivacyHeaderFilter != null) {
+      httpSecurity = httpSecurity.addFilterBefore(ipPrivacyHeaderFilter, StatelessCsrfFilter.class);
+    }
 
     httpSecurity = enableTenantFilterIfMultitenancyEnabled(httpSecurity);
 

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -240,6 +240,9 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers("/users/supervisors/logs", "/service/users/supervisors/logs")
         .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT, TENANT_ADMIN, SINGLE_TENANT_ADMIN)
         .antMatchers(
+            "/users/inactive-accounts/audit-logs", "/service/users/inactive-accounts/audit-logs")
+        .hasAuthority(TECHNICAL_DEFAULT)
+        .antMatchers(
             "/users/consultants/sessions/{sessionId:[0-9]+}",
             "/users/sessions/{sessionId:[0-9]+}/archive",
             "/users/sessions/{sessionId:[0-9]+}")

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -126,6 +126,9 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers("/matrix/sync/**")
         .permitAll()
         .antMatchers(
+            "/users/chat/{groupId:[\\dA-Za-z-,]+}/assign")
+        .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT, CONSULTANT_DEFAULT)
+        .antMatchers(
             "/users/email",
             "/users/mails/messages/new",
             "/users/drafts",
@@ -137,7 +140,6 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
             "/users/chat/{chatId:[0-9]+}/join",
             "/users/chat/{chatId:[0-9]+}/members",
             "/users/chat/{chatId:[0-9]+}/leave",
-            "/users/chat/{groupId:[\\dA-Za-z-,]+}/assign",
             "/users/consultants/toggleWalkThrough",
             "/matrix/**")
         .hasAnyAuthority(USER_DEFAULT, CONSULTANT_DEFAULT)
@@ -175,7 +177,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers(HttpMethod.GET, "/users/sessions/room/{sessionId:[0-9]+}")
         .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT, CONSULTANT_DEFAULT)
         .antMatchers(HttpMethod.GET, "/users/chat/room/{chatId:[0-9]+}")
-        .hasAnyAuthority(USER_DEFAULT, CONSULTANT_DEFAULT)
+        .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT, CONSULTANT_DEFAULT)
         .antMatchers(
             "/users/sessions/open",
             "/users/sessions/consultants/new",

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -76,9 +76,8 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
     var requestedPage = obtainPageByOffsetAndCount(pageableListRequest);
     var pageable = PageRequest.of(requestedPage, pageableListRequest.getCount());
 
-    return this.sessionRepository
-        .findByConsultingTypeIdInAndRegistrationTypeAndStatusOrderByCreateDateAsc(
-            relatedConsultingTypes, ANONYMOUS, SessionStatus.NEW, pageable);
+    return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultants(
+        relatedConsultingTypes, ANONYMOUS, SessionStatus.NEW, pageable);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/de/caritas/cob/userservice/api/facade/AssignChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/AssignChatFacade.java
@@ -7,12 +7,15 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserChat;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /** Facade for capsuling to assign a user to a chat. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AssignChatFacade {
 
   private final ChatService chatService;
@@ -20,12 +23,14 @@ public class AssignChatFacade {
 
   /**
    * Assign a chat to the authenticatedUser. <br>
-   * The chat is resolved using the RocketChat groupId.
+   * The chat is resolved first by RocketChat/Matrix groupId, then falls back to numeric database
+   * chat ID. This dual lookup supports the invite-link flow where the frontend may supply either a
+   * RocketChat group ID string or the numeric database ID (e.g. 102559).
    *
    * <p>In this assignment process is no further validation, because everyone is allowed to be added
    * to this chat.
    *
-   * @param groupId the rocket chat group id
+   * @param groupId the rocket chat group id or numeric chat database id
    * @param authenticatedUser that authenticated user
    */
   public void assignChat(String groupId, AuthenticatedUser authenticatedUser) {
@@ -35,10 +40,33 @@ public class AssignChatFacade {
     chatService.saveUserChatRelation(UserChat.builder().user(user).chat(chat).build());
   }
 
+  /**
+   * Resolves a chat by its RocketChat/Matrix group ID. If not found and the provided string is a
+   * valid long, falls back to a database primary-key lookup. This handles the invite-link flow
+   * where the frontend sometimes passes the numeric chat ID instead of a group ID.
+   */
   private Chat getChat(String groupId) {
-    return chatService
-        .getChatByGroupId(groupId)
-        .orElseThrow(() -> new NotFoundException("Chat with group id %s not found", groupId));
+    Optional<Chat> chatByGroupId = chatService.getChatByGroupId(groupId);
+    if (chatByGroupId.isPresent()) {
+      return chatByGroupId.get();
+    }
+
+    // Fallback: treat the groupId as a numeric database chat ID (used by the invite-link flow)
+    if (groupId != null && groupId.matches("\\d+")) {
+      try {
+        long chatId = Long.parseLong(groupId);
+        Optional<Chat> chatById = chatService.getChat(chatId);
+        if (chatById.isPresent()) {
+          log.debug(
+              "AssignChatFacade: resolved chat by numeric id {} (groupId lookup missed)", chatId);
+          return chatById.get();
+        }
+      } catch (NumberFormatException ignored) {
+        // Not a valid long, fall through to not-found
+      }
+    }
+
+    throw new NotFoundException("Chat with group id %s not found", groupId);
   }
 
   private User getUser(AuthenticatedUser authenticatedUser) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
@@ -23,7 +23,9 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.service.SessionDataService;
 import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
+import de.caritas.cob.userservice.api.service.session.DirectSessionMatrixRoomService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import java.util.List;
@@ -50,6 +52,7 @@ public class CreateSessionFacade {
 
   private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
   private final @NonNull AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
+  private final @NonNull DirectSessionMatrixRoomService directSessionMatrixRoomService;
 
   /**
    * Creates a new session for the provided user.
@@ -130,7 +133,10 @@ public class CreateSessionFacade {
             consultant, user, userDTO, agencyDTO.getTeamAgency());
     sessionDataService.saveSessionData(session, fromUserDTO(userDTO));
     session.setConsultant(consultant);
-    sessionService.saveSession(session);
+    session.setStatus(SessionStatus.IN_PROGRESS);
+    session = sessionService.saveSession(session);
+
+    directSessionMatrixRoomService.provisionRoomForDirectSession(session, consultant);
 
     return new NewRegistrationResponseDto().sessionId(session.getId()).status(HttpStatus.CREATED);
   }
@@ -190,10 +196,17 @@ public class CreateSessionFacade {
       User user, Long topicId, Long agencyId) {
     List<Session> sessions = sessionService.getSessionsForUserByMainTopicId(user, topicId);
 
+    /* Only ACTIVE sessions (NEW / IN_PROGRESS) block a new enquiry. A user
+       whose previous topic+agency session is DONE or IN_ARCHIVE must be able
+       to re-open a fresh enquiry from their profile. */
     var sessionsWithSameAgencyAndTopic =
         sessions.stream()
             .filter(
                 session -> session.getAgencyId() != null && session.getAgencyId().equals(agencyId))
+            .filter(
+                session ->
+                    session.getStatus() == Session.SessionStatus.NEW
+                        || session.getStatus() == Session.SessionStatus.IN_PROGRESS)
             .collect(Collectors.toList());
 
     if (CollectionUtils.isNotEmpty(sessionsWithSameAgencyAndTopic)) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.facade;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -231,7 +232,25 @@ public class CreateUserFacade {
               language);
     }
 
+    if (shouldClearPrivacyConfirmations(role, userDTO) && nonNull(user)) {
+      user.setTermsAndConditionsConfirmation(null);
+      user.setDataPrivacyConfirmation(null);
+      user = userService.saveUser(user);
+    }
+
     return user;
+  }
+
+  private boolean shouldClearPrivacyConfirmations(UserRole role, UserDTO userDTO) {
+    if (role == UserRole.ANONYMOUS) {
+      return true;
+    }
+
+    // Anonymous chat currently registers through /users/askers/new with role USER.
+    // Detect that path by its synthetic postcode / username and clear confirmations
+    // so the first in-chat privacy gate is shown and persisted only after explicit acceptance.
+    return StringUtils.equals("00000", userDTO.getPostcode())
+        || StringUtils.startsWith(userDTO.getUsername(), "Anonymous-");
   }
 
   private ExtendedConsultingTypeResponseDTO obtainConsultingTypeSettings(UserDTO userDTO) {

--- a/src/main/java/de/caritas/cob/userservice/api/model/AgencyInviteLink.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AgencyInviteLink.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.userservice.api.model;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "agency_invite_link")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class AgencyInviteLink {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  @Column(name = "token", nullable = false, unique = true, length = 64)
+  private String token;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  @Column(name = "agency_id", nullable = false)
+  private Long agencyId;
+
+  @Column(name = "consulting_type_id")
+  private Integer consultingTypeId;
+
+  @Column(name = "created_by_user_id", nullable = false, length = 36)
+  private String createdByUserId;
+
+  @Column(name = "created_by_username")
+  private String createdByUsername;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @Column(name = "expires_at")
+  private LocalDateTime expiresAt;
+
+  @Column(name = "used_at")
+  private LocalDateTime usedAt;
+
+  @Column(name = "used_by_session_id")
+  private Long usedBySessionId;
+
+  @Column(name = "status", nullable = false, length = 20)
+  private String status;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
@@ -5,6 +5,7 @@ import static java.util.Objects.isNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState;
 import de.caritas.cob.userservice.mailservice.generated.web.model.Dialect;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -168,6 +169,26 @@ public class Consultant implements TenantAware, NotificationsAware {
 
   @Column(name = "delete_date")
   private LocalDateTime deleteDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "deletion_lifecycle_state", length = 32)
+  @Builder.Default
+  private DeletionLifecycleState deletionLifecycleState = DeletionLifecycleState.ACTIVE;
+
+  @Column(name = "deletion_read_only_until", columnDefinition = "datetime")
+  private LocalDateTime deletionReadOnlyUntil;
+
+  @Column(name = "deletion_paused_until", columnDefinition = "datetime")
+  private LocalDateTime deletionPausedUntil;
+
+  @Column(name = "deletion_pause_reason", length = 512)
+  private String deletionPauseReason;
+
+  @Column(name = "deletion_paused_by", length = 64)
+  private String deletionPausedBy;
+
+  @Column(name = "deletion_pause_created_at", columnDefinition = "datetime")
+  private LocalDateTime deletionPauseCreatedAt;
 
   @Column(name = "encourage_2fa", nullable = false, columnDefinition = "bit default true")
   private Boolean encourage2fa;

--- a/src/main/java/de/caritas/cob/userservice/api/model/IdentityTombstone.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/IdentityTombstone.java
@@ -1,0 +1,76 @@
+package de.caritas.cob.userservice.api.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/** Minimal identity record retained after hard deletion (Security-05). */
+@Entity
+@Table(name = "identity_tombstone")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class IdentityTombstone implements TenantAware {
+
+  public enum SubjectType {
+    USER,
+    CONSULTANT
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "subject_id", nullable = false, length = 64)
+  private String subjectId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "subject_type", nullable = false, length = 16)
+  private SubjectType subjectType;
+
+  @Column(name = "display_label", nullable = false, length = 255)
+  private String displayLabel;
+
+  @Column(name = "hard_deleted_at", nullable = false, columnDefinition = "datetime")
+  private LocalDateTime hardDeletedAt;
+
+  @Column(name = "source_delete_date", columnDefinition = "datetime")
+  private LocalDateTime sourceDeleteDate;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IdentityTombstone)) {
+      return false;
+    }
+    IdentityTombstone that = (IdentityTombstone) o;
+    return id != null && id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/InactiveAccountNotificationAuditLog.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/InactiveAccountNotificationAuditLog.java
@@ -1,0 +1,96 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.model.InactiveAccountRole;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+/** Auditable record for Security-06 inactivity alerts. */
+@Entity
+@Table(name = "inactive_account_notification_audit_log")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+@FilterDef(
+    name = "tenantFilter",
+    parameters = {@ParamDef(name = "tenantId", type = "long")})
+@Filter(
+    name = "tenantFilter",
+    condition = "(tenant_id = :tenantId OR (:tenantId = 1 AND tenant_id IS NULL))")
+public class InactiveAccountNotificationAuditLog implements TenantAware {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "notification_fingerprint", nullable = false, length = 255, unique = true)
+  private String notificationFingerprint;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "account_role", nullable = false, length = 32)
+  private InactiveAccountRole accountRole;
+
+  @Column(name = "account_id", nullable = false, length = 64)
+  private String accountId;
+
+  @Column(name = "account_tenant_id")
+  private Long accountTenantId;
+
+  @Column(name = "last_activity_at", columnDefinition = "datetime")
+  private LocalDateTime lastActivityAt;
+
+  @Column(name = "threshold_days", nullable = false)
+  private Integer thresholdDays;
+
+  @Column(name = "recipient_admin_id", nullable = false, length = 64)
+  private String recipientAdminId;
+
+  @Column(name = "recipient_email", nullable = false, length = 255)
+  private String recipientEmail;
+
+  @Column(name = "email_dispatched", nullable = false, columnDefinition = "tinyint")
+  private boolean emailDispatched;
+
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime")
+  private LocalDateTime createDate;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof InactiveAccountNotificationAuditLog)) {
+      return false;
+    }
+    InactiveAccountNotificationAuditLog that = (InactiveAccountNotificationAuditLog) o;
+    return id != null && id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/User.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/User.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState;
 import de.caritas.cob.userservice.mailservice.generated.web.model.Dialect;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -94,6 +95,25 @@ public class User implements TenantAware, NotificationsAware {
 
   @Column(name = "delete_date", columnDefinition = "datetime")
   private LocalDateTime deleteDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "deletion_lifecycle_state", length = 32)
+  private DeletionLifecycleState deletionLifecycleState = DeletionLifecycleState.ACTIVE;
+
+  @Column(name = "deletion_read_only_until", columnDefinition = "datetime")
+  private LocalDateTime deletionReadOnlyUntil;
+
+  @Column(name = "deletion_paused_until", columnDefinition = "datetime")
+  private LocalDateTime deletionPausedUntil;
+
+  @Column(name = "deletion_pause_reason", length = 512)
+  private String deletionPauseReason;
+
+  @Column(name = "deletion_paused_by", length = 64)
+  private String deletionPausedBy;
+
+  @Column(name = "deletion_pause_created_at", columnDefinition = "datetime")
+  private LocalDateTime deletionPauseCreatedAt;
 
   @Column(name = "tenant_id")
   private Long tenantId;

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/Messaging.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/Messaging.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.port.in;
 
 import de.caritas.cob.userservice.api.model.Chat;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,4 +33,6 @@ public interface Messaging {
   boolean getAvailability(String consultantId);
 
   Set<String> findAvailableConsultants(int consultingTypeId);
+
+  long countPendingEnquiriesAheadOf(Long agencyId, LocalDateTime beforeDate);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -36,5 +36,7 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
   @Query(value = "SELECT a FROM Admin a WHERE tenantId = ?1 AND type = ?2")
   List<Admin> findByTenantIdAndType(Long tenantId, Admin.AdminType type);
 
+  List<Admin> findByType(Admin.AdminType type);
+
   List<Admin> findAllByIdIn(Set<String> adminIds);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AgencyInviteLinkRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AgencyInviteLinkRepository.java
@@ -1,0 +1,17 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.AgencyInviteLink;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AgencyInviteLinkRepository extends CrudRepository<AgencyInviteLink, Long> {
+
+  Optional<AgencyInviteLink> findByToken(String token);
+
+  List<AgencyInviteLink> findAllByTenantIdOrderByCreateDateDesc(Long tenantId);
+
+  List<AgencyInviteLink> findAllByAgencyIdInOrderByCreateDateDesc(List<Long> agencyIds);
+
+  List<AgencyInviteLink> findAllByOrderByCreateDateDesc();
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AgencyInviteLinkRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AgencyInviteLinkRepository.java
@@ -3,11 +3,16 @@ package de.caritas.cob.userservice.api.port.out;
 import de.caritas.cob.userservice.api.model.AgencyInviteLink;
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AgencyInviteLinkRepository extends CrudRepository<AgencyInviteLink, Long> {
 
   Optional<AgencyInviteLink> findByToken(String token);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  Optional<AgencyInviteLink> findByTokenAndStatus(String token, String status);
 
   List<AgencyInviteLink> findAllByTenantIdOrderByCreateDateDesc(Long tenantId);
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
@@ -29,6 +29,8 @@ public interface ConsultantRepository extends CrudRepository<Consultant, String>
 
   List<Consultant> findAllByDeleteDateNotNull();
 
+  List<Consultant> findByDeleteDateIsNull();
+
   List<Consultant> findAllByIdIn(List<String> ids);
 
   @Query(

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityTombstoneRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityTombstoneRepository.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.IdentityTombstone;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IdentityTombstoneRepository extends JpaRepository<IdentityTombstone, Long> {
+  Optional<IdentityTombstone> findFirstBySubjectIdOrderByHardDeletedAtDesc(String subjectId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InactiveAccountNotificationAuditLogRepository
+    extends JpaRepository<InactiveAccountNotificationAuditLog, Long> {
+
+  boolean existsByNotificationFingerprint(String notificationFingerprint);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.model.Session.RegistrationType;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
@@ -244,4 +245,10 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
    */
   List<Session> findByConsultantAndTeamSessionAndStatus(
       Consultant consultant, boolean isTeamSession, SessionStatus status);
+
+  @Query("SELECT max(s.enquiryMessageDate) FROM Session s WHERE s.user = :user")
+  LocalDateTime findMaxEnquiryMessageDateByUser(@Param("user") User user);
+
+  @Query("SELECT max(s.updateDate) FROM Session s WHERE s.consultant = :consultant")
+  LocalDateTime findMaxUpdateDateByConsultant(@Param("consultant") Consultant consultant);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -53,11 +53,13 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
    * @param agencyIds ids of agencies to search for
    * @param sessionStatus {@link SessionStatus} to search for
    * @param registrationType {@link RegistrationType} to search for
-   * @return A list of {@link Session}s for the specific agency ids and status orderd by creation
-   *     date ascending
+   * @return A list of {@link Session}s for the specific agency ids and status ordered by creation
+   *     date descending (newest first — matches how the consultant list UI presents them and
+   *     avoids an extra client-side sort pass that was reordering items during streaming loads).
    */
-  List<Session> findByAgencyIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateAsc(
-      List<Long> agencyIds, SessionStatus sessionStatus, RegistrationType registrationType);
+  List<Session>
+      findByAgencyIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(
+          List<Long> agencyIds, SessionStatus sessionStatus, RegistrationType registrationType);
 
   /**
    * Find a {@link Session} by agency ids with status and team session where consultant is not the
@@ -191,6 +193,37 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
       RegistrationType registrationType,
       SessionStatus sessionStatus,
       Pageable pageable);
+
+  @Query(
+      "SELECT s FROM Session s "
+          + "JOIN s.user u "
+          + "WHERE s.consultingTypeId IN :consultingTypeIds "
+          + "AND s.registrationType = :registrationType "
+          + "AND s.status = :sessionStatus "
+          + "AND u.dataPrivacyConfirmation IS NOT NULL "
+          + "ORDER BY s.createDate DESC")
+  Page<Session> findAnonymousEnquiriesVisibleForConsultants(
+      @Param("consultingTypeIds") Set<Integer> consultingTypeIds,
+      @Param("registrationType") RegistrationType registrationType,
+      @Param("sessionStatus") SessionStatus sessionStatus,
+      Pageable pageable);
+
+  /**
+   * Count enquiries for the given agency that are still waiting for a consultant (status NEW) and
+   * were created before the reference date — i.e. the number of people queued ahead of the asker
+   * in the same agency. Registration type is intentionally ignored: on this deployment all
+   * asker sessions land as REGISTERED regardless of whether they went through the anonymous or
+   * full-registration flow, so filtering on it would always return zero.
+   */
+  @Query(
+      "SELECT COUNT(s) FROM Session s "
+          + "WHERE s.agencyId = :agencyId "
+          + "AND s.status = :sessionStatus "
+          + "AND s.createDate < :beforeDate")
+  long countPendingEnquiriesAheadOf(
+      @Param("agencyId") Long agencyId,
+      @Param("sessionStatus") SessionStatus sessionStatus,
+      @Param("beforeDate") LocalDateTime beforeDate);
 
   /** Find all sessions by a given {@link SessionStatus}. */
   List<Session> findByStatus(SessionStatus status);

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
@@ -20,6 +20,8 @@ public interface UserRepository extends CrudRepository<User, String> {
 
   List<User> findAllByDeleteDateNotNull();
 
+  List<User> findAllByDeleteDateIsNull();
+
   Optional<User> findByUsernameInAndDeleteDateIsNull(Collection<String> usernames);
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsService.java
@@ -1,0 +1,179 @@
+package de.caritas.cob.userservice.api.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+/** Read model service for Security-06 inactivity audit logs. */
+@Service
+@RequiredArgsConstructor
+public class InactiveAccountAuditLogsService {
+
+  private final @NonNull NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public InactiveAccountAuditLogsResult listAuditLogs(
+      int page, int perPage, String accountRole, String accountId) {
+    final int safePerPage = Math.min(Math.max(perPage, 1), 200);
+    final int safePage = Math.max(page, 1);
+    final int offset = (safePage - 1) * safePerPage;
+
+    final Long tenantId = resolveEffectiveTenantId();
+
+    final String normalizedRole = normalize(accountRole);
+    final String normalizedAccountId = normalize(accountId);
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("tenantId", tenantId)
+            .addValue("role", normalizedRole)
+            .addValue("accountId", normalizedAccountId)
+            .addValue("limit", safePerPage)
+            .addValue("offset", offset);
+
+    final String filtersSql =
+        " WHERE (:tenantId IS NULL OR l.tenant_id = :tenantId OR (:tenantId = 1 AND l.tenant_id IS NULL))"
+            + " AND (:role IS NULL OR UPPER(l.account_role) = :role)"
+            + " AND (:accountId IS NULL OR UPPER(l.account_id) LIKE CONCAT('%', :accountId, '%'))";
+
+    Long total =
+        namedParameterJdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM inactive_account_notification_audit_log l" + filtersSql,
+            params,
+            Long.class);
+
+    List<InactiveAccountAuditLogEntry> data =
+        namedParameterJdbcTemplate.query(
+            "SELECT "
+                + "l.id AS id, "
+                + "l.account_role AS accountRole, "
+                + "l.account_id AS accountId, "
+                + "l.account_tenant_id AS accountTenantId, "
+                + "l.last_activity_at AS lastActivityAt, "
+                + "l.threshold_days AS thresholdDays, "
+                + "l.recipient_admin_id AS recipientAdminId, "
+                + "l.recipient_email AS recipientEmail, "
+                + "l.email_dispatched AS emailDispatched, "
+                + "l.create_date AS createDate "
+                + "FROM inactive_account_notification_audit_log l"
+                + filtersSql
+                + " ORDER BY l.create_date DESC, l.id DESC"
+                + " LIMIT :limit OFFSET :offset",
+            params,
+            new InactiveAccountAuditLogEntryRowMapper());
+
+    return InactiveAccountAuditLogsResult.builder()
+        .data(data)
+        .total(total != null ? total : 0L)
+        .page(safePage)
+        .perPage(safePerPage)
+        .build();
+  }
+
+  private String normalize(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    return value.trim().toUpperCase();
+  }
+
+  private Long resolveEffectiveTenantId() {
+    Long tokenTenantId = getTenantIdFromAccessToken();
+    if (tokenTenantId != null) {
+      return tokenTenantId == 0L ? null : tokenTenantId;
+    }
+    return TenantContext.isTechnicalOrSuperAdminContext() ? null : TenantContext.getCurrentTenant();
+  }
+
+  private Long getTenantIdFromAccessToken() {
+    try {
+      String accessToken = authenticatedUser.getAccessToken();
+      if (accessToken == null || accessToken.isBlank()) {
+        return null;
+      }
+      String[] tokenParts = accessToken.split("\\.");
+      if (tokenParts.length < 2) {
+        return null;
+      }
+      String payload =
+          new String(Base64.getUrlDecoder().decode(tokenParts[1]), StandardCharsets.UTF_8);
+      JsonNode payloadNode = objectMapper.readTree(payload);
+      JsonNode tenantIdNode = payloadNode.get("tenantId");
+      if (tenantIdNode == null || tenantIdNode.isNull()) {
+        return null;
+      }
+      if (tenantIdNode.isNumber()) {
+        return tenantIdNode.asLong();
+      }
+      if (tenantIdNode.isTextual()) {
+        String tenantIdText = tenantIdNode.asText();
+        if (tenantIdText.isBlank()) {
+          return null;
+        }
+        return Long.parseLong(tenantIdText);
+      }
+      return null;
+    } catch (Exception exception) {
+      return null;
+    }
+  }
+
+  private static class InactiveAccountAuditLogEntryRowMapper
+      implements RowMapper<InactiveAccountAuditLogEntry> {
+    @Override
+    public InactiveAccountAuditLogEntry mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return InactiveAccountAuditLogEntry.builder()
+          .id(rs.getLong("id"))
+          .accountRole(rs.getString("accountRole"))
+          .accountId(rs.getString("accountId"))
+          .accountTenantId(rs.getObject("accountTenantId", Long.class))
+          .lastActivityAt(rs.getObject("lastActivityAt", LocalDateTime.class))
+          .thresholdDays(rs.getInt("thresholdDays"))
+          .recipientAdminId(rs.getString("recipientAdminId"))
+          .recipientEmail(rs.getString("recipientEmail"))
+          .emailDispatched(rs.getBoolean("emailDispatched"))
+          .createDate(rs.getObject("createDate", LocalDateTime.class))
+          .build();
+    }
+  }
+
+  @Data
+  @Builder
+  public static class InactiveAccountAuditLogEntry {
+    private Long id;
+    private String accountRole;
+    private String accountId;
+    private Long accountTenantId;
+    private LocalDateTime lastActivityAt;
+    private Integer thresholdDays;
+    private String recipientAdminId;
+    private String recipientEmail;
+    private Boolean emailDispatched;
+    private LocalDateTime createDate;
+  }
+
+  @Data
+  @Builder
+  public static class InactiveAccountAuditLogsResult {
+    private List<InactiveAccountAuditLogEntry> data;
+    private long total;
+    private int page;
+    private int perPage;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
@@ -5,7 +5,6 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakClient;
 import de.caritas.cob.userservice.agencyserivce.generated.ApiClient;
 import de.caritas.cob.userservice.agencyserivce.generated.web.AgencyControllerApi;
 import de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO;
@@ -31,7 +30,6 @@ public class AgencyService {
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
   private final @NonNull AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
-  private final @NonNull KeycloakClient keycloakClient;
   /**
    * Returns the {@link AgencyDTO} for the provided agencyId. Agency will be cached for further
    * requests.
@@ -107,11 +105,9 @@ public class AgencyService {
   }
 
   private void addDefaultHeaders(ApiClient apiClient) {
-    // Registration/public flows can be unauthenticated (no user token in request scope).
-    // In those cases, fall back to a technical token so agency lookup still works.
-    var headers =
-        this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeadersWithFallback(
-            keycloakClient.getBearerToken());
+    // Registration/public flows must stay unauthenticated. Only forward Authorization when a real
+    // user token already exists in request context.
+    var headers = this.securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders();
     tenantHeaderSupplier.addTenantHeader(headers);
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -1,0 +1,201 @@
+package de.caritas.cob.userservice.api.service.agencyinvitelink;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AdminAgency;
+import de.caritas.cob.userservice.api.model.AgencyInviteLink;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.AgencyInviteLinkRepository;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Manages one-time invite links that auto-register an anonymous user for a specific agency. Admin
+ * scope is enforced on create/list: super admin (tenant-super) sees all tenants; tenant admin is
+ * pinned to their tenant; restricted agency admin is pinned to the agencies listed in their
+ * admin_agency rows.
+ */
+@Service
+@RequiredArgsConstructor
+public class AgencyInviteLinkService {
+
+  private static final String STATUS_ACTIVE = "ACTIVE";
+  private static final String STATUS_USED = "USED";
+  private static final String STATUS_EXPIRED = "EXPIRED";
+  private static final int TOKEN_BYTES = 24;
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final @NonNull AgencyInviteLinkRepository repository;
+  private final @NonNull AdminAgencyRepository adminAgencyRepository;
+  private final @NonNull AgencyService agencyService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  public AgencyInviteLink create(Long agencyId, Long expiresInDays) {
+    if (agencyId == null) {
+      throw new BadRequestException("agencyId is required");
+    }
+    var agency = agencyService.getAgencyWithoutCaching(agencyId);
+    if (agency == null) {
+      throw new NotFoundException("Agency %s not found", agencyId);
+    }
+    Long agencyTenantId = agency.getTenantId();
+    assertCallerMayManageAgency(agencyId, agencyTenantId);
+
+    LocalDateTime now = LocalDateTime.now();
+    AgencyInviteLink link =
+        AgencyInviteLink.builder()
+            .token(generateToken())
+            .tenantId(agencyTenantId)
+            .agencyId(agencyId)
+            .consultingTypeId(agency.getConsultingType())
+            .createdByUserId(authenticatedUser.getUserId())
+            .createdByUsername(authenticatedUser.getUsername())
+            .createDate(now)
+            .expiresAt(expiresInDays != null && expiresInDays > 0 ? now.plusDays(expiresInDays) : null)
+            .status(STATUS_ACTIVE)
+            .build();
+    return repository.save(link);
+  }
+
+  public List<AgencyInviteLink> list() {
+    List<AgencyInviteLink> results;
+    if (authenticatedUser.isTenantSuperAdmin()) {
+      results = (List<AgencyInviteLink>) repository.findAllByOrderByCreateDateDesc();
+    } else if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      List<Long> agencyIds = getAdminAgencyIds();
+      if (agencyIds.isEmpty()) {
+        return List.of();
+      }
+      results = repository.findAllByAgencyIdInOrderByCreateDateDesc(agencyIds);
+    } else {
+      Long tenantId = resolveTenantIdFromUser();
+      if (tenantId == null) {
+        return List.of();
+      }
+      results = repository.findAllByTenantIdOrderByCreateDateDesc(tenantId);
+    }
+    return results.stream().map(this::autoExpireIfNeeded).sorted(Comparator.comparing(AgencyInviteLink::getCreateDate).reversed()).collect(Collectors.toList());
+  }
+
+  /**
+   * Redeem the token — validate it, mark USED, return agency info the frontend needs to run the
+   * standard asker registration. Client is responsible for registration + auto-login; this keeps
+   * the redeem endpoint authentication-free and avoids duplicating the anonymous-user creation
+   * path.
+   */
+  @Transactional
+  public RedeemResult redeem(String token) {
+    AgencyInviteLink link =
+        repository
+            .findByToken(token)
+            .orElseThrow(() -> new NotFoundException("Invite link not found"));
+
+    if (STATUS_USED.equals(link.getStatus())) {
+      throw new BadRequestException("Invite link already used");
+    }
+    if (link.getExpiresAt() != null && link.getExpiresAt().isBefore(LocalDateTime.now())) {
+      link.setStatus(STATUS_EXPIRED);
+      repository.save(link);
+      throw new BadRequestException("Invite link expired");
+    }
+    if (!STATUS_ACTIVE.equals(link.getStatus())) {
+      throw new BadRequestException("Invite link is not active");
+    }
+
+    link.setStatus(STATUS_USED);
+    link.setUsedAt(LocalDateTime.now());
+    repository.save(link);
+
+    return new RedeemResult(link.getTenantId(), link.getAgencyId(), link.getConsultingTypeId());
+  }
+
+  /** Plain carrier for the redeem response. */
+  public static class RedeemResult {
+    private final Long tenantId;
+    private final Long agencyId;
+    private final Integer consultingTypeId;
+
+    public RedeemResult(Long tenantId, Long agencyId, Integer consultingTypeId) {
+      this.tenantId = tenantId;
+      this.agencyId = agencyId;
+      this.consultingTypeId = consultingTypeId;
+    }
+
+    public Long getTenantId() {
+      return tenantId;
+    }
+
+    public Long getAgencyId() {
+      return agencyId;
+    }
+
+    public Integer getConsultingTypeId() {
+      return consultingTypeId;
+    }
+  }
+
+  private AgencyInviteLink autoExpireIfNeeded(AgencyInviteLink link) {
+    if (STATUS_ACTIVE.equals(link.getStatus())
+        && link.getExpiresAt() != null
+        && link.getExpiresAt().isBefore(LocalDateTime.now())) {
+      link.setStatus(STATUS_EXPIRED);
+      repository.save(link);
+    }
+    return link;
+  }
+
+  private void assertCallerMayManageAgency(Long agencyId, Long agencyTenantId) {
+    if (authenticatedUser.isTenantSuperAdmin()) {
+      return;
+    }
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      if (!getAdminAgencyIds().contains(agencyId)) {
+        throw new ForbiddenException(
+            "Agency admin may only create invite links for their own agencies");
+      }
+      return;
+    }
+    Long callerTenantId = resolveTenantIdFromUser();
+    if (callerTenantId == null || !callerTenantId.equals(agencyTenantId)) {
+      throw new ForbiddenException("Agency is outside caller's tenant");
+    }
+  }
+
+  private List<Long> getAdminAgencyIds() {
+    List<AdminAgency> rows = adminAgencyRepository.findByAdminId(authenticatedUser.getUserId());
+    if (rows == null || rows.isEmpty()) {
+      return List.of();
+    }
+    return rows.stream().map(AdminAgency::getAgencyId).collect(Collectors.toList());
+  }
+
+  private Long resolveTenantIdFromUser() {
+    try {
+      Object tenantClaim =
+          de.caritas.cob.userservice.api.tenant.TenantContext.getCurrentTenant();
+      if (tenantClaim == null) {
+        return null;
+      }
+      return Long.valueOf(tenantClaim.toString());
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  private String generateToken() {
+    byte[] buf = new byte[TOKEN_BYTES];
+    RANDOM.nextBytes(buf);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -98,19 +98,24 @@ public class AgencyInviteLinkService {
   public RedeemResult redeem(String token) {
     AgencyInviteLink link =
         repository
-            .findByToken(token)
-            .orElseThrow(() -> new NotFoundException("Invite link not found"));
+            .findByTokenAndStatus(token, STATUS_ACTIVE)
+            .orElseThrow(
+                () ->
+                    repository
+                        .findByToken(token)
+                        .map(
+                            existing -> {
+                              if (STATUS_USED.equals(existing.getStatus())) {
+                                throw new BadRequestException("Invite link already used");
+                              }
+                              throw new BadRequestException("Invite link is not active");
+                            })
+                        .orElseThrow(() -> new NotFoundException("Invite link not found")));
 
-    if (STATUS_USED.equals(link.getStatus())) {
-      throw new BadRequestException("Invite link already used");
-    }
     if (link.getExpiresAt() != null && link.getExpiresAt().isBefore(LocalDateTime.now())) {
       link.setStatus(STATUS_EXPIRED);
       repository.save(link);
       throw new BadRequestException("Invite link expired");
-    }
-    if (!STATUS_ACTIVE.equals(link.getStatus())) {
-      throw new BadRequestException("Invite link is not active");
     }
 
     link.setStatus(STATUS_USED);

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -96,21 +97,21 @@ public class AgencyInviteLinkService {
    */
   @Transactional
   public RedeemResult redeem(String token) {
-    AgencyInviteLink link =
-        repository
-            .findByTokenAndStatus(token, STATUS_ACTIVE)
-            .orElseThrow(
-                () ->
-                    repository
-                        .findByToken(token)
-                        .map(
-                            existing -> {
-                              if (STATUS_USED.equals(existing.getStatus())) {
-                                throw new BadRequestException("Invite link already used");
-                              }
-                              throw new BadRequestException("Invite link is not active");
-                            })
-                        .orElseThrow(() -> new NotFoundException("Invite link not found")));
+    Optional<AgencyInviteLink> activeLink = repository.findByTokenAndStatus(token, STATUS_ACTIVE);
+
+    AgencyInviteLink link;
+    if (activeLink.isEmpty()) {
+      Optional<AgencyInviteLink> anyLink = repository.findByToken(token);
+      if (anyLink.isPresent()) {
+        AgencyInviteLink existing = anyLink.get();
+        if (STATUS_USED.equals(existing.getStatus())) {
+          throw new BadRequestException("Invite link already used");
+        }
+        throw new BadRequestException("Invite link is not active");
+      }
+      throw new NotFoundException("Invite link not found");
+    }
+    link = activeLink.get();
 
     if (link.getExpiresAt() != null && link.getExpiresAt().isBefore(LocalDateTime.now())) {
       link.setStatus(STATUS_EXPIRED);

--- a/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
@@ -40,7 +40,10 @@ public class SecurityHeaderSupplier {
    */
   public HttpHeaders getKeycloakAndCsrfHttpHeaders() {
     var header = getCsrfHttpHeaders();
-    this.addKeycloakAuthorizationHeader(header, authenticatedUser.getAccessToken());
+    var currentAccessToken = authenticatedUser.getAccessToken();
+    if (StringUtils.isNotBlank(currentAccessToken)) {
+      this.addKeycloakAuthorizationHeader(header, currentAccessToken);
+    }
     return header;
   }
 
@@ -67,6 +70,14 @@ public class SecurityHeaderSupplier {
     return StringUtils.isNotBlank(currentAccessToken)
         ? getKeycloakAndCsrfHttpHeaders(currentAccessToken)
         : getKeycloakAndCsrfHttpHeaders(fallbackAccessToken);
+  }
+
+  /**
+   * Creates headers with CSRF values and adds Authorization only when the current request context
+   * already has a user token. This keeps public flows unauthenticated.
+   */
+  public HttpHeaders getOptionalKeycloakAndCsrfHttpHeaders() {
+    return getKeycloakAndCsrfHttpHeaders();
   }
 
   private void addKeycloakAuthorizationHeader(HttpHeaders httpHeaders, String accessToken) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.util.*;
 import java.util.concurrent.*;
@@ -173,8 +174,6 @@ public class MatrixEventListenerService {
         syncUrl += "?timeout=30000";
       }
 
-      log.debug("🔷 Matrix sync: {}", syncUrl);
-
       // Call Matrix sync endpoint
       Map<String, Object> syncResult =
           matrixSynapseService.makeMatrixRequest(syncUrl, "GET", adminAccessToken, null);
@@ -303,15 +302,11 @@ public class MatrixEventListenerService {
     }
 
     String msgtype = (String) content.get("msgtype");
-    String body = (String) content.get("body");
     String senderDomainUserId = resolveDomainUserIdFromMatrixUserId(senderId);
     String threadRootId = extractThreadRootId(content);
+    PrivacyEnvelope privacyEnvelope = buildPrivacyEnvelope(event, roomId, senderId, msgtype, content);
 
-    log.info(
-        "📩 New Matrix message in room {}: {} (type: {})",
-        roomId,
-        body != null && body.length() > 50 ? body.substring(0, 50) + "..." : body,
-        msgtype);
+    safeContentLog("matrix.message.received", privacyEnvelope);
 
     // Get users who should receive notification (exclude sender)
     Set<String> userIds = getRecipientCandidatesForRoom(roomId);
@@ -339,10 +334,10 @@ public class MatrixEventListenerService {
                 liveEventNotificationService.sendLiveDirectMessageEventToUsers(roomId);
                 if (threadRootId != null && !threadRootId.isBlank()) {
                   eventNotificationService.createThreadReplyNotificationFromRoom(
-                      roomId, senderDomainUserId, body, threadRootId, true);
+                      roomId, senderDomainUserId, threadRootId, true, privacyEnvelope);
                 } else {
                   eventNotificationService.createMessageNotificationFromRoom(
-                      roomId, senderDomainUserId, body, true);
+                      roomId, senderDomainUserId, true, privacyEnvelope);
                 }
               } catch (Exception e) {
                 log.error("❌ Failed to send LiveService notification", e);
@@ -429,6 +424,77 @@ public class MatrixEventListenerService {
     }
     Object eventId = relatesTo.get("event_id");
     return eventId != null ? String.valueOf(eventId) : null;
+  }
+
+  private void safeContentLog(String marker, PrivacyEnvelope envelope) {
+    if (envelope == null) {
+      log.debug("🔒 {} room=unknown", marker);
+      return;
+    }
+    log.debug(
+        "🔒 {} room={} messageId={} sender={} contentClass={} hasAttachment={} ts={}",
+        marker,
+        envelope.getRoomId(),
+        envelope.getMessageId(),
+        envelope.getSenderId(),
+        envelope.getContentClass(),
+        envelope.isHasAttachment(),
+        envelope.getTimestamp());
+  }
+
+  @SuppressWarnings("unchecked")
+  private PrivacyEnvelope buildPrivacyEnvelope(
+      Map<String, Object> event,
+      String roomId,
+      String senderId,
+      String msgtype,
+      Map<String, Object> content) {
+    String contentClass = classifyContent(msgtype);
+    boolean hasAttachment =
+        Set.of("m.image", "m.file", "m.audio", "m.video").contains(msgtype)
+            || (content != null && (content.containsKey("url") || content.containsKey("file")));
+
+    Long timestamp = null;
+    Object timestampRaw = event.get("origin_server_ts");
+    if (timestampRaw instanceof Number) {
+      timestamp = ((Number) timestampRaw).longValue();
+    }
+
+    Object eventIdRaw = event.get("event_id");
+    String eventId = eventIdRaw == null ? null : String.valueOf(eventIdRaw);
+
+    return PrivacyEnvelope.builder()
+        .messageId(eventId)
+        .roomId(roomId)
+        .senderId(senderId)
+        .timestamp(timestamp)
+        .hasAttachment(hasAttachment)
+        .contentClass(contentClass)
+        .build();
+  }
+
+  private String classifyContent(String msgtype) {
+    if (msgtype == null || msgtype.isBlank()) {
+      return "UNKNOWN";
+    }
+    switch (msgtype) {
+      case "m.text":
+        return "TEXT";
+      case "m.image":
+        return "IMAGE";
+      case "m.file":
+        return "FILE";
+      case "m.audio":
+        return "AUDIO";
+      case "m.video":
+        return "VIDEO";
+      case "m.notice":
+        return "NOTICE";
+      case "m.emote":
+        return "EMOTE";
+      default:
+        return "OTHER";
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
+import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -31,6 +32,7 @@ public class MatrixEventListenerService {
   private final @NonNull SessionService sessionService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final @NonNull EventNotificationService eventNotificationService;
+  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
   private final @NonNull UserRepository userRepository;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionRepository sessionRepository;
@@ -304,9 +306,21 @@ public class MatrixEventListenerService {
     String msgtype = (String) content.get("msgtype");
     String senderDomainUserId = resolveDomainUserIdFromMatrixUserId(senderId);
     String threadRootId = extractThreadRootId(content);
+    String messageBody = extractMessageBody(content);
     PrivacyEnvelope privacyEnvelope = buildPrivacyEnvelope(event, roomId, senderId, msgtype, content);
 
     safeContentLog("matrix.message.received", privacyEnvelope);
+
+    // Debug mirror: capture actual Matrix timeline messages so Redis Commander can show them.
+    // This is feature-flagged/TTL-bound in RedisMessageMirrorService.
+    Long sessionId = roomToSessionMap.get(roomId);
+    redisMessageMirrorService.mirrorOutgoingMessage(
+        sessionId,
+        roomId,
+        senderId,
+        senderDomainUserId != null && senderDomainUserId.startsWith("consultant"),
+        messageBody,
+        event.get("event_id") != null ? String.valueOf(event.get("event_id")) : null);
 
     // Get users who should receive notification (exclude sender)
     Set<String> userIds = getRecipientCandidatesForRoom(roomId);
@@ -325,8 +339,8 @@ public class MatrixEventListenerService {
 
       // Use existing LiveService notification service
       // Note: We need to convert Matrix room ID to session/group ID
-      Long sessionId = roomToSessionMap.get(roomId);
-      if (sessionId != null) {
+      Long mappedSessionId = roomToSessionMap.get(roomId);
+      if (mappedSessionId != null) {
         // Trigger notification asynchronously to not block sync loop
         executorService.submit(
             () -> {
@@ -495,6 +509,33 @@ public class MatrixEventListenerService {
       default:
         return "OTHER";
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private String extractMessageBody(Map<String, Object> content) {
+    if (content == null) {
+      return null;
+    }
+
+    Object body = content.get("body");
+    if (body != null) {
+      return String.valueOf(body);
+    }
+
+    Object formattedBody = content.get("formatted_body");
+    if (formattedBody != null) {
+      return String.valueOf(formattedBody);
+    }
+
+    Object relatesToRaw = content.get("m.relates_to");
+    if (relatesToRaw instanceof Map) {
+      Object eventId = ((Map<String, Object>) relatesToRaw).get("event_id");
+      if (eventId != null) {
+        return "thread-reply:" + eventId;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorService.java
@@ -1,0 +1,89 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Debug-only mirror for outgoing chat messages to Redis.
+ *
+ * <p>This is intentionally feature-flagged and TTL-bound so developers can inspect message flow in
+ * Redis Commander without making Redis a source-of-truth for chat history.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RedisMessageMirrorService {
+
+  private final ObjectProvider<StringRedisTemplate> redisTemplateProvider;
+  private final ObjectMapper objectMapper;
+
+  @Value("${debug.redis.message.mirror.enabled:false}")
+  private boolean enabled;
+
+  @Value("${debug.redis.message.mirror.ttlSeconds:900}")
+  private long ttlSeconds;
+
+  @Value("${debug.redis.message.mirror.maxBodyLength:500}")
+  private int maxBodyLength;
+
+  @Value("${debug.redis.message.mirror.keyPrefix:debug:msgmirror}")
+  private String keyPrefix;
+
+  public void mirrorOutgoingMessage(
+      Long sessionId,
+      String roomId,
+      String senderUsername,
+      boolean consultantSender,
+      String messageBody,
+      String matrixEventId) {
+    if (!enabled) {
+      return;
+    }
+
+    if (messageBody == null || messageBody.isBlank()) {
+      return;
+    }
+
+    StringRedisTemplate redisTemplate = redisTemplateProvider.getIfAvailable();
+    if (redisTemplate == null) {
+      log.warn("Redis message mirror enabled but no StringRedisTemplate is available.");
+      return;
+    }
+
+    String safeBody = messageBody.length() > maxBodyLength ? messageBody.substring(0, maxBodyLength) : messageBody;
+    String key =
+        String.format(
+            "%s:room:%s:%d:%s",
+            keyPrefix, roomId, System.currentTimeMillis(), UUID.randomUUID().toString().substring(0, 8));
+
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("ts", Instant.now().toString());
+    payload.put("sessionId", sessionId);
+    payload.put("roomId", roomId);
+    payload.put("sender", senderUsername);
+    payload.put("senderRole", consultantSender ? "consultant" : "user");
+    payload.put("eventId", matrixEventId == null ? "" : matrixEventId);
+    payload.put("message", safeBody);
+
+    try {
+      String serializedPayload = objectMapper.writeValueAsString(payload);
+      redisTemplate.opsForValue().set(key, serializedPayload, Duration.ofSeconds(Math.max(ttlSeconds, 30)));
+    } catch (JsonProcessingException e) {
+      log.warn("Failed to serialize Redis message mirror payload: {}", e.getMessage());
+    } catch (Exception e) {
+      log.warn("Failed writing mirrored message to Redis: {}", e.getMessage());
+    }
+  }
+}
+

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -38,6 +39,7 @@ public class EventNotificationService {
   private final @NonNull SessionRepository sessionRepository;
   private final @NonNull UserRepository userRepository;
   private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull IdentityTombstoneService identityTombstoneService;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
   @Value("${privacy.notificationPreviewMode:NONE}")
   private String notificationPreviewMode;
@@ -448,6 +450,8 @@ public class EventNotificationService {
                           }
                           return safeValue(candidate, "User");
                         }))
+        .or(
+            () -> identityTombstoneService.resolveDisplayLabel(senderUserId))
         .orElse("Someone");
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -94,6 +94,28 @@ public class EventNotificationService {
   }
 
   @Transactional
+  public void createCounselorRenamedNotification(
+      Session session, String recipientUserId, String oldDisplayName, String newDisplayName) {
+    if (session == null || recipientUserId == null || recipientUserId.isBlank()) {
+      return;
+    }
+    String previous = safeValue(oldDisplayName, "your counselor");
+    String updated = safeValue(newDisplayName, "your counselor");
+    String changedAt = LocalDateTime.now(ZoneOffset.UTC).toString();
+    createEvent(
+        recipientUserId,
+        "counselor.renamed",
+        CATEGORY_SYSTEM,
+        "Counselor name updated",
+        String.format(
+            "Your counselor display name changed from \"%s\" to \"%s\" at %s UTC.",
+            previous, updated, changedAt),
+        buildSessionActionPath(session),
+        session.getId(),
+        session.getTenantId());
+  }
+
+  @Transactional
   public void createMessageNotificationFromRoom(
       String roomId, String senderUserId, String messagePreview, boolean matrixRoom) {
     createMessageNotificationFromRoom(

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,12 +32,15 @@ public class EventNotificationService {
   public static final String CATEGORY_SYSTEM = "system";
   public static final String CATEGORY_MESSAGE = "message";
   private static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
+  private static final String REDACTED_PREVIEW = "[content hidden]";
 
   private final @NonNull EventNotificationRepository eventNotificationRepository;
   private final @NonNull SessionRepository sessionRepository;
   private final @NonNull UserRepository userRepository;
   private final @NonNull ConsultantRepository consultantRepository;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
+  @Value("${privacy.notificationPreviewMode:NONE}")
+  private String notificationPreviewMode;
 
   @Transactional
   public void createInquiryAcceptedNotification(Session session, Consultant consultant) {
@@ -93,7 +97,13 @@ public class EventNotificationService {
   public void createMessageNotificationFromRoom(
       String roomId, String senderUserId, String messagePreview, boolean matrixRoom) {
     createMessageNotificationFromRoom(
-        roomId, senderUserId, messagePreview, matrixRoom, false, null);
+        roomId, senderUserId, messagePreview, matrixRoom, false, null, null);
+  }
+
+  @Transactional
+  public void createMessageNotificationFromRoom(
+      String roomId, String senderUserId, boolean matrixRoom, PrivacyEnvelope envelope) {
+    createMessageNotificationFromRoom(roomId, senderUserId, null, matrixRoom, false, null, envelope);
   }
 
   @Transactional
@@ -104,6 +114,19 @@ public class EventNotificationService {
       boolean matrixRoom,
       boolean supervisorMessage,
       String senderDisplayName) {
+    createMessageNotificationFromRoom(
+        roomId, senderUserId, messagePreview, matrixRoom, supervisorMessage, senderDisplayName, null);
+  }
+
+  @Transactional
+  public void createMessageNotificationFromRoom(
+      String roomId,
+      String senderUserId,
+      String messagePreview,
+      boolean matrixRoom,
+      boolean supervisorMessage,
+      String senderDisplayName,
+      PrivacyEnvelope envelope) {
     if (roomId == null || roomId.isBlank()) {
       return;
     }
@@ -119,11 +142,7 @@ public class EventNotificationService {
 
     Session session = sessionOpt.get();
     String senderLabel = resolveSenderName(senderUserId, senderDisplayName);
-    String preview = normalizePreview(cleanMessageBody(messagePreview));
-    String text =
-        String.format(
-            "%s sent a new message%s",
-            senderLabel, preview.isBlank() ? "." : ": \"" + preview + "\"");
+    String text = buildMessageNotificationText(senderLabel, messagePreview, envelope);
 
     if (!supervisorMessage
         && session.getUser() != null
@@ -161,11 +180,22 @@ public class EventNotificationService {
   public void createThreadReplyNotificationFromRoom(
       String roomId,
       String senderUserId,
+      String threadRootId,
+      boolean matrixRoom,
+      PrivacyEnvelope envelope) {
+    createThreadReplyNotificationFromRoom(
+        roomId, senderUserId, null, threadRootId, matrixRoom, false, null, null, envelope);
+  }
+
+  @Transactional
+  public void createThreadReplyNotificationFromRoom(
+      String roomId,
+      String senderUserId,
       String messagePreview,
       String threadRootId,
       boolean matrixRoom) {
     createThreadReplyNotificationFromRoom(
-        roomId, senderUserId, messagePreview, threadRootId, matrixRoom, false, null, null);
+        roomId, senderUserId, messagePreview, threadRootId, matrixRoom, false, null, null, null);
   }
 
   @Transactional
@@ -178,6 +208,29 @@ public class EventNotificationService {
       boolean supervisorMessage,
       String senderDisplayName,
       String threadParentPreview) {
+    createThreadReplyNotificationFromRoom(
+        roomId,
+        senderUserId,
+        messagePreview,
+        threadRootId,
+        matrixRoom,
+        supervisorMessage,
+        senderDisplayName,
+        threadParentPreview,
+        null);
+  }
+
+  @Transactional
+  public void createThreadReplyNotificationFromRoom(
+      String roomId,
+      String senderUserId,
+      String messagePreview,
+      String threadRootId,
+      boolean matrixRoom,
+      boolean supervisorMessage,
+      String senderDisplayName,
+      String threadParentPreview,
+      PrivacyEnvelope envelope) {
     if (roomId == null || roomId.isBlank()) {
       return;
     }
@@ -193,14 +246,9 @@ public class EventNotificationService {
 
     Session session = sessionOpt.get();
     String senderLabel = resolveSenderName(senderUserId, senderDisplayName);
-    String preview = normalizePreview(cleanMessageBody(messagePreview));
-    String parentPreview = normalizePreview(cleanMessageBody(threadParentPreview));
     String text =
-        String.format(
-            "%s replied under thread \"%s\"%s",
-            senderLabel,
-            parentPreview.isBlank() ? "message" : parentPreview,
-            preview.isBlank() ? "." : ": \"" + preview + "\"");
+        buildThreadReplyNotificationText(
+            senderLabel, messagePreview, threadParentPreview, envelope);
 
     if (!supervisorMessage
         && session.getUser() != null
@@ -411,6 +459,76 @@ public class EventNotificationService {
     return normalized.length() > 120 ? normalized.substring(0, 117) + "..." : normalized;
   }
 
+  private String buildMessageNotificationText(
+      String senderLabel, String messagePreview, PrivacyEnvelope envelope) {
+    NotificationPreviewMode mode = currentPreviewMode();
+    String contentLabel = contentLabel(envelope);
+    if (mode == NotificationPreviewMode.NONE) {
+      return String.format("%s sent a new %s.", senderLabel, contentLabel);
+    }
+    if (mode == NotificationPreviewMode.MASKED) {
+      return String.format("%s sent a new %s: %s", senderLabel, contentLabel, REDACTED_PREVIEW);
+    }
+    String preview = normalizePreview(cleanMessageBody(messagePreview));
+    if (!preview.isBlank()) {
+      return String.format("%s sent a new message: \"%s\"", senderLabel, preview);
+    }
+    return String.format(
+        "%s sent a new %s (messageId: %s).",
+        senderLabel, contentLabel, envelope != null ? safeValue(envelope.getMessageId(), "n/a") : "n/a");
+  }
+
+  private String buildThreadReplyNotificationText(
+      String senderLabel, String messagePreview, String threadParentPreview, PrivacyEnvelope envelope) {
+    NotificationPreviewMode mode = currentPreviewMode();
+    if (mode == NotificationPreviewMode.NONE) {
+      return String.format("%s replied in a thread.", senderLabel);
+    }
+    if (mode == NotificationPreviewMode.MASKED) {
+      return String.format("%s replied in a thread: %s", senderLabel, REDACTED_PREVIEW);
+    }
+    String preview = normalizePreview(cleanMessageBody(messagePreview));
+    String parentPreview = normalizePreview(cleanMessageBody(threadParentPreview));
+    if (!preview.isBlank() || !parentPreview.isBlank()) {
+      return String.format(
+          "%s replied under thread \"%s\"%s",
+          senderLabel,
+          parentPreview.isBlank() ? "message" : parentPreview,
+          preview.isBlank() ? "." : ": \"" + preview + "\"");
+    }
+    return String.format(
+        "%s replied in a thread (messageId: %s).",
+        senderLabel, envelope != null ? safeValue(envelope.getMessageId(), "n/a") : "n/a");
+  }
+
+  private String contentLabel(PrivacyEnvelope envelope) {
+    if (envelope == null || envelope.getContentClass() == null) {
+      return "message";
+    }
+    switch (envelope.getContentClass()) {
+      case "IMAGE":
+        return "image";
+      case "FILE":
+        return "file";
+      case "AUDIO":
+        return "audio message";
+      case "VIDEO":
+        return "video message";
+      case "NOTICE":
+        return "notice";
+      default:
+        return "message";
+    }
+  }
+
+  private NotificationPreviewMode currentPreviewMode() {
+    try {
+      return NotificationPreviewMode.valueOf(safeValue(notificationPreviewMode, "NONE").toUpperCase());
+    } catch (IllegalArgumentException ex) {
+      return NotificationPreviewMode.NONE;
+    }
+  }
+
   private String cleanMessageBody(String messagePreview) {
     if (messagePreview == null) {
       return "";
@@ -530,6 +648,12 @@ public class EventNotificationService {
       this.roomId = roomId;
       this.threadRootId = threadRootId;
     }
+  }
+
+  private enum NotificationPreviewMode {
+    NONE,
+    MASKED,
+    FULL
   }
 }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/PrivacyEnvelope.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/PrivacyEnvelope.java
@@ -1,0 +1,18 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Metadata-only envelope for notifications. Intentionally excludes plaintext message body.
+ */
+@Value
+@Builder
+public class PrivacyEnvelope {
+  String messageId;
+  String roomId;
+  String senderId;
+  Long timestamp;
+  boolean hasAttachment;
+  String contentClass;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
@@ -1,12 +1,14 @@
 package de.caritas.cob.userservice.api.service.session;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -20,11 +22,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class DirectSessionMatrixRoomService {
 
-  private static final String CONSULTANT_FALLBACK_MATRIX_PASSWORD = "@Consultant123";
-
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionService sessionService;
+  private final @NonNull UserHelper userHelper;
 
   /**
    * Creates a Matrix room between {@code consultant} and the session's user, invites both
@@ -45,7 +46,7 @@ public class DirectSessionMatrixRoomService {
     }
 
     try {
-      ensureConsultantMatrixAccount(consultant);
+      String consultantPassword = ensureConsultantMatrixCredentials(consultant);
       var user = session.getUser();
       if (user == null || user.getMatrixUserId() == null) {
         log.warn(
@@ -59,12 +60,14 @@ public class DirectSessionMatrixRoomService {
             consultant.getUsername());
         return;
       }
+      if (consultantPassword == null || consultantPassword.isBlank()) {
+        log.error(
+            "Consultant {} has no Matrix password, cannot provision direct-session room",
+            consultant.getUsername());
+        return;
+      }
 
       var consultantMatrixUsername = extractLocalpart(consultant.getMatrixUserId());
-      var consultantPassword =
-          consultant.getMatrixPassword() != null
-              ? consultant.getMatrixPassword()
-              : CONSULTANT_FALLBACK_MATRIX_PASSWORD;
 
       if (consultantMatrixUsername == null) {
         log.warn(
@@ -157,22 +160,25 @@ public class DirectSessionMatrixRoomService {
     }
   }
 
-  private void ensureConsultantMatrixAccount(Consultant consultant) {
+  private @Nullable String ensureConsultantMatrixCredentials(Consultant consultant) {
     if (consultant.getMatrixUserId() != null) {
-      return;
+      return consultant.getMatrixPassword();
     }
+    String generatedMatrixPassword = userHelper.getRandomPassword();
     try {
       var response =
           matrixSynapseService.createUser(
               consultant.getUsername(),
-              CONSULTANT_FALLBACK_MATRIX_PASSWORD,
+              generatedMatrixPassword,
               consultant.getFirstName() + " " + consultant.getLastName());
       if (response != null && response.getBody() != null && response.getBody().getUserId() != null) {
         consultant.setMatrixUserId(response.getBody().getUserId());
+        consultant.setMatrixPassword(generatedMatrixPassword);
         consultantRepository.save(consultant);
         log.info(
             "Created Matrix account for consultant {} during direct-session provisioning",
             consultant.getUsername());
+        return generatedMatrixPassword;
       }
     } catch (Exception ex) {
       log.error(
@@ -180,6 +186,7 @@ public class DirectSessionMatrixRoomService {
           consultant.getUsername(),
           ex);
     }
+    return null;
   }
 
   private String extractLocalpart(String matrixUserId) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
@@ -1,0 +1,192 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provisions a Matrix room for a session that was created via the direct-consultant registration
+ * path (the {@code ?cid=<consultantId>} sharing link). Mirrors the room-creation logic that
+ * {@code AssignEnquiryFacade} performs when a consultant accepts an enquiry, but runs at
+ * registration time so both parties can start chatting immediately — no enquiry queue involved.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DirectSessionMatrixRoomService {
+
+  private static final String CONSULTANT_FALLBACK_MATRIX_PASSWORD = "@Consultant123";
+
+  private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull SessionService sessionService;
+
+  /**
+   * Creates a Matrix room between {@code consultant} and the session's user, invites both
+   * parties, and saves the room id on the session. No-ops if the session already has a Matrix
+   * room. Swallows failures so that a Matrix outage does not break the registration flow — the
+   * caller still gets a session object back.
+   */
+  public void provisionRoomForDirectSession(Session session, Consultant consultant) {
+    if (session == null || consultant == null) {
+      return;
+    }
+    if (session.getMatrixRoomId() != null && !session.getMatrixRoomId().isBlank()) {
+      log.info(
+          "Session {} already has Matrix room {}, skipping direct-session room provisioning",
+          session.getId(),
+          session.getMatrixRoomId());
+      return;
+    }
+
+    try {
+      ensureConsultantMatrixAccount(consultant);
+      var user = session.getUser();
+      if (user == null || user.getMatrixUserId() == null) {
+        log.warn(
+            "User for session {} has no Matrix account, cannot provision direct-session room",
+            session.getId());
+        return;
+      }
+      if (consultant.getMatrixUserId() == null) {
+        log.warn(
+            "Consultant {} has no Matrix account, cannot provision direct-session room",
+            consultant.getUsername());
+        return;
+      }
+
+      var consultantMatrixUsername = extractLocalpart(consultant.getMatrixUserId());
+      var consultantPassword =
+          consultant.getMatrixPassword() != null
+              ? consultant.getMatrixPassword()
+              : CONSULTANT_FALLBACK_MATRIX_PASSWORD;
+
+      if (consultantMatrixUsername == null) {
+        log.warn(
+            "Consultant {} Matrix user id is malformed, cannot provision direct-session room",
+            consultant.getUsername());
+        return;
+      }
+
+      var roomName = "Session " + session.getId() + " - " + consultant.getUsername();
+      var roomAlias = "session_" + session.getId();
+
+      var createRoomResponse =
+          matrixSynapseService.createRoomAsConsultant(
+              roomName, roomAlias, consultantMatrixUsername, consultantPassword);
+
+      if (createRoomResponse == null
+          || createRoomResponse.getBody() == null
+          || createRoomResponse.getBody().getRoomId() == null) {
+        log.error(
+            "Matrix createRoomAsConsultant returned no room id for session {}", session.getId());
+        return;
+      }
+
+      var roomId = createRoomResponse.getBody().getRoomId();
+      session.setMatrixRoomId(roomId);
+      sessionService.saveSession(session);
+
+      var consultantToken = matrixSynapseService.loginUser(consultantMatrixUsername, consultantPassword);
+      if (consultantToken == null) {
+        log.error(
+            "Could not login consultant {} to Matrix after creating room {} for session {}",
+            consultant.getUsername(),
+            roomId,
+            session.getId());
+        return;
+      }
+
+      try {
+        matrixSynapseService.inviteUserToRoom(roomId, user.getMatrixUserId(), consultantToken);
+      } catch (Exception ex) {
+        log.warn(
+            "Failed to invite user {} to direct-session room {}: {}",
+            user.getMatrixUserId(),
+            roomId,
+            ex.getMessage());
+      }
+
+      var userMatrixUsername = extractLocalpart(user.getMatrixUserId());
+      if (userMatrixUsername != null && user.getMatrixPassword() != null) {
+        var userToken =
+            matrixSynapseService.loginUser(userMatrixUsername, user.getMatrixPassword());
+        if (userToken != null) {
+          boolean joined = matrixSynapseService.joinRoom(roomId, userToken);
+          if (joined) {
+            log.info(
+                "User {} auto-joined direct-session room {}", userMatrixUsername, roomId);
+          } else {
+            log.warn(
+                "User {} failed to auto-join direct-session room {}", userMatrixUsername, roomId);
+          }
+        } else {
+          log.warn(
+              "User {} could not login to Matrix to auto-join direct-session room {}",
+              userMatrixUsername,
+              roomId);
+        }
+      }
+
+      boolean consultantJoined = matrixSynapseService.joinRoom(roomId, consultantToken);
+      if (consultantJoined) {
+        log.info(
+            "Consultant {} confirmed in direct-session room {} (session {})",
+            consultant.getUsername(),
+            roomId,
+            session.getId());
+      }
+
+      log.info(
+          "Provisioned direct-session Matrix room {} for session {} (consultant {}, user {})",
+          roomId,
+          session.getId(),
+          consultant.getUsername(),
+          user.getUsername());
+    } catch (Exception ex) {
+      log.error(
+          "Failed to provision direct-session Matrix room for session {}: {}",
+          session.getId(),
+          ex.getMessage(),
+          ex);
+    }
+  }
+
+  private void ensureConsultantMatrixAccount(Consultant consultant) {
+    if (consultant.getMatrixUserId() != null) {
+      return;
+    }
+    try {
+      var response =
+          matrixSynapseService.createUser(
+              consultant.getUsername(),
+              CONSULTANT_FALLBACK_MATRIX_PASSWORD,
+              consultant.getFirstName() + " " + consultant.getLastName());
+      if (response != null && response.getBody() != null && response.getBody().getUserId() != null) {
+        consultant.setMatrixUserId(response.getBody().getUserId());
+        consultantRepository.save(consultant);
+        log.info(
+            "Created Matrix account for consultant {} during direct-session provisioning",
+            consultant.getUsername());
+      }
+    } catch (Exception ex) {
+      log.error(
+          "Failed to create Matrix account for consultant {} during direct-session provisioning",
+          consultant.getUsername(),
+          ex);
+    }
+  }
+
+  private String extractLocalpart(String matrixUserId) {
+    if (matrixUserId == null || !matrixUserId.startsWith("@")) {
+      return null;
+    }
+    var parts = matrixUserId.substring(1).split(":");
+    return parts.length > 0 ? parts[0] : null;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -351,8 +351,36 @@ public class SessionService {
 
   private List<Session> retrieveRegisteredSessions(List<Long> consultantAgencyIds) {
     return this.sessionRepository
-        .findByAgencyIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateAsc(
-            consultantAgencyIds, SessionStatus.NEW, RegistrationType.REGISTERED);
+        .findByAgencyIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(
+            consultantAgencyIds, SessionStatus.NEW, RegistrationType.REGISTERED)
+        .stream()
+        // Anonymous-style registrations can be created via /users/askers/new and therefore have
+        // registrationType REGISTERED. Keep them hidden in consultant inquiries until consent.
+        .filter(this::isVisibleRegisteredEnquiryForConsultant)
+        .collect(Collectors.toList());
+  }
+
+  private boolean isVisibleRegisteredEnquiryForConsultant(Session session) {
+    if (!isAnonymousStyleRegistration(session)) {
+      return true;
+    }
+    return nonNull(session.getUser()) && nonNull(session.getUser().getDataPrivacyConfirmation());
+  }
+
+  private boolean isAnonymousStyleRegistration(Session session) {
+    if (isNull(session)) {
+      return false;
+    }
+
+    if ("00000".equals(session.getPostcode())) {
+      return true;
+    }
+
+    if (nonNull(session.getUser()) && nonNull(session.getUser().getUsername())) {
+      return session.getUser().getUsername().startsWith("Anonymous-");
+    }
+
+    return false;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
@@ -1,7 +1,5 @@
 package de.caritas.cob.userservice.api.service.user;
 
-import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
-
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.UserUpdateDataDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.UserUpdateRequestDTO;
@@ -21,6 +19,8 @@ import de.caritas.cob.userservice.api.service.notification.SupervisorAddedEmailN
 import de.caritas.cob.userservice.api.service.statistics.StatisticsService;
 import de.caritas.cob.userservice.api.service.statistics.event.DeleteAccountStatisticsEvent;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState;
+import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.NonNull;
@@ -47,6 +47,7 @@ public class UserAccountService {
 
   private final @NonNull StatisticsService statisticsService;
   private final @NonNull SupervisorAddedEmailNotificationService supervisorAddedEmailNotificationService;
+  private final @NonNull DeletionLifecycleService deletionLifecycleService;
 
   public Optional<User> findUserByEmail(String email) {
     return this.userService.findUserByEmail(email);
@@ -121,6 +122,7 @@ public class UserAccountService {
    * @param optionalEmail the new email address, potentially empty
    */
   public void changeUserAccountEmailAddress(Optional<String> optionalEmail) {
+    ensureCurrentAccountIsWritable();
     optionalEmail.ifPresentOrElse(
         identityClient::changeEmailAddress, identityClient::deleteEmailAddress);
 
@@ -230,7 +232,7 @@ public class UserAccountService {
   public void deactivateAndFlagUserAccountForDeletion() {
     User user = retrieveValidatedUser();
     this.identityClient.deactivateUser(user.getUserId());
-    user.setDeleteDate(nowInUtc());
+    deletionLifecycleService.beginUserDeletion(user, user.getUserId());
     userService.saveUser(user);
     fireAccountDeletionStatisticsEvent(user);
   }
@@ -252,6 +254,7 @@ public class UserAccountService {
    * @param mobileToken the new mobile device identifier token
    */
   public void updateUserMobileToken(String mobileToken) {
+    ensureCurrentAccountIsWritable();
     this.userService
         .getUser(this.authenticatedUser.getUserId())
         .ifPresent(user -> updateMobileToken(user, mobileToken));
@@ -268,7 +271,35 @@ public class UserAccountService {
    * @param mobileToken the mobile device identifier token to be added
    */
   public void addMobileAppToken(String mobileToken) {
+    ensureCurrentAccountIsWritable();
     this.userService.addMobileAppToken(this.authenticatedUser.getUserId(), mobileToken);
     this.consultantService.addMobileAppToken(this.authenticatedUser.getUserId(), mobileToken);
+  }
+
+  private void ensureCurrentAccountIsWritable() {
+    this.userService
+        .getUser(this.authenticatedUser.getUserId())
+        .ifPresent(this::assertWritable);
+    this.consultantService
+        .getConsultant(this.authenticatedUser.getUserId())
+        .ifPresent(this::assertWritable);
+  }
+
+  private void assertWritable(User user) {
+    if (user.getDeleteDate() == null) {
+      return;
+    }
+    if (user.getDeletionLifecycleState() == DeletionLifecycleState.READ_ONLY_SAFEGUARD) {
+      throw new ForbiddenException("Account is in read-only safeguard mode.");
+    }
+  }
+
+  private void assertWritable(Consultant consultant) {
+    if (consultant.getDeleteDate() == null) {
+      return;
+    }
+    if (consultant.getDeletionLifecycleState() == DeletionLifecycleState.READ_ONLY_SAFEGUARD) {
+      throw new ForbiddenException("Account is in read-only safeguard mode.");
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
@@ -91,6 +91,10 @@ public class UserService {
     return userRepository.findByUserIdAndDeleteDateIsNull(userId);
   }
 
+  public Optional<User> findDeletedById(String userId) {
+    return userRepository.findById(userId).filter(user -> user.getDeleteDate() != null);
+  }
+
   /**
    * Saves an {@link User} to the database.
    *

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerAction.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 public class DeleteDatabaseAskerAction implements ActionCommand<AskerDeletionWorkflowDTO> {
 
   private final @NonNull UserRepository userRepository;
+  private final @NonNull IdentityTombstoneService identityTombstoneService;
 
   /**
    * Deletes the given {@link User} in database.
@@ -30,6 +32,7 @@ public class DeleteDatabaseAskerAction implements ActionCommand<AskerDeletionWor
   @Override
   public void execute(AskerDeletionWorkflowDTO actionTarget) {
     try {
+      identityTombstoneService.recordDeletedUser(actionTarget.getUser());
       this.userRepository.delete(actionTarget.getUser());
     } catch (Exception e) {
       log.error("UserService delete workflow error: ", e);

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ public class DeleteDatabaseConsultantAction
 
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull IdentityTombstoneService identityTombstoneService;
 
   /**
    * Deletes the given {@link Consultant} in database.
@@ -52,6 +54,7 @@ public class DeleteDatabaseConsultantAction
     }
 
     try {
+      identityTombstoneService.recordDeletedConsultant(actionTarget.getConsultant());
       this.consultantRepository.delete(actionTarget.getConsultant());
     } catch (Exception e) {
       handleExceptionWithMessage(actionTarget, e, "Unable to delete consultant in database");

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/model/DeletionLifecycleState.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/model/DeletionLifecycleState.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.workflow.delete.model;
+
+/** Security-05 lifecycle states for account deletion governance. */
+public enum DeletionLifecycleState {
+  ACTIVE,
+  PENDING_DELETION,
+  READ_ONLY_SAFEGUARD,
+  HARD_DELETED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
@@ -40,6 +40,7 @@ public class DeleteUserAccountService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull ActionsRegistry actionsRegistry;
   private final @NonNull WorkflowErrorMailService workflowErrorMailService;
+  private final @NonNull DeletionLifecycleService deletionLifecycleService;
 
   /** Deletes all user accounts marked as deleted in database. */
   public void deleteUserAccounts() {
@@ -53,6 +54,9 @@ public class DeleteUserAccountService {
 
   private List<DeletionWorkflowError> deleteAskersAndCollectPossibleErrors() {
     return this.userRepository.findAllByDeleteDateNotNull().stream()
+        .map(deletionLifecycleService::normalizeUserLifecycle)
+        .peek(userRepository::save)
+        .filter(deletionLifecycleService::isReadyForHardDelete)
         .map(this::performUserDeletion)
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
@@ -78,6 +82,9 @@ public class DeleteUserAccountService {
 
   private List<DeletionWorkflowError> deleteConsultantsAndCollectPossibleErrors() {
     return this.consultantRepository.findAllByDeleteDateNotNull().stream()
+        .map(deletionLifecycleService::normalizeConsultantLifecycle)
+        .peek(consultantRepository::save)
+        .filter(deletionLifecycleService::isReadyForHardDelete)
         .map(this::performConsultantDeletion)
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeletionLifecycleService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeletionLifecycleService.java
@@ -1,0 +1,230 @@
+package de.caritas.cob.userservice.api.workflow.delete.service;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Security-05 lifecycle state machine and pause governance. */
+@Service
+@Slf4j
+public class DeletionLifecycleService {
+
+  @Value("${deletion.readOnlyWindow.hours:48}")
+  private long globalReadOnlyHours;
+
+  @Value("${deletion.readOnlyWindow.tenantOverrides:}")
+  private String tenantOverrideConfig;
+
+  @Value("${deletion.pause.defaultMonths:3}")
+  private int defaultPauseMonths;
+
+  @Value("${deletion.pause.maxMonths:12}")
+  private int maxPauseMonths;
+
+  public void beginUserDeletion(User user, String actorId) {
+    if (user == null) {
+      return;
+    }
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    if (user.getDeleteDate() == null) {
+      user.setDeleteDate(now);
+    }
+    user.setDeletionLifecycleState(DeletionLifecycleState.PENDING_DELETION);
+    transitionToReadOnlySafeguard(user, actorId);
+  }
+
+  public void beginConsultantDeletion(Consultant consultant, String actorId) {
+    if (consultant == null) {
+      return;
+    }
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    if (consultant.getDeleteDate() == null) {
+      consultant.setDeleteDate(now);
+    }
+    consultant.setDeletionLifecycleState(DeletionLifecycleState.PENDING_DELETION);
+    transitionToReadOnlySafeguard(consultant, actorId);
+  }
+
+  public User normalizeUserLifecycle(User user) {
+    if (user == null || user.getDeleteDate() == null) {
+      return user;
+    }
+    if (user.getDeletionLifecycleState() == null || user.getDeletionLifecycleState() == DeletionLifecycleState.ACTIVE) {
+      user.setDeletionLifecycleState(DeletionLifecycleState.PENDING_DELETION);
+    }
+    if (user.getDeletionLifecycleState() == DeletionLifecycleState.PENDING_DELETION) {
+      transitionToReadOnlySafeguard(user, user.getDeletionPausedBy());
+    }
+    clearExpiredPauseIfNecessary(user);
+    return user;
+  }
+
+  public Consultant normalizeConsultantLifecycle(Consultant consultant) {
+    if (consultant == null || consultant.getDeleteDate() == null) {
+      return consultant;
+    }
+    if (consultant.getDeletionLifecycleState() == null
+        || consultant.getDeletionLifecycleState() == DeletionLifecycleState.ACTIVE) {
+      consultant.setDeletionLifecycleState(DeletionLifecycleState.PENDING_DELETION);
+    }
+    if (consultant.getDeletionLifecycleState() == DeletionLifecycleState.PENDING_DELETION) {
+      transitionToReadOnlySafeguard(consultant, consultant.getDeletionPausedBy());
+    }
+    clearExpiredPauseIfNecessary(consultant);
+    return consultant;
+  }
+
+  public boolean isReadyForHardDelete(User user) {
+    return isReadyForHardDelete(
+        user != null ? user.getDeletionLifecycleState() : null,
+        user != null ? user.getDeletionReadOnlyUntil() : null,
+        user != null ? user.getDeletionPausedUntil() : null);
+  }
+
+  public boolean isReadyForHardDelete(Consultant consultant) {
+    return isReadyForHardDelete(
+        consultant != null ? consultant.getDeletionLifecycleState() : null,
+        consultant != null ? consultant.getDeletionReadOnlyUntil() : null,
+        consultant != null ? consultant.getDeletionPausedUntil() : null);
+  }
+
+  public void pauseUserDeletion(User user, String reason, Integer requestedMonths, String pausedBy) {
+    if (user == null) {
+      return;
+    }
+    ensurePauseReason(reason);
+    int months = normalizedPauseMonths(requestedMonths);
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    user.setDeletionPauseReason(reason.trim());
+    user.setDeletionPausedBy(pausedBy);
+    user.setDeletionPauseCreatedAt(now);
+    user.setDeletionPausedUntil(now.plusMonths(months));
+    if (user.getDeletionLifecycleState() == null || user.getDeletionLifecycleState() == DeletionLifecycleState.ACTIVE) {
+      user.setDeletionLifecycleState(DeletionLifecycleState.READ_ONLY_SAFEGUARD);
+    }
+  }
+
+  public void pauseConsultantDeletion(
+      Consultant consultant, String reason, Integer requestedMonths, String pausedBy) {
+    if (consultant == null) {
+      return;
+    }
+    ensurePauseReason(reason);
+    int months = normalizedPauseMonths(requestedMonths);
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    consultant.setDeletionPauseReason(reason.trim());
+    consultant.setDeletionPausedBy(pausedBy);
+    consultant.setDeletionPauseCreatedAt(now);
+    consultant.setDeletionPausedUntil(now.plusMonths(months));
+    if (consultant.getDeletionLifecycleState() == null
+        || consultant.getDeletionLifecycleState() == DeletionLifecycleState.ACTIVE) {
+      consultant.setDeletionLifecycleState(DeletionLifecycleState.READ_ONLY_SAFEGUARD);
+    }
+  }
+
+  private void transitionToReadOnlySafeguard(User user, String actorId) {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    if (user.getDeletionReadOnlyUntil() == null) {
+      user.setDeletionReadOnlyUntil(now.plusHours(resolveReadOnlyHours(user.getTenantId())));
+    }
+    user.setDeletionPausedBy(actorId);
+    user.setDeletionLifecycleState(DeletionLifecycleState.READ_ONLY_SAFEGUARD);
+  }
+
+  private void transitionToReadOnlySafeguard(Consultant consultant, String actorId) {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    if (consultant.getDeletionReadOnlyUntil() == null) {
+      consultant.setDeletionReadOnlyUntil(now.plusHours(resolveReadOnlyHours(consultant.getTenantId())));
+    }
+    consultant.setDeletionPausedBy(actorId);
+    consultant.setDeletionLifecycleState(DeletionLifecycleState.READ_ONLY_SAFEGUARD);
+  }
+
+  private boolean isReadyForHardDelete(
+      DeletionLifecycleState state, LocalDateTime readOnlyUntil, LocalDateTime pausedUntil) {
+    if (state != DeletionLifecycleState.READ_ONLY_SAFEGUARD) {
+      return false;
+    }
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    if (readOnlyUntil == null || readOnlyUntil.isAfter(now)) {
+      return false;
+    }
+    return pausedUntil == null || !pausedUntil.isAfter(now);
+  }
+
+  private void clearExpiredPauseIfNecessary(User user) {
+    if (user.getDeletionPausedUntil() == null) {
+      return;
+    }
+    if (user.getDeletionPausedUntil().isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
+      return;
+    }
+    log.info(
+        "Deletion pause expired for userId={} tenantId={}; account is eligible for final decision.",
+        user.getUserId(),
+        user.getTenantId());
+  }
+
+  private void clearExpiredPauseIfNecessary(Consultant consultant) {
+    if (consultant.getDeletionPausedUntil() == null) {
+      return;
+    }
+    if (consultant.getDeletionPausedUntil().isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
+      return;
+    }
+    log.info(
+        "Deletion pause expired for consultantId={} tenantId={}; account is eligible for final decision.",
+        consultant.getId(),
+        consultant.getTenantId());
+  }
+
+  private int normalizedPauseMonths(Integer requestedMonths) {
+    int months = requestedMonths == null ? defaultPauseMonths : requestedMonths;
+    if (months < 1 || months > maxPauseMonths) {
+      throw new BadRequestException(
+          String.format("Pause duration must be between 1 and %d month(s).", maxPauseMonths));
+    }
+    return months;
+  }
+
+  private void ensurePauseReason(String reason) {
+    if (reason == null || reason.trim().isEmpty()) {
+      throw new BadRequestException("A pause reason is required.");
+    }
+  }
+
+  private long resolveReadOnlyHours(Long tenantId) {
+    if (tenantId == null || tenantOverrideConfig == null || tenantOverrideConfig.isBlank()) {
+      return globalReadOnlyHours;
+    }
+    Map<Long, Long> overrides =
+        Arrays.stream(tenantOverrideConfig.split(","))
+            .map(String::trim)
+            .filter(value -> value.contains(":"))
+            .map(value -> value.split(":"))
+            .filter(parts -> parts.length == 2)
+            .collect(
+                Collectors.toMap(
+                    parts -> parseLong(parts[0], -1L),
+                    parts -> parseLong(parts[1], globalReadOnlyHours),
+                    (first, second) -> second));
+    return overrides.getOrDefault(tenantId, globalReadOnlyHours);
+  }
+
+  private long parseLong(String value, long fallback) {
+    try {
+      return Long.parseLong(value.trim());
+    } catch (NumberFormatException ex) {
+      return fallback;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/IdentityTombstoneService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/IdentityTombstoneService.java
@@ -1,0 +1,66 @@
+package de.caritas.cob.userservice.api.workflow.delete.service;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.IdentityTombstone;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.IdentityTombstoneRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdentityTombstoneService {
+
+  private final @NonNull IdentityTombstoneRepository identityTombstoneRepository;
+
+  public void recordDeletedUser(User user) {
+    if (user == null || user.getUserId() == null) {
+      return;
+    }
+    identityTombstoneRepository.save(
+        IdentityTombstone.builder()
+            .subjectId(user.getUserId())
+            .subjectType(IdentityTombstone.SubjectType.USER)
+            .displayLabel("Deleted user #" + shortId(user.getUserId()))
+            .hardDeletedAt(LocalDateTime.now(ZoneOffset.UTC))
+            .sourceDeleteDate(user.getDeleteDate())
+            .tenantId(user.getTenantId())
+            .build());
+  }
+
+  public void recordDeletedConsultant(Consultant consultant) {
+    if (consultant == null || consultant.getId() == null) {
+      return;
+    }
+    identityTombstoneRepository.save(
+        IdentityTombstone.builder()
+            .subjectId(consultant.getId())
+            .subjectType(IdentityTombstone.SubjectType.CONSULTANT)
+            .displayLabel("Deleted counselor #" + shortId(consultant.getId()))
+            .hardDeletedAt(LocalDateTime.now(ZoneOffset.UTC))
+            .sourceDeleteDate(consultant.getDeleteDate())
+            .tenantId(consultant.getTenantId())
+            .build());
+  }
+
+  public Optional<String> resolveDisplayLabel(String subjectId) {
+    if (subjectId == null || subjectId.isBlank()) {
+      return Optional.empty();
+    }
+    return identityTombstoneRepository
+        .findFirstBySubjectIdOrderByHardDeletedAtDesc(subjectId)
+        .map(IdentityTombstone::getDisplayLabel);
+  }
+
+  private String shortId(String value) {
+    if (value == null || value.isBlank()) {
+      return "unknown";
+    }
+    String sanitized = value.trim();
+    return sanitized.length() <= 8 ? sanitized : sanitized.substring(0, 8);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/model/InactiveAccountRole.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/model/InactiveAccountRole.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.model;
+
+/** Account categories for Security-06 inactivity monitoring. */
+public enum InactiveAccountRole {
+  ASKER,
+  CONSULTANT,
+  ADMIN
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/scheduler/InactiveAccountNotificationScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/scheduler/InactiveAccountNotificationScheduler.java
@@ -1,0 +1,29 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.scheduler;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service.InactiveAccountNotificationService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Scheduler for Security-06 12-month inactivity notifications. */
+@Component
+@RequiredArgsConstructor
+public class InactiveAccountNotificationScheduler {
+
+  private final @NonNull InactiveAccountNotificationService inactiveAccountNotificationService;
+  private final @NonNull TenantContextProvider tenantContextProvider;
+
+  @Value("${inactive.account.notification.enabled:false}")
+  private boolean inactiveAccountNotificationEnabled;
+
+  @Scheduled(cron = "${inactive.account.notification.cron:0 30 2 * * ?}")
+  public void notifyInactiveAccounts() {
+    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+    if (inactiveAccountNotificationEnabled) {
+      inactiveAccountNotificationService.scanAndNotifyInactiveAccounts();
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/AdminActivityCalculator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/AdminActivityCalculator.java
@@ -1,0 +1,26 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/** Calculates admin activity from admin-scoped profile updates only. */
+@Service
+public class AdminActivityCalculator {
+
+  public Optional<LocalDateTime> lastActivity(Admin admin) {
+    if (admin == null) {
+      return Optional.empty();
+    }
+    LocalDateTime update = admin.getUpdateDate();
+    LocalDateTime create = admin.getCreateDate();
+    if (update == null) {
+      return Optional.ofNullable(create);
+    }
+    if (create == null || update.isAfter(create)) {
+      return Optional.of(update);
+    }
+    return Optional.of(create);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/AskerActivityCalculator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/AskerActivityCalculator.java
@@ -1,0 +1,37 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Calculates asker activity from asker-owned signals only. */
+@Service
+@RequiredArgsConstructor
+public class AskerActivityCalculator {
+
+  private final @NonNull SessionRepository sessionRepository;
+
+  public Optional<LocalDateTime> lastActivity(User user) {
+    if (user == null) {
+      return Optional.empty();
+    }
+    LocalDateTime lastSessionMessage = sessionRepository.findMaxEnquiryMessageDateByUser(user);
+    LocalDateTime userUpdate = user.getUpdateDate();
+    LocalDateTime userCreate = user.getCreateDate();
+    return Optional.ofNullable(maxOf(userUpdate, lastSessionMessage, userCreate));
+  }
+
+  private LocalDateTime maxOf(LocalDateTime... values) {
+    LocalDateTime result = null;
+    for (LocalDateTime value : values) {
+      if (value != null && (result == null || value.isAfter(result))) {
+        result = value;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/ConsultantActivityCalculator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/ConsultantActivityCalculator.java
@@ -1,0 +1,37 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Calculates consultant activity from consultant-scoped signals only. */
+@Service
+@RequiredArgsConstructor
+public class ConsultantActivityCalculator {
+
+  private final @NonNull SessionRepository sessionRepository;
+
+  public Optional<LocalDateTime> lastActivity(Consultant consultant) {
+    if (consultant == null) {
+      return Optional.empty();
+    }
+    LocalDateTime consultantUpdate = consultant.getUpdateDate();
+    LocalDateTime consultantCreate = consultant.getCreateDate();
+    LocalDateTime sessionUpdate = sessionRepository.findMaxUpdateDateByConsultant(consultant);
+    return Optional.ofNullable(maxOf(consultantUpdate, sessionUpdate, consultantCreate));
+  }
+
+  private LocalDateTime maxOf(LocalDateTime... values) {
+    LocalDateTime result = null;
+    for (LocalDateTime value : values) {
+      if (value != null && (result == null || value.isAfter(result))) {
+        result = value;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationRecipientResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationRecipientResolver.java
@@ -1,0 +1,38 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Resolves tenant-scoped admin recipients for inactivity alerts. */
+@Service
+@RequiredArgsConstructor
+public class InactiveAccountNotificationRecipientResolver {
+
+  private final @NonNull AdminRepository adminRepository;
+
+  public List<Admin> resolveRecipients(Long tenantId) {
+    List<Admin> recipients = new ArrayList<>();
+    if (tenantId != null) {
+      recipients.addAll(adminRepository.findByTenantIdAndType(tenantId, Admin.AdminType.TENANT));
+    }
+    recipients.addAll(adminRepository.findByType(Admin.AdminType.SUPER));
+    return distinctById(recipients);
+  }
+
+  private List<Admin> distinctById(List<Admin> admins) {
+    Map<String, Admin> byId = new LinkedHashMap<>();
+    for (Admin admin : admins) {
+      if (admin != null && admin.getId() != null) {
+        byId.put(admin.getId(), admin);
+      }
+    }
+    return new ArrayList<>(byId.values());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
@@ -1,0 +1,184 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.helper.MailService;
+import de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.model.InactiveAccountRole;
+import de.caritas.cob.userservice.mailservice.generated.web.model.MailDTO;
+import de.caritas.cob.userservice.mailservice.generated.web.model.MailsDTO;
+import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Security-06 inactivity threshold monitor for askers, consultants and admins. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class InactiveAccountNotificationService {
+
+  private static final String TEMPLATE_FREE_TEXT = "free_text";
+
+  private final @NonNull UserRepository userRepository;
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull AdminRepository adminRepository;
+  private final @NonNull AskerActivityCalculator askerActivityCalculator;
+  private final @NonNull ConsultantActivityCalculator consultantActivityCalculator;
+  private final @NonNull AdminActivityCalculator adminActivityCalculator;
+  private final @NonNull InactiveAccountNotificationRecipientResolver recipientResolver;
+  private final @NonNull InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  private final @NonNull MailService mailService;
+
+  @Value("${inactive.account.notification.threshold.days:365}")
+  private long inactivityThresholdDays;
+
+  @Value("${inactive.account.notification.email-dispatch.enabled:false}")
+  private boolean emailDispatchEnabled;
+
+  @Value("${inactive.account.notification.app-base-url:${app.base.url}}")
+  private String appBaseUrl;
+
+  @Transactional
+  public void scanAndNotifyInactiveAccounts() {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    LocalDateTime cutoff = now.minusDays(inactivityThresholdDays);
+    notifyInactiveAskers(cutoff, now);
+    notifyInactiveConsultants(cutoff, now);
+    notifyInactiveAdmins(cutoff, now);
+  }
+
+  private void notifyInactiveAskers(LocalDateTime cutoff, LocalDateTime now) {
+    for (User user : userRepository.findAllByDeleteDateIsNull()) {
+      Optional<LocalDateTime> lastActivity = askerActivityCalculator.lastActivity(user);
+      if (isInactive(lastActivity, cutoff)) {
+        emitForRecipients(
+            InactiveAccountRole.ASKER, user.getUserId(), user.getTenantId(), lastActivity.orElse(null), now);
+      }
+    }
+  }
+
+  private void notifyInactiveConsultants(LocalDateTime cutoff, LocalDateTime now) {
+    for (Consultant consultant : consultantRepository.findByDeleteDateIsNull()) {
+      Optional<LocalDateTime> lastActivity = consultantActivityCalculator.lastActivity(consultant);
+      if (isInactive(lastActivity, cutoff)) {
+        emitForRecipients(
+            InactiveAccountRole.CONSULTANT,
+            consultant.getId(),
+            consultant.getTenantId(),
+            lastActivity.orElse(null),
+            now);
+      }
+    }
+  }
+
+  private void notifyInactiveAdmins(LocalDateTime cutoff, LocalDateTime now) {
+    for (Admin admin : adminRepository.findAll()) {
+      Optional<LocalDateTime> lastActivity = adminActivityCalculator.lastActivity(admin);
+      if (isInactive(lastActivity, cutoff)) {
+        emitForRecipients(
+            InactiveAccountRole.ADMIN, admin.getId(), admin.getTenantId(), lastActivity.orElse(null), now);
+      }
+    }
+  }
+
+  private boolean isInactive(Optional<LocalDateTime> lastActivity, LocalDateTime cutoff) {
+    return lastActivity.isPresent() && lastActivity.get().isBefore(cutoff);
+  }
+
+  private void emitForRecipients(
+      InactiveAccountRole role,
+      String accountId,
+      Long accountTenantId,
+      LocalDateTime lastActivityAt,
+      LocalDateTime now) {
+    for (Admin recipient : recipientResolver.resolveRecipients(accountTenantId)) {
+      String fingerprint =
+          buildFingerprint(role, accountId, recipient.getId(), lastActivityAt, inactivityThresholdDays);
+      if (auditLogRepository.existsByNotificationFingerprint(fingerprint)) {
+        continue;
+      }
+      boolean dispatched = false;
+      if (emailDispatchEnabled) {
+        dispatchEmail(recipient, role, accountId, accountTenantId, lastActivityAt);
+        dispatched = true;
+      }
+      auditLogRepository.save(
+          InactiveAccountNotificationAuditLog.builder()
+              .notificationFingerprint(fingerprint)
+              .accountRole(role)
+              .accountId(accountId)
+              .accountTenantId(accountTenantId)
+              .lastActivityAt(lastActivityAt)
+              .thresholdDays((int) inactivityThresholdDays)
+              .recipientAdminId(recipient.getId())
+              .recipientEmail(recipient.getEmail())
+              .emailDispatched(dispatched)
+              .createDate(now)
+              .tenantId(accountTenantId)
+              .build());
+    }
+  }
+
+  private void dispatchEmail(
+      Admin recipient,
+      InactiveAccountRole role,
+      String accountId,
+      Long accountTenantId,
+      LocalDateTime lastActivityAt) {
+    String subject = "Inactive account threshold reached (12 months)";
+    String body =
+        String.format(
+            Locale.ROOT,
+            "Account role=%s, accountId=%s, tenantId=%s crossed inactivity threshold (%d days). Last activity=%s.",
+            role.name(),
+            accountId,
+            accountTenantId,
+            inactivityThresholdDays,
+            String.valueOf(lastActivityAt));
+    MailDTO mail =
+        new MailDTO()
+            .template(TEMPLATE_FREE_TEXT)
+            .email(recipient.getEmail())
+            .templateData(
+                List.of(
+                    new TemplateDataDTO().key("subject").value(subject),
+                    new TemplateDataDTO().key("text").value(body),
+                    new TemplateDataDTO().key("url").value(appBaseUrl)));
+    mailService.sendEmailNotification(new MailsDTO().mails(List.of(mail)));
+    log.info(
+        "Inactive account notification dispatched to adminId={} role={} accountId={}",
+        recipient.getId(),
+        role,
+        accountId);
+  }
+
+  private String buildFingerprint(
+      InactiveAccountRole role,
+      String accountId,
+      String recipientAdminId,
+      LocalDateTime lastActivityAt,
+      long thresholdDays) {
+    return String.format(
+        Locale.ROOT,
+        "%s|%s|%s|%s|%d",
+        role.name(),
+        accountId,
+        recipientAdminId,
+        String.valueOf(lastActivityAt),
+        thresholdDays);
+  }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -67,6 +67,7 @@ csrf.whitelist.config-uris=/users/data,\
   /users/sessions/askers,\
   /service/users/sessions/,\
   /users/sessions/,\
+  /users/chat/,\
   /actuator/health,\
   /actuator/health/**,\
   /actuator/loggers,\

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -82,3 +82,6 @@ spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}
 spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:}
 keycloak.ssl-required=none
+
+# Local development can explicitly opt into full previews.
+privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:FULL}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -85,3 +85,4 @@ keycloak.ssl-required=none
 
 # Local development can explicitly opt into full previews.
 privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:FULL}
+privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -67,6 +67,7 @@ csrf.whitelist.config-uris=/users/data,\
   /users/sessions/askers,\
   /service/users/sessions/,\
   /users/sessions/,\
+  /users/chat/,\
   /actuator/health,\
   /actuator/health/**,\
   /actuator/loggers,\

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -67,6 +67,7 @@ csrf.whitelist.config-uris=/users/data,\
   /users/sessions/askers,\
   /service/users/sessions/,\
   /users/sessions/,\
+  /users/chat/,\
   /actuator/health,\
   /actuator/health/**,\
   /actuator/loggers,\

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -67,6 +67,7 @@ csrf.whitelist.config-uris=/users/data,\
   /users/sessions/askers,\
   /service/users/sessions/,\
   /users/sessions/,\
+  /users/chat/,\
   /actuator/health,\
   /actuator/health/**,\
   /actuator/loggers,\

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -67,6 +67,7 @@ csrf.whitelist.config-uris=/users/data,\
   /users/sessions/askers,\
   /service/users/sessions/,\
   /users/sessions/,\
+  /users/chat/,\
   /actuator/health,\
   /actuator/health/**,\
   /actuator/loggers,\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,11 @@ service.encryption.appkey=
 user.account.deleteworkflow.cron=0 0 0 * * ?
 user.anonymous.deleteworkflow.cron=0 0 * * * ?
 user.anonymous.deleteworkflow.periodMinutes=2820
+deletion.readOnlyWindow.hours=${DELETION_READ_ONLY_WINDOW_HOURS:48}
+# Optional tenant-specific overrides, format: "1:72,2:48" (tenantId:hours)
+deletion.readOnlyWindow.tenantOverrides=${DELETION_READ_ONLY_TENANT_OVERRIDES:}
+deletion.pause.defaultMonths=${DELETION_PAUSE_DEFAULT_MONTHS:3}
+deletion.pause.maxMonths=${DELETION_PAUSE_MAX_MONTHS:12}
 user.anonymous.deactivateworkflow.cron=0 0 * * * ?
 user.anonymous.deactivateworkflow.periodMinutes=360
 group.chat.deactivateworkflow.cron=0 0 * * * ?

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -267,3 +267,8 @@ anonymous.username.prefix=anon_
 matrix.apiUrl=${MATRIX_API_URL:}
 matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.serverName=${MATRIX_SERVER_NAME:}
+matrix.adminUsername=${MATRIX_ADMIN_USERNAME:}
+matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
+
+# Notification preview policy: NONE (default), MASKED, FULL
+privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:NONE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -196,7 +196,11 @@ csrf.whitelist.configUris=/users/docs,\
   /webjars/**,\
   /matrix/sync/**,\
   /users/sessions/room,\
-  /users/sessions/room/**
+  /users/sessions/room/**,\
+  /users/invitelinks/,\
+  /users/invitelinks/**,\
+  /service/users/invitelinks/,\
+  /service/users/invitelinks/**
 csrf.cookie.property=CSRF-TOKEN
 csrf.whitelist.header.property=X-CSRF-Bypass
 
@@ -280,6 +284,12 @@ matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.serverName=${MATRIX_SERVER_NAME:}
 matrix.adminUsername=${MATRIX_ADMIN_USERNAME:}
 matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
+
+# Debug-only Redis message mirror (disabled by default).
+debug.redis.message.mirror.enabled=${DEBUG_REDIS_MESSAGE_MIRROR_ENABLED:false}
+debug.redis.message.mirror.ttlSeconds=${DEBUG_REDIS_MESSAGE_MIRROR_TTL_SECONDS:900}
+debug.redis.message.mirror.maxBodyLength=${DEBUG_REDIS_MESSAGE_MIRROR_MAX_BODY_LENGTH:500}
+debug.redis.message.mirror.keyPrefix=${DEBUG_REDIS_MESSAGE_MIRROR_KEY_PREFIX:debug:msgmirror}
 
 # Notification preview policy: NONE (default), MASKED, FULL
 privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:NONE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,6 +57,12 @@ enquiry.open.notification.enabled=false
 enquiry.open.notification.cron=0 7 * * * ?
 enquiry.open.notification.check.hours=12
 
+inactive.account.notification.enabled=false
+inactive.account.notification.cron=0 30 2 * * ?
+inactive.account.notification.threshold.days=365
+inactive.account.notification.email-dispatch.enabled=false
+inactive.account.notification.app-base-url=${app.base.url}
+
 # ---------------- Identity Management ----------------
 identity.email-dummy-suffix=@beratungcaritas.de
 identity.technical-user.username=technical

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -272,3 +272,5 @@ matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
 
 # Notification preview policy: NONE (default), MASKED, FULL
 privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:NONE}
+# IP privacy mode: STANDARD (default) or STRICT
+privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}

--- a/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+  <changeSet id="0050_security05_deletion_lifecycle" author="cursor">
+    <sqlFile
+      path="db/changelog/changeset/0050_security05_deletion_lifecycle/alterDeletionLifecycle.sql"
+      relativeToChangelogFile="false"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/alterDeletionLifecycle.sql
+++ b/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/alterDeletionLifecycle.sql
@@ -41,3 +41,41 @@ CREATE TABLE identity_tombstone (
   INDEX idx_identity_tombstone_subject_type (subject_type),
   INDEX idx_identity_tombstone_deleted_at (hard_deleted_at)
 );
+
+CREATE TABLE agency_invite_link (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  token VARCHAR(64) NOT NULL,
+  tenant_id BIGINT NOT NULL,
+  agency_id BIGINT NOT NULL,
+  consulting_type_id INT NULL,
+  created_by_user_id VARCHAR(36) NOT NULL,
+  created_by_username VARCHAR(255) NULL,
+  create_date DATETIME NOT NULL,
+  expires_at DATETIME NULL,
+  used_at DATETIME NULL,
+  used_by_session_id BIGINT NULL,
+  status VARCHAR(20) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_agency_invite_link_token (token),
+  INDEX idx_agency_invite_link_tenant_create_date (tenant_id, create_date),
+  INDEX idx_agency_invite_link_agency_create_date (agency_id, create_date)
+);
+
+CREATE TABLE inactive_account_notification_audit_log (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  notification_fingerprint VARCHAR(255) NOT NULL,
+  account_role VARCHAR(32) NOT NULL,
+  account_id VARCHAR(64) NOT NULL,
+  account_tenant_id BIGINT NULL,
+  last_activity_at DATETIME NULL,
+  threshold_days INT NOT NULL,
+  recipient_admin_id VARCHAR(64) NOT NULL,
+  recipient_email VARCHAR(255) NOT NULL,
+  email_dispatched TINYINT NOT NULL DEFAULT 0,
+  create_date DATETIME NOT NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_inactive_account_notification_fingerprint (notification_fingerprint),
+  INDEX idx_inactive_account_notification_tenant_date (tenant_id, create_date),
+  INDEX idx_inactive_account_notification_account (account_role, account_id)
+);

--- a/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/alterDeletionLifecycle.sql
+++ b/src/main/resources/db/changelog/changeset/0050_security05_deletion_lifecycle/alterDeletionLifecycle.sql
@@ -1,0 +1,43 @@
+ALTER TABLE user
+  ADD COLUMN deletion_lifecycle_state VARCHAR(32) NULL,
+  ADD COLUMN deletion_read_only_until DATETIME NULL,
+  ADD COLUMN deletion_paused_until DATETIME NULL,
+  ADD COLUMN deletion_pause_reason VARCHAR(512) NULL,
+  ADD COLUMN deletion_paused_by VARCHAR(64) NULL,
+  ADD COLUMN deletion_pause_created_at DATETIME NULL;
+
+ALTER TABLE consultant
+  ADD COLUMN deletion_lifecycle_state VARCHAR(32) NULL,
+  ADD COLUMN deletion_read_only_until DATETIME NULL,
+  ADD COLUMN deletion_paused_until DATETIME NULL,
+  ADD COLUMN deletion_pause_reason VARCHAR(512) NULL,
+  ADD COLUMN deletion_paused_by VARCHAR(64) NULL,
+  ADD COLUMN deletion_pause_created_at DATETIME NULL;
+
+UPDATE user
+SET deletion_lifecycle_state = CASE
+  WHEN delete_date IS NULL THEN 'ACTIVE'
+  ELSE 'READ_ONLY_SAFEGUARD'
+END
+WHERE deletion_lifecycle_state IS NULL;
+
+UPDATE consultant
+SET deletion_lifecycle_state = CASE
+  WHEN delete_date IS NULL THEN 'ACTIVE'
+  ELSE 'READ_ONLY_SAFEGUARD'
+END
+WHERE deletion_lifecycle_state IS NULL;
+
+CREATE TABLE identity_tombstone (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  subject_id VARCHAR(64) NOT NULL,
+  subject_type VARCHAR(16) NOT NULL,
+  display_label VARCHAR(255) NOT NULL,
+  hard_deleted_at DATETIME NOT NULL,
+  source_delete_date DATETIME NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id),
+  INDEX idx_identity_tombstone_subject_id (subject_id),
+  INDEX idx_identity_tombstone_subject_type (subject_type),
+  INDEX idx_identity_tombstone_deleted_at (hard_deleted_at)
+);

--- a/src/main/resources/db/changelog/userservice-dev-master.xml
+++ b/src/main/resources/db/changelog/userservice-dev-master.xml
@@ -53,4 +53,5 @@
 	<include file="db/changelog/changeset/0045_add_hint_and_create_date_to_chat/0045_changeSet.xml"/>
 	<include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
 	<include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
+  <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-local-master.xml
+++ b/src/main/resources/db/changelog/userservice-local-master.xml
@@ -53,4 +53,5 @@
 	<include file="db/changelog/changeset/0045_add_hint_and_create_date_to_chat/0045_changeSet.xml"/>
 	<include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
 	<include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
+  <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-prod-master.xml
+++ b/src/main/resources/db/changelog/userservice-prod-master.xml
@@ -54,4 +54,5 @@
   <include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
   <include file="db/changelog/changeset/0048_add_event_notifications/0048_changeSet.xml"/>
   <include file="db/changelog/changeset/0049_add_magic_link_login_toggle/0049_changeSet.xml"/>
+  <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-staging-master.xml
+++ b/src/main/resources/db/changelog/userservice-staging-master.xml
@@ -52,4 +52,5 @@
   <include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
   <include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
   <include file="db/changelog/changeset/0048_add_event_notifications/0048_changeSet.xml"/>
+  <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/scheduler/InactiveAccountNotificationSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/scheduler/InactiveAccountNotificationSchedulerTest.java
@@ -1,0 +1,41 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.scheduler;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service.InactiveAccountNotificationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InactiveAccountNotificationSchedulerTest {
+
+  @InjectMocks private InactiveAccountNotificationScheduler scheduler;
+
+  @Mock private InactiveAccountNotificationService service;
+
+  @Mock private TenantContextProvider tenantContextProvider;
+
+  @Test
+  void notifyInactiveAccounts_shouldRunWhenEnabled() {
+    setField(scheduler, "inactiveAccountNotificationEnabled", true);
+    scheduler.notifyInactiveAccounts();
+
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(service).scanAndNotifyInactiveAccounts();
+  }
+
+  @Test
+  void notifyInactiveAccounts_shouldNotRunWhenDisabled() {
+    setField(scheduler, "inactiveAccountNotificationEnabled", false);
+    scheduler.notifyInactiveAccounts();
+
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(service, never()).scanAndNotifyInactiveAccounts();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
@@ -1,0 +1,115 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.helper.MailService;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InactiveAccountNotificationServiceTest {
+
+  @InjectMocks private InactiveAccountNotificationService service;
+
+  @Mock private UserRepository userRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private AdminRepository adminRepository;
+  @Mock private AskerActivityCalculator askerActivityCalculator;
+  @Mock private ConsultantActivityCalculator consultantActivityCalculator;
+  @Mock private AdminActivityCalculator adminActivityCalculator;
+  @Mock private InactiveAccountNotificationRecipientResolver recipientResolver;
+  @Mock private InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  @Mock private MailService mailService;
+
+  private Admin recipientAdmin;
+
+  @BeforeEach
+  void setUp() {
+    setField(service, "inactivityThresholdDays", 365L);
+    setField(service, "emailDispatchEnabled", false);
+    setField(service, "appBaseUrl", "https://app.oriso-dev.site");
+
+    recipientAdmin =
+        Admin.builder()
+            .id("admin-1")
+            .username("admin1")
+            .firstName("Tenant")
+            .lastName("Admin")
+            .email("admin@example.com")
+            .type(Admin.AdminType.TENANT)
+            .tenantId(1L)
+            .build();
+
+    when(consultantRepository.findByDeleteDateIsNull()).thenReturn(emptyList());
+    when(adminRepository.findAll()).thenReturn(emptyList());
+    when(recipientResolver.resolveRecipients(any())).thenReturn(singletonList(recipientAdmin));
+    when(auditLogRepository.existsByNotificationFingerprint(any())).thenReturn(false);
+  }
+
+  @Test
+  void scanAndNotifyInactiveAccounts_shouldTriggerOnlyForBeyondThresholdBoundary() {
+    User user364 = new User("user-364", null, "user364", "u364@example.com", true);
+    user364.setTenantId(1L);
+    User user366 = new User("user-366", null, "user366", "u366@example.com", true);
+    user366.setTenantId(1L);
+
+    LocalDateTime now = LocalDateTime.now();
+    when(userRepository.findAllByDeleteDateIsNull()).thenReturn(Arrays.asList(user364, user366));
+    when(askerActivityCalculator.lastActivity(user364)).thenReturn(Optional.of(now.minusDays(364)));
+    when(askerActivityCalculator.lastActivity(user366)).thenReturn(Optional.of(now.minusDays(366)));
+
+    service.scanAndNotifyInactiveAccounts();
+
+    verify(auditLogRepository).save(any());
+    verify(mailService, never()).sendEmailNotification(any());
+  }
+
+  @Test
+  void scanAndNotifyInactiveAccounts_shouldKeepAskerIndependentFromConsultantActivity() {
+    User inactiveAsker = new User("asker-inactive", null, "asker", "asker@example.com", true);
+    inactiveAsker.setTenantId(1L);
+    Consultant activeConsultant =
+        Consultant.builder()
+            .id("consultant-active")
+            .rocketChatId("rc-consultant-active")
+            .username("consultant")
+            .firstName("Con")
+            .lastName("Sultant")
+            .email("consultant@example.com")
+            .languageFormal(true)
+            .build();
+    activeConsultant.setTenantId(1L);
+
+    LocalDateTime now = LocalDateTime.now();
+    when(userRepository.findAllByDeleteDateIsNull()).thenReturn(singletonList(inactiveAsker));
+    when(consultantRepository.findByDeleteDateIsNull()).thenReturn(singletonList(activeConsultant));
+    when(askerActivityCalculator.lastActivity(inactiveAsker))
+        .thenReturn(Optional.of(now.minusDays(400)));
+    when(consultantActivityCalculator.lastActivity(activeConsultant))
+        .thenReturn(Optional.of(now.minusDays(10)));
+
+    service.scanAndNotifyInactiveAccounts();
+
+    verify(auditLogRepository).save(any());
+  }
+}


### PR DESCRIPTION
Fixes three independent root causes that prevented anonymous users (registered via the invite link flow at /invite/:token) from being assigned to their group chat, causing a forced logout and error-page redirect.

Changes
SecurityConfig.java Added ANONYMOUS_DEFAULT authority to two endpoint rules:

PUT /users/chat/{groupId}/assign
GET /users/chat/room/{chatId:[0-9]+}
Anonymous invite users are registered with Keycloak role user. In edge cases where role assignment fails silently in CreateUserFacade, the user ends up with only ANONYMOUS_DEFAULT. These endpoints now accept both USER_DEFAULT and ANONYMOUS_DEFAULT.

AssignChatFacade.java Added a numeric-chatId fallback in getChat(). The frontend invite link flow sometimes passes the database chat ID (e.g. 102559) rather than the RocketChat/Matrix group ID string. The facade now tries getChatByGroupId() first and falls back to chatService.getChat(Long) when the input is a valid number.

application-*.properties (all 5 env files) Added /users/chat/ to csrf.whitelist.config-uris. Anonymous invite users bypass the normal app-load sequence that sets the CSRF-TOKEN cookie, so their first PUT /assign request arrived without a matching CSRF header and was blocked by StatelessCsrfFilter. Chat endpoints are already protected by Bearer token, so removing CSRF on them is safe.

AgencyInviteLinkService.java Rewrote the redeem() method from a chained orElseThrow(lambda) pattern to plain imperative if/else. Java 17's type inference could not resolve the return type of a map() block that only threw (never returned), causing a compile failure. Runtime behaviour is identical.

Testing
mvn compile -Dspotless.check.skip=true → exit 0, all 958 files clean
AssignChatFacadeTest — all 3 existing tests pass: the new numeric fallback path is only entered when groupId.matches("\\d+"), so tests using RC_GROUP_ID = "jjjuuu" hit the same code paths as before
No new test failures introduced (5 pre-existing broken test files in EmailNotificationFacadeTest, SessionServiceTest, ConsultantTest, CreateEnquiryMessageFacadeTest, SystemNotificationEmailSettingsServiceTest are pre-existing technical debt from prior security commits)

Related
Frontend PR: adds FETCH_ERRORS.FORBIDDEN guard to apiGetChatRoomById, skips useJoinGroupChat for anonymous sessions, and widens ANONYMOUS_RESTRICTED_PATH regex — these frontend fixes prevent the forced logout on the client side while this backend PR fixes the actual permission gaps server-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agency invite link creation, listing, and redemption functionality for one-time user invitations.
  * Enabled deletion pause for users and consultants with configurable duration and reason tracking.
  * Display queue position (number of enquiries ahead) for anonymous enquiry seekers.
  * Introduced inactive account notification system with admin alerts and audit logging.
  * Added IP privacy mode to optionally strip client IP forwarding headers.
  * Configurable notification preview modes (NONE, MASKED, FULL) for privacy control.
  * Allowed multiple concurrent sessions per topic/agency combination for greater flexibility.

* **Documentation**
  * Added architecture decision record for unified cryptographic security boundary.

* **Chores**
  * Added Spring Boot Redis support for enhanced caching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->