### PR TITLE
Wait for Dev SHA image before deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -42,7 +42,17 @@ jobs:
 
       - name: Resolve immutable image digest
         run: |
-          DIGEST="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          DIGEST=""
+          for attempt in {1..30}; do
+            DIGEST="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')" || true
+
+            if [ -n "$DIGEST" ] && [ "$DIGEST" != "null" ]; then
+              break
+            fi
+
+            echo "Image ${IMAGE_REF} is not available yet. Waiting 20s before retry ${attempt}/30..."
+            sleep 20
+          done
 
           if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
             echo "Could not resolve digest for $IMAGE_REF"


### PR DESCRIPTION
Adds polling to the dev-branch Deploy Dev workflow so it waits for the selected commit SHA image tag to appear in GHCR before resolving the immutable digest. This avoids failures when deploy is triggered before the dev image publish job has finished.