### PR TITLE
MT-04-12 support multiple platform admins

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -69,6 +69,9 @@ public class KeycloakConfig {
         authenticatedUser.setUserId(securityContext.getToken().getSubject());
         authenticatedUser.setAccessToken(securityContext.getTokenString());
         authenticatedUser.setRoles(securityContext.getToken().getRealmAccess().getRoles());
+        if (claimMap.containsKey("tenantId")) {
+          authenticatedUser.setTenantId(Long.valueOf(claimMap.get("tenantId").toString()));
+        }
       } catch (Exception exception) {
         throw new KeycloakException("Keycloak data missing.", exception);
       }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
@@ -123,9 +123,7 @@ public class AdminDtoMapper implements DtoMapperUtils {
     adminDTO.setCreateDate((String) adminUserMap.get("createdAt"));
     adminDTO.setUpdateDate((String) adminUserMap.get("updatedAt"));
 
-    if (multiTenancyEnabled) {
-      enrichResponseWithTenantInformation(adminUserMap, adminDTO);
-    }
+    enrichResponseWithTenantInformation(adminUserMap, adminDTO);
 
     var agencies = new ArrayList<AgencyAdminResponseDTO>();
     var agencyMaps = (ArrayList<Map<String, Object>>) adminUserMap.get("agencies");
@@ -151,7 +149,7 @@ public class AdminDtoMapper implements DtoMapperUtils {
       Map<String, Object> adminUserMap, AdminDTO adminDTO) {
     Long tenantId = (Long) adminUserMap.get("tenantId");
     adminDTO.setTenantId(String.valueOf(tenantId));
-    if (tenantId != null) {
+    if (tenantId != null && !tenantId.equals(0L) && multiTenancyEnabled) {
       enrichWithTenantSubdomainAndName(adminDTO, tenantId);
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -12,6 +12,8 @@ import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminSe
 import de.caritas.cob.userservice.api.admin.service.admin.update.UpdateAdminService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import java.util.List;
@@ -34,6 +36,7 @@ public class TenantAdminUserService {
   private final @NonNull DeleteAdminService deleteAdminService;
   private final @NonNull UserServiceMapper userServiceMapper;
   private final @NonNull TenantService tenantService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
 
   @Value("${multitenancy.enabled}")
   private boolean multiTenancyEnabled;
@@ -56,8 +59,8 @@ public class TenantAdminUserService {
     if (inputTenantId == null) {
       throw new BadRequestException("Tenant id must be provided");
     }
-    if (inputTenantId.equals(0)) {
-      throw new BadRequestException("Tenant id cannot be equal to 0");
+    if (inputTenantId.equals(0) && !authenticatedUser.isPlatformAdmin()) {
+      throw new ForbiddenException("Only platform admins can create platform admin accounts");
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/helper/AuthenticatedUser.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/AuthenticatedUser.java
@@ -26,7 +26,22 @@ public class AuthenticatedUser {
 
   @NonNull private String accessToken;
 
+  private Long tenantId;
+
   private Set<String> grantedAuthorities;
+
+  public AuthenticatedUser(
+      String userId,
+      String username,
+      Set<String> roles,
+      String accessToken,
+      Set<String> grantedAuthorities) {
+    this.userId = userId;
+    this.username = username;
+    this.roles = roles;
+    this.accessToken = accessToken;
+    this.grantedAuthorities = grantedAuthorities;
+  }
 
   @JsonIgnore
   public boolean isRestrictedAgencyAdmin() {
@@ -61,6 +76,11 @@ public class AuthenticatedUser {
   @JsonIgnore
   public boolean isTenantSuperAdmin() {
     return nonNull(roles) && roles.contains(UserRole.TENANT_ADMIN.getValue());
+  }
+
+  @JsonIgnore
+  public boolean isPlatformAdmin() {
+    return Long.valueOf(0L).equals(tenantId) && isAgencySuperAdmin() && isTenantSuperAdmin();
   }
 
   @JsonIgnore

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -74,7 +74,8 @@ class TenantAdminUserServiceTest {
   }
 
   @Test
-  void createNewTenantAdmin_Should_RejectPlatformTenantId_WhenAuthenticatedUserIsNotPlatformAdmin() {
+  void
+      createNewTenantAdmin_Should_RejectPlatformTenantId_WhenAuthenticatedUserIsNotPlatformAdmin() {
     // given
     CreateAdminDTO createAdminDTO = new CreateAdminDTO();
     createAdminDTO.setTenantId(0);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -1,16 +1,20 @@
 package de.caritas.cob.userservice.api.admin.service.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.UserServiceMapper;
 import de.caritas.cob.userservice.api.adapters.web.dto.AdminResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateTenantAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.create.CreateAdminService;
 import de.caritas.cob.userservice.api.admin.service.admin.delete.DeleteAdminService;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.admin.service.admin.update.UpdateAdminService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -50,6 +54,39 @@ class TenantAdminUserServiceTest {
 
   @Mock private AgencyService agencyService;
 
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @Test
+  void createNewTenantAdmin_Should_AllowPlatformTenantId_WhenAuthenticatedUserIsPlatformAdmin() {
+    // given
+    CreateAdminDTO createAdminDTO = new CreateAdminDTO();
+    createAdminDTO.setTenantId(0);
+    Admin platformAdmin = tenantAdmin("platform-admin", 0L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(createAdminService.createNewTenantAdmin(createAdminDTO)).thenReturn(platformAdmin);
+
+    // when
+    AdminResponseDTO response = tenantAdminUserService.createNewTenantAdmin(createAdminDTO);
+
+    // then
+    Mockito.verify(createAdminService).createNewTenantAdmin(createAdminDTO);
+    assertThat(response.getEmbedded().getTenantId()).isEqualTo("0");
+  }
+
+  @Test
+  void createNewTenantAdmin_Should_RejectPlatformTenantId_WhenAuthenticatedUserIsNotPlatformAdmin() {
+    // given
+    CreateAdminDTO createAdminDTO = new CreateAdminDTO();
+    createAdminDTO.setTenantId(0);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+
+    // when, then
+    assertThatThrownBy(() -> tenantAdminUserService.createNewTenantAdmin(createAdminDTO))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessage("Only platform admins can create platform admin accounts");
+    Mockito.verifyNoInteractions(createAdminService);
+  }
+
   @Test
   void updateTenantAdmin_Should_UpdateTenantAndEnrichResponseWithTenantSubdomain() {
     // given
@@ -70,5 +107,13 @@ class TenantAdminUserServiceTest {
     Mockito.verify(tenantService).getRestrictedTenantData(1L);
 
     assertThat(adminResponseDTO.getEmbedded().getTenantSubdomain()).isEqualTo("subdomain");
+  }
+
+  private Admin tenantAdmin(String id, Long tenantId) {
+    Admin admin = new Admin();
+    admin.setId(id);
+    admin.setType(Admin.AdminType.TENANT);
+    admin.setTenantId(tenantId);
+    return admin;
   }
 }


### PR DESCRIPTION
Implements MT-04-12 backend support for multiple platform admins via Platform ID (`tenantId=0`).

Changes:
- Read `tenantId` from the authenticated Keycloak token.
- Allow creating Tenant-Admin records with `tenantId=0` only for platform admins.
- Keep `tenantId=0` visible in admin search/list responses without resolving it through TenantService.
- Added targeted backend tests.

Verified locally:
- Created two test platform-admin users with `tenantId=0`.
- Confirmed both were created successfully.
- Confirmed search/list returns platform admin users with `tenantId: "0"`.
- Ran `TenantAdminUserServiceTest` successfully.

Frontend note:
- Manual verification was done through API/Postman because the current Admin panel create flow does not expose a platform option (`tenantId=0`) for selection.
- If platform-admin creation should be possible from the UI, frontend support is still needed.


@shazia-k please do a code review