### PR TITLE
MT-04-13 add user master table fields

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -1368,6 +1368,14 @@ components:
           type: string
         displayName:
           type: string
+        publicName:
+          type: string
+        roleInOrg:
+          type: string
+        vacated:
+          type: boolean
+        adminRights:
+          type: boolean
         topics:
           type: array
           description: topics directly assigned to the consultant, enriched with names
@@ -1491,6 +1499,14 @@ components:
           type: array
           items:
             $ref: './../services/agencyadminservice.yaml#/components/schemas/AgencyAdminResponseDTO'
+        publicName:
+          type: string
+        roleInOrg:
+          type: string
+        vacated:
+          type: boolean
+        adminRights:
+          type: boolean
 
     AskerResponseDTO:
       type: object

--- a/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
@@ -259,6 +259,7 @@ public class UserServiceMapper {
     map.put("isLanguageFormal", nonNull(fullConsultant) && fullConsultant.isLanguageFormal());
     map.put("isTeamConsultant", nonNull(fullConsultant) && fullConsultant.isTeamConsultant());
     map.put("isSupervisor", nonNull(fullConsultant) && fullConsultant.isSupervisor());
+    map.put("displayName", nonNull(fullConsultant) ? fullConsultant.getDisplayName() : null);
     map.put(
         "createdAt",
         nonNull(fullConsultant) && nonNull(fullConsultant.getCreateDate())
@@ -297,6 +298,7 @@ public class UserServiceMapper {
     map.put("firstName", adminBase.getFirstName());
     map.put("lastName", adminBase.getLastName());
     map.put("username", fullAdmin.getUsername());
+    map.put("type", fullAdmin.getType());
     map.put("tenantId", fullAdmin.getTenantId());
     map.put("tenantName", getTenantName(fullAdmin, tenantIdsToNameMap));
     map.put(

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.HalLink;
 import de.caritas.cob.userservice.api.adapters.web.dto.HalLink.MethodEnum;
 import de.caritas.cob.userservice.api.adapters.web.dto.PaginationLinks;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UseradminApi;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import java.util.ArrayList;
@@ -126,6 +127,10 @@ public class AdminDtoMapper implements DtoMapperUtils {
     adminDTO.setUsername((String) adminUserMap.get("username"));
     adminDTO.setCreateDate((String) adminUserMap.get("createdAt"));
     adminDTO.setUpdateDate((String) adminUserMap.get("updatedAt"));
+    adminDTO.setPublicName(null);
+    adminDTO.setRoleInOrg(roleInOrgOf((Admin.AdminType) adminUserMap.get("type")));
+    adminDTO.setVacated(false);
+    adminDTO.setAdminRights(true);
 
     enrichResponseWithTenantInformation(adminUserMap, adminDTO);
 
@@ -169,6 +174,22 @@ public class AdminDtoMapper implements DtoMapperUtils {
         return;
       }
       throw exception;
+    }
+  }
+
+  private String roleInOrgOf(Admin.AdminType adminType) {
+    if (adminType == null) {
+      return null;
+    }
+    switch (adminType) {
+      case SUPER:
+        return "Platform Admin";
+      case TENANT:
+        return "Tenant Admin";
+      case AGENCY:
+        return "Agency Admin";
+      default:
+        return null;
     }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
@@ -165,6 +165,9 @@ public class ConsultantDtoMapper implements DtoMapperUtils {
     consultant.setCreateDate((String) consultantMap.get("createdAt"));
     consultant.setUpdateDate((String) consultantMap.get("updatedAt"));
     consultant.setDeleteDate((String) consultantMap.get("deletedAt"));
+    consultant.setDisplayName((String) consultantMap.get("displayName"));
+    consultant.setPublicName((String) consultantMap.get("displayName"));
+    consultant.setVacated(consultantMap.get("deletedAt") != null);
     Long tenantId = (Long) consultantMap.get("tenantId");
     if (tenantId != null) {
       consultant.setTenantId(tenantId.intValue());
@@ -185,6 +188,9 @@ public class ConsultantDtoMapper implements DtoMapperUtils {
     // Get supervisor permission from database field (from map, not DTO)
     Boolean isSupervisor = (Boolean) consultantMap.get("isSupervisor");
     consultant.setIsSupervisor(isSupervisor != null && isSupervisor);
+    consultant.setAdminRights(isSupervisor != null && isSupervisor);
+    consultant.setRoleInOrg(
+        isSupervisor != null && isSupervisor ? "Counsellor Admin" : "Counsellor");
 
     var agencies = new ArrayList<AgencyAdminResponseDTO>();
     var agencyMaps = (ArrayList<Map<String, Object>>) consultantMap.get("agencies");

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminResponseDTOBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminResponseDTOBuilder.java
@@ -88,6 +88,26 @@ public class AdminResponseDTOBuilder implements HalLinkBuilder {
         .email(admin.getEmail())
         .tenantId(String.valueOf(admin.getTenantId()))
         .createDate(String.valueOf(admin.getCreateDate()))
-        .updateDate(String.valueOf(admin.getUpdateDate()));
+        .updateDate(String.valueOf(admin.getUpdateDate()))
+        .publicName(null)
+        .roleInOrg(roleInOrgOf(admin.getType()))
+        .vacated(false)
+        .adminRights(true);
+  }
+
+  private String roleInOrgOf(Admin.AdminType adminType) {
+    if (adminType == null) {
+      return null;
+    }
+    switch (adminType) {
+      case SUPER:
+        return "Platform Admin";
+      case TENANT:
+        return "Tenant Admin";
+      case AGENCY:
+        return "Agency Admin";
+      default:
+        return null;
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
@@ -145,5 +145,7 @@ public class Admin implements TenantAware {
     String getEmail();
 
     Long getTenantId();
+
+    AdminType getType();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -15,6 +15,7 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
   @Query(
       value =
           "SELECT a.id as id, a.firstName as firstName, a.lastName as lastName, a.email as email, a.tenantId as tenantId "
+              + ", a.type as type "
               + "FROM Admin a "
               + "WHERE"
               + "  type = ?2 "

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.model.Admin;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,10 @@ class AdminDtoMapperTest {
     assertThat(result.getEmbedded().get(0).getEmbedded().getTenantId()).isEqualTo("2");
     assertThat(result.getEmbedded().get(0).getEmbedded().getTenantName()).isNull();
     assertThat(result.getEmbedded().get(0).getEmbedded().getTenantSubdomain()).isNull();
+    assertThat(result.getEmbedded().get(0).getEmbedded().getPublicName()).isNull();
+    assertThat(result.getEmbedded().get(0).getEmbedded().getRoleInOrg()).isEqualTo("Tenant Admin");
+    assertThat(result.getEmbedded().get(0).getEmbedded().getVacated()).isFalse();
+    assertThat(result.getEmbedded().get(0).getEmbedded().getAdminRights()).isTrue();
   }
 
   private Map<String, Object> resultMap() {
@@ -49,6 +54,7 @@ class AdminDtoMapperTest {
     adminMap.put("createdAt", "2026-06-08T10:00:00");
     adminMap.put("updatedAt", "2026-06-08T10:00:00");
     adminMap.put("tenantId", 2L);
+    adminMap.put("type", Admin.AdminType.TENANT);
     adminMap.put("agencies", new ArrayList<Map<String, Object>>());
 
     Map<String, Object> resultMap = new HashMap<>();

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -1,0 +1,63 @@
+package de.caritas.cob.userservice.api.adapters.web.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ConsultantDtoMapperTest {
+
+  @Mock private IdentityClient identityClient;
+
+  @Test
+  void consultantDtoOf_Should_MapMasterTableFields() {
+    // given
+    ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
+    when(identityClient.userHasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT.getValue()))
+        .thenReturn(false);
+
+    // when
+    var consultant = consultantDtoMapper.consultantDtoOf(consultantMap());
+
+    // then
+    assertThat(consultant.getDisplayName()).isEqualTo("Public Name");
+    assertThat(consultant.getPublicName()).isEqualTo("Public Name");
+    assertThat(consultant.getVacated()).isTrue();
+    assertThat(consultant.getAdminRights()).isTrue();
+    assertThat(consultant.getRoleInOrg()).isEqualTo("Counsellor Admin");
+  }
+
+  private Map<String, Object> consultantMap() {
+    Map<String, Object> consultantMap = new HashMap<>();
+    consultantMap.put("id", "consultant-id");
+    consultantMap.put("email", "consultant@example.org");
+    consultantMap.put("firstName", "First");
+    consultantMap.put("lastName", "Last");
+    consultantMap.put("username", "consultant");
+    consultantMap.put("status", "ACTIVE");
+    consultantMap.put("absenceMessage", "absence");
+    consultantMap.put("isAbsent", false);
+    consultantMap.put("isLanguageFormal", true);
+    consultantMap.put("isTeamConsultant", false);
+    consultantMap.put("isSupervisor", true);
+    consultantMap.put("createdAt", "2026-06-08T10:00:00");
+    consultantMap.put("updatedAt", "2026-06-08T10:00:00");
+    consultantMap.put("deletedAt", "2026-06-09T10:00:00");
+    consultantMap.put("displayName", "Public Name");
+    consultantMap.put("tenantId", 1L);
+    consultantMap.put("tenantName", "Tenant");
+    consultantMap.put("agencies", new ArrayList<Map<String, Object>>());
+    return consultantMap;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -125,6 +125,11 @@ class AgencyAdminUserServiceTest {
       public Long getTenantId() {
         return tenantId;
       }
+
+      @Override
+      public Admin.AdminType getType() {
+        return Admin.AdminType.AGENCY;
+      }
     };
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -221,6 +221,11 @@ class TenantAdminUserServiceTest {
       public Long getTenantId() {
         return tenantId;
       }
+
+      @Override
+      public Admin.AdminType getType() {
+        return Admin.AdminType.TENANT;
+      }
     };
   }
 }


### PR DESCRIPTION
Implements backend support for MT-04-13 user master table fields.

Changes:
- Added new master-table fields to UserService API DTOs:
  - publicName
  - roleInOrg
  - vacated
  - adminRights
- Added field mapping for:
  - Tenant Admins
  - Agency Admins
  - Counsellors / Counsellor Admins
- Added targeted mapper/service tests for the new fields.

Verified locally:
- Tenant Admin search returns the new fields.
- Agency Admin search returns the new fields.
- Consultant search returns the new fields.
- `roleInOrg` is mapped as Tenant Admin / Agency Admin / Counsellor / Counsellor Admin.
- `adminRights` is mapped for admins and supervisor counsellors.
- `vacated` is mapped from deletion state.

Tests:
- `AdminDtoMapperTest`
- `ConsultantDtoMapperTest`
- `AgencyAdminUserServiceTest`
- `TenantAdminUserServiceTest`
- `mvn spotless:check`

Open:
- `Last Logged in` is not included yet because the source is still unclear and should be confirmed separately.