### PR TITLE
Fix invite-link redeem: native Rocket.Chat login after createUser

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatService.java
@@ -502,6 +502,20 @@ public class RocketChatService implements MessageClient {
   }
 
   /**
+   * Standard Rocket.Chat login (form POST, no LDAP). Use after {@link #createUser} created the
+   * account via the admin API.
+   *
+   * @param username the username
+   * @param password the password
+   * @return the login result
+   * @throws RocketChatLoginException on failure
+   */
+  public ResponseEntity<LoginResponseDTO> loginWithPassword(String username, String password)
+      throws RocketChatLoginException {
+    return rcCredentialHelper.loginUser(username, password);
+  }
+
+  /**
    * Initial login to synchronize ldap and Rocket.Chat user.
    *
    * @param username the username

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -59,8 +59,7 @@ public class AnonymousUserCreatorService {
     try {
       kcLoginResponseDTO = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
       ensureRocketChatUserExists(userDto, response.getUserId());
-      rcLoginResponseDto =
-          rocketChatService.loginUserFirstTime(userDto.getUsername(), userDto.getPassword());
+      rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
     } catch (RocketChatLoginException | BadRequestException e) {
       rollBackAnonymousUserAccount(response.getUserId());
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
@@ -89,13 +88,53 @@ public class AnonymousUserCreatorService {
             ? userDto.getEmail()
             : userHelper.getDummyEmail(keycloakUserId);
     try {
-      rocketChatService.createUser(encodedUsername, userDto.getPassword(), email);
+      var createResponse =
+          rocketChatService.createUser(encodedUsername, userDto.getPassword(), email);
+      if (createResponse.getBody() != null && !createResponse.getBody().isSuccess()) {
+        String error = createResponse.getBody().getError();
+        if (!isRocketChatUserAlreadyExists(error)) {
+          throw new RocketChatLoginException(
+              String.format(
+                  "Could not create user (%s) in Rocket.Chat: %s", encodedUsername, error));
+        }
+        log.warn("Rocket.Chat user {} already exists: {}", encodedUsername, error);
+      }
     } catch (RocketChatLoginException e) {
+      if (!isRocketChatUserAlreadyExists(e.getMessage())) {
+        throw e;
+      }
       log.warn(
           "Rocket.Chat user {} might already exist, continuing with login: {}",
           encodedUsername,
           e.getMessage());
     }
+  }
+
+  /**
+   * Users created via {@link RocketChatService#createUser} must log in with the native login API.
+   * LDAP first-login only applies to accounts provisioned from Keycloak/LDAP.
+   */
+  private ResponseEntity<LoginResponseDTO> loginRocketChatUser(String username, String password)
+      throws RocketChatLoginException {
+    try {
+      return rocketChatService.loginWithPassword(username, password);
+    } catch (RocketChatLoginException nativeLoginEx) {
+      log.warn(
+          "Native Rocket.Chat login failed for {}, trying LDAP first-login: {}",
+          username,
+          nativeLoginEx.getMessage());
+      return rocketChatService.loginUserFirstTime(username, password);
+    }
+  }
+
+  private static boolean isRocketChatUserAlreadyExists(String errorMessage) {
+    if (errorMessage == null) {
+      return false;
+    }
+    String lower = errorMessage.toLowerCase();
+    return lower.contains("already exists")
+        || lower.contains("in use")
+        || lower.contains("duplicate");
   }
 
   private void rollBackAnonymousUserAccount(String userId) {

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.StandardResponseDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.LoginResponseDTO;
 import de.caritas.cob.userservice.api.conversation.model.AnonymousUserCredentials;
 import de.caritas.cob.userservice.api.conversation.service.user.anonymous.AnonymousUserCreatorService;
@@ -88,6 +89,11 @@ class AnonymousUserCreatorServiceTest {
           when(keycloakService.loginUser(anyString(), anyString()))
               .thenReturn(easyRandom.nextObject(KeycloakLoginResponseDTO.class));
           when(userHelper.getDummyEmail(anyString())).thenReturn("user-id@beratungcaritas.de");
+          when(rocketChatService.createUser(anyString(), anyString(), anyString()))
+              .thenReturn(ResponseEntity.ok(new StandardResponseDTO(true, null)));
+          when(rocketChatService.loginWithPassword(
+                  USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
+              .thenThrow(new RocketChatLoginException("Rocket.Chat login failed"));
           when(rocketChatService.loginUserFirstTime(
                   USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
               .thenThrow(new RocketChatLoginException("Rocket.Chat login failed"));
@@ -110,7 +116,9 @@ class AnonymousUserCreatorServiceTest {
     LoginResponseDTO loginResponseDTO = easyRandom.nextObject(LoginResponseDTO.class);
     ResponseEntity<LoginResponseDTO> responseEntity =
         new ResponseEntity<>(loginResponseDTO, HttpStatus.OK);
-    when(rocketChatService.loginUserFirstTime(
+    when(rocketChatService.createUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.ok(new StandardResponseDTO(true, null)));
+    when(rocketChatService.loginWithPassword(
             USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
         .thenReturn(responseEntity);
     when(userService.getUser(any())).thenReturn(Optional.of(mock(User.class)));
@@ -143,7 +151,9 @@ class AnonymousUserCreatorServiceTest {
     LoginResponseDTO loginResponseDTO = easyRandom.nextObject(LoginResponseDTO.class);
     ResponseEntity<LoginResponseDTO> responseEntity =
         new ResponseEntity<>(loginResponseDTO, HttpStatus.OK);
-    when(rocketChatService.loginUserFirstTime(
+    when(rocketChatService.createUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.ok(new StandardResponseDTO(true, null)));
+    when(rocketChatService.loginWithPassword(
             USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
         .thenReturn(responseEntity);
 


### PR DESCRIPTION
## Summary

After PR #19, redeem still failed with:

```
Could not login user (enc.*) in Rocket.Chat for the first time
```

`createUser` provisions a **local** Rocket.Chat account, but `loginUserFirstTime` uses **LDAP** login (Keycloak/LDAP has decoded `anon_*` usernames, not `enc.*`).

This PR:
- Logs in via native Rocket.Chat password API after `createUser`
- Falls back to LDAP first-login only if native login fails
- Surfaces `createUser` failures instead of swallowing them

## Test plan

- [ ] Merge and redeploy UserService on dev
- [ ] New invite link → redeem returns **200**
- [ ] Logs should not show `Could not login user ... for the first time` (unless RC is down)


Made with [Cursor](https://cursor.com)