### PR TITLE
Fix invite-link redeem 409: skip anonymous usernames still present in Keycloak

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
@@ -5,6 +5,7 @@ import static java.util.Collections.sort;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.LinkedList;
@@ -20,6 +21,7 @@ public class AnonymousUsernameRegistry {
 
   private final @NonNull UserService userService;
   private final @NonNull ConsultantService consultantService;
+  private final @NonNull IdentityClient identityClient;
   private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @Value("${anonymous.username.prefix}")
@@ -63,8 +65,13 @@ public class AnonymousUsernameRegistry {
   }
 
   private boolean isUsernameOccupied(String username) {
+    // The in-memory ID_REGISTRY resets on every restart, so after a restart the generator hands
+    // out low ids again. Besides the local DB we must therefore also consult Keycloak: a username
+    // that still exists there (e.g. a previous anonymous user) would otherwise trigger a 409
+    // "username already exists" when creating the Keycloak account during invite-link redeem.
     return userService.findUserByUsername(username).isPresent()
-        || consultantService.getConsultantByUsername(username).isPresent();
+        || consultantService.getConsultantByUsername(username).isPresent()
+        || !identityClient.isUsernameAvailable(username);
   }
 
   private int obtainUsernameId(String username) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import de.caritas.cob.userservice.api.conversation.service.user.anonymous.AnonymousUsernameRegistry;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.LinkedList;
@@ -36,12 +37,15 @@ class AnonymousUsernameRegistryTest {
   @InjectMocks private AnonymousUsernameRegistry anonymousUsernameRegistry;
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
+  @Mock private IdentityClient identityClient;
   @Mock private UsernameTranscoder usernameTranscoder;
 
   @BeforeEach
   void setUp() {
     setField(anonymousUsernameRegistry, "usernameTranscoder", usernameTranscoder);
     setField(anonymousUsernameRegistry, "usernamePrefix", "Ratsuchende_r ");
+    // By default every candidate username is free in Keycloak; individual tests override this.
+    when(identityClient.isUsernameAvailable(anyString())).thenReturn(true);
   }
 
   @Test
@@ -131,6 +135,24 @@ class AnonymousUsernameRegistryTest {
     when(consultantService.getConsultantByUsername("Ratsuchende_r 5"))
         .thenReturn(Optional.of(CONSULTANT));
     when(consultantService.getConsultantByUsername("Ratsuchende_r 7")).thenReturn(Optional.empty());
+
+    anonymousUsernameRegistry.generateUniqueUsername();
+
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(usernameTranscoder, times(1)).encodeUsername(argumentCaptor.capture());
+    assertThat(argumentCaptor.getValue(), is("Ratsuchende_r 7"));
+  }
+
+  @Test
+  void generateUniqueUsername_Should_SkipUsernamesStillPresentInKeycloak_When_NotInLocalDb() {
+    LinkedList<Integer> idRegistry = new LinkedList<>(List.of(1, 2, 4, 6));
+    setIdRegistryField(idRegistry);
+    when(userService.findUserByUsername(any())).thenReturn(Optional.empty());
+    when(consultantService.getConsultantByUsername(any())).thenReturn(Optional.empty());
+    // 3 and 5 are gone from the local DB but still exist in Keycloak -> must be skipped.
+    when(identityClient.isUsernameAvailable("Ratsuchende_r 3")).thenReturn(false);
+    when(identityClient.isUsernameAvailable("Ratsuchende_r 5")).thenReturn(false);
+    when(identityClient.isUsernameAvailable("Ratsuchende_r 7")).thenReturn(true);
 
     anonymousUsernameRegistry.generateUniqueUsername();
 


### PR DESCRIPTION
## Problem
After the role fix, redeeming an invite link now fails with **HTTP 409 `USERNAME_NOT_AVAILABLE`** at `createKeycloakUser` (verified live: `x-reason: USERNAME_NOT_AVAILABLE`).

Root cause:
- `AnonymousUsernameRegistry.ID_REGISTRY` is a **static in-memory list** that resets on every pod restart, so the generator re-issues low ids (`anon_1`, `anon_2`, …).
- `isUsernameOccupied()` checked only the **local DB** (users + consultants), **not Keycloak**. A username that still exists in Keycloak (a previous anonymous user, or leftovers from the earlier failed redeems) was treated as free → Keycloak create returns **409**.

## Fix
`isUsernameOccupied()` now also consults Keycloak via `IdentityClient.isUsernameAvailable(username)`, so usernames still present in Keycloak are skipped. Survives restarts; eliminates the 409.

## Tests (local, JDK 11)
- New case `generateUniqueUsername_Should_SkipUsernamesStillPresentInKeycloak_When_NotInLocalDb`.
- Related suites all green: `AnonymousUsernameRegistryTest` (12), `CreateAnonymousEnquiryFacadeTest` (2), `AnonymousConversationCreatorServiceTest` (4), `AnonymousUserCreatorServiceTest` (4) — 22 total, 0 failures.

## Note
Second of two fixes for invite-link redeem. The first (role fix, #14) is already merged to `dev`; this one removes the remaining 409. Requires UserService rebuild + redeploy to take effect.