### PR TITLE
Fix invite-link redeem: create Rocket.Chat user before login

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -14,17 +14,21 @@ import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginExcept
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackUserAccountInformation;
+import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 /** Service to create anonymous user accounts. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AnonymousUserCreatorService {
 
   private final @NonNull CreateUserFacade createUserFacade;
@@ -32,6 +36,7 @@ public class AnonymousUserCreatorService {
   private final @NonNull RocketChatService rocketChatService;
   private final @NonNull RollbackFacade rollbackFacade;
   private final @NonNull UserService userService;
+  private final @NonNull UserHelper userHelper;
 
   /**
    * Creates an anonymous user account in Keycloak, MariaDB and Rocket.Chat.
@@ -53,6 +58,7 @@ public class AnonymousUserCreatorService {
     ResponseEntity<LoginResponseDTO> rcLoginResponseDto;
     try {
       kcLoginResponseDTO = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
+      ensureRocketChatUserExists(userDto, response.getUserId());
       rcLoginResponseDto =
           rocketChatService.loginUserFirstTime(userDto.getUsername(), userDto.getPassword());
     } catch (RocketChatLoginException | BadRequestException e) {
@@ -73,6 +79,23 @@ public class AnonymousUserCreatorService {
     updateRocketChatUserIdInDatabase(anonymousUserCredentials);
 
     return anonymousUserCredentials;
+  }
+
+  private void ensureRocketChatUserExists(UserDTO userDto, String keycloakUserId)
+      throws RocketChatLoginException {
+    String encodedUsername = userDto.getUsername();
+    String email =
+        StringUtils.isNotBlank(userDto.getEmail())
+            ? userDto.getEmail()
+            : userHelper.getDummyEmail(keycloakUserId);
+    try {
+      rocketChatService.createUser(encodedUsername, userDto.getPassword(), email);
+    } catch (RocketChatLoginException e) {
+      log.warn(
+          "Rocket.Chat user {} might already exist, continuing with login: {}",
+          encodedUsername,
+          e.getMessage());
+    }
   }
 
   private void rollBackAnonymousUserAccount(String userId) {

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
+import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.Optional;
@@ -51,6 +52,7 @@ class AnonymousUserCreatorServiceTest {
   @Mock private RocketChatService rocketChatService;
   @Mock private RollbackFacade rollbackFacade;
   @Mock private UserService userService;
+  @Mock private UserHelper userHelper;
 
   EasyRandom easyRandom = new EasyRandom();
 
@@ -83,11 +85,12 @@ class AnonymousUserCreatorServiceTest {
           KeycloakCreateUserResponseDTO responseDTO =
               easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
           when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
-          RocketChatLoginException exception =
-              easyRandom.nextObject(RocketChatLoginException.class);
+          when(keycloakService.loginUser(anyString(), anyString()))
+              .thenReturn(easyRandom.nextObject(KeycloakLoginResponseDTO.class));
+          when(userHelper.getDummyEmail(anyString())).thenReturn("user-id@beratungcaritas.de");
           when(rocketChatService.loginUserFirstTime(
                   USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
-              .thenThrow(exception);
+              .thenThrow(new RocketChatLoginException("Rocket.Chat login failed"));
 
           anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
 
@@ -111,6 +114,7 @@ class AnonymousUserCreatorServiceTest {
             USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
         .thenReturn(responseEntity);
     when(userService.getUser(any())).thenReturn(Optional.of(mock(User.class)));
+    when(userHelper.getDummyEmail(anyString())).thenReturn("user-id@beratungcaritas.de");
 
     AnonymousUserCredentials credentials =
         anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
@@ -122,6 +126,7 @@ class AnonymousUserCreatorServiceTest {
     assertThat(credentials.getAccessToken(), is(keycloakLoginResponseDTO.getAccessToken()));
     assertThat(credentials.getRefreshToken(), is(keycloakLoginResponseDTO.getRefreshToken()));
     verifyNoInteractions(rollbackFacade);
+    verify(rocketChatService, times(1)).createUser(anyString(), anyString(), anyString());
     verify(userService, times(1)).updateRocketChatIdInDatabase(any(), any());
   }
 


### PR DESCRIPTION
## Summary

Invite-link redeem fails with 500 after Keycloak login succeeds:

```
Could not login user (enc.*) in Rocket.Chat for the first time
```

Anonymous user creation called `loginUserFirstTime` without creating the user in Rocket.Chat first. Registered askers already use `createUser` then `loginUserFirstTime` in `CreateUserChatRelationFacade`.

This PR adds `ensureRocketChatUserExists()` before the LDAP first-login call, matching the registered-asker flow.

Depends on PR #18 (Keycloak username decode), already merged to `dev`.

## Test plan

- [ ] Merge to `dev` and redeploy UserService on dev
- [ ] Create a new invite link in admin
- [ ] Open invite URL and confirm `POST .../invitelinks/{token}/redeem` returns **200** with `sessionId`, `accessToken`, etc.
- [ ] Check logs: no `Could not login user ... in Rocket.Chat for the first time`


Made with [Cursor](https://cursor.com)