### PR TITLE
Fix admin search with missing tenant data

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
@@ -19,12 +19,16 @@ import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminDtoMapper implements DtoMapperUtils {
 
   private final @NonNull TenantService tenantService;
@@ -155,8 +159,16 @@ public class AdminDtoMapper implements DtoMapperUtils {
   }
 
   private void enrichWithTenantSubdomainAndName(AdminDTO adminDTO, Long tenantId) {
-    RestrictedTenantDTO restrictedTenantData = tenantService.getRestrictedTenantData(tenantId);
-    adminDTO.setTenantSubdomain(restrictedTenantData.getSubdomain());
-    adminDTO.setTenantName(restrictedTenantData.getName());
+    try {
+      RestrictedTenantDTO restrictedTenantData = tenantService.getRestrictedTenantData(tenantId);
+      adminDTO.setTenantSubdomain(restrictedTenantData.getSubdomain());
+      adminDTO.setTenantName(restrictedTenantData.getName());
+    } catch (HttpClientErrorException exception) {
+      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
+        log.warn("Tenant data not found while mapping admin response for tenantId {}", tenantId);
+        return;
+      }
+      throw exception;
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -14,17 +14,22 @@ import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AgencyAdminUserService {
 
   private final @NonNull RetrieveAdminService retrieveAdminService;
@@ -65,14 +70,7 @@ public class AgencyAdminUserService {
     var adminIds = adminsPage.stream().map(AdminBase::getId).collect(Collectors.toSet());
     var fullAdmins = retrieveAdminService.findAllById(adminIds);
 
-    var tenantIdsToNameMap =
-        adminsPage.stream()
-            .filter(admin -> admin.getTenantId() != null)
-            .collect(
-                Collectors.toMap(
-                    AdminBase::getTenantId,
-                    admin -> tenantService.getRestrictedTenantData(admin.getTenantId()).getName(),
-                    (existing, replacement) -> existing));
+    var tenantIdsToNameMap = tenantIdsToNameMap(fullAdmins);
 
     var agenciesOfAdmin = retrieveAdminService.agenciesOfAdmin(adminIds);
     var agencyIds =
@@ -91,5 +89,30 @@ public class AgencyAdminUserService {
 
     final Admin updatedAdmin = updateAdminService.patchAgencyAdmin(adminId, patchAdminDTO);
     return AdminResponseDTOBuilder.getInstance(updatedAdmin).buildAgencyAdminResponseDTO();
+  }
+
+  private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {
+    return fullAdmins.stream()
+        .filter(admin -> admin.getTenantId() != null)
+        .map(admin -> new AbstractMap.SimpleEntry<>(admin.getTenantId(), tenantName(admin)))
+        .filter(entry -> entry.getValue() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing));
+  }
+
+  private String tenantName(Admin admin) {
+    try {
+      return tenantService.getRestrictedTenantData(admin.getTenantId()).getName();
+    } catch (HttpClientErrorException exception) {
+      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
+        log.warn(
+            "Tenant data not found for agency admin {} and tenantId {}",
+            admin.getId(),
+            admin.getTenantId());
+        return null;
+      }
+      throw exception;
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.userservice.api.adapters.web.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDtoMapperTest {
+
+  @Mock private TenantService tenantService;
+
+  @Test
+  void adminSearchResultOf_Should_NotFail_WhenTenantServiceReturnsNotFound() {
+    // given
+    AdminDtoMapper adminDtoMapper = new AdminDtoMapper(tenantService);
+    ReflectionTestUtils.setField(adminDtoMapper, "multiTenancyEnabled", true);
+    when(tenantService.getRestrictedTenantData(2L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+    // when
+    var result = adminDtoMapper.adminSearchResultOf(resultMap(), "*", 1, 10, "FIRSTNAME", "ASC");
+
+    // then
+    assertThat(result.getEmbedded()).hasSize(1);
+    assertThat(result.getEmbedded().get(0).getEmbedded().getTenantId()).isEqualTo("2");
+    assertThat(result.getEmbedded().get(0).getEmbedded().getTenantName()).isNull();
+    assertThat(result.getEmbedded().get(0).getEmbedded().getTenantSubdomain()).isNull();
+  }
+
+  private Map<String, Object> resultMap() {
+    Map<String, Object> adminMap = new HashMap<>();
+    adminMap.put("id", "admin-id");
+    adminMap.put("email", "admin@example.org");
+    adminMap.put("firstName", "First");
+    adminMap.put("lastName", "Last");
+    adminMap.put("username", "admin");
+    adminMap.put("createdAt", "2026-06-08T10:00:00");
+    adminMap.put("updatedAt", "2026-06-08T10:00:00");
+    adminMap.put("tenantId", 2L);
+    adminMap.put("agencies", new ArrayList<Map<String, Object>>());
+
+    Map<String, Object> resultMap = new HashMap<>();
+    resultMap.put("admins", List.of(adminMap));
+    resultMap.put("totalElements", 1);
+    resultMap.put("isFirstPage", true);
+    resultMap.put("isLastPage", true);
+    return resultMap;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -1,0 +1,130 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.UserServiceMapper;
+import de.caritas.cob.userservice.api.admin.service.admin.create.CreateAdminService;
+import de.caritas.cob.userservice.api.admin.service.admin.delete.DeleteAdminService;
+import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
+import de.caritas.cob.userservice.api.admin.service.admin.update.UpdateAdminService;
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminUserServiceTest {
+
+  @InjectMocks private AgencyAdminUserService agencyAdminUserService;
+
+  @Mock private RetrieveAdminService retrieveAdminService;
+
+  @Mock private CreateAdminService createAdminService;
+
+  @Mock private UpdateAdminService updateAdminService;
+
+  @Mock private DeleteAdminService deleteAdminService;
+
+  @Mock private UserServiceMapper userServiceMapper;
+
+  @Mock private AgencyService agencyService;
+
+  @Mock private TenantService tenantService;
+
+  @Test
+  void findAgencyAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {
+    // given
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Admin.AdminBase firstAdminBase = adminBase("agency-admin-1", 1L);
+    Admin.AdminBase secondAdminBase = adminBase("agency-admin-2", 2L);
+    Page<Admin.AdminBase> adminsPage =
+        new PageImpl<>(Arrays.asList(firstAdminBase, secondAdminBase), pageRequest, 2);
+    Admin firstAgencyAdmin = agencyAdmin("agency-admin-1", 1L);
+    Admin secondAgencyAdmin = agencyAdmin("agency-admin-2", 2L);
+    List<Admin> fullAdmins = Arrays.asList(firstAgencyAdmin, secondAgencyAdmin);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.AGENCY, pageRequest))
+        .thenReturn(adminsPage);
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
+    when(retrieveAdminService.agenciesOfAdmin(Mockito.anySet()))
+        .thenReturn(Collections.emptyList());
+    when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+    when(tenantService.getRestrictedTenantData(1L))
+        .thenReturn(new RestrictedTenantDTO().name("Known tenant"));
+    when(tenantService.getRestrictedTenantData(2L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(), Mockito.anyList(), Mockito.anyList(), Mockito.anyList(), Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    // when
+    agencyAdminUserService.findAgencyAdminsByInfix("*", pageRequest);
+
+    // then
+    ArgumentCaptor<Map<Long, String>> tenantNameMapCaptor = ArgumentCaptor.forClass(Map.class);
+    Mockito.verify(userServiceMapper)
+        .mapOfAdmin(
+            Mockito.eq(adminsPage),
+            Mockito.eq(fullAdmins),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            tenantNameMapCaptor.capture());
+    Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
+    Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
+  }
+
+  private Admin agencyAdmin(String id, Long tenantId) {
+    Admin admin = new Admin();
+    admin.setId(id);
+    admin.setType(Admin.AdminType.AGENCY);
+    admin.setTenantId(tenantId);
+    return admin;
+  }
+
+  private Admin.AdminBase adminBase(String id, Long tenantId) {
+    return new Admin.AdminBase() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public String getFirstName() {
+        return "First";
+      }
+
+      @Override
+      public String getLastName() {
+        return "Last";
+      }
+
+      @Override
+      public String getEmail() {
+        return id + "@example.org";
+      }
+
+      @Override
+      public Long getTenantId() {
+        return tenantId;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Implements a fix for admin search/list responses when UserService contains admin records with tenant IDs that no longer exist in TenantService.

Changes:
- Tenant enrichment now tolerates `404 NOT_FOUND` from TenantService instead of failing the whole admin response.
- Applied this for agency-admin search/list and shared admin DTO mapping.
- Added targeted unit tests for missing tenant data scenarios.

Verified locally:
- `TenantAdminUserServiceTest#findTenantAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound`
- `AgencyAdminUserServiceTest#findAgencyAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound`
- `AdminDtoMapperTest#adminSearchResultOf_Should_NotFail_WhenTenantServiceReturnsNotFound`

Note:
I could not fully verify the Admin UI end-to-end locally because my local frontend still hangs after login / route load with `500` requests in the browser, so UI testing is currently blocked on my machine. Screenshot attached.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/402de523-1abf-416e-80f7-633648542760" />
