### PR TITLE
Fix invite-link redeem: decode username for Keycloak login

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -147,7 +147,8 @@ public class KeycloakService implements IdentityClient {
    * @return {@link KeycloakLoginResponseDTO}
    */
   public KeycloakLoginResponseDTO loginUser(final String userName, final String password) {
-    var entity = loginRequest(userName, password);
+    // Keycloak stores decoded usernames; callers often pass the encoded form from MariaDB.
+    var entity = loginRequest(usernameTranscoder.decodeUsername(userName), password);
     var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
 
     try {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -220,8 +220,7 @@ public class CreateUserFacade {
         if (ex instanceof RuntimeException) {
           throw (RuntimeException) ex;
         }
-        throw new InternalServerErrorException(
-            "Keycloak operations failed for anonymous user", ex);
+        throw new InternalServerErrorException("Keycloak operations failed for anonymous user", ex);
       }
       log.error(
           "Keycloak operations failed for user {}, but continuing with user creation",

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -212,11 +212,22 @@ public class CreateUserFacade {
               language);
 
     } catch (Exception ex) {
+      if (role == UserRole.ANONYMOUS) {
+        log.error(
+            "Keycloak operations failed for anonymous user {}, aborting account creation",
+            userDTO.getUsername(),
+            ex);
+        if (ex instanceof RuntimeException runtimeException) {
+          throw runtimeException;
+        }
+        throw new InternalServerErrorException(
+            "Keycloak operations failed for anonymous user", ex);
+      }
       log.error(
           "Keycloak operations failed for user {}, but continuing with user creation",
           userDTO.getUsername(),
           ex);
-      // Continue with user creation even if Keycloak operations fail
+      // Continue with user creation even if Keycloak operations fail (registered askers / Matrix)
       var extendedConsultingTypeResponseDTO =
           consultingTypeManager.getConsultingTypeSettings(userDTO.getConsultingType());
       var language =

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -217,8 +217,8 @@ public class CreateUserFacade {
             "Keycloak operations failed for anonymous user {}, aborting account creation",
             userDTO.getUsername(),
             ex);
-        if (ex instanceof RuntimeException runtimeException) {
-          throw runtimeException;
+        if (ex instanceof RuntimeException) {
+          throw (RuntimeException) ex;
         }
         throw new InternalServerErrorException(
             "Keycloak operations failed for anonymous user", ex);

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -217,9 +217,6 @@ public class CreateUserFacade {
             "Keycloak operations failed for anonymous user {}, aborting account creation",
             userDTO.getUsername(),
             ex);
-        if (ex instanceof RuntimeException) {
-          throw (RuntimeException) ex;
-        }
         throw new InternalServerErrorException("Keycloak operations failed for anonymous user", ex);
       }
       log.error(


### PR DESCRIPTION
Anonymous users are stored in Keycloak with decoded usernames (anon_*) but login was attempted with the encoded form (enc.*), causing 401 invalid_grant during invite-link redeem. Also abort anonymous account setup when Keycloak role/password assignment fails instead of continuing without a password.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

