### PR TITLE
Refactor user controller chat endpoints

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
@@ -1,0 +1,157 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatInfoResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatMembersResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateChatResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UpdateChatResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.AssignChatFacade;
+import de.caritas.cob.userservice.api.facade.CreateChatFacade;
+import de.caritas.cob.userservice.api.facade.GetChatFacade;
+import de.caritas.cob.userservice.api.facade.GetChatMembersFacade;
+import de.caritas.cob.userservice.api.facade.JoinAndLeaveChatFacade;
+import de.caritas.cob.userservice.api.facade.StartChatFacade;
+import de.caritas.cob.userservice.api.facade.StopChatFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class UserChatControllerDelegate {
+
+  private final @NonNull UserAccountService userAccountProvider;
+  private final @NonNull ChatService chatService;
+  private final @NonNull StartChatFacade startChatFacade;
+  private final @NonNull GetChatFacade getChatFacade;
+  private final @NonNull JoinAndLeaveChatFacade joinAndLeaveChatFacade;
+  private final @NonNull AssignChatFacade assignChatFacade;
+  private final @NonNull CreateChatFacade createChatFacade;
+  private final @NonNull StopChatFacade stopChatFacade;
+  private final @NonNull GetChatMembersFacade getChatMembersFacade;
+  private final @NonNull AccountManaging accountManager;
+  private final @NonNull Messaging messenger;
+  private final @NonNull UserDtoMapper userDtoMapper;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  ResponseEntity<CreateChatResponseDTO> createChatV1(ChatDTO chatDTO) {
+    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
+    var response = createChatFacade.createChatV1(chatDTO, callingConsultant);
+
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  ResponseEntity<CreateChatResponseDTO> createChatV2(ChatDTO chatDTO) {
+    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
+    var response = createChatFacade.createChatV2(chatDTO, callingConsultant);
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  ResponseEntity<Void> startChat(Long chatId) {
+    var chat =
+        chatService
+            .getChat(chatId)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        String.format("Chat with id %s not found for starting chat.", chatId)));
+
+    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
+    startChatFacade.startChat(chat, callingConsultant);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<ChatInfoResponseDTO> getChat(Long chatId) {
+    var response = getChatFacade.getChat(chatId);
+    messenger
+        .findChatMetaInfo(chatId, authenticatedUser.getUserId())
+        .ifPresent(
+            chatMetaInfoMap -> {
+              var bannedChatUserIds = userDtoMapper.bannedChatUserIdsOf(chatMetaInfoMap);
+              response.setBannedUsers(bannedChatUserIds);
+            });
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> assignChat(String groupId) {
+    assignChatFacade.assignChat(groupId, authenticatedUser);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> joinChat(Long chatId) {
+    joinAndLeaveChatFacade.joinChat(chatId, authenticatedUser);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> verifyCanModerateChat(Long chatId) {
+    joinAndLeaveChatFacade.verifyCanModerate(chatId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> stopChat(Long chatId) {
+    var chat =
+        chatService
+            .getChat(chatId)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        String.format(
+                            "Chat with id %s not found while trying to stop the chat.", chatId)));
+
+    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
+    messenger.unbanUsersInChat(chatId, callingConsultant.getId());
+    stopChatFacade.stopChat(chat, callingConsultant);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<ChatMembersResponseDTO> getChatMembers(Long chatId) {
+    var chatMembersResponseDTO = getChatMembersFacade.getChatMembers(chatId);
+
+    return new ResponseEntity<>(chatMembersResponseDTO, HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> leaveChat(Long chatId) {
+    joinAndLeaveChatFacade.leaveChat(chatId, authenticatedUser);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<UpdateChatResponseDTO> updateChat(Long chatId, ChatDTO chatDTO) {
+    var updateChatResponseDTO = chatService.updateChat(chatId, chatDTO, authenticatedUser);
+    return new ResponseEntity<>(updateChatResponseDTO, HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> banFromChat(String chatUserId, Long chatId) {
+    var adviceSeeker =
+        accountManager
+            .findAdviceSeekerByChatUserId(chatUserId)
+            .orElseThrow(
+                () -> {
+                  throw new NotFoundException("Chat User (%s) not found", chatUserId);
+                });
+    if (!messenger.existsChat(chatId)) {
+      throw new NotFoundException("Chat (%s) not found", chatId);
+    }
+
+    var adviceSeekerId = adviceSeeker.getUserId();
+    if (!messenger.banUserFromChat(adviceSeekerId, chatId)) {
+      throw new NotFoundException("User (%s) not found in Chat (%s)", adviceSeekerId, chatId);
+    }
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -58,17 +58,10 @@ import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
-import de.caritas.cob.userservice.api.facade.AssignChatFacade;
-import de.caritas.cob.userservice.api.facade.CreateChatFacade;
 import de.caritas.cob.userservice.api.facade.CreateEnquiryMessageFacade;
 import de.caritas.cob.userservice.api.facade.CreateNewSessionFacade;
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
-import de.caritas.cob.userservice.api.facade.GetChatFacade;
-import de.caritas.cob.userservice.api.facade.GetChatMembersFacade;
-import de.caritas.cob.userservice.api.facade.JoinAndLeaveChatFacade;
-import de.caritas.cob.userservice.api.facade.StartChatFacade;
-import de.caritas.cob.userservice.api.facade.StopChatFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
 import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
@@ -77,7 +70,6 @@ import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
@@ -88,7 +80,6 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.AskerImportService;
-import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -152,14 +143,7 @@ public class UserController implements UsersApi {
   private final @NotNull AssignSessionFacade assignSessionFacade;
   private final @NotNull AssignEnquiryFacade assignEnquiryFacade;
   private final @NotNull DecryptionService decryptionService;
-  private final @NotNull ChatService chatService;
-  private final @NotNull StartChatFacade startChatFacade;
-  private final @NotNull GetChatFacade getChatFacade;
-  private final @NotNull JoinAndLeaveChatFacade joinAndLeaveChatFacade;
-  private final @NotNull AssignChatFacade assignChatFacade;
-  private final @NotNull CreateChatFacade createChatFacade;
-  private final @NotNull StopChatFacade stopChatFacade;
-  private final @NotNull GetChatMembersFacade getChatMembersFacade;
+  private final @NotNull UserChatControllerDelegate userChatControllerDelegate;
   private final @NotNull CreateUserFacade createUserFacade;
   private final @NotNull CreateNewSessionFacade createNewSessionFacade;
   private final @NotNull ConsultantDataFacade consultantDataFacade;
@@ -1124,11 +1108,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<CreateChatResponseDTO> createChatV1(@RequestBody ChatDTO chatDTO) {
-
-    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
-    var response = createChatFacade.createChatV1(chatDTO, callingConsultant);
-
-    return new ResponseEntity<>(response, HttpStatus.CREATED);
+    return userChatControllerDelegate.createChatV1(chatDTO);
   }
 
   /**
@@ -1142,10 +1122,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<CreateChatResponseDTO> createChatV2(@RequestBody ChatDTO chatDTO) {
-
-    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
-    var response = createChatFacade.createChatV2(chatDTO, callingConsultant);
-    return new ResponseEntity<>(response, HttpStatus.CREATED);
+    return userChatControllerDelegate.createChatV2(chatDTO);
   }
 
   /**
@@ -1156,19 +1133,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> startChat(@PathVariable Long chatId) {
-
-    var chat =
-        chatService
-            .getChat(chatId)
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format("Chat with id %s not found for starting chat.", chatId)));
-
-    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
-    startChatFacade.startChat(chat, callingConsultant);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.startChat(chatId);
   }
 
   /**
@@ -1179,16 +1144,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ChatInfoResponseDTO> getChat(Long chatId) {
-    var response = getChatFacade.getChat(chatId);
-    messenger
-        .findChatMetaInfo(chatId, authenticatedUser.getUserId())
-        .ifPresent(
-            chatMetaInfoMap -> {
-              var bannedChatUserIds = userDtoMapper.bannedChatUserIdsOf(chatMetaInfoMap);
-              response.setBannedUsers(bannedChatUserIds);
-            });
-
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return userChatControllerDelegate.getChat(chatId);
   }
 
   /**
@@ -1199,10 +1155,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> assignChat(String groupId) {
-
-    assignChatFacade.assignChat(groupId, authenticatedUser);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.assignChat(groupId);
   }
 
   /**
@@ -1213,14 +1166,12 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> joinChat(@PathVariable Long chatId) {
-    joinAndLeaveChatFacade.joinChat(chatId, authenticatedUser);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.joinChat(chatId);
   }
 
   @Override
   public ResponseEntity<Void> verifyCanModerateChat(@PathVariable Long chatId) {
-    joinAndLeaveChatFacade.verifyCanModerate(chatId);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.verifyCanModerateChat(chatId);
   }
 
   /**
@@ -1232,21 +1183,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> stopChat(Long chatId) {
-
-    var chat =
-        chatService
-            .getChat(chatId)
-            .orElseThrow(
-                () ->
-                    new BadRequestException(
-                        String.format(
-                            "Chat with id %s not found while trying to stop the chat.", chatId)));
-
-    var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
-    messenger.unbanUsersInChat(chatId, callingConsultant.getId());
-    stopChatFacade.stopChat(chat, callingConsultant);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.stopChat(chatId);
   }
 
   /**
@@ -1257,10 +1194,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ChatMembersResponseDTO> getChatMembers(@PathVariable Long chatId) {
-
-    var chatMembersResponseDTO = getChatMembersFacade.getChatMembers(chatId);
-
-    return new ResponseEntity<>(chatMembersResponseDTO, HttpStatus.OK);
+    return userChatControllerDelegate.getChatMembers(chatId);
   }
 
   /**
@@ -1271,14 +1205,11 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> leaveChat(@PathVariable Long chatId) {
-
-    joinAndLeaveChatFacade.leaveChat(chatId, authenticatedUser);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userChatControllerDelegate.leaveChat(chatId);
   }
 
   /**
-   * Updates the settings of the given {@link Chat}.
+   * Updates the settings of the given chat.
    *
    * @param chatId Chat Id (required)
    * @param chatDTO {@link ChatDTO} (required)
@@ -1287,30 +1218,12 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<UpdateChatResponseDTO> updateChat(
       @PathVariable Long chatId, @RequestBody ChatDTO chatDTO) {
-
-    var updateChatResponseDTO = chatService.updateChat(chatId, chatDTO, authenticatedUser);
-    return new ResponseEntity<>(updateChatResponseDTO, HttpStatus.OK);
+    return userChatControllerDelegate.updateChat(chatId, chatDTO);
   }
 
   @Override
   public ResponseEntity<Void> banFromChat(String token, String chatUserId, Long chatId) {
-    var adviceSeeker =
-        accountManager
-            .findAdviceSeekerByChatUserId(chatUserId)
-            .orElseThrow(
-                () -> {
-                  throw new NotFoundException("Chat User (%s) not found", chatUserId);
-                });
-    if (!messenger.existsChat(chatId)) {
-      throw new NotFoundException("Chat (%s) not found", chatId);
-    }
-
-    var adviceSeekerId = adviceSeeker.getUserId();
-    if (!messenger.banUserFromChat(adviceSeekerId, chatId)) {
-      throw new NotFoundException("User (%s) not found in Chat (%s)", adviceSeekerId, chatId);
-    }
-
-    return ResponseEntity.noContent().build();
+    return userChatControllerDelegate.banFromChat(chatUserId, chatId);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
@@ -1,0 +1,273 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatInfoResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatMembersResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateChatResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UpdateChatResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.AssignChatFacade;
+import de.caritas.cob.userservice.api.facade.CreateChatFacade;
+import de.caritas.cob.userservice.api.facade.GetChatFacade;
+import de.caritas.cob.userservice.api.facade.GetChatMembersFacade;
+import de.caritas.cob.userservice.api.facade.JoinAndLeaveChatFacade;
+import de.caritas.cob.userservice.api.facade.StartChatFacade;
+import de.caritas.cob.userservice.api.facade.StopChatFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class UserChatControllerDelegateTest {
+
+  @Mock private UserAccountService userAccountProvider;
+  @Mock private ChatService chatService;
+  @Mock private StartChatFacade startChatFacade;
+  @Mock private GetChatFacade getChatFacade;
+  @Mock private JoinAndLeaveChatFacade joinAndLeaveChatFacade;
+  @Mock private AssignChatFacade assignChatFacade;
+  @Mock private CreateChatFacade createChatFacade;
+  @Mock private StopChatFacade stopChatFacade;
+  @Mock private GetChatMembersFacade getChatMembersFacade;
+  @Mock private AccountManaging accountManager;
+  @Mock private Messaging messenger;
+  @Mock private UserDtoMapper userDtoMapper;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private UserChatControllerDelegate delegate;
+
+  @Test
+  void createChatV1ShouldReturnCreatedResponseFromFacade() {
+    var chatDTO = new ChatDTO();
+    var consultant = consultant();
+    var createChatResponseDTO = new CreateChatResponseDTO();
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(createChatFacade.createChatV1(chatDTO, consultant)).thenReturn(createChatResponseDTO);
+
+    var response = delegate.createChatV1(chatDTO);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isSameAs(createChatResponseDTO);
+  }
+
+  @Test
+  void createChatV2ShouldReturnCreatedResponseFromFacade() {
+    var chatDTO = new ChatDTO();
+    var consultant = consultant();
+    var createChatResponseDTO = new CreateChatResponseDTO();
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(createChatFacade.createChatV2(chatDTO, consultant)).thenReturn(createChatResponseDTO);
+
+    var response = delegate.createChatV2(chatDTO);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isSameAs(createChatResponseDTO);
+  }
+
+  @Test
+  void startChatShouldStartExistingChatAndReturnOk() {
+    var chat = chat();
+    var consultant = consultant();
+    when(chatService.getChat(1L)).thenReturn(Optional.of(chat));
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+
+    var response = delegate.startChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(startChatFacade).startChat(chat, consultant);
+  }
+
+  @Test
+  void startChatShouldThrowBadRequestWhenChatDoesNotExist() {
+    when(chatService.getChat(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> delegate.startChat(1L)).isInstanceOf(BadRequestException.class);
+
+    verify(chatService).getChat(1L);
+  }
+
+  @Test
+  void getChatShouldReturnOkAndEnrichBannedUsersWhenMetadataExists() {
+    var chatInfoResponseDTO = new ChatInfoResponseDTO();
+    var metadata = Map.<String, Object>of("banned", List.of("user-id"));
+    when(getChatFacade.getChat(1L)).thenReturn(chatInfoResponseDTO);
+    when(authenticatedUser.getUserId()).thenReturn("consultant-id");
+    when(messenger.findChatMetaInfo(1L, "consultant-id")).thenReturn(Optional.of(metadata));
+    when(userDtoMapper.bannedChatUserIdsOf(metadata)).thenReturn(List.of("banned-user"));
+
+    var response = delegate.getChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(chatInfoResponseDTO);
+    assertThat(chatInfoResponseDTO.getBannedUsers()).containsExactly("banned-user");
+  }
+
+  @Test
+  void assignChatShouldDelegateAndReturnOk() {
+    var response = delegate.assignChat("group-id");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(assignChatFacade).assignChat("group-id", authenticatedUser);
+  }
+
+  @Test
+  void joinChatShouldDelegateAndReturnOk() {
+    var response = delegate.joinChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(joinAndLeaveChatFacade).joinChat(1L, authenticatedUser);
+  }
+
+  @Test
+  void verifyCanModerateChatShouldDelegateAndReturnOk() {
+    var response = delegate.verifyCanModerateChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(joinAndLeaveChatFacade).verifyCanModerate(1L);
+  }
+
+  @Test
+  void stopChatShouldUnbanStopAndReturnOk() {
+    var chat = chat();
+    var consultant = consultant();
+    when(chatService.getChat(1L)).thenReturn(Optional.of(chat));
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+
+    var response = delegate.stopChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(messenger).unbanUsersInChat(1L, "consultant-id");
+    verify(stopChatFacade).stopChat(chat, consultant);
+  }
+
+  @Test
+  void stopChatShouldThrowBadRequestWhenChatDoesNotExist() {
+    when(chatService.getChat(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> delegate.stopChat(1L)).isInstanceOf(BadRequestException.class);
+
+    verify(chatService).getChat(1L);
+  }
+
+  @Test
+  void getChatMembersShouldReturnOkWithFacadeResponse() {
+    var chatMembersResponseDTO = new ChatMembersResponseDTO();
+    when(getChatMembersFacade.getChatMembers(1L)).thenReturn(chatMembersResponseDTO);
+
+    var response = delegate.getChatMembers(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(chatMembersResponseDTO);
+  }
+
+  @Test
+  void leaveChatShouldDelegateAndReturnOk() {
+    var response = delegate.leaveChat(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(joinAndLeaveChatFacade).leaveChat(1L, authenticatedUser);
+  }
+
+  @Test
+  void updateChatShouldReturnOkWithServiceResponse() {
+    var chatDTO = new ChatDTO();
+    var updateChatResponseDTO = new UpdateChatResponseDTO();
+    when(chatService.updateChat(1L, chatDTO, authenticatedUser)).thenReturn(updateChatResponseDTO);
+
+    var response = delegate.updateChat(1L, chatDTO);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(updateChatResponseDTO);
+  }
+
+  @Test
+  void banFromChatShouldBanAdviceSeekerAndReturnNoContent() {
+    var adviceSeeker = adviceSeeker();
+    when(accountManager.findAdviceSeekerByChatUserId("chat-user-id"))
+        .thenReturn(Optional.of(adviceSeeker));
+    when(messenger.existsChat(1L)).thenReturn(true);
+    when(messenger.banUserFromChat("advice-seeker-id", 1L)).thenReturn(true);
+
+    var response = delegate.banFromChat("chat-user-id", 1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(messenger).banUserFromChat("advice-seeker-id", 1L);
+  }
+
+  @Test
+  void banFromChatShouldThrowNotFoundWhenAdviceSeekerDoesNotExist() {
+    when(accountManager.findAdviceSeekerByChatUserId("chat-user-id")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> delegate.banFromChat("chat-user-id", 1L))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void banFromChatShouldThrowNotFoundWhenChatDoesNotExist() {
+    when(accountManager.findAdviceSeekerByChatUserId("chat-user-id"))
+        .thenReturn(Optional.of(adviceSeeker()));
+    when(messenger.existsChat(1L)).thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.banFromChat("chat-user-id", 1L))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void banFromChatShouldThrowNotFoundWhenBanFails() {
+    when(accountManager.findAdviceSeekerByChatUserId("chat-user-id"))
+        .thenReturn(Optional.of(adviceSeeker()));
+    when(messenger.existsChat(1L)).thenReturn(true);
+    when(messenger.banUserFromChat(any(), anyLong())).thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.banFromChat("chat-user-id", 1L))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  private Chat chat() {
+    var now = LocalDateTime.now();
+    return Chat.builder().id(1L).topic("topic").initialStartDate(now).startDate(now).build();
+  }
+
+  private User adviceSeeker() {
+    return User.builder()
+        .userId("advice-seeker-id")
+        .username("advice-seeker")
+        .email("advice-seeker@example.com")
+        .build();
+  }
+
+  private Consultant consultant() {
+    return Consultant.builder()
+        .id("consultant-id")
+        .rocketChatId("rocket-chat-id")
+        .username("consultant")
+        .firstName("Con")
+        .lastName("Sultant")
+        .email("consultant@example.com")
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -47,11 +47,15 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
+import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -74,6 +78,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -82,6 +87,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(UserChatControllerDelegate.class)
 @TestPropertySource(properties = "spring.profiles.active=testing,feature.topics.enabled=true")
 class UserControllerIT {
 
@@ -303,6 +309,15 @@ class UserControllerIT {
   @SuppressWarnings("unused")
   private ConsultantDtoMapper consultantDtoMapper;
 
+  // Required by the ConsultantDtoMapper spy bean when this WebMvcTest context is created.
+  @MockBean
+  @SuppressWarnings("unused")
+  private ConsultantTopicRepository consultantTopicRepository;
+
+  @MockBean
+  @SuppressWarnings("unused")
+  private TopicService topicService;
+
   @MockBean
   @SuppressWarnings("unused")
   private UserDtoMapper userDtoMapper;
@@ -327,7 +342,15 @@ class UserControllerIT {
 
   @MockBean private AdminUserFacade adminUserFacade;
 
+  @MockBean
+  @SuppressWarnings("unused")
+  private MagicLinkLoginService magicLinkLoginService;
+
   @MockBean private SessionDeleteService sessionDeleteService;
+
+  @MockBean
+  @SuppressWarnings("unused")
+  private EventNotificationService eventNotificationService;
 
   @Mock private Logger logger;
 


### PR DESCRIPTION
## Summary
- Extracted chat endpoint orchestration from `UserController` into `UserChatControllerDelegate`.
- Kept existing routes, DTOs, status codes, exceptions, and facade/service calls unchanged.
- Added focused unit coverage for the extracted chat delegate flows.
- Added required WebMvcTest context mocks for `ConsultantDtoMapper` dependencies.

## Testing
- `mvn -Dtest=UserChatControllerDelegateTest -Dspotless.check.skip=true test`
- `mvn -DskipTests -Dspotless.check.skip=true compile`