### PR TITLE
fix: roll back Keycloak user when admin creation fails

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
@@ -9,7 +9,6 @@ import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
-import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
@@ -93,13 +92,14 @@ public class CreateAdminService {
             : userHelper.getRandomPassword();
     try {
       identityClient.updatePassword(keycloakUserId, password);
-    } catch (CustomValidationHttpStatusException e) {
+      getDefaultRoles(adminType).forEach(role -> identityClient.updateRole(keycloakUserId, role));
+      return adminRepository.save(buildAdmin(createAdminDTO, adminType, keycloakUserId));
+    } catch (Exception e) {
+      // ohne Rollback bleibt ein verwaister Keycloak-User zurück und jeder
+      // weitere Versuch mit gleichem Benutzernamen/E-Mail endet im 409 Conflict
       identityClient.rollBackUser(keycloakUserId);
       throw e;
     }
-    getDefaultRoles(adminType).stream()
-        .forEach(role -> identityClient.updateRole(keycloakUserId, role));
-    return adminRepository.save(buildAdmin(createAdminDTO, adminType, keycloakUserId));
   }
 
   private String createKeycloakUser(final CreateAdminDTO createAgencyAdminDTO) {


### PR DESCRIPTION
## Problem

When creating an agency administrator (`POST /useradmin/agencyadmins`), the Keycloak user is created first, followed by the password, roles, and the database entry. If any of the subsequent steps fail (e.g., because the `restricted-agency-admin` realm role is missing in Keycloak, resulting in a 500 error), an **orphaned Keycloak user** remains. Any further attempt using the same username or email address then results in a **409 Conflict** error.

This exact pattern (initial 500 error followed by persistent 409 errors) occurred today on api.oriso.org.

## Fix

Wrap the password update, role assignment, and `adminRepository.save` call in a shared try/catch block and invoke `identityClient.rollBackUser(...)` upon any failure (previously, this was only done during the password step).

## Operational Note

The root cause is the missing `restricted-agency-admin` role in the `online-beratung` realm—see the corresponding fix in ORISO-Keycloak (realm.json). Additionally, the role must be created once in the running Keycloak instance.

## Test

- `mvn compile` + Spotless check passed
- `CreateAdminServiceTest`: 2/2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)