### PR TITLE
Deploy Dev by commit SHA image only

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,11 +2,6 @@ name: Deploy Dev
 
 on:
   workflow_dispatch:
-    inputs:
-      image_tag:
-        description: "Published GHCR image tag to deploy, for example sha-abc1234 or dev. Leave empty to use this workflow ref SHA."
-        required: false
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -26,18 +21,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Select image tag
-        env:
-          REQUESTED_IMAGE_TAG: ${{ inputs.image_tag }}
+      - name: Select dev commit SHA image tag
         run: |
-          if [ -n "$REQUESTED_IMAGE_TAG" ]; then
-            IMAGE_TAG="$REQUESTED_IMAGE_TAG"
-          else
-            IMAGE_TAG="sha-${GITHUB_SHA::7}"
-          fi
+          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          IMAGE_REF="${REGISTRY}/${ORG}/${IMAGE}:${IMAGE_TAG}"
 
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_ENV"
-          echo "IMAGE_REF=${REGISTRY}/${ORG}/${IMAGE}:${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_ENV"
+          echo "Using image tag ${IMAGE_TAG} for commit ${GITHUB_SHA}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Removes the manual image_tag input from the visible Deploy Dev workflow. The workflow now always resolves the selected branch commit to its Docker SHA tag, then deploys the immutable digest for that SHA-tagged image.