### PR TITLE
[refactor]: Enhance UserController and KeycloakUserDataProvider with …

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -80,6 +80,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
@@ -625,10 +626,7 @@ public class UserController implements UsersApi {
       var user = userAccountProvider.retrieveValidatedUser();
       partialUserData = askerDataProvider.retrieveData(user);
     }
-    var otpInfoDTO =
-        identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())
-            ? identityManager.getOtpCredential(authenticatedUser.getUsername())
-            : null;
+    var otpInfoDTO = retrieveOtpCredentialIfAllowed();
 
     var fullUserData =
         userDtoMapper.userDataOf(
@@ -638,6 +636,21 @@ public class UserController implements UsersApi {
             identityClientConfig.getDisplayNameAllowedForConsultants());
 
     return new ResponseEntity<>(fullUserData, HttpStatus.OK);
+  }
+
+  private OtpInfoDTO retrieveOtpCredentialIfAllowed() {
+    if (!identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())) {
+      return null;
+    }
+    try {
+      return identityManager.getOtpCredential(authenticatedUser.getUsername());
+    } catch (Exception ex) {
+      log.warn(
+          "Could not retrieve OTP credential for authenticated user {}; returning user data without OTP state",
+          authenticatedUser.getUserId(),
+          ex);
+      return null;
+    }
   }
 
   private boolean isAgencyAdmin() {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -95,15 +95,23 @@ public class TenantAdminUserService {
 
     var tenantIdsToNameMap =
         fullAdmins.stream()
-            .filter(consultant -> consultant.getTenantId() != null)
+            .filter(admin -> admin.getTenantId() != null)
             .collect(
                 Collectors.toMap(
                     Admin::getTenantId,
-                    admin -> tenantService.getRestrictedTenantData(admin.getTenantId()).getName(),
+                    admin -> resolveTenantName(admin.getTenantId()),
                     (existing, replacement) -> existing));
 
     return userServiceMapper.mapOfAdmin(
         adminsPage, fullAdmins, Lists.newArrayList(), Lists.newArrayList(), tenantIdsToNameMap);
+  }
+
+  private String resolveTenantName(Long tenantId) {
+    try {
+      return tenantService.getRestrictedTenantData(tenantId).getName();
+    } catch (Exception ex) {
+      return "";
+    }
   }
 
   public List<AdminResponseDTO> findTenantAdmins(Long tenantId) {

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -221,6 +221,10 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
             "/users/chat/{chatId:[0-9]+}/update",
             "/users/{chatUserId:[0-9A-Za-z]+}/chat/{chatId:[0-9]+}/ban")
         .hasAuthority(UPDATE_CHAT)
+        .antMatchers(HttpMethod.GET, "/useradmin/tenantadmins/search")
+        .hasAnyAuthority(TENANT_ADMIN, USER_ADMIN)
+        .antMatchers(HttpMethod.GET, "/useradmin/tenantadmins")
+        .hasAnyAuthority(TENANT_ADMIN, USER_ADMIN)
         .antMatchers("/useradmin/tenantadmins/", "/useradmin/tenantadmins/**")
         .hasAuthority(TENANT_ADMIN)
         .antMatchers("/useradmin/data/*")

--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/KeycloakUserDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/KeycloakUserDataProvider.java
@@ -6,11 +6,13 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 /** Provider for consultant information. */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KeycloakUserDataProvider {
@@ -20,7 +22,22 @@ public class KeycloakUserDataProvider {
 
   public UserDataResponseDTO retrieveAuthenticatedUserData() {
     assertCalledInAuthenticatedUserContext();
-    var user = identityClient.getById(authenticatedUser.getUserId());
+    UserRepresentation user;
+    try {
+      user = identityClient.getById(authenticatedUser.getUserId());
+    } catch (Exception ex) {
+      log.warn(
+          "Could not retrieve Keycloak user data for authenticated user {}; returning token-based user data",
+          authenticatedUser.getUserId(),
+          ex);
+      return fallbackUserDataResponseDto();
+    }
+    if (user == null) {
+      log.warn(
+          "Keycloak user lookup returned no data for authenticated user {}; returning token-based user data",
+          authenticatedUser.getUserId());
+      return fallbackUserDataResponseDto();
+    }
     return userDataResponseDtoOf(user);
   }
 
@@ -37,6 +54,21 @@ public class KeycloakUserDataProvider {
         .firstName(keycloakUser.getFirstName())
         .lastName(keycloakUser.getLastName())
         .email(keycloakUser.getEmail())
+        .encourage2fa(false)
+        .absenceMessage("")
+        .isInTeamAgency(false)
+        .agencies(Lists.newArrayList())
+        .userRoles(authenticatedUser.getRoles())
+        .grantedAuthorities(authenticatedUser.getGrantedAuthorities())
+        .hasAnonymousConversations(false)
+        .hasArchive(false)
+        .build();
+  }
+
+  private UserDataResponseDTO fallbackUserDataResponseDto() {
+    return UserDataResponseDTO.builder()
+        .userId(authenticatedUser.getUserId())
+        .userName(authenticatedUser.getUsername())
         .encourage2fa(false)
         .absenceMessage("")
         .isInTeamAgency(false)

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -656,6 +656,46 @@ class UserAdminControllerE2EIT {
 
   @Test
   @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void searchTenantAdmin_Should_returnOk_When_attemptedToSearchTenantsWithUserAdminAuthority()
+      throws Exception {
+
+    when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
+        .thenReturn(new RestrictedTenantDTO().subdomain("subdomain").name("name"));
+
+    MvcResult mvcResult =
+        this.mockMvc
+            .perform(
+                get(
+                    "/useradmin/tenantadmins/search?query=*&page=1&perPage=10&order=ASC&field=FIRSTNAME"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("_embedded", hasSize(PAGE_SIZE)))
+            .andReturn();
+
+    String contentAsString = mvcResult.getResponse().getContentAsString();
+    JSONArray embedded = JsonPath.read(contentAsString, "_embedded");
+
+    assertAllElementsAreOfAdminType(embedded, AdminType.TENANT);
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void searchTenantAdmin_Should_returnOkAndEmptyTenantName_When_tenantServiceThrows()
+      throws Exception {
+
+    when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
+        .thenThrow(new RuntimeException("Tenant service unavailable"));
+
+    this.mockMvc
+        .perform(
+            get(
+                "/useradmin/tenantadmins/search?query=*&page=1&perPage=10&order=ASC&field=FIRSTNAME"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("_embedded", hasSize(PAGE_SIZE)))
+        .andExpect(jsonPath("_embedded[0]._embedded.tenantName", is("")));
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
   void searchAgencyAdmins_Should_returnOk_When_attemptedToSearchTenantsWithUserAdminAuthority()
       throws Exception {
     // when

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerGetUserDataTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerGetUserDataTest.java
@@ -1,0 +1,82 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
+import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
+import de.caritas.cob.userservice.api.admin.service.consultant.update.ConsultantUpdateService;
+import de.caritas.cob.userservice.api.config.VideoChatConfig;
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.facade.userdata.AskerDataProvider;
+import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
+import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
+import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerGetUserDataTest {
+
+  private static final String USER_ID = "user-id";
+  private static final String USERNAME = "username";
+
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityManaging identityManager;
+  @Mock private AccountManaging accountManager;
+  @Mock private Messaging messenger;
+  @Mock private ConsultantDtoMapper consultantDtoMapper;
+  @Mock private UserDtoMapper userDtoMapper;
+  @Mock private ConsultantService consultantService;
+  @Mock private ConsultantUpdateService consultantUpdateService;
+  @Mock private ConsultantDataProvider consultantDataProvider;
+  @Mock private AskerDataProvider askerDataProvider;
+  @Mock private VideoChatConfig videoChatConfig;
+  @Mock private KeycloakUserDataProvider keycloakUserDataProvider;
+  @Mock private MagicLinkLoginService magicLinkLoginService;
+  @Mock private SessionDeleteService sessionDeleteService;
+  @Mock private EventNotificationService eventNotificationService;
+
+  @InjectMocks private UserController userController;
+
+  @Test
+  void getUserData_Should_ReturnUserDataWithoutOtpState_WhenOtpLookupFails() {
+    var roles = Set.of(UserRole.TENANT_ADMIN.getValue());
+    var partialUserData = new UserDataResponseDTO();
+    var fullUserData = new UserDataResponseDTO();
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(authenticatedUser.getUsername()).thenReturn(USERNAME);
+    when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
+    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityManager.getOtpCredential(USERNAME)).thenThrow(new RuntimeException("OTP down"));
+    when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
+        .thenReturn(fullUserData);
+
+    var response = userController.getUserData();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(fullUserData);
+    verify(userDtoMapper).userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -52,6 +52,8 @@ import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
+import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -328,6 +330,10 @@ class UserControllerIT {
   @MockBean private AdminUserFacade adminUserFacade;
 
   @MockBean private SessionDeleteService sessionDeleteService;
+
+  @MockBean private MagicLinkLoginService magicLinkLoginService;
+
+  @MockBean private EventNotificationService eventNotificationService;
 
   @Mock private Logger logger;
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/KeycloakUserDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/KeycloakUserDataProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -46,6 +47,46 @@ class KeycloakUserDataProviderTest {
     // then
     assertKeycloakUserRepresentationAttributesConverted(userRepresentation, userDataResponseDTO);
     assertRolesTakenFromAuthenticatedUserBean(userDataResponseDTO);
+    assertOtherDtoAttributesSetToDefaults(userDataResponseDTO);
+  }
+
+  @Test
+  void retrieveData_Should_ReturnTokenBasedUserData_When_KeycloakUserLookupThrows() {
+    // given
+    Mockito.when(authenticatedUser.isAnonymous()).thenReturn(false);
+    Mockito.when(authenticatedUser.getUserId()).thenReturn("userId");
+    Mockito.when(authenticatedUser.getUsername()).thenReturn("username");
+    Mockito.when(authenticatedUser.getRoles()).thenReturn(Set.of("tenant-admin"));
+    Mockito.when(authenticatedUser.getGrantedAuthorities()).thenReturn(Set.of("tenant-admin"));
+    Mockito.when(keycloakService.getById("userId")).thenThrow(new RuntimeException("not found"));
+
+    // when
+    UserDataResponseDTO userDataResponseDTO =
+        keycloakUserDataProvider.retrieveAuthenticatedUserData();
+
+    // then
+    assertThat(userDataResponseDTO.getUserId()).isEqualTo("userId");
+    assertThat(userDataResponseDTO.getUserName()).isEqualTo("username");
+    assertThat(userDataResponseDTO.getUserRoles()).containsExactly("tenant-admin");
+    assertThat(userDataResponseDTO.getGrantedAuthorities()).containsExactly("tenant-admin");
+    assertOtherDtoAttributesSetToDefaults(userDataResponseDTO);
+  }
+
+  @Test
+  void retrieveData_Should_ReturnTokenBasedUserData_When_KeycloakUserLookupReturnsNull() {
+    // given
+    Mockito.when(authenticatedUser.isAnonymous()).thenReturn(false);
+    Mockito.when(authenticatedUser.getUserId()).thenReturn("userId");
+    Mockito.when(authenticatedUser.getUsername()).thenReturn("username");
+    Mockito.when(keycloakService.getById("userId")).thenReturn(null);
+
+    // when
+    UserDataResponseDTO userDataResponseDTO =
+        keycloakUserDataProvider.retrieveAuthenticatedUserData();
+
+    // then
+    assertThat(userDataResponseDTO.getUserId()).isEqualTo("userId");
+    assertThat(userDataResponseDTO.getUserName()).isEqualTo("username");
     assertOtherDtoAttributesSetToDefaults(userDataResponseDTO);
   }
 


### PR DESCRIPTION
This commit makes the user-data and tenant-admin-list endpoints resilient to Keycloak/tenant-service failures, and fixes a 403 bug where USER_ADMIN roles couldn't search tenant admins.