### PR TITLE
docs(graph): update Understand-Anything graph

### DIFF
--- a/.understand-anything/ARCHITECTURE.md
+++ b/.understand-anything/ARCHITECTURE.md
@@ -1,101 +1,158 @@
-# ORISO UserService Architecture
-
-## Navigation
-
-- [Purpose](#purpose)
-- [Architecture Layers](#architecture-layers)
-- [Major Modules](#major-modules)
-- [Data Flow](#data-flow)
-- [Authentication Flow](#authentication-flow)
-- [API Structure](#api-structure)
-- [Dependencies](#dependencies)
-- [Deployment And Config](#deployment-and-config)
-- [Top Files](#top-files)
+# Architecture Notes: ORISO-UserService
 
 ## Purpose
 
-ORISO UserService is the user/session lifecycle backend for the Online-Beratung platform. It manages askers, consultants, admins, sessions, conversations, chat setup, notifications, account deletion, inactive-account notifications, and integration with identity and messaging services.
-
-The repository is a Spring Boot service rooted at `src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java`. Maven drives compilation, OpenAPI code generation, tests, profiles, and packaging through `pom.xml`.
+The UserService provides different functionalities from creating and updating user accounts and their sessions, providing session lists up to creating and editing Rocket.Chat groups.
 
 ## Architecture Layers
 
-- API HTTP adapters: `adapters/web/controller/*` implements generated OpenAPI contracts and custom REST endpoints.
-- Security and tenancy: `config/auth/SecurityConfig.java`, `StatelessCsrfFilter.java`, `HttpTenantFilter.java`, and `tenant/*` protect requests and establish tenant context.
-- Facades and use cases: `facade/*`, `conversation/facade/*`, and `admin/facade/*` orchestrate multi-step business flows.
-- Domain services: `service/*`, `admin/service/*`, `conversation/service/*`, and `manager/*` contain reusable business operations.
-- External adapters: `adapters/keycloak/*`, `adapters/rocketchat/*`, `adapters/matrix/*`, `config/apiclient/*`, and `services/*.yaml` connect to ORISO peer services.
-- Persistence and data: `model/*`, `port/out/*Repository.java`, and `src/main/resources/db/changelog/*` own database state and schema evolution.
-- Scheduled workflows: `workflow/delete/*`, `workflow/deactivate/*`, `workflow/enquirynotification/*`, and `workflow/inactiveaccountnotification/*` run background lifecycle jobs.
-- Runtime configuration: `application*.properties`, `Dockerfile`, `deploy-development.sh`, `logback-spring.xml`, and monitoring JSON files define operational behavior.
+### Api And Routing
 
-## Major Modules
+HTTP routes, controllers, API clients, and request boundaries.
 
-- Registration and session lifecycle: `UserController.java`, `CreateUserFacade.java`, `CreateNewSessionFacade.java`, `CreateSessionFacade.java`.
-- Assignment and consultant workflows: `AssignSessionFacade.java`, `AssignEnquiryFacade.java`, `SessionToConsultantVerifier.java`.
-- Admin API: `UserAdminController.java`, `AdminUserFacade.java`, `ConsultantAdminFacade.java`, `AskerUserAdminFacade.java`.
-- Conversations: `ConversationController.java`, `ConversationListResolver.java`, `ConversationListProviderRegistry.java`, anonymous/registered/archive providers.
-- Chat and messaging: `RocketChatService.java`, `RocketChatFacade.java`, `MatrixSynapseService.java`, `MatrixMessageController.java`, `MatrixSyncController.java`.
-- Persistence: JPA entities such as `User.java`, `Consultant.java`, `Session.java`, `Chat.java`, and repositories under `port/out`.
-- Deletion and retention: schedulers/services/actions under `workflow/delete` and `workflow/deactivate`.
-- Notifications: `EmailNotificationFacade.java`, `EventNotificationService.java`, `MobilePushNotificationService.java`, inactive account and enquiry notification workflows.
+Key files:
+- `src/main/java/de/caritas/cob/userservice/api/AccountManager.java` - src/main/java/de/caritas/cob/userservice/api/AccountManager.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/IdentityManager.java` - src/main/java/de/caritas/cob/userservice/api/IdentityManager.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/Messenger.java` - src/main/java/de/caritas/cob/userservice/api/Messenger.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/Organizer.java` - src/main/java/de/caritas/cob/userservice/api/Organizer.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/PatchConsultantSaga.java` - src/main/java/de/caritas/cob/userservice/api/PatchConsultantSaga.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/PatchConsultantSagaRollbackHandler.java` - src/main/java/de/caritas/cob/userservice/api/PatchConsultantSagaRollbackHandler.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java` - src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java is a code file under src; starts with "@SpringBootApplication(exclude = MongoAutoConfiguration.class, MongoDataAutoConfiguration.class)".
+- `src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java` - src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/actions/ActionCommand.java` - src/main/java/de/caritas/cob/userservice/api/actions/ActionCommand.java is a code file under src; starts with "public interface ActionCommandT".
+- `src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java` - src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommand.java` - src/main/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommand.java is a code file under src; starts with "/** Action to perform all necessary steps to stop an active group chat. */".
+- `src/main/java/de/caritas/cob/userservice/api/actions/registry/ActionContainer.java` - src/main/java/de/caritas/cob/userservice/api/actions/registry/ActionContainer.java is a code file under src; starts with "* Container class to collect fluently actions to peform.".
 
-## Data Flow
+### Application Core
 
-Registration enters through `UserController.registerUser`, validates the request, creates identity in Keycloak through `IdentityClient` / `KeycloakService`, persists a `User`, optionally provisions Matrix user state, creates a `Session` through `CreateSessionFacade`, stores `SessionData`, and emits registration statistics.
+Core application code and shared utilities.
 
-Session assignment enters through `UserController.assignSession`, loads session and consultant state, validates assignment rules, updates session status, updates Rocket.Chat membership, removes unauthorized consultants, sends reassignment mail, and emits statistics.
+Key files:
+- `.gitignore` - .gitignore is a code file under repository root in this repository.
+- `.swagger-codegen-ignore` - .swagger-codegen-ignore is a code file under repository root; starts with "# Swagger Codegen Ignore".
+- `LICENSE` - LICENSE is a code file under repository root; starts with "GNU AFFERO GENERAL PUBLIC LICENSE".
+- `check-version.sh` - check-version.sh is a script file under repository root in this repository.
+- `commitlint.config.js` - commitlint.config.js is a code file under repository root; starts with "module.exports =  extends: '@commitlint/config-conventional' ;".
+- `deploy-development.sh` - deploy-development.sh is a script file under repository root in this repository.
+- `mvnw` - mvnw is a code file under repository root in this repository.
+- `run-trivy.sh` - run-trivy.sh is a script file under repository root; starts with "rm report*.sarif".
 
-Anonymous conversations enter through `ConversationController.createAnonymousEnquiry`, validate the consulting type, generate anonymous credentials, create Keycloak/MariaDB/Rocket.Chat state, create the anonymous session, and return access/refresh/Rocket.Chat credentials to the caller.
+### Configuration
 
-Scheduled deletion workflows read users/sessions from repositories, run action registries for Keycloak, Rocket.Chat, appointment service, database rows, and room/session cleanup, then write workflow error records or tombstones as needed.
+Runtime, build, package, framework, and environment configuration.
 
-## Authentication Flow
+Key files:
+- `.github/actions/docker-build-push/action.yml` - .github/actions/docker-build-push/action.yml is a config file under .github; starts with "name: Reusable Docker Build and Publish steps".
+- `.github/actions/maven-build/action.yml` - .github/actions/maven-build/action.yml is a config file under .github; starts with "name: Reusable Maven Build steps".
+- `.mvn/wrapper/maven-wrapper.properties` - .mvn/wrapper/maven-wrapper.properties is a config file under .mvn; starts with "wrapperVersion=3.3.4".
+- `api/appointmentservice.yaml` - api/appointmentservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/conversationservice.yaml` - api/conversationservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/useradminservice.yaml` - api/useradminservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/userservice.yaml` - api/userservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/userstatisticsservice.yaml` - api/userstatisticsservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `package-lock.json` - package-lock.json is a config file under repository root; starts with ""name": "online-beratung-userservice",".
+- `package.json` - package.json is a config file under repository root; starts with ""name": "online-beratung-userservice",".
+- `pom.xml` - pom.xml is a config file under repository root; starts with "?xml version="1.0" encoding="UTF-8"?".
+- `services/agencyadminservice.yaml` - services/agencyadminservice.yaml is a config file under services; starts with "openapi: 3.0.1".
 
-`SecurityConfig.java` extends Keycloak's Spring Security adapter. It disables default session-backed CSRF, adds `StatelessCsrfFilter`, optionally adds `IpPrivacyHeaderFilter`, then enables `HttpTenantFilter` when multitenancy is active.
+### Data And Schema
 
-The service is bearer-only through `keycloak.bearer-only=true` in `application.properties`. Keycloak roles are mapped by `RoleAuthorizationAuthorityMapper.java` and checked with explicit `antMatchers` in `SecurityConfig.java`.
+Database schema, migrations, GraphQL/protobuf/schema files, and seed data.
 
-Tenant resolution is request scoped. `HttpTenantFilter.java` asks `TenantResolverService.java`, which tries technical/super-admin, access-token claims, custom header, single-domain rules, and subdomain resolution depending on authentication state and feature flags.
+Key files:
+- `src/main/java/de/caritas/cob/userservice/api/config/migration/TemporaryPublicPrivateKeysTask.java` - src/main/java/de/caritas/cob/userservice/api/config/migration/TemporaryPublicPrivateKeysTask.java is a data file under src in this repository.
+- `src/main/resources/migration/KeycloakRoleNameMigration.py` - src/main/resources/migration/KeycloakRoleNameMigration.py is a data file under src; starts with "server = 'https://DOMAIN_NAME'".
+- `src/main/resources/db/changelog/changeset/0001_initsql/initTables.sql` - src/main/resources/db/changelog/changeset/0001_initsql/initTables.sql is a data file under src; starts with "CREATE TABLE userservice.user (".
+- `src/main/resources/db/changelog/changeset/0001_initsql/initTrigger.sql` - src/main/resources/db/changelog/changeset/0001_initsql/initTrigger.sql is a data file under src; starts with "CREATE TRIGGER userservice.user_update BEFORE UPDATE ON userservice.user FOR EACH ROW BEGIN".
+- `src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/feedbackChatColumn-rollback.sql` - src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/feedbackChatColumn-rollback.sql is a data file under src; starts with "ALTER TABLE userservice.session".
+- `src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/feedbackChatColumn.sql` - src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/feedbackChatColumn.sql is a data file under src; starts with "ALTER TABLE userservice.session".
+- `src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/monitoringKeys-rollback.sql` - src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/monitoringKeys-rollback.sql is a data file under src; starts with "ALTER TABLE userservice.session_monitoring".
+- `src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/monitoringKeys.sql` - src/main/resources/db/changelog/changeset/0002_monitoringKeys_feedbackChatClumn/monitoringKeys.sql is a data file under src; starts with "ALTER TABLE userservice.session_monitoring".
+- `src/main/resources/db/changelog/changeset/0003_user_attribute_languageFormal/userLanguageFormalColumn-rollback.sql` - src/main/resources/db/changelog/changeset/0003_user_attribute_languageFormal/userLanguageFormalColumn-rollback.sql is a data file under src; starts with "ALTER TABLE userservice.user".
+- `src/main/resources/db/changelog/changeset/0003_user_attribute_languageFormal/userLanguageFormalColumn.sql` - src/main/resources/db/changelog/changeset/0003_user_attribute_languageFormal/userLanguageFormalColumn.sql is a data file under src; starts with "ALTER TABLE userservice.user".
+- `src/main/resources/db/changelog/changeset/0004_consultant_attribute_languageFormal/consultantLanguageFormalColumn-rollback.sql` - src/main/resources/db/changelog/changeset/0004_consultant_attribute_languageFormal/consultantLanguageFormalColumn-rollback.sql is a data file under src; starts with "ALTER TABLE userservice.consultant".
+- `src/main/resources/db/changelog/changeset/0004_consultant_attribute_languageFormal/consultantLanguageFormalColumn.sql` - src/main/resources/db/changelog/changeset/0004_consultant_attribute_languageFormal/consultantLanguageFormalColumn.sql is a data file under src; starts with "ALTER TABLE userservice.consultant".
 
-Public or semi-public paths include registration, anonymous enquiry creation, magic-link request/consume, docs/health endpoints, Matrix sync registration, consultant public data, invite-link redemption, and selected session room lookups. All unmatched requests end in `denyAll()`.
+### Deployment And Operations
 
-## API Structure
+Docker, Kubernetes, CI/CD, infrastructure, and operational resources.
 
-Inbound API contracts live under `api/`:
+Key files:
+- `.github/workflows/ci-feature-branch.yml` - .github/workflows/ci-feature-branch.yml is a pipeline file under .github; starts with "name: CI - Feature Branch".
+- `.github/workflows/ci-main.yml` - .github/workflows/ci-main.yml is a pipeline file under .github; starts with "name: CI - Main".
+- `.github/workflows/ci-pull-request.yml` - .github/workflows/ci-pull-request.yml is a pipeline file under .github; starts with "name: CI - Pull Request".
+- `Dockerfile` - Dockerfile is a infra file under repository root; starts with "FROM eclipse-temurin:17-jre".
 
-- `api/userservice.yaml`: user registration, sessions, chats, notifications, password, 2FA, consultant data, import, and live proxy operations.
-- `api/useradminservice.yaml`: admin root, sessions, consultants, askers, agency admins, tenant admins, relation management, and violation reports.
-- `api/conversationservice.yaml`: consultant enquiry lists, anonymous enquiry creation/acceptance/finish, and archive views.
-- `api/appointmentservice.yaml`: appointment CRUD and appointment-backed enquiry creation.
-- `api/userstatisticsservice.yaml`: user statistics endpoint.
+### Documentation
 
-Controllers in `adapters/web/controller` implement these generated interfaces and also define custom endpoints for Matrix, draft messages, event notifications, supervisor logs, invite links, inactive account audit logs, version, and SMTP test email.
+Human-facing documentation and project notes.
 
-## Dependencies
+Key files:
+- `CHANGELOG.md` - CHANGELOG.md is a docs file under repository root in this repository.
+- `INVITE_LINKS_API.md` - INVITE_LINKS_API.md is a docs file under repository root; starts with "# Invite Links API — for the Frontend Developer".
+- `README.md` - README.md is a docs file under repository root; starts with "# Online-Beratung UserService".
+- `documentation/ADR-SECURITY-02-unified-crypto-boundary.md` - documentation/ADR-SECURITY-02-unified-crypto-boundary.md is a docs file under documentation; starts with "# ADR Security-02: Unified Cryptographic Boundary".
+- `readme.md` - readme.md is a docs file under repository root; starts with "# Online-Beratung UserService".
 
-The service depends on Spring Boot, Spring Security, Spring Data JPA, Keycloak adapter/client, OpenAPI Generator, Liquibase, MariaDB, Rocket.Chat REST/Mongo access, Matrix Synapse REST access, RabbitMQ, Redis, Firebase Admin, Springfox, Hibernate Search, and test tooling such as Testcontainers, H2, Mockito, PowerMock, and Awaitility.
+## Major Flows
 
-Outbound ORISO service clients are generated from `services/*.yaml` for agency, tenant, consulting type, topic, application settings, appointment, mail, message, live, statistics, and Keycloak extension APIs.
+- Entry and boot flow: `Dockerfile`, `src/main/java/de/caritas/cob/userservice/api/AccountManager.java`, `src/main/java/de/caritas/cob/userservice/api/actions/ActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java`, `src/main/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/registry/ActionContainer.java`, `src/main/java/de/caritas/cob/userservice/api/actions/registry/ActionsRegistry.java`, `src/main/java/de/caritas/cob/userservice/api/actions/session/DeactivateSessionActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/session/PostConversationFinishedAliasMessageActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/session/SendFinishedAnonymousConversationEventActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/session/SetRocketChatRoomReadOnlyActionCommand.java`, `src/main/java/de/caritas/cob/userservice/api/actions/user/DeactivateKeycloakUserActionCommand.java`
+- API/service flow: `api/appointmentservice.yaml`, `api/conversationservice.yaml`, `api/useradminservice.yaml`, `api/userservice.yaml`, `api/userstatisticsservice.yaml`, `INVITE_LINKS_API.md`, `services/agencyadminservice.yaml`, `services/agencyservice.yaml`, `services/applicationsettingsservice.yaml`, `services/appointmentService.yaml`, `services/consultingtypeservice.yaml`, `services/keycloakextension.yaml`
+- Configuration flow: `.github/actions/docker-build-push/action.yml`, `.github/actions/maven-build/action.yml`, `.mvn/wrapper/maven-wrapper.properties`, `api/appointmentservice.yaml`, `api/conversationservice.yaml`, `api/useradminservice.yaml`, `api/userservice.yaml`, `api/userstatisticsservice.yaml`
 
-## Deployment And Config
+## API And Service Dependencies
 
-`application.properties` is the central defaults file. It expects runtime values through environment variables for database, Keycloak, Rocket.Chat, Matrix, RabbitMQ, SMTP, and peer service URLs.
+- `api/appointmentservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `api/conversationservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `api/useradminservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `api/userservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `api/userstatisticsservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `INVITE_LINKS_API.md` contributes API, service, route, client, or service-boundary behavior.
+- `services/agencyadminservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `services/agencyservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `services/applicationsettingsservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `services/appointmentService.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `services/consultingtypeservice.yaml` contributes API, service, route, client, or service-boundary behavior.
+- `services/keycloakextension.yaml` contributes API, service, route, client, or service-boundary behavior.
 
-`Dockerfile` runs `UserService.jar` with Java 11 and optional JDWP debugging. `deploy-development.sh` builds the Maven package, copies `target/UserService.jar`, builds/imports a Docker image into k3s, and restarts the Kubernetes deployment.
+## Authentication Relationship
 
-Liquibase changelog masters are under `src/main/resources/db/changelog/userservice-*-master.xml`. The root README currently says database schemas may be managed by a separate ORISO-Database repository; verify the active environment before enabling migrations.
+- `documentation/ADR-SECURITY-02-unified-crypto-boundary.md` is auth/security-related by filename or path.
+- `services/keycloakextension.yaml` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/actions/user/DeactivateKeycloakUserActionCommand.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakCustomConfig.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/dto/KeycloakCreateUserResponseDTO.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/dto/KeycloakLoginResponseDTO.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakClient.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java` is auth/security-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java` is auth/security-related by filename or path.
 
-## Top Files
+## Database Relationship
 
-1. `src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java`
-2. `src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java`
-3. `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java`
-4. `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java`
-5. `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationController.java`
-6. `src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java`
-7. `src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java`
-8. `src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignSessionFacade.java`
-9. `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java`
-10. `src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatService.java`
+- `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiDefaultResponseEntityExceptionHandler.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/admin/report/model/AgencyDependedViolationReportRule.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/admin/report/model/ViolationReportRule.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/config/migration/TemporaryPublicPrivateKeysTask.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/conversation/model/AnonymousUserCredentials.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/conversation/model/ConversationListType.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/conversation/model/PageableListRequest.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/IdentityManager.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/model/Admin.java` is database, schema, repository, entity, model, or migration-related by filename or path.
+- `src/main/java/de/caritas/cob/userservice/api/model/AdminAgency.java` is database, schema, repository, entity, model, or migration-related by filename or path.
 
+## Deployment Relationship
+
+- `.github/workflows/ci-feature-branch.yml` participates in deployment, infrastructure, or CI/CD.
+- `.github/workflows/ci-main.yml` participates in deployment, infrastructure, or CI/CD.
+- `.github/workflows/ci-pull-request.yml` participates in deployment, infrastructure, or CI/CD.
+- `Dockerfile` participates in deployment, infrastructure, or CI/CD.
+
+## ORISO Ecosystem Fit
+
+`ORISO-UserService` is one repository in the ORISO system. The graph focuses only on this repo's files and records cross-cutting evidence such as API, auth, database, and deployment files when those relationships are visible locally.

--- a/.understand-anything/DEPENDENCY-AUDIT.md
+++ b/.understand-anything/DEPENDENCY-AUDIT.md
@@ -1,51 +1,127 @@
-# ORISO UserService Dependency Notes
+# Dependency Audit: ORISO-UserService
 
-## Navigation
+## Detected Manifests
 
-- [Build Systems](#build-systems)
-- [Runtime Dependency Families](#runtime-dependency-families)
-- [Generated Clients](#generated-clients)
-- [Static Risk Notes](#static-risk-notes)
-- [Suggested Verification](#suggested-verification)
+- `package.json`
+- `pom.xml`
 
-## Build Systems
+## Detected Dependencies
 
-- Maven is the production build system through `pom.xml`.
-- Node/npm is present for release tooling only through `package.json` and `package-lock.json`.
+- - npm: `@commitlint/cli`
+- - npm: `@commitlint/config-conventional`
+- - npm: `cz-conventional-changelog`
+- - npm: `husky`
+- - npm: `standard-version`
+- - Maven: `userservice`
+- - Maven: `spring-boot-starter-parent`
+- - Maven: `spring-cloud-dependencies`
+- - Maven: `spring-boot-starter-web`
+- - Maven: `spring-boot-starter-security`
+- - Maven: `spring-web`
+- - Maven: `spring-boot-starter-validation`
+- - Maven: `spring-boot-starter-data-jpa`
+- - Maven: `spring-boot-starter-cache`
+- - Maven: `spring-boot-starter-data-redis`
+- - Maven: `spring-boot-starter-aop`
+- - Maven: `spring-boot-starter-hateoas`
+- - Maven: `spring-boot-starter-amqp`
+- - Maven: `spring-boot-configuration-processor`
+- - Maven: `spring-security-core`
+- - Maven: `spring-beans`
+- - Maven: `spring-webmvc`
+- - Maven: `spring-core`
+- - Maven: `spring-cloud-starter-sleuth`
+- - Maven: `spring-cloud-starter-zipkin`
+- - Maven: `spring-boot-starter-actuator`
+- - Maven: `hibernate-validator`
+- - Maven: `json-smart`
+- - Maven: `hibernate-search-orm`
+- - Maven: `openapi-generator-maven-plugin`
+- - Maven: `jackson-databind-nullable`
+- - Maven: `jackson-datatype-jsr310`
+- - Maven: `plexus-utils`
+- - Maven: `springfox-swagger2`
+- - Maven: `validation-api`
+- - Maven: `keycloak-spring-security-adapter`
+- - Maven: `keycloak-spring-boot-starter`
+- - Maven: `keycloak-admin-client`
+- - Maven: `javax.ws.rs-api`
+- - Maven: `lombok`
+- - Maven: `handlebars`
+- - Maven: `commons-lang3`
+- - Maven: `commons-text`
+- - Maven: `commons-validator`
+- - Maven: `commons-codec`
+- - Maven: `liquibase-maven-plugin`
+- - Maven: `liquibase-core`
+- - Maven: `mariadb-java-client`
+- - Maven: `log4j-core`
+- - Maven: `log4j-api`
+- - Maven: `log4j-to-slf4j`
+- - Maven: `logstash-logback-encoder`
+- - Maven: `jsoup`
+- - Maven: `commons-csv`
+- - Maven: `passay`
+- - Maven: `nv-i18n`
+- - Maven: `ehcache`
+- - Maven: `jackson-databind`
+- - Maven: `spring-context-support`
+- - Maven: `firebase-admin`
+- - Maven: `h2`
+- - Maven: `easy-random-core`
+- - Maven: `spring-boot-starter-test`
+- - Maven: `spring-security-test`
+- - Maven: `spring-security-core`
+- - Maven: `powermock-module-junit4`
+- - Maven: `junit`
+- - Maven: `mockito-core`
+- - Maven: `mockito-junit-jupiter`
+- - Maven: `byte-buddy`
+- - Maven: `powermock-api-mockito2`
+- - Maven: `reflections`
+- - Maven: `commons-collections4`
+- - Maven: `awaitility`
+- - Maven: `junit-jupiter`
+- - Maven: `mariadb`
+- - Maven: `jna`
+- - Maven: `rabbitmq-mock`
+- - Maven: `json-unit`
+- - Maven: `plantuml`
+- - Maven: `spring-boot-starter-data-mongodb`
+- - Maven: `snakeyaml`
+- - Maven: `spring-boot-maven-plugin`
+- - Maven: `rewrite-maven-plugin`
+- - Maven: `rewrite-spring`
 
-## Runtime Dependency Families
+## Operational Dependency Files
 
-- Spring Boot web/security/JPA/cache/Redis/AOP/HATEOAS/AMQP/actuator.
-- Keycloak Spring adapter, Spring Boot starter, and admin client.
-- OpenAPI Generator and generated Spring/Java clients.
-- MariaDB JDBC, Liquibase, Hibernate Search.
-- Rocket.Chat REST and MongoDB access.
-- Matrix Synapse REST access.
-- RabbitMQ, Redis, Firebase Admin, mail/SMTP, statistics publishing.
-- Logging through SLF4J/Logback plus Log4j bridges and logstash encoder.
-
-## Generated Clients
-
-`pom.xml` generates inbound API interfaces from `api/*.yaml` and outbound Java clients from `services/*.yaml`. Generated sources are written under `target/generated-sources` and should not be edited directly.
-
-## Static Risk Notes
-
-This file does not replace SCA output. It flags dependency areas to verify:
-
-- Spring Boot 2.7.x / Spring Security 5.x upgrade path.
-- Legacy Keycloak adapters.
-- Springfox 2.x.
-- PowerMock and mixed JUnit-era test support.
-- Old test/runtime utility versions: H2 1.4.200, jsoup 1.14.3, firebase-admin 8.1.0, commons-csv 1.8, json-unit 2.28.0.
-- Forced Log4j 2.17.1 pin should be checked against the current approved baseline.
-
-## Suggested Verification
-
-```bash
-./mvnw -DskipTests dependency:tree
-./mvnw test
-npm audit
-```
-
-For production release, run the organization-approved Maven dependency vulnerability scanner and store the report next to the deployment evidence.
-
+- `.github/actions/docker-build-push/action.yml` (config)
+- `.github/actions/maven-build/action.yml` (config)
+- `.mvn/wrapper/maven-wrapper.properties` (config)
+- `api/appointmentservice.yaml` (config)
+- `api/conversationservice.yaml` (config)
+- `api/useradminservice.yaml` (config)
+- `api/userservice.yaml` (config)
+- `api/userstatisticsservice.yaml` (config)
+- `package-lock.json` (config)
+- `package.json` (config)
+- `pom.xml` (config)
+- `services/agencyadminservice.yaml` (config)
+- `services/agencyservice.yaml` (config)
+- `services/applicationsettingsservice.yaml` (config)
+- `services/appointmentService.yaml` (config)
+- `services/consultingtypeservice.yaml` (config)
+- `services/keycloakextension.yaml` (config)
+- `services/liveservice.yaml` (config)
+- `services/mailservice.yaml` (config)
+- `services/messageservice.yaml` (config)
+- `services/statisticsservice.yaml` (config)
+- `services/tenantadminservice.yaml` (config)
+- `services/tenantservice.yaml` (config)
+- `services/topicservice.yaml` (config)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/http-client.env.json` (config)
+- `src/main/resources/application-dev.properties` (config)
+- `src/main/resources/application-prod.properties` (config)
+- `src/main/resources/application-staging.properties` (config)
+- `src/main/resources/application-testing.properties` (config)
+- `src/main/resources/application.properties` (config)

--- a/.understand-anything/FINDINGS.md
+++ b/.understand-anything/FINDINGS.md
@@ -1,62 +1,26 @@
-# ORISO UserService Findings
+# Findings: ORISO-UserService
 
-## Navigation
+## Generation Summary
 
-- [Missing Documentation](#missing-documentation)
-- [Dead Or Suspicious Files](#dead-or-suspicious-files)
-- [Risky Dependencies](#risky-dependencies)
-- [Unclear Boundaries](#unclear-boundaries)
-- [Duplicated Or Repeated Logic](#duplicated-or-repeated-logic)
-- [Recommended Cleanup Order](#recommended-cleanup-order)
+- Generated from latest dev commit: `3e6707fbb14400428ddfe44e0dc36648e4aba41c`
+- Previous graph commit: `65bd6a263f0a362d086121bdafb20992f00949a5`; regenerated at latest dev commit `3e6707fbb14400428ddfe44e0dc36648e4aba41c`.
+- Files analyzed: 1141
+- Category breakdown: {"code":922,"config":95,"data":112,"docs":5,"infra":1,"pipeline":3,"script":3}
+- Graph nodes: 4806
+- Graph edges: 5842
 
-## Missing Documentation
+## Notable Concentrations
 
-- The root documentation is inconsistent: git tracks both `README.md` and `readme.md`, and the current working-tree content differs from the committed `README.md`.
-- There is no single local onboarding guide that explains generated API contracts, Maven codegen, Keycloak roles, tenant behavior, and required external services together.
-- The Matrix migration behavior is visible in code comments and logs in `CreateUserFacade.java`, but it needs a short architecture note covering expected fallback semantics.
-- Deployment assumptions are split across `application.properties`, `Dockerfile`, `deploy-development.sh`, and root README content. The active Kubernetes manifests are not in this repository.
-- Liquibase status is ambiguous: changelogs exist here, while the root README diff says schemas may be managed by `ORISO-Database`.
+- 922 code files detected.
+- 95 config files detected.
+- 112 data files detected.
+- 5 docs files detected.
+- 1 infra files detected.
+- 3 pipeline files detected.
+- 3 script files detected.
 
-## Dead Or Suspicious Files
+## Review Notes
 
-- `src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java.backup` is tracked but not part of Java compilation.
-- `cookies.txt` is tracked and should be reviewed for accidental local/session data.
-- `.DS_Store` exists in the working tree and should stay untracked/ignored.
-- `README.md` and `readme.md` are both tracked. On case-insensitive filesystems this is fragile and can hide changes.
-
-## Risky Dependencies
-
-This is a static repository review, not a live CVE scan. Run a Maven/OWASP or enterprise SCA scan before release.
-
-- Spring Boot 2.7.x and Spring Security 5.x are old platform lines and make upgrades harder as peer libraries move to Spring Boot 3/4.
-- `keycloak-spring-security-adapter` and `keycloak-spring-boot-starter` are from the legacy Keycloak adapter model; future work should plan migration to Spring Security OAuth2 resource server patterns.
-- Springfox 2.x is a legacy Swagger stack; OpenAPI Generator already exists and should be the preferred API-contract path.
-- PowerMock 2.x and JUnit4-era patterns increase test maintenance cost with newer Java and Mockito versions.
-- H2 1.4.200 is test scoped but old; keep it isolated from production packaging.
-- `json-smart`, `jsoup`, `firebase-admin`, `commons-csv`, `passay`, `logstash-logback-encoder`, and Log4j pinning should be checked by a live dependency scanner.
-
-## Unclear Boundaries
-
-- `UserController.java` is very large and handles many unrelated flows: registration, sessions, chats, notifications, password, email, mobile tokens, archive, 2FA, and consultant data.
-- `CreateUserFacade.java` currently coordinates Keycloak, MariaDB, Matrix, session creation, statistics, tenant/agency lookup, rollback, and fallback behavior. It is a high-change-risk file.
-- Messaging is split between Rocket.Chat and Matrix, with migration/fallback logic embedded in user/session flows. Document which backend is authoritative for each feature.
-- Tenant context is a thread-local cross-cutting concern. Any async work or scheduled flow needs explicit tenant assumptions.
-- Generated API contracts and hand-written custom controllers coexist. New endpoints need a clear rule: OpenAPI-first or hand-written only when there is a deliberate exception.
-
-## Duplicated Or Repeated Logic
-
-- Authorization rules are centralized but large in `SecurityConfig.java`; endpoint additions require duplicated path knowledge across OpenAPI and security matchers.
-- Admin create/update/search flows repeat patterns across agency admins, tenant admins, consultants, and askers.
-- External client factories under `config/apiclient` repeat setup patterns for generated APIs.
-- Notification email suppliers share tenant template and content-building behavior that should stay consistently factored.
-- Workflow deletion actions repeat external-system deletion semantics for asker and consultant targets.
-
-## Recommended Cleanup Order
-
-1. Resolve the tracked `README.md` / `readme.md` conflict and keep one canonical root README.
-2. Remove or archive `UserController.java.backup` outside compiled source.
-3. Review and remove `cookies.txt` if it is local data.
-4. Add a short `docs/` hub for codegen, auth, tenancy, messaging migration, and local run dependencies.
-5. Run a live dependency scan and convert this static dependency list into tracked upgrade tickets.
-6. Split new behavior away from `UserController.java` and `CreateUserFacade.java` rather than growing them further.
-
+- The graph was regenerated from the current repository only.
+- Scratch directories `.understand-anything/intermediate/` and `.understand-anything/tmp/` were not created by this generator.
+- Validate with `python -m json.tool .understand-anything/knowledge-graph.json > /dev/null`.

--- a/.understand-anything/ONBOARDING.md
+++ b/.understand-anything/ONBOARDING.md
@@ -1,87 +1,21 @@
-# ORISO UserService Developer Onboarding
+# Onboarding Guide: ORISO-UserService
 
-## Navigation
+1. Read `README.md` in the repository root if present.
+2. Open `.understand-anything/README.md` and launch the dashboard using the command shown there.
+3. Start with these tour files:
 
-- [First Read](#first-read)
-- [Run And Build](#run-and-build)
-- [How To Trace A Request](#how-to-trace-a-request)
-- [Where To Change Things](#where-to-change-things)
-- [Testing Map](#testing-map)
-- [Common Pitfalls](#common-pitfalls)
+- `README.md` - README.md is a docs file under repository root; starts with "# Online-Beratung UserService".
+- `package.json` - package.json is a config file under repository root; starts with ""name": "online-beratung-userservice",".
+- `pom.xml` - pom.xml is a config file under repository root; starts with "?xml version="1.0" encoding="UTF-8"?".
+- `src/main/java/de/caritas/cob/userservice/api/AccountManager.java` - src/main/java/de/caritas/cob/userservice/api/AccountManager.java is a code file under src in this repository.
+- `src/main/java/de/caritas/cob/userservice/api/actions/ActionCommand.java` - src/main/java/de/caritas/cob/userservice/api/actions/ActionCommand.java is a code file under src; starts with "public interface ActionCommandT".
+- `src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java` - src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java is a code file under src in this repository.
+- `.github/actions/docker-build-push/action.yml` - .github/actions/docker-build-push/action.yml is a config file under .github; starts with "name: Reusable Docker Build and Publish steps".
+- `.github/actions/maven-build/action.yml` - .github/actions/maven-build/action.yml is a config file under .github; starts with "name: Reusable Maven Build steps".
+- `.mvn/wrapper/maven-wrapper.properties` - .mvn/wrapper/maven-wrapper.properties is a config file under .mvn; starts with "wrapperVersion=3.3.4".
+- `api/appointmentservice.yaml` - api/appointmentservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/conversationservice.yaml` - api/conversationservice.yaml is a config file under api; starts with "openapi: 3.0.1".
+- `api/useradminservice.yaml` - api/useradminservice.yaml is a config file under api; starts with "openapi: 3.0.1".
 
-## First Read
-
-Start with these files in order:
-
-1. `README.md` and `readme.md` to understand the existing project-level documentation split.
-2. `pom.xml` to understand generated sources, service clients, Java version, profiles, and test separation.
-3. `src/main/resources/application.properties` to understand runtime dependencies and feature flags.
-4. `src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java` for the Spring Boot entry point.
-5. `src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java` before changing any endpoint.
-
-## Run And Build
-
-Common local commands:
-
-```bash
-./mvnw clean test
-./mvnw spring-boot:run -Dspring-boot.run.profiles=local -DskipTests
-./mvnw clean package -DskipTests
-```
-
-The service listens on `server.port=8082` by default. Health is exposed at:
-
-```bash
-curl http://localhost:8082/actuator/health
-```
-
-This repository depends on external services. A productive local run needs MariaDB, Keycloak, Rocket.Chat, Matrix, RabbitMQ, and several ORISO service URLs depending on the flow being tested.
-
-## How To Trace A Request
-
-For generated API endpoints, start at the OpenAPI file under `api/`, find the `operationId`, then find the matching method in a controller under `adapters/web/controller`.
-
-For registration:
-
-`api/userservice.yaml` -> `UserController.registerUser` -> `CreateUserFacade` -> `KeycloakService` / `UserService` / `MatrixSynapseService` -> `CreateNewSessionFacade` -> `CreateSessionFacade` -> repositories and statistics.
-
-For assignment:
-
-`api/userservice.yaml` -> `UserController.assignSession` -> `AssignSessionFacade` -> `SessionService` -> `RocketChatFacade` / `RocketChatService` -> notification and statistics services.
-
-For anonymous enquiry:
-
-`api/conversationservice.yaml` -> `ConversationController.createAnonymousEnquiry` -> `CreateAnonymousEnquiryFacade` -> `AnonymousUserCreatorService` -> `AnonymousConversationCreatorService`.
-
-## Where To Change Things
-
-- Add or change public API shape in `api/*.yaml`, then regenerate generated sources through Maven.
-- Add admin API behavior in `UserAdminController.java` plus the matching admin facade/service.
-- Add user/session/chat behavior in `UserController.java` only as routing glue; keep orchestration in facades and business rules in services.
-- Add persistence in `model/*`, `port/out/*Repository.java`, and Liquibase changelogs.
-- Add outbound service integration by updating `services/*.yaml`, `pom.xml` generator config, and a factory/client wrapper under `config/apiclient`.
-- Add authorization in `SecurityConfig.java` at the same time as adding an endpoint.
-- Add tenant-aware behavior with explicit `TenantContext` assumptions and tests.
-
-## Testing Map
-
-The test suite is large and split across unit/integration-style tests under `src/test/java`.
-
-- Controller behavior: `src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/*`
-- Facades: `src/test/java/de/caritas/cob/userservice/api/facade/*`
-- Admin services: `src/test/java/de/caritas/cob/userservice/api/admin/service/*`
-- Workflows: `src/test/java/de/caritas/cob/userservice/api/workflow/*`
-- Repositories: `src/test/java/de/caritas/cob/userservice/api/port/out/*`
-- External adapters: `KeycloakServiceTest.java`, `RocketChatServiceTest.java`, Matrix tests where present.
-
-Before changing security, run the authorization tests around `UserControllerAuthorizationIT.java` and `ConversationControllerAuthorizationIT.java` if the local environment supports them.
-
-## Common Pitfalls
-
-- `SecurityConfig.java` uses explicit path matchers and ends with `denyAll()`; new endpoints will be blocked until mapped.
-- The repository has both `README.md` and `readme.md` tracked in git, but on a case-insensitive filesystem they collapse to one working-tree file.
-- `UserController.java.backup` is tracked but not compiled; do not use it as implementation source.
-- Registration currently has Matrix and Rocket.Chat fallback paths that log errors and continue in some cases. Check business expectations before tightening failures.
-- Tenant behavior changes need both authenticated and anonymous request tests.
-- Some runtime defaults are empty and must be injected from Kubernetes or local environment variables.
-
+4. Review architecture layers in `.understand-anything/ARCHITECTURE.md`.
+5. For changes, inspect files connected by `imports`, `configures`, `routes`, `deploys`, and `tested_by` edges in the graph.

--- a/.understand-anything/ORISO-ECOSYSTEM.md
+++ b/.understand-anything/ORISO-ECOSYSTEM.md
@@ -1,44 +1,36 @@
-# ORISO Ecosystem Connections
+# ORISO Ecosystem Notes: ORISO-UserService
 
-## Navigation
+This graph was generated for `ORISO-UserService` only. It does not analyze sibling repositories.
 
-- [Role In The Platform](#role-in-the-platform)
-- [Inbound Consumers](#inbound-consumers)
-- [Outbound Services](#outbound-services)
-- [Shared Runtime Infrastructure](#shared-runtime-infrastructure)
-- [Data Ownership](#data-ownership)
+## Local Role Evidence
 
-## Role In The Platform
+- Purpose: The UserService provides different functionalities from creating and updating user accounts and their sessions, providing session lists up to creating and editing Rocket.Chat groups.
+- Languages: dockerfile, java, javascript, json, markdown, properties, python, shell, sql, xml, yaml
+- Frameworks/tools: Docker, Spring Boot
+- API/service-related files: 12
+- Auth-related files: 12
+- Database-related files: 12
+- Deployment-related files: 4
 
-UserService is the central user/session lifecycle service in the ORISO ecosystem. It owns asker and consultant accounts in its database, coordinates identity state in Keycloak, provisions chat state in Rocket.Chat and Matrix, and exposes APIs consumed by frontend/admin clients and other backend services.
+## Integration Clues
 
-## Inbound Consumers
-
-- ORISO-Frontend uses `/users/**`, `/conversations/**`, `/matrix/**`, appointment, notification, draft, and session endpoints for registration, counselling, chat, profile, and messaging flows.
-- ORISO-Admin uses `/useradmin/**`, consultant/admin/search/report endpoints, invite links, audit logs, and deletion-pause operations.
-- Technical backend callers use endpoints such as `/users/notifications`, `/users/messages/key`, imports, statistics, and lifecycle operations guarded by technical roles.
-
-## Outbound Services
-
-The `services/*.yaml` contracts and `config/apiclient/*` factories connect UserService to:
-
-- Keycloak and keycloak-extension for authentication, roles, password, 2FA, and user administration.
-- Rocket.Chat for group/user membership, E2E keys, room state, and legacy chat lifecycle.
-- Matrix Synapse for Matrix user/room/message/media functionality.
-- Agency service and agency admin service for agency metadata and agency administration.
-- Tenant service and tenant admin service for tenant lookup and tenant-admin flows.
-- Consulting type, topic, and application settings services for registration rules and feature content.
-- Appointment service for booking-backed enquiries and consultant/agency sync.
-- Message service for message streams, keys, and drafts.
-- Mail service and SMTP for user/admin/system notifications.
-- Live service for live event dispatch.
-- Statistics service and RabbitMQ for event reporting.
-
-## Shared Runtime Infrastructure
-
-Runtime settings in `application.properties` expect externally injected URLs and credentials for MariaDB, Keycloak, Rocket.Chat, Matrix, RabbitMQ, Redis, SMTP, Firebase, and peer ORISO APIs. Docker packaging is local to this repository, while Kubernetes deployment appears to be managed from the surrounding ORISO workspace.
-
-## Data Ownership
-
-UserService owns its MariaDB tables for users, consultants, sessions, chats, admin relations, mobile tokens, invite links, notifications, deletion lifecycle, tombstones, and workflow audit logs. It does not own Keycloak, Rocket.Chat, Matrix, agency, tenant, appointment, message, mail, live, or statistics data; it coordinates those systems through adapters and generated clients.
-
+- `api/appointmentservice.yaml` (config, yaml)
+- `api/conversationservice.yaml` (config, yaml)
+- `api/useradminservice.yaml` (config, yaml)
+- `api/userservice.yaml` (config, yaml)
+- `api/userstatisticsservice.yaml` (config, yaml)
+- `INVITE_LINKS_API.md` (docs, markdown)
+- `services/agencyadminservice.yaml` (config, yaml)
+- `services/agencyservice.yaml` (config, yaml)
+- `services/applicationsettingsservice.yaml` (config, yaml)
+- `services/appointmentService.yaml` (config, yaml)
+- `services/consultingtypeservice.yaml` (config, yaml)
+- `services/keycloakextension.yaml` (config, yaml)
+- `documentation/ADR-SECURITY-02-unified-crypto-boundary.md` (docs, markdown)
+- `services/keycloakextension.yaml` (config, yaml)
+- `src/main/java/de/caritas/cob/userservice/api/actions/user/DeactivateKeycloakUserActionCommand.java` (code, java)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java` (code, java)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakCustomConfig.java` (code, java)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/dto/KeycloakCreateUserResponseDTO.java` (code, java)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/dto/KeycloakLoginResponseDTO.java` (code, java)
+- `src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakClient.java` (code, java)

--- a/.understand-anything/README.md
+++ b/.understand-anything/README.md
@@ -1,47 +1,48 @@
-# ORISO UserService Knowledge Graph
+# Understand-Anything Graph: ORISO-UserService
 
-Developer map for the ORISO UserService repository. This folder is generated for onboarding and architecture exploration.
+This directory contains the Understand-Anything graph and developer notes for `ORISO-UserService`.
 
-## Navigation
+## Graph
 
-- [Architecture Summary](./ARCHITECTURE.md)
-- [Developer Onboarding](./ONBOARDING.md)
-- [ORISO Ecosystem Connections](./ORISO-ECOSYSTEM.md)
-- [Findings And Maintenance Risks](./FINDINGS.md)
-- [Dependency Audit Notes](./DEPENDENCY-AUDIT.md)
-- [Visuals](./visuals/)
-- [Raw Knowledge Graph](./knowledge-graph.json)
+- Graph file: `.understand-anything/knowledge-graph.json`
+- Generated at: `2026-06-11T18:45:43.355Z`
+- Source commit: `3e6707fbb14400428ddfe44e0dc36648e4aba41c`
+- Files analyzed: 1141
+- Nodes: 4806
+- Edges: 5842
 
-## Graph Files
+## Repository Purpose
 
-- `knowledge-graph.json` is the dashboard data file.
-- `meta.json` records analysis time, git commit, file count, and graph stats.
-- `fingerprints.json` records file hashes for future incremental updates.
-- `config.json` enables Understand-Anything auto-update behavior for this repository.
+The UserService provides different functionalities from creating and updating user accounts and their sessions, providing session lists up to creating and editing Rocket.Chat groups.
 
-## Open The Dashboard
+## Existing Setup Status
 
-Run this from any terminal:
+Previous graph commit: `65bd6a263f0a362d086121bdafb20992f00949a5`; regenerated at latest dev commit `3e6707fbb14400428ddfe44e0dc36648e4aba41c`.
 
-```bash
-ORISO_USERSERVICE="$HOME/Developer/freelance/Germany/Oriso-frank-client/ORISO/ORISO-UserService"
-cd ~/.understand-anything/repo/understand-anything-plugin/packages/dashboard
-GRAPH_DIR="$ORISO_USERSERVICE" pnpm exec vite --host 127.0.0.1
+## Dashboard
+
+From this repository root:
+
+```sh
+PLUGIN_ROOT="$HOME/.understand-anything-plugin"
+test -d "$PLUGIN_ROOT/packages/dashboard" || PLUGIN_ROOT="$HOME/.understand-anything/repo/understand-anything-plugin"
+cd "$PLUGIN_ROOT/packages/dashboard"
+GRAPH_DIR="$(pwd)" npx vite --host 127.0.0.1
 ```
 
-Open the full `Dashboard URL` printed in the terminal, including the `?token=...` value.
+Use the tokenized URL printed by Vite. The dashboard reads `.understand-anything/knowledge-graph.json`.
 
-## Auto Update
+## Main Files Scanned
 
-Auto-update is enabled in `config.json`. In an agent environment, the matching command is:
-
-```bash
-/understand . --auto-update
-```
-
-If the graph looks stale or your environment does not run the auto-update hook, rebuild it manually:
-
-```bash
-/understand . --full
-```
-
+- `.github/actions/docker-build-push/action.yml (config, yaml)`
+- `.github/actions/maven-build/action.yml (config, yaml)`
+- `.github/workflows/ci-feature-branch.yml (pipeline, yaml)`
+- `.github/workflows/ci-main.yml (pipeline, yaml)`
+- `.github/workflows/ci-pull-request.yml (pipeline, yaml)`
+- `.gitignore (code, unknown)`
+- `.mvn/wrapper/maven-wrapper.properties (config, properties)`
+- `.swagger-codegen-ignore (code, unknown)`
+- `api/appointmentservice.yaml (config, yaml)`
+- `api/conversationservice.yaml (config, yaml)`
+- `api/useradminservice.yaml (config, yaml)`
+- `api/userservice.yaml (config, yaml)`

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,12 +1,7 @@
 {
-  "lastAnalyzedAt": "2026-05-27T18:55:00.394Z",
-  "gitCommitHash": "65bd6a263f0a362d086121bdafb20992f00949a5",
+  "lastAnalyzedAt": "2026-06-11T18:45:43.355Z",
+  "gitCommitHash": "3e6707fbb14400428ddfe44e0dc36648e4aba41c",
   "version": "1.0.0",
-  "analyzedFiles": 1130,
-  "graphStats": {
-    "nodes": 2295,
-    "edges": 3854,
-    "layers": 12,
-    "tourSteps": 6
-  }
+  "analyzedFiles": 1141,
+  "generator": "oriso-ua-generate.mjs deterministic Understand-Anything fallback"
 }

--- a/.understand-anything/visuals/README.md
+++ b/.understand-anything/visuals/README.md
@@ -1,0 +1,5 @@
+# Visuals
+
+Use the Understand-Anything dashboard for the interactive graph view.
+
+Graph source: `../knowledge-graph.json`


### PR DESCRIPTION
## Summary

- Refreshes the Understand-Anything graph from latest dev commit 3e6707fbb14400428ddfe44e0dc36648e4aba41c.
- Updates graph documentation under .understand-anything/.
- Keeps the change scoped to graph/docs only; no application source or product logic changes.

## Graph Details

- Graph path: .understand-anything/knowledge-graph.json
- Nodes: 4,806
- Edges: 5,842
- Layers: 6
- Tour steps: 4
- Graph size: 5,606,542 bytes, below the 10 MB LFS review threshold.

## Validation

- python3 -m json.tool .understand-anything/knowledge-graph.json
- jq metadata/schema checks
- git diff --check dev...HEAD
- Diff scope check confirmed only .understand-anything/** changed
- Secret/local-path scan completed; no secrets or machine-local paths found
- Scratch files skipped: .understand-anything/intermediate/, .understand-anything/diff-overlay.json, node_modules/, dist/, build/, coverage/, .env, logs, .DS_Store

## Reviewer Notes

This is a docs/graph-only PR. Please focus review on whether the graph documentation accurately represents the latest dev codebase and whether generated files are acceptable for the repository.