### PR TITLE
MT-04-08 support multiple tenant admins

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -933,9 +933,9 @@ paths:
             description: field to sort by
             schema:
               type: string
-              enum: [ FIRSTNAME, LASTNAME, EMAIL, TENANT_ID ]
+              enum: [ FIRSTNAME, LASTNAME, EMAIL, TENANT_ID, UPDATE_DATE ]
               default: FIRSTNAME
-              pattern: '^(FIRSTNAME|LASTNAME|EMAIL|TENANT_ID)$'
+              pattern: '^(FIRSTNAME|LASTNAME|EMAIL|TENANT_ID|UPDATE_DATE)$'
           - name: order
             in: query
             description: sort order

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/DtoMapperUtils.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/DtoMapperUtils.java
@@ -66,6 +66,8 @@ public interface DtoMapperUtils {
         return "email";
       case "TENANT_ID":
         return "tenantId";
+      case "UPDATE_DATE":
+        return "updateDate";
       default:
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -14,18 +14,23 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TenantAdminUserService {
 
   private final @NonNull RetrieveAdminService retrieveAdminService;
@@ -93,17 +98,35 @@ public class TenantAdminUserService {
     var adminIds = adminsPage.stream().map(AdminBase::getId).collect(Collectors.toSet());
     var fullAdmins = retrieveAdminService.findAllById(adminIds);
 
-    var tenantIdsToNameMap =
-        fullAdmins.stream()
-            .filter(consultant -> consultant.getTenantId() != null)
-            .collect(
-                Collectors.toMap(
-                    Admin::getTenantId,
-                    admin -> tenantService.getRestrictedTenantData(admin.getTenantId()).getName(),
-                    (existing, replacement) -> existing));
+    var tenantIdsToNameMap = tenantIdsToNameMap(fullAdmins);
 
     return userServiceMapper.mapOfAdmin(
         adminsPage, fullAdmins, Lists.newArrayList(), Lists.newArrayList(), tenantIdsToNameMap);
+  }
+
+  private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {
+    return fullAdmins.stream()
+        .filter(admin -> admin.getTenantId() != null)
+        .map(admin -> new AbstractMap.SimpleEntry<>(admin.getTenantId(), tenantName(admin)))
+        .filter(entry -> entry.getValue() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing));
+  }
+
+  private String tenantName(Admin admin) {
+    try {
+      return tenantService.getRestrictedTenantData(admin.getTenantId()).getName();
+    } catch (HttpClientErrorException exception) {
+      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
+        log.warn(
+            "Tenant data not found for tenant admin {} and tenantId {}",
+            admin.getId(),
+            admin.getTenantId());
+        return null;
+      }
+      throw exception;
+    }
   }
 
   public List<AdminResponseDTO> findTenantAdmins(Long tenantId) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
@@ -78,18 +78,10 @@ public class CreateAdminService {
 
   private ArrayList<UserRole> getUserRolesForTenantAdmin() {
     if (multitenancyWithSingleDomain) {
-      return Lists.newArrayList(
-          UserRole.USER_ADMIN,
-          UserRole.AGENCY_ADMIN,
-          UserRole.SINGLE_TENANT_ADMIN,
-          UserRole.TENANT_ADMIN);
+      return Lists.newArrayList(UserRole.USER_ADMIN, UserRole.AGENCY_ADMIN, UserRole.TENANT_ADMIN);
     } else {
       return Lists.newArrayList(
-          UserRole.USER_ADMIN,
-          UserRole.AGENCY_ADMIN,
-          UserRole.SINGLE_TENANT_ADMIN,
-          UserRole.TENANT_ADMIN,
-          UserRole.TOPIC_ADMIN);
+          UserRole.USER_ADMIN, UserRole.AGENCY_ADMIN, UserRole.TENANT_ADMIN, UserRole.TOPIC_ADMIN);
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -655,6 +655,29 @@ class UserAdminControllerE2EIT {
   }
 
   @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void searchTenantAdmin_Should_returnOk_When_sortingByUpdateDate() throws Exception {
+
+    when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
+        .thenReturn(new RestrictedTenantDTO().subdomain("subdomain").name("name"));
+
+    MvcResult mvcResult =
+        this.mockMvc
+            .perform(
+                get(
+                    "/useradmin/tenantadmins/search?query=*&page=1&perPage=10&order=DESC&field=UPDATE_DATE"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("_embedded", hasSize(PAGE_SIZE)))
+            .andExpect(jsonPath("_embedded[0]._embedded.updateDate").exists())
+            .andReturn();
+
+    String contentAsString = mvcResult.getResponse().getContentAsString();
+    JSONArray embedded = JsonPath.read(contentAsString, "_embedded");
+
+    assertAllElementsAreOfAdminType(embedded, AdminType.TENANT);
+  }
+
+  @Test
   @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
   void searchAgencyAdmins_Should_returnOk_When_attemptedToSearchTenantsWithUserAdminAuthority()
       throws Exception {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/DtoMapperUtilsTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/DtoMapperUtilsTest.java
@@ -1,0 +1,13 @@
+package de.caritas.cob.userservice.api.adapters.web.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DtoMapperUtilsTest implements DtoMapperUtils {
+
+  @Test
+  void mappedFieldOf_Should_MapUpdateDate() {
+    assertThat(mappedFieldOf("UPDATE_DATE")).isEqualTo("updateDate");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -16,13 +16,24 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,5 +81,108 @@ class TenantAdminUserServiceTest {
     Mockito.verify(tenantService).getRestrictedTenantData(1L);
 
     assertThat(adminResponseDTO.getEmbedded().getTenantSubdomain()).isEqualTo("subdomain");
+  }
+
+  @Test
+  void findTenantAdmins_Should_ReturnAllAdminsForSameTenant() {
+    // given
+    Long tenantId = 42L;
+    Admin firstTenantAdmin = new Admin();
+    firstTenantAdmin.setId("tenant-admin-1");
+    firstTenantAdmin.setType(Admin.AdminType.TENANT);
+    firstTenantAdmin.setTenantId(tenantId);
+    Admin secondTenantAdmin = new Admin();
+    secondTenantAdmin.setId("tenant-admin-2");
+    secondTenantAdmin.setType(Admin.AdminType.TENANT);
+    secondTenantAdmin.setTenantId(tenantId);
+    when(retrieveAdminService.findTenantAdminsByTenantId(tenantId))
+        .thenReturn(Arrays.asList(firstTenantAdmin, secondTenantAdmin));
+
+    // when
+    List<AdminResponseDTO> tenantAdmins = tenantAdminUserService.findTenantAdmins(tenantId);
+
+    // then
+    assertThat(tenantAdmins).hasSize(2);
+    assertThat(tenantAdmins)
+        .extracting(admin -> admin.getEmbedded().getId())
+        .containsExactly("tenant-admin-1", "tenant-admin-2");
+    assertThat(tenantAdmins)
+        .extracting(admin -> admin.getEmbedded().getTenantId())
+        .containsExactly("42", "42");
+  }
+
+  @Test
+  void findTenantAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {
+    // given
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Admin.AdminBase firstAdminBase = adminBase("tenant-admin-1", 1L);
+    Admin.AdminBase secondAdminBase = adminBase("tenant-admin-2", 2L);
+    Page<Admin.AdminBase> adminsPage =
+        new PageImpl<>(Arrays.asList(firstAdminBase, secondAdminBase), pageRequest, 2);
+    Admin firstTenantAdmin = tenantAdmin("tenant-admin-1", 1L);
+    Admin secondTenantAdmin = tenantAdmin("tenant-admin-2", 2L);
+    List<Admin> fullAdmins = Arrays.asList(firstTenantAdmin, secondTenantAdmin);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
+        .thenReturn(adminsPage);
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
+    when(tenantService.getRestrictedTenantData(1L))
+        .thenReturn(new RestrictedTenantDTO().name("Known tenant"));
+    when(tenantService.getRestrictedTenantData(2L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(), Mockito.anyList(), Mockito.anyList(), Mockito.anyList(), Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    // when
+    tenantAdminUserService.findTenantAdminsByInfix("*", pageRequest);
+
+    // then
+    ArgumentCaptor<Map<Long, String>> tenantNameMapCaptor = ArgumentCaptor.forClass(Map.class);
+    Mockito.verify(userServiceMapper)
+        .mapOfAdmin(
+            Mockito.eq(adminsPage),
+            Mockito.eq(fullAdmins),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            tenantNameMapCaptor.capture());
+    Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
+    Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
+  }
+
+  private Admin tenantAdmin(String id, Long tenantId) {
+    Admin admin = new Admin();
+    admin.setId(id);
+    admin.setType(Admin.AdminType.TENANT);
+    admin.setTenantId(tenantId);
+    return admin;
+  }
+
+  private Admin.AdminBase adminBase(String id, Long tenantId) {
+    return new Admin.AdminBase() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public String getFirstName() {
+        return "First";
+      }
+
+      @Override
+      public String getLastName() {
+        return "Last";
+      }
+
+      @Override
+      public String getEmail() {
+        return id + "@example.org";
+      }
+
+      @Override
+      public Long getTenantId() {
+        return tenantId;
+      }
+    };
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -202,8 +202,8 @@ class CreateAdminServiceIT {
     Whitebox.setInternalState(createAdminService, "multitenancyWithSingleDomain", true);
     List<UserRole> defaultRoles = this.createAdminService.getDefaultRoles(AdminType.TENANT);
 
-    assertThat(defaultRoles)
-        .containsOnly(UserRole.AGENCY_ADMIN, UserRole.SINGLE_TENANT_ADMIN, USER_ADMIN);
+    assertThat(defaultRoles).containsOnly(UserRole.AGENCY_ADMIN, UserRole.TENANT_ADMIN, USER_ADMIN);
+    assertThat(defaultRoles).doesNotContain(UserRole.SINGLE_TENANT_ADMIN);
   }
 
   @Test
@@ -212,7 +212,8 @@ class CreateAdminServiceIT {
     List<UserRole> defaultRoles = this.createAdminService.getDefaultRoles(AdminType.TENANT);
 
     assertThat(defaultRoles)
-        .containsOnly(UserRole.AGENCY_ADMIN, UserRole.SINGLE_TENANT_ADMIN, USER_ADMIN, TOPIC_ADMIN);
+        .containsOnly(UserRole.AGENCY_ADMIN, UserRole.TENANT_ADMIN, USER_ADMIN, TOPIC_ADMIN);
+    assertThat(defaultRoles).doesNotContain(UserRole.SINGLE_TENANT_ADMIN);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
@@ -1,0 +1,59 @@
+package de.caritas.cob.userservice.api.admin.service.admin.create;
+
+import static de.caritas.cob.userservice.api.config.auth.UserRole.AGENCY_ADMIN;
+import static de.caritas.cob.userservice.api.config.auth.UserRole.SINGLE_TENANT_ADMIN;
+import static de.caritas.cob.userservice.api.config.auth.UserRole.TENANT_ADMIN;
+import static de.caritas.cob.userservice.api.config.auth.UserRole.TOPIC_ADMIN;
+import static de.caritas.cob.userservice.api.config.auth.UserRole.USER_ADMIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CreateAdminServiceTest {
+
+  @InjectMocks private CreateAdminService createAdminService;
+
+  @Mock private IdentityClient identityClient;
+
+  @Mock private UserAccountInputValidator userAccountInputValidator;
+
+  @Mock private UserHelper userHelper;
+
+  @Mock private AdminRepository adminRepository;
+
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @Test
+  void getDefaultRoles_Should_NotAssignLegacySingleTenantAdmin_ForSingleDomainTenantAdmin() {
+    ReflectionTestUtils.setField(createAdminService, "multitenancyWithSingleDomain", true);
+
+    List<UserRole> defaultRoles = createAdminService.getDefaultRoles(Admin.AdminType.TENANT);
+
+    assertThat(defaultRoles).containsOnly(USER_ADMIN, AGENCY_ADMIN, TENANT_ADMIN);
+    assertThat(defaultRoles).doesNotContain(SINGLE_TENANT_ADMIN);
+  }
+
+  @Test
+  void getDefaultRoles_Should_NotAssignLegacySingleTenantAdmin_ForMultidomainTenantAdmin() {
+    ReflectionTestUtils.setField(createAdminService, "multitenancyWithSingleDomain", false);
+
+    List<UserRole> defaultRoles = createAdminService.getDefaultRoles(Admin.AdminType.TENANT);
+
+    assertThat(defaultRoles).containsOnly(USER_ADMIN, AGENCY_ADMIN, TENANT_ADMIN, TOPIC_ADMIN);
+    assertThat(defaultRoles).doesNotContain(SINGLE_TENANT_ADMIN);
+  }
+}


### PR DESCRIPTION
Implements MT-04-08 backend changes for multiple Tenant-Admins per Tenant-Unit.

Changes:

Add UPDATE_DATE sort support for Tenant-Admin search.
Stop assigning legacy single-tenant-admin role to newly created Tenant-Admins.
Allow Tenant-Admin search/list to continue when old dev data references a missing tenant.
Add targeted backend tests.
Verified locally:

Created multiple Tenant-Admins with the same tenant_id.
Deleted one Tenant-Admin and confirmed the other remained.
Verified UPDATE_DATE sorting via backend/API for ASC and DESC.
Open:

Last Tenant-Admin removal rule still needs product clarification.