### PR TITLE
Sanitary Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<spring-context-support.version>5.3.35</spring-context-support.version>
 		<ehcache.version>2.10.9.2</ehcache.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
+		<sentry.version>8.43.2</sentry.version>
 	</properties>
 
 	<dependencyManagement>
@@ -110,6 +111,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.sentry</groupId>
+			<artifactId>sentry-spring-boot-starter</artifactId>
+			<version>${sentry.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -301,6 +307,11 @@
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
 			<version>7.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.sentry</groupId>
+			<artifactId>sentry-logback</artifactId>
+			<version>${sentry.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,15 @@ spring.data.jpa.repositories.bootstrap-mode=default
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
 
+# ---------------- Sentry ----------------
+sentry.dsn=${SENTRY_DSN:}
+sentry.environment=${SENTRY_ENVIRONMENT:dev}
+sentry.release=${SENTRY_RELEASE:oriso-userservice@local}
+sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
+sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
+sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
+sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
+
 # ---------------- Server ----------------
 server.port=8082
 server.host=http://localhost


### PR DESCRIPTION
## Summary
- Add Sentry Spring Boot starter to capture UserService application exceptions.
- Add Sentry Logback integration so warning/error logs can be sent to Sentry.
- Configure Sentry through environment-backed properties for DSN, environment, release, PII, tracing, and log thresholds.

## Validation
- `./mvnw -q -DskipTests -Dspotless.check.skip=true compile`

## Deployment Notes
- Set `SENTRY_DSN` in the deployment secret/env for UserService.
- Optional: adjust `SENTRY_LOGGING_MINIMUM_EVENT_LEVEL` and `SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL` if warning volume is too noisy.
