### PR TITLE
Tolerate agency metadata errors during consultant login

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
@@ -27,7 +27,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientResponseException;
 
 /** Provider for consultant information. */
 @Component
@@ -62,6 +62,7 @@ public class ConsultantDataProvider {
   }
 
   private UserDataResponseDTO userDataResponseDtoOf(Consultant consultant) {
+    var agencies = agencyDTOsOf(consultant);
 
     return UserDataResponseDTO.builder()
         .userId(consultant.getId())
@@ -77,13 +78,12 @@ public class ConsultantDataProvider {
         .magicLinkLoginEnabled(consultant.getMagicLinkLoginEnabled())
         .absenceMessage(consultant.getAbsenceMessage())
         .isInTeamAgency(consultant.isTeamConsultant())
-        .agencies(agencyDTOsOf(consultant))
+        .agencies(agencies)
         .userRoles(authenticatedUser.getRoles())
         .grantedAuthorities(authenticatedUser.getGrantedAuthorities())
         .isWalkThroughEnabled(consultant.getWalkThroughEnabled())
         .emailToggles(emailTogglesOf(consultant))
-        .hasAnonymousConversations(
-            hasAtLeastOneTypeWithAllowedAnonymousConversations(agencyDTOsOf(consultant)))
+        .hasAnonymousConversations(hasAtLeastOneTypeWithAllowedAnonymousConversations(agencies))
         .hasArchive(hasArchive(consultant))
         .dataPrivacyConfirmation(consultant.getDataPrivacyConfirmation())
         .termsAndConditionsConfirmation(consultant.getTermsAndConditionsConfirmation())
@@ -106,13 +106,14 @@ public class ConsultantDataProvider {
   private List<AgencyDTO> agencyDTOsOf(Consultant consultant) {
     try {
       return agencyService.getAgencies(agencyIdsOf(consultant.getConsultantAgencies()));
-    } catch (HttpClientErrorException.Forbidden e) {
-      // Do not block login when agency-service scope denies this token;
-      // return a minimal consultant profile instead of surfacing a 500.
+    } catch (RestClientResponseException e) {
+      // Do not block login when agency-service cannot provide metadata for this token/agency.
+      // Return a minimal consultant profile instead of surfacing agency errors as login failures.
       log.warn(
-          "Forbidden while loading agencies for consultant {}: {}",
+          "Could not load agencies for consultant {}: status={}, body={}",
           consultant.getId(),
-          e.getMessage());
+          e.getRawStatusCode(),
+          e.getResponseBodyAsString());
       return List.of();
     }
   }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
@@ -34,6 +34,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsultantDataProviderTest {
@@ -74,6 +76,19 @@ public class ConsultantDataProviderTest {
 
     assertNotNull(result);
     assertEquals(AGENCY_DTO_SUCHT, result.get(0));
+  }
+
+  @Test
+  public void retrieveData_Should_ReturnMinimalProfile_When_AgencyServiceReturnsServerError() {
+    when(agencyService.getAgencies(any()))
+        .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    var result = underTest.retrieveData(CONSULTANT_WITH_AGENCY);
+
+    assertEquals(CONSULTANT_WITH_AGENCY.getId(), result.getUserId());
+    assertTrue(result.getAgencies().isEmpty());
+    assertFalse(result.isHasAnonymousConversations());
+    Mockito.verifyNoInteractions(consultingTypeManager);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,6 +83,19 @@ public class ConsultantDataProviderTest {
   public void retrieveData_Should_ReturnMinimalProfile_When_AgencyServiceReturnsServerError() {
     when(agencyService.getAgencies(any()))
         .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    var result = underTest.retrieveData(CONSULTANT_WITH_AGENCY);
+
+    assertEquals(CONSULTANT_WITH_AGENCY.getId(), result.getUserId());
+    assertTrue(result.getAgencies().isEmpty());
+    assertFalse(result.isHasAnonymousConversations());
+    Mockito.verifyNoInteractions(consultingTypeManager);
+  }
+
+  @Test
+  public void retrieveData_Should_ReturnMinimalProfile_When_AgencyServiceReturnsNotFound() {
+    when(agencyService.getAgencies(any()))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
     var result = underTest.retrieveData(CONSULTANT_WITH_AGENCY);
 


### PR DESCRIPTION
## Problem
Consultant login succeeds at Keycloak, but the frontend cannot enter the app when `GET /service/users/data` fails while enriching the consultant profile with agency metadata.

Observed for `livechatconsult` on 2026-06-12:
- Keycloak token: HTTP 200
- `GET /service/users/data`: HTTP 500
- Correlation ID: `a666f559-a73e-4b6a-bc13-9b4d805e2930`
- UserService stacktrace: `ConsultantDataProvider.retrieveData -> AgencyService.getAgencies -> AgencyService returned 500 for /agencies/250`

Fixes #96

## Solution
- Load consultant agencies once while building the profile response.
- Treat AgencyService HTTP response failures like missing optional metadata for this login path.
- Return the core consultant profile with an empty agencies list instead of surfacing the AgencyService error as a login failure.
- Keep a warning log with the consultant id, status code, and response body for later cleanup of the broken agency reference/service response.

## Checks
- `git diff --check`
- `./mvnw -Dtest=ConsultantDataProviderTest test` was attempted, but this checkout still fails during project compilation with broad generated/Lombok missing-symbol errors outside the touched files before the targeted test can run.

## Notes
`counsellor1006` is a separate account-data case: Keycloak returns a token, but UserService correctly rejects `/users/data` with 403 because the consultant is flagged for deletion.