### PR TITLE
Fix invite-link redeem 500: use existing 'user' role for anonymous users

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -42,8 +42,13 @@ public class AnonymousUserCreatorService {
   public AnonymousUserCredentials createAnonymousUser(UserDTO userDto) {
 
     KeycloakCreateUserResponseDTO response = identityClient.createKeycloakUser(userDto);
+    // Use the existing "user" realm role instead of "anonymous": the Keycloak realm does not
+    // define an "anonymous" role, so assigning it 404s, the password step is skipped, and the
+    // subsequent login fails with 401 (breaking invite-link redeem). The anonymous chat endpoints
+    // in SecurityConfig all accept USER_DEFAULT, matching how /users/askers/new already registers
+    // anonymous chat users (see CreateUserFacade).
     createUserFacade.updateIdentityAndCreateAccount(
-        response.getUserId(), userDto, UserRole.ANONYMOUS);
+        response.getUserId(), userDto, UserRole.USER);
 
     KeycloakLoginResponseDTO kcLoginResponseDTO;
     ResponseEntity<LoginResponseDTO> rcLoginResponseDto;


### PR DESCRIPTION
## Problem
Redeeming an invite link (and `/conversations/askers/anonymous/new`) returned **HTTP 500**.

Root cause traced from production logs:
1. Anonymous user creation assigns `UserRole.ANONYMOUS` ("anonymous").
2. The Keycloak realm has **no `anonymous` role** → `updateRole` returns **404**.
3. Because role assignment throws, the **password step is skipped** (`CreateUserFacade.updateKeycloakRoleAndPassword` sets role before password).
4. The subsequent `loginUser` fails with **401 invalid_grant** → 500.

## Fix
`AnonymousUserCreatorService` now assigns `UserRole.USER` instead. The `user` role exists in the realm and is accepted by every anonymous chat endpoint in `SecurityConfig` (`USER_DEFAULT`) — matching how `/users/askers/new` already registers anonymous chat users.

## Scope / tradeoff
- No Keycloak / realm.json changes.
- Anonymous user gets `user` authority instead of `anonymous`. All anonymous endpoints accept `USER_DEFAULT` except user-initiated `/conversations/anonymous/{id}/finish` (consultant can still end the chat).

## Verification
Requires UserService rebuild + redeploy, then re-test the redeem link — login should succeed with no 404/401 in logs.