### PR TITLE
Fix user list update date sorting

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -598,9 +598,9 @@ paths:
           description: field to sort by
           schema:
             type: string
-            enum: [ FIRSTNAME, LASTNAME, EMAIL ]
+            enum: [ FIRSTNAME, LASTNAME, EMAIL, UPDATE_DATE ]
             default: FIRSTNAME
-            pattern: '^(FIRSTNAME|LASTNAME|EMAIL)$'
+            pattern: '^(FIRSTNAME|LASTNAME|EMAIL|UPDATE_DATE)$'
         - name: order
           in: query
           description: sort order

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -1044,9 +1044,9 @@ paths:
           description: field to sort by
           schema:
             type: string
-            enum: [ FIRSTNAME, LASTNAME, EMAIL ]
+            enum: [ FIRSTNAME, LASTNAME, EMAIL, UPDATE_DATE ]
             default: FIRSTNAME
-            pattern: '^(FIRSTNAME|LASTNAME|EMAIL)$'
+            pattern: '^(FIRSTNAME|LASTNAME|EMAIL|UPDATE_DATE)$'
         - name: order
           in: query
           description: sort order

--- a/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
@@ -145,5 +145,7 @@ public class Admin implements TenantAware {
     String getEmail();
 
     Long getTenantId();
+
+    LocalDateTime getUpdateDate();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
@@ -374,5 +374,7 @@ public class Consultant implements TenantAware, NotificationsAware {
     String getLastName();
 
     String getEmail();
+
+    LocalDateTime getUpdateDate();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -14,7 +14,8 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
 
   @Query(
       value =
-          "SELECT a.id as id, a.firstName as firstName, a.lastName as lastName, a.email as email, a.tenantId as tenantId "
+          "SELECT a.id as id, a.firstName as firstName, a.lastName as lastName, a.email as email, "
+              + "a.tenantId as tenantId, a.updateDate as updateDate "
               + "FROM Admin a "
               + "WHERE"
               + "  type = ?2 "

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
@@ -37,7 +37,8 @@ public interface ConsultantRepository
 
   @Query(
       value =
-          "SELECT c.id as id, c.firstName as firstName, c.lastName as lastName, c.email as email "
+          "SELECT c.id as id, c.firstName as firstName, c.lastName as lastName, c.email as email, "
+              + "c.updateDate as updateDate "
               + "FROM Consultant c "
               + "WHERE "
               + "  (?2 IS NULL OR ?2 = 0 OR c.tenantId = ?2) "
@@ -55,7 +56,8 @@ public interface ConsultantRepository
 
   @Query(
       value =
-          "SELECT distinct c.id as id, c.firstName as firstName, c.lastName as lastName, c.email as email "
+          "SELECT distinct c.id as id, c.firstName as firstName, c.lastName as lastName, "
+              + "c.email as email, c.updateDate as updateDate "
               + "FROM Consultant c "
               + "INNER JOIN ConsultantAgency ca ON c.id = ca.consultant.id "
               + "WHERE "

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -700,6 +700,28 @@ class UserAdminControllerE2EIT {
     assertAllElementsAreOfAdminType(embedded, AdminType.AGENCY);
   }
 
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void searchAgencyAdmins_Should_returnOk_When_sortingByUpdateDate() throws Exception {
+    when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
+        .thenReturn(new RestrictedTenantDTO().subdomain("subdomain").name("name"));
+
+    MvcResult mvcResult =
+        this.mockMvc
+            .perform(
+                get(
+                    "/useradmin/agencyadmins/search?query=*&page=1&perPage=10&order=DESC&field=UPDATE_DATE"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("_embedded", hasSize(PAGE_SIZE)))
+            .andExpect(jsonPath("_embedded[0]._embedded.updateDate").exists())
+            .andReturn();
+
+    String contentAsString = mvcResult.getResponse().getContentAsString();
+    JSONArray embedded = JsonPath.read(contentAsString, "_embedded");
+
+    assertAllElementsAreOfAdminType(embedded, AdminType.AGENCY);
+  }
+
   private void assertAllElementsAreOfAdminType(JSONArray embedded, AdminType adminType) {
     for (int i = 0; i < PAGE_SIZE; i++) {
       assertAllElementsAreOfAdminType(embedded, PAGE_SIZE, adminType);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
@@ -615,6 +615,35 @@ class UserControllerConsultantE2EIT {
   }
 
   @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN, AuthorityValue.RESTRICTED_AGENCY_ADMIN})
+  void searchConsultantsShouldRespondOkWhenRestrictedAdminSortsByUpdateDate() throws Exception {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("d42c2e5e-143c-4db1-a90f-7cccf82fbb15");
+    long agencyIdToSearchFor = 2L;
+    when(adminUserFacade.findAdminUserAgencyIds(authenticatedUser.getUserId()))
+        .thenReturn(Lists.newArrayList(agencyIdToSearchFor));
+    givenAnInfix();
+    var numMatching = 12;
+    givenConsultantsMatching(numMatching, infix, Lists.newArrayList(agencyIdToSearchFor));
+
+    mockMvc
+        .perform(
+            get("/users/consultants/search")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .accept("application/hal+json")
+                .param("query", URLEncoder.encode(infix, StandardCharsets.UTF_8))
+                .param("page", "1")
+                .param("perPage", "10")
+                .param("field", "UPDATE_DATE")
+                .param("order", "DESC"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("total", is(numMatching)))
+        .andExpect(jsonPath("_embedded", hasSize(10)))
+        .andExpect(jsonPath("_embedded[0]._embedded.updateDate", notNullValue()));
+  }
+
+  @Test
   @WithMockUser(authorities = AuthorityValue.USER_ADMIN)
   void searchConsultantsShouldRespondOkAndPayloadIfStarQueryIsGiven() throws Exception {
     givenAnInfix();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,6 +125,11 @@ class AgencyAdminUserServiceTest {
       @Override
       public Long getTenantId() {
         return tenantId;
+      }
+
+      @Override
+      public LocalDateTime getUpdateDate() {
+        return LocalDateTime.now();
       }
     };
   }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -220,6 +221,11 @@ class TenantAdminUserServiceTest {
       @Override
       public Long getTenantId() {
         return tenantId;
+      }
+
+      @Override
+      public LocalDateTime getUpdateDate() {
+        return LocalDateTime.now();
       }
     };
   }


### PR DESCRIPTION
## Summary
- Allow UPDATE_DATE as a valid sort field for counsellor and agency admin search endpoints.
- Include updateDate in Consultant/Admin search projections so sorting by last updated works.
- Add regression coverage for UPDATE_DATE sorting on counsellor and agency admin lists.

## Testing
- mvn -DskipTests -Dspotless.check.skip=true compile
- mvn -Dtest=AgencyAdminUserServiceTest,TenantAdminUserServiceTest -Dspotless.check.skip=true test
- Manually verified in Admin Panel that Counsellors and Counsellor Admin sorting by Last updated returns 200 OK.