### PR TITLE
fix: tolerate deleted agencies in consultant search

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -24,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,6 +36,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Service
@@ -122,7 +125,7 @@ public class AccountManager implements AccountManaging {
 
     var consultingAgencies = consultantAgencyRepository.findByConsultantIdIn(consultantIds);
     var agencyIds = userServiceMapper.agencyIdsOf(consultingAgencies);
-    var agencies = agencyService.getAgenciesWithoutCaching(agencyIds);
+    var agencies = fetchAgenciesTolerantly(agencyIds);
 
     var tenantIdsToNameMap =
         fullConsultants.stream()
@@ -222,6 +225,23 @@ public class AccountManager implements AccountManaging {
     return () -> {
       throw new InternalServerErrorException(message);
     };
+  }
+
+  /**
+   * Agencies are resolved via the AgencyService, which responds with 404 when none of the requested
+   * ids exist anymore (e.g. consultants whose agencies were deleted). A consultant listing must not
+   * fail entirely because of such orphaned relations.
+   */
+  private List<AgencyDTO> fetchAgenciesTolerantly(List<Long> agencyIds) {
+    try {
+      return agencyService.getAgenciesWithoutCaching(agencyIds);
+    } catch (RestClientException e) {
+      log.warn(
+          "Could not fetch agencies {} for consultant search; continuing without agency data",
+          agencyIds,
+          e);
+      return List.of();
+    }
   }
 
   private Long resolveEffectiveTenantId() {

--- a/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
@@ -123,7 +123,8 @@ public class AccountManager implements AccountManaging {
         consultantPage.stream().map(ConsultantBase::getId).collect(Collectors.toList());
     var fullConsultants = consultantRepository.findAllByIdIn(consultantIds);
 
-    var consultingAgencies = consultantAgencyRepository.findByConsultantIdIn(consultantIds);
+    var consultingAgencies =
+        consultantAgencyRepository.findByConsultantIdInAndDeleteDateIsNull(consultantIds);
     var agencyIds = userServiceMapper.agencyIdsOf(consultingAgencies);
     var agencies = fetchAgenciesTolerantly(agencyIds);
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
@@ -77,7 +77,8 @@ public class ConsultantAgencyAdminService {
   public void appendAgenciesForConsultants(Set<ConsultantDTO> consultants) {
     var consultantIds = consultants.stream().map(ConsultantDTO::getId).collect(Collectors.toSet());
 
-    var consultantAgencies = consultantAgencyRepository.findByConsultantIdIn(consultantIds);
+    var consultantAgencies =
+        consultantAgencyRepository.findByConsultantIdInAndDeleteDateIsNull(consultantIds);
 
     var agencyIds =
         consultantAgencies.stream().map(ConsultantAgency::getAgencyId).collect(Collectors.toSet());

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantAgencyRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantAgencyRepository.java
@@ -32,8 +32,8 @@ public interface ConsultantAgencyRepository extends CrudRepository<ConsultantAge
 
   List<ConsultantAgency> findByAgencyIdInAndDeleteDateIsNull(Collection<Long> agencyIds);
 
-  List<ConsultantAgency> findByConsultantIdIn(Set<String> consultantIds);
+  List<ConsultantAgency> findByConsultantIdInAndDeleteDateIsNull(Set<String> consultantIds);
 
   @SuppressWarnings("all")
-  List<ConsultantAgencyBase> findByConsultantIdIn(List<String> consultantIds);
+  List<ConsultantAgencyBase> findByConsultantIdInAndDeleteDateIsNull(List<String> consultantIds);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/AccountManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/AccountManagerTest.java
@@ -1,11 +1,14 @@
 package de.caritas.cob.userservice.api;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +17,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
 class AccountManagerTest {
@@ -47,6 +52,51 @@ class AccountManagerTest {
     // then
     Mockito.verify(consultantRepository)
         .findAllByInfix(Mockito.eq("infix"), Mockito.isNull(), Mockito.any(PageRequest.class));
+  }
+
+  @Test
+  void findConsultantsByInfix_Should_NotFail_When_AgencyServiceRespondsWithClientError() {
+    // given: consultants whose agencies were all deleted make the AgencyService
+    // bulk lookup respond with 404, raised by the generated client as a client error
+    Mockito.when(
+            consultantRepository.findAllByInfix(
+                Mockito.eq("infix"), Mockito.isNull(), Mockito.any(PageRequest.class)))
+        .thenReturn(page);
+    Mockito.when(agencyService.getAgenciesWithoutCaching(Mockito.anyList()))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    // when
+    assertDoesNotThrow(
+        () ->
+            accountManager.findConsultantsByInfix(
+                "infix", false, Lists.newArrayList(), 1, 10, "email", true));
+
+    // then: the listing is still mapped, just without agency data
+    Mockito.verify(userServiceMapper)
+        .mapOf(
+            Mockito.eq(page),
+            Mockito.anyList(),
+            Mockito.eq(List.of()),
+            Mockito.anyList(),
+            Mockito.anyMap());
+  }
+
+  @Test
+  void findConsultantsByInfix_Should_OnlyResolveAgenciesOfNotDeletedRelations() {
+    // given
+    Mockito.when(
+            consultantRepository.findAllByInfix(
+                Mockito.eq("infix"), Mockito.isNull(), Mockito.any(PageRequest.class)))
+        .thenReturn(page);
+
+    // when
+    accountManager.findConsultantsByInfix(
+        "infix", false, Lists.newArrayList(), 1, 10, "email", true);
+
+    // then: soft-deleted consultant-agency relations must not be resolved at all
+    Mockito.verify(consultantAgencyRepository)
+        .findByConsultantIdInAndDeleteDateIsNull(Mockito.<List<String>>any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

`GET /users/consultants/search` returned **500** for every page containing a consultant whose agencies were all deleted, which made the admin "Counsellors" list show no data at all (on dev there are currently two such consultants: `bertabusch1` and `frank0806beratungpupslingen`, both tenant 27).

Root cause chain:
- `findByConsultantIdIn` were the **only** `ConsultantAgencyRepository` queries without the `DeleteDateIsNull` filter, so listings also resolved agency ids of soft-deleted relations
- UserService resolves those agencies per result page via AgencyService `getAgenciesByIds`
- AgencyService responds **404 when none of the requested ids exist** (`AgencyController.getAgenciesByIds`)
- The generated client throws, `AccountManager.findConsultantsByInfix` didn't catch it → 500 for the whole page

Two complementary fixes:
1. **Correctness**: add `DeleteDateIsNull` to the two listing queries (consultant search + admin agency enrichment), so soft-deleted relations are never resolved
2. **Resilience**: catch `RestClientException` in `AccountManager.findConsultantsByInfix` and render affected consultants without agency data instead of failing the entire listing (covers hard-orphaned relations, e.g. from tenant deletion)

Follow-ups worth discussing:
- AgencyService could return `200 []` instead of 404 for bulk get-by-ids
- Agency/tenant deletion should consistently soft-delete `consultant_agency` relations

## Test plan

- `./mvnw compile` passes (spotless applied)
- Root cause verified against dev: `query=*` pages containing the two consultants 500, pages without them 200; their `/useradmin/consultants/{id}/agencies` also 500s, while `/useradmin/consultants/{id}` (no agency resolution) returns 200

## Deploy note

The cluster runs `pullPolicy: Never` (local k3s images), so merging alone does not deploy — the image has to be imported on the host and the pod restarted before the dev admin shows consultants again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)