### PR TITLE
Add username availability endpoint

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -198,6 +198,14 @@ public class UserController implements UsersApi {
     return ResponseEntity.notFound().build();
   }
 
+  @GetMapping("/users/availability/{username}")
+  public ResponseEntity<Void> usernameAvailability(@PathVariable String username) {
+    val usernameAvailable = identityClient.isUsernameAvailable(username);
+    return usernameAvailable
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.status(HttpStatus.CONFLICT).build();
+  }
+
   @org.springframework.web.bind.annotation.PostMapping("/users/magic-link/request")
   public ResponseEntity<Void> requestMagicLink(@Valid @RequestBody MagicLinkRequestDTO requestDTO) {
     var result = magicLinkLoginService.requestMagicLink(requestDTO.getUsername());

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -279,6 +279,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .permitAll()
         .antMatchers(HttpMethod.POST, "/actuator/loggers/*")
         .permitAll()
+        .mvcMatchers(HttpMethod.GET, "/users/availability/{username}")
+        .permitAll()
         .mvcMatchers(HttpMethod.GET, "/users/{username}")
         .permitAll()
         .anyRequest()

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -368,6 +368,30 @@ class UserControllerIT {
         .andExpect(status().isOk());
   }
 
+  @Test
+  void usernameAvailability_Should_ReturnNoContent_When_UserDoesNotExist() throws Exception {
+    /* given */
+    val username = "john@doe.com";
+    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
+
+    /* when */
+    mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
+        /* then */
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void usernameAvailability_Should_ReturnConflict_When_UserDoesExist() throws Exception {
+    /* given */
+    val username = "john@doe.com";
+    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
+
+    /* when */
+    mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
+        /* then */
+        .andExpect(status().isConflict());
+  }
+
   /** Method: registerUser */
   @Test
   void registerUser_Should_ReturnBadRequest_WhenProvidedWithInvalidRequestBody() throws Exception {


### PR DESCRIPTION
## Problem
Registration step 4 currently checks username availability through `GET /users/{username}`. That endpoint returns 404 for the normal "username is available" case, so the frontend devtools show expected validation as an error and make real registration failures harder to spot.

Related to OpenResilienceInitiative/ORISO-Frontend#145

## Solution
- Add anonymous `GET /users/availability/{username}`.
- Return `204 No Content` when the username is available.
- Return `409 Conflict` when the username already exists.
- Permit the endpoint in security config.
- Cover both response paths in `UserControllerIT`.

## Checks
- Targeted Maven test was attempted for the existing and new `UserControllerIT` username checks.
- The run currently fails before these tests because the repo does not compile cleanly in this checkout; errors are broad generated model/Lombok-style missing symbol failures outside the touched files.

## Deploy note
This should be deployed before or together with the frontend PR that switches registration step 4 to the new endpoint.