### PR TITLE
Handle agency service errors gracefully for asker /users/data

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProvider.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientResponseException;
 
 /** Provider for asker information. */
 @Component
@@ -97,18 +97,8 @@ public class AskerDataProvider {
   }
 
   private LinkedHashMap<String, Object> getConsultingTypes(User user) {
-
     Set<Session> sessionList = SetUtils.emptyIfNull(user.getSessions());
-    List<Long> agencyIds = mergeAgencyIdsFromSessionAndUser(user, sessionList);
-    List<AgencyDTO> agencyDTOs;
-    try {
-      agencyDTOs = this.agencyService.getAgencies(agencyIds);
-    } catch (HttpClientErrorException.Forbidden e) {
-      // Login must not fail if downstream agency lookup denies this token scope.
-      log.warn(
-          "Forbidden while loading agencies for user {}: {}", user.getUserId(), e.getMessage());
-      agencyDTOs = Collections.emptyList();
-    }
+    List<AgencyDTO> agencyDTOs = agencyDTOsOf(user, sessionList);
     LinkedHashMap<String, Object> consultingTypes = new LinkedHashMap<>();
     for (int type : consultingTypeManager.getAllConsultingTypeIds()) {
       consultingTypes.put(
@@ -116,6 +106,21 @@ public class AskerDataProvider {
     }
 
     return consultingTypes;
+  }
+
+  private List<AgencyDTO> agencyDTOsOf(User user, Set<Session> sessionList) {
+    try {
+      return agencyService.getAgencies(mergeAgencyIdsFromSessionAndUser(user, sessionList));
+    } catch (RestClientResponseException e) {
+      // Do not block login when agency-service cannot provide metadata for this token/agency.
+      // Return a minimal asker profile instead of surfacing agency errors as login failures.
+      log.warn(
+          "Could not load agencies for user {}: status={}, body={}",
+          user.getUserId(),
+          e.getRawStatusCode(),
+          e.getResponseBodyAsString());
+      return List.of();
+    }
   }
 
   private LinkedHashMap<String, Object> getConsultingTypeData(

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProviderTest.java
@@ -40,6 +40,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
 class AskerDataProviderTest {
@@ -100,6 +102,27 @@ class AskerDataProviderTest {
     AgencyDTO agency = (AgencyDTO) consultingTypeData.get("agency");
 
     assertEquals(AGENCY_DTO_KREUZBUND, agency);
+  }
+
+  @Test
+  void retrieveData_Should_ReturnUserDataWithoutAgency_When_AgencyServiceReturnsNotFound() {
+    givenAnEmailDummySuffixConfig();
+    when(authenticatedUser.getRoles()).thenReturn(asSet(UserRole.USER.getValue()));
+    when(agencyService.getAgencies(Mockito.anyList()))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(consultingTypeManager.getAllConsultingTypeIds())
+        .thenReturn(IntStream.range(0, 22).boxed().collect(Collectors.toList()));
+
+    @SuppressWarnings("unchecked")
+    LinkedHashMap<String, Object> consultingTypeData =
+        (LinkedHashMap<String, Object>)
+            askerDataProvider
+                .retrieveData(USER)
+                .getConsultingTypes()
+                .get(Integer.toString(AGENCY_DTO_SUCHT.getConsultingType()));
+
+    assertNull(consultingTypeData.get("agency"));
+    assertFalse((boolean) consultingTypeData.get("isRegistered"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Align `AskerDataProvider` with `ConsultantDataProvider` by extracting `agencyDTOsOf()` and catching `RestClientResponseException` on agency lookup.
- Return an empty agency list and log a warning instead of surfacing agency-service errors (404, 403, etc.) as 500 on asker `GET /users/data`.

## Test
- `mvn test -Dtest=AskerDataProviderTest` passes
- `GET /users/data` as **asker** returns 200 when agency service returns 404 (agency null, `isRegistered: false`)
- `GET /users/data` as **asker** still returns agencies when agency service responds successfully