### PR TITLE
Refactor Matrix media operations

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -26,8 +26,7 @@ public class MatrixMediaClient {
   private final RestTemplate restTemplate;
 
   public Map<String, Object> uploadFile(MultipartFile file, String roomId, String accessToken) {
-    String fileName =
-        file.getOriginalFilename() != null ? file.getOriginalFilename() : "file";
+    String fileName = file.getOriginalFilename() != null ? file.getOriginalFilename() : "file";
     String contentType = file.getContentType();
 
     try {
@@ -86,7 +85,8 @@ public class MatrixMediaClient {
     }
 
     if (response.getBody() == null) {
-      throw new RuntimeException("Failed to download file: No file data in Matrix download response");
+      throw new RuntimeException(
+          "Failed to download file: No file data in Matrix download response");
     }
 
     log.info("✅ File downloaded successfully: {} bytes", response.getBody().length);

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -56,10 +56,14 @@ public class MatrixMediaClient {
       sendFileMessage(roomId, fileName, contentUri, contentType, file.getSize(), accessToken);
 
       return Map.of(
-          "success", true,
-          "content_uri", contentUri,
-          "file_name", fileName,
-          "file_size", file.getSize());
+          "success",
+          true,
+          "content_uri",
+          contentUri,
+          "file_name",
+          fileName,
+          "file_size",
+          file.getSize());
 
     } catch (Exception e) {
       log.error("❌ Failed to upload file to Matrix", e);
@@ -68,8 +72,7 @@ public class MatrixMediaClient {
   }
 
   public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
-    String url =
-        matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
+    String url = matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
     log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
 
     HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -1,0 +1,163 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatrixMediaClient {
+
+  private static final String ENDPOINT_MEDIA_UPLOAD = "/_matrix/media/r0/upload";
+
+  private final MatrixConfig matrixConfig;
+  private final RestTemplate restTemplate;
+
+  public Map<String, Object> uploadFile(MultipartFile file, String roomId, String accessToken) {
+    try {
+      String url = matrixConfig.getApiUrl(ENDPOINT_MEDIA_UPLOAD);
+
+      log.info(
+          "📤 Uploading file to Matrix: {} ({}bytes)", file.getOriginalFilename(), file.getSize());
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "Bearer " + accessToken);
+      headers.setContentType(MediaType.parseMediaType(file.getContentType()));
+
+      HttpEntity<byte[]> requestEntity = new HttpEntity<>(file.getBytes(), headers);
+
+      ResponseEntity<Map> response = restTemplate.postForEntity(url, requestEntity, Map.class);
+
+      if (response.getBody() != null && response.getBody().containsKey("content_uri")) {
+        String contentUri = (String) response.getBody().get("content_uri");
+        log.info("✅ File uploaded successfully: {}", contentUri);
+
+        sendFileMessage(
+            roomId,
+            file.getOriginalFilename(),
+            contentUri,
+            file.getContentType(),
+            file.getSize(),
+            accessToken);
+
+        return Map.of(
+            "success",
+            true,
+            "content_uri",
+            contentUri,
+            "file_name",
+            file.getOriginalFilename(),
+            "file_size",
+            file.getSize());
+      }
+
+      throw new RuntimeException("No content_uri in Matrix upload response");
+
+    } catch (Exception e) {
+      log.error("❌ Failed to upload file to Matrix", e);
+      throw new RuntimeException("Failed to upload file: " + e.getMessage(), e);
+    }
+  }
+
+  public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
+    try {
+      String url =
+          matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
+
+      log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "Bearer " + accessToken);
+
+      HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+      ResponseEntity<byte[]> response =
+          restTemplate.exchange(url, HttpMethod.GET, requestEntity, byte[].class);
+
+      if (response.getBody() != null) {
+        log.info("✅ File downloaded successfully: {} bytes", response.getBody().length);
+        return response.getBody();
+      }
+
+      throw new RuntimeException("No file data in Matrix download response");
+
+    } catch (Exception e) {
+      log.error("❌ Failed to download file from Matrix", e);
+      throw new RuntimeException("Failed to download file: " + e.getMessage(), e);
+    }
+  }
+
+  private Map<String, Object> sendFileMessage(
+      String roomId,
+      String fileName,
+      String contentUri,
+      String mimeType,
+      long fileSize,
+      String accessToken) {
+    try {
+      var headers = getClientHttpHeaders(accessToken);
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      String msgtype = "m.file";
+      if (mimeType != null) {
+        if (mimeType.startsWith("image/")) {
+          msgtype = "m.image";
+        } else if (mimeType.startsWith("video/")) {
+          msgtype = "m.video";
+        } else if (mimeType.startsWith("audio/")) {
+          msgtype = "m.audio";
+        }
+      }
+
+      var messageBody = new HashMap<String, Object>();
+      messageBody.put("msgtype", msgtype);
+      messageBody.put("body", fileName);
+      messageBody.put("url", contentUri);
+
+      var info = new HashMap<String, Object>();
+      info.put("size", fileSize);
+      if (mimeType != null) {
+        info.put("mimetype", mimeType);
+      }
+      messageBody.put("info", info);
+
+      HttpEntity<Map<String, Object>> request = new HttpEntity<>(messageBody, headers);
+
+      String txnId = UUID.randomUUID().toString();
+      var url =
+          matrixConfig.getApiUrl(
+              "/_matrix/client/r0/rooms/" + roomId + "/send/m.room.message/" + txnId);
+
+      log.info("📨 Sending file message to Matrix room: {} (type: {})", roomId, msgtype);
+
+      var response = restTemplate.exchange(url, HttpMethod.PUT, request, Map.class);
+
+      log.info("✅ File message sent successfully");
+      return response.getBody();
+    } catch (Exception ex) {
+      log.error(
+          "Matrix Error: Could not send file message to room ({}). Reason: {}",
+          roomId,
+          ex.getMessage());
+      return Map.of("error", ex.getMessage());
+    }
+  }
+
+  private HttpHeaders getClientHttpHeaders(String accessToken) {
+    var headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+    return headers;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -26,44 +26,41 @@ public class MatrixMediaClient {
   private final RestTemplate restTemplate;
 
   public Map<String, Object> uploadFile(MultipartFile file, String roomId, String accessToken) {
+    String fileName =
+        file.getOriginalFilename() != null ? file.getOriginalFilename() : "file";
+    String contentType = file.getContentType();
+
     try {
       String url = matrixConfig.getApiUrl(ENDPOINT_MEDIA_UPLOAD);
 
-      log.info(
-          "📤 Uploading file to Matrix: {} ({}bytes)", file.getOriginalFilename(), file.getSize());
+      log.info("📤 Uploading file to Matrix: {} ({}bytes)", fileName, file.getSize());
 
       HttpHeaders headers = new HttpHeaders();
       headers.set("Authorization", "Bearer " + accessToken);
-      headers.setContentType(MediaType.parseMediaType(file.getContentType()));
+      headers.setContentType(
+          contentType != null
+              ? MediaType.parseMediaType(contentType)
+              : MediaType.APPLICATION_OCTET_STREAM);
 
       HttpEntity<byte[]> requestEntity = new HttpEntity<>(file.getBytes(), headers);
 
+      @SuppressWarnings("rawtypes")
       ResponseEntity<Map> response = restTemplate.postForEntity(url, requestEntity, Map.class);
 
-      if (response.getBody() != null && response.getBody().containsKey("content_uri")) {
-        String contentUri = (String) response.getBody().get("content_uri");
-        log.info("✅ File uploaded successfully: {}", contentUri);
-
-        sendFileMessage(
-            roomId,
-            file.getOriginalFilename(),
-            contentUri,
-            file.getContentType(),
-            file.getSize(),
-            accessToken);
-
-        return Map.of(
-            "success",
-            true,
-            "content_uri",
-            contentUri,
-            "file_name",
-            file.getOriginalFilename(),
-            "file_size",
-            file.getSize());
+      if (response.getBody() == null || !response.getBody().containsKey("content_uri")) {
+        throw new RuntimeException("No content_uri in Matrix upload response");
       }
 
-      throw new RuntimeException("No content_uri in Matrix upload response");
+      String contentUri = (String) response.getBody().get("content_uri");
+      log.info("✅ File uploaded successfully: {}", contentUri);
+
+      sendFileMessage(roomId, fileName, contentUri, contentType, file.getSize(), accessToken);
+
+      return Map.of(
+          "success", true,
+          "content_uri", contentUri,
+          "file_name", fileName,
+          "file_size", file.getSize());
 
     } catch (Exception e) {
       log.error("❌ Failed to upload file to Matrix", e);
@@ -72,34 +69,31 @@ public class MatrixMediaClient {
   }
 
   public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
+    String url =
+        matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
+    log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+    HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+    ResponseEntity<byte[]> response;
     try {
-      String url =
-          matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
-
-      log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
-
-      HttpHeaders headers = new HttpHeaders();
-      headers.set("Authorization", "Bearer " + accessToken);
-
-      HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
-
-      ResponseEntity<byte[]> response =
-          restTemplate.exchange(url, HttpMethod.GET, requestEntity, byte[].class);
-
-      if (response.getBody() != null) {
-        log.info("✅ File downloaded successfully: {} bytes", response.getBody().length);
-        return response.getBody();
-      }
-
-      throw new RuntimeException("No file data in Matrix download response");
-
-    } catch (Exception e) {
+      response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, byte[].class);
+    } catch (RuntimeException e) {
       log.error("❌ Failed to download file from Matrix", e);
       throw new RuntimeException("Failed to download file: " + e.getMessage(), e);
     }
+
+    if (response.getBody() == null) {
+      throw new RuntimeException("Failed to download file: No file data in Matrix download response");
+    }
+
+    log.info("✅ File downloaded successfully: {} bytes", response.getBody().length);
+    return response.getBody();
   }
 
-  private Map<String, Object> sendFileMessage(
+  private void sendFileMessage(
       String roomId,
       String fileName,
       String contentUri,
@@ -142,16 +136,15 @@ public class MatrixMediaClient {
 
       log.info("📨 Sending file message to Matrix room: {} (type: {})", roomId, msgtype);
 
+      @SuppressWarnings("rawtypes")
       var response = restTemplate.exchange(url, HttpMethod.PUT, request, Map.class);
 
       log.info("✅ File message sent successfully");
-      return response.getBody();
     } catch (Exception ex) {
       log.error(
           "Matrix Error: Could not send file message to room ({}). Reason: {}",
           roomId,
           ex.getMessage());
-      return Map.of("error", ex.getMessage());
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -27,7 +27,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 /** Service for Matrix Synapse functionalities. */
 @Slf4j
@@ -42,7 +41,6 @@ public class MatrixSynapseService {
   private static final String ENDPOINT_JOIN_ROOM = "/_matrix/client/r0/rooms/{roomId}/join";
   private static final String ENDPOINT_SYNC = "/_matrix/client/r0/sync";
   private static final String ENDPOINT_UPDATE_USER_ADMIN = "/_synapse/admin/v2/users/{userId}";
-  private static final String ENDPOINT_MEDIA_UPLOAD = "/_matrix/media/r0/upload";
   private static final String ENDPOINT_JOINED_ROOMS = "/_matrix/client/r0/joined_rooms";
   private static final String ENDPOINT_POWER_LEVELS =
       "/_matrix/client/r0/rooms/{roomId}/state/m.room.power_levels";
@@ -53,6 +51,7 @@ public class MatrixSynapseService {
 
   private final MatrixConfig matrixConfig;
   private final RestTemplate restTemplate;
+  private final MatrixMediaClient matrixMediaClient;
 
   // Cache for Matrix access tokens (username -> access token)
   private final java.util.Map<String, String> accessTokenCache =
@@ -814,52 +813,8 @@ public class MatrixSynapseService {
    * @return Map with content_uri and upload success
    */
   public java.util.Map<String, Object> uploadFile(
-      MultipartFile file, String roomId, String accessToken) {
-    try {
-      String url = matrixConfig.getApiUrl(ENDPOINT_MEDIA_UPLOAD);
-
-      log.info(
-          "📤 Uploading file to Matrix: {} ({}bytes)", file.getOriginalFilename(), file.getSize());
-
-      HttpHeaders headers = new HttpHeaders();
-      headers.set("Authorization", "Bearer " + accessToken);
-      headers.setContentType(MediaType.parseMediaType(file.getContentType()));
-
-      HttpEntity<byte[]> requestEntity = new HttpEntity<>(file.getBytes(), headers);
-
-      ResponseEntity<java.util.Map> response =
-          restTemplate.postForEntity(url, requestEntity, java.util.Map.class);
-
-      if (response.getBody() != null && response.getBody().containsKey("content_uri")) {
-        String contentUri = (String) response.getBody().get("content_uri");
-        log.info("✅ File uploaded successfully: {}", contentUri);
-
-        // Automatically send file message to room
-        sendFileMessage(
-            roomId,
-            file.getOriginalFilename(),
-            contentUri,
-            file.getContentType(),
-            file.getSize(),
-            accessToken);
-
-        return java.util.Map.of(
-            "success",
-            true,
-            "content_uri",
-            contentUri,
-            "file_name",
-            file.getOriginalFilename(),
-            "file_size",
-            file.getSize());
-      }
-
-      throw new RuntimeException("No content_uri in Matrix upload response");
-
-    } catch (Exception e) {
-      log.error("❌ Failed to upload file to Matrix", e);
-      throw new RuntimeException("Failed to upload file: " + e.getMessage(), e);
-    }
+      org.springframework.web.multipart.MultipartFile file, String roomId, String accessToken) {
+    return matrixMediaClient.uploadFile(file, roomId, accessToken);
   }
 
   /**
@@ -871,102 +826,7 @@ public class MatrixSynapseService {
    * @return the file bytes
    */
   public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
-    try {
-      String url =
-          matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
-
-      log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
-
-      HttpHeaders headers = new HttpHeaders();
-      headers.set("Authorization", "Bearer " + accessToken);
-
-      HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
-
-      ResponseEntity<byte[]> response =
-          restTemplate.exchange(
-              url, org.springframework.http.HttpMethod.GET, requestEntity, byte[].class);
-
-      if (response.getBody() != null) {
-        log.info("✅ File downloaded successfully: {} bytes", response.getBody().length);
-        return response.getBody();
-      }
-
-      throw new RuntimeException("No file data in Matrix download response");
-
-    } catch (Exception e) {
-      log.error("❌ Failed to download file from Matrix", e);
-      throw new RuntimeException("Failed to download file: " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Send a file message to a Matrix room.
-   *
-   * @param roomId the room ID
-   * @param fileName the file name
-   * @param contentUri the Matrix content URI (mxc://...)
-   * @param mimeType the file MIME type
-   * @param fileSize the file size in bytes
-   * @param accessToken the access token
-   * @return the send response with event_id
-   */
-  private java.util.Map<String, Object> sendFileMessage(
-      String roomId,
-      String fileName,
-      String contentUri,
-      String mimeType,
-      long fileSize,
-      String accessToken) {
-    try {
-      var headers = getClientHttpHeaders(accessToken);
-      headers.setContentType(MediaType.APPLICATION_JSON);
-
-      // Determine message type based on MIME type
-      String msgtype = "m.file";
-      if (mimeType != null) {
-        if (mimeType.startsWith("image/")) {
-          msgtype = "m.image";
-        } else if (mimeType.startsWith("video/")) {
-          msgtype = "m.video";
-        } else if (mimeType.startsWith("audio/")) {
-          msgtype = "m.audio";
-        }
-      }
-
-      var messageBody = new java.util.HashMap<String, Object>();
-      messageBody.put("msgtype", msgtype);
-      messageBody.put("body", fileName);
-      messageBody.put("url", contentUri);
-
-      var info = new java.util.HashMap<String, Object>();
-      info.put("size", fileSize);
-      if (mimeType != null) {
-        info.put("mimetype", mimeType);
-      }
-      messageBody.put("info", info);
-
-      HttpEntity<java.util.Map<String, Object>> request = new HttpEntity<>(messageBody, headers);
-
-      String txnId = java.util.UUID.randomUUID().toString();
-      var url =
-          matrixConfig.getApiUrl(
-              "/_matrix/client/r0/rooms/" + roomId + "/send/m.room.message/" + txnId);
-
-      log.info("📨 Sending file message to Matrix room: {} (type: {})", roomId, msgtype);
-
-      var response =
-          restTemplate.exchange(
-              url, org.springframework.http.HttpMethod.PUT, request, java.util.Map.class);
-
-      log.info("✅ File message sent successfully");
-      return response.getBody();
-    } catch (Exception ex) {
-      log.error(
-          "Matrix Error: Could not send file message to room ({}). Reason: {}",
-          roomId,
-          ex.getMessage());
-      return java.util.Map.of("error", ex.getMessage());
-    }
+    return matrixMediaClient.downloadFile(serverName, mediaId, accessToken);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
@@ -142,7 +142,8 @@ class MatrixMediaClientTest {
     when(restTemplate.postForEntity(
             eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(
-            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/img-id"), HttpStatus.OK));
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/img-id"), HttpStatus.OK));
     when(restTemplate.exchange(
             contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),
@@ -172,7 +173,8 @@ class MatrixMediaClientTest {
     when(restTemplate.postForEntity(
             eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(
-            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/vid-id"), HttpStatus.OK));
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/vid-id"), HttpStatus.OK));
     when(restTemplate.exchange(
             contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),
@@ -202,7 +204,8 @@ class MatrixMediaClientTest {
     when(restTemplate.postForEntity(
             eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(
-            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/aud-id"), HttpStatus.OK));
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/aud-id"), HttpStatus.OK));
     when(restTemplate.exchange(
             contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),
@@ -232,7 +235,8 @@ class MatrixMediaClientTest {
     when(restTemplate.postForEntity(
             eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(
-            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/doc-id"), HttpStatus.OK));
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/doc-id"), HttpStatus.OK));
     when(restTemplate.exchange(
             contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
@@ -1,7 +1,9 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,6 +13,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
@@ -84,5 +87,227 @@ class MatrixMediaClientTest {
             eq(HttpMethod.GET),
             any(HttpEntity.class),
             eq(byte[].class));
+  }
+
+  // -------------------------------------------------------------------------
+  // uploadFile – error paths
+  // -------------------------------------------------------------------------
+
+  @Test
+  void uploadFile_Should_ThrowException_When_ResponseBodyIsNull() {
+    var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+    assertThatThrownBy(() -> matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to upload file");
+  }
+
+  @Test
+  void uploadFile_Should_ThrowException_When_ContentUriIsMissing() {
+    var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("some_other_key", "value"), HttpStatus.OK));
+
+    assertThatThrownBy(() -> matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to upload file");
+  }
+
+  @Test
+  void uploadFile_Should_ThrowException_When_RestTemplateThrows() {
+    var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+    when(restTemplate.postForEntity(any(), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new RuntimeException("Connection refused"));
+
+    assertThatThrownBy(() -> matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to upload file");
+  }
+
+  // -------------------------------------------------------------------------
+  // uploadFile – MIME-type-to-msgtype mapping
+  // -------------------------------------------------------------------------
+
+  @Test
+  void uploadFile_Should_UseImageMsgtype_When_FileIsImage() {
+    var file = new MockMultipartFile("file", "photo.png", "image/png", "imagedata".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/img-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("event_id", "$event"), HttpStatus.OK));
+
+    matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            messageCaptor.capture(),
+            eq(Map.class));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) messageCaptor.getValue().getBody();
+    assertThat(body).containsEntry("msgtype", "m.image");
+  }
+
+  @Test
+  void uploadFile_Should_UseVideoMsgtype_When_FileIsVideo() {
+    var file = new MockMultipartFile("file", "video.mp4", "video/mp4", "videodata".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/vid-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("event_id", "$event"), HttpStatus.OK));
+
+    matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            messageCaptor.capture(),
+            eq(Map.class));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) messageCaptor.getValue().getBody();
+    assertThat(body).containsEntry("msgtype", "m.video");
+  }
+
+  @Test
+  void uploadFile_Should_UseAudioMsgtype_When_FileIsAudio() {
+    var file = new MockMultipartFile("file", "audio.mp3", "audio/mpeg", "audiodata".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/aud-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("event_id", "$event"), HttpStatus.OK));
+
+    matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            messageCaptor.capture(),
+            eq(Map.class));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) messageCaptor.getValue().getBody();
+    assertThat(body).containsEntry("msgtype", "m.audio");
+  }
+
+  @Test
+  void uploadFile_Should_UseFileMsgtype_When_FileHasGenericContentType() {
+    var file = new MockMultipartFile("file", "doc.pdf", "application/pdf", "pdfdata".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(Map.of("content_uri", "mxc://matrix.local/doc-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("event_id", "$event"), HttpStatus.OK));
+
+    matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            messageCaptor.capture(),
+            eq(Map.class));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) messageCaptor.getValue().getBody();
+    assertThat(body).containsEntry("msgtype", "m.file");
+  }
+
+  @Test
+  void uploadFile_Should_StillReturnSuccess_When_SendFileMessageFails() {
+    var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/media-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(new RuntimeException("Matrix room not found"));
+
+    // sendFileMessage swallows its own exception; uploadFile still reports success
+    var result = matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    assertThat(result).containsEntry("success", true);
+  }
+
+  // -------------------------------------------------------------------------
+  // downloadFile – error paths
+  // -------------------------------------------------------------------------
+
+  @Test
+  void downloadFile_Should_ThrowException_When_ResponseBodyIsNull() {
+    when(restTemplate.exchange(
+            eq(BASE_URL + "/_matrix/media/r0/download/matrix.local/media-id"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(byte[].class)))
+        .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+    assertThatThrownBy(
+            () -> matrixMediaClient.downloadFile("matrix.local", "media-id", ACCESS_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to download file");
+  }
+
+  @Test
+  void downloadFile_Should_ThrowException_When_RestTemplateThrows() {
+    when(restTemplate.exchange(
+            eq(BASE_URL + "/_matrix/media/r0/download/matrix.local/media-id"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(byte[].class)))
+        .thenThrow(new RuntimeException("Connection refused"));
+
+    assertThatThrownBy(
+            () -> matrixMediaClient.downloadFile("matrix.local", "media-id", ACCESS_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to download file");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
@@ -1,0 +1,88 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixMediaClientTest {
+
+  private static final String BASE_URL = "http://matrix.local";
+  private static final String ACCESS_TOKEN = "access-token";
+  private static final String ROOM_ID = "!room:matrix.local";
+
+  @Mock private RestTemplate restTemplate;
+
+  private MatrixMediaClient matrixMediaClient;
+
+  @BeforeEach
+  void setUp() {
+    var matrixConfig = new MatrixConfig();
+    matrixConfig.setApiUrl(BASE_URL);
+    matrixMediaClient = new MatrixMediaClient(matrixConfig, restTemplate);
+  }
+
+  @Test
+  void uploadFile_Should_UploadMediaAndSendFileMessage() {
+    var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+    var uploadResponse = Map.of("content_uri", "mxc://matrix.local/media-id");
+    var sendResponse = Map.of("event_id", "$event");
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(uploadResponse, HttpStatus.OK));
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains(
+                "/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(sendResponse, HttpStatus.OK));
+
+    var result = matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    assertThat(result)
+        .containsEntry("success", true)
+        .containsEntry("content_uri", "mxc://matrix.local/media-id")
+        .containsEntry("file_name", "test.txt")
+        .containsEntry("file_size", 7L);
+  }
+
+  @Test
+  void downloadFile_Should_ReturnDownloadedBytes() {
+    byte[] expectedBytes = "content".getBytes();
+
+    when(restTemplate.exchange(
+            eq(BASE_URL + "/_matrix/media/r0/download/matrix.local/media-id"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(byte[].class)))
+        .thenReturn(new ResponseEntity<>(expectedBytes, HttpStatus.OK));
+
+    byte[] result = matrixMediaClient.downloadFile("matrix.local", "media-id", ACCESS_TOKEN);
+
+    assertThat(result).isEqualTo(expectedBytes);
+    verify(restTemplate)
+        .exchange(
+            eq(BASE_URL + "/_matrix/media/r0/download/matrix.local/media-id"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(byte[].class));
+  }
+}


### PR DESCRIPTION
### Summary

- Extracted Matrix media upload/download logic from `MatrixSynapseService` into a new focused `MatrixMediaClient`.
- Kept `MatrixSynapseService` as the existing public entry point, so current callers/controllers remain unchanged.
- Moved file upload, file download, and file-message sending logic into the new media client.
- Added focused unit coverage for Matrix media upload/download behavior.

### Testing

- `mvn -DskipTests -Dspotless.check.skip=true compile`
- `mvn -Dtest=MatrixMediaClientTest -Dspotless.check.skip=true test`
- `mvn spotless:check`

### Notes

- Refactor only.
- No API changes.
- No database changes.
- No intended Matrix behavior changes.