### PR TITLE
US-H03 Fix Keycloak refresh token logging

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -67,8 +67,11 @@ import org.springframework.web.client.RestTemplate;
 public class KeycloakService implements IdentityClient {
 
   private static final String KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+  private static final String KEYCLOAK_GRANT_TYPE_PASSWORD = "password";
   private static final String BODY_KEY_CLIENT_ID = "client_id";
   private static final String BODY_KEY_GRANT_TYPE = "grant_type";
+  private static final String BODY_KEY_PASSWORD = "password";
+  private static final String BODY_KEY_USERNAME = "username";
   private static final String ENDPOINT_OPENID_CONNECT_LOGIN = "/token";
   private static final String ENDPOINT_OPENID_CONNECT_LOGOUT = "/logout";
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
@@ -163,11 +166,11 @@ public class KeycloakService implements IdentityClient {
   }
 
   private HttpEntity<MultiValueMap<String, String>> loginRequest(String userName, String password) {
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("username", userName);
-    map.add("password", password);
+    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
+    map.add(BODY_KEY_USERNAME, userName);
+    map.add(BODY_KEY_PASSWORD, password);
     map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
-    map.add(BODY_KEY_GRANT_TYPE, "password");
+    map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_PASSWORD);
 
     var httpHeaders = new HttpHeaders();
     httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -204,7 +207,7 @@ public class KeycloakService implements IdentityClient {
    * @return true if logout was successful
    */
   public boolean logoutUser(final String refreshToken) {
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
     map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
     map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN);
     map.add(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, refreshToken);
@@ -217,21 +220,38 @@ public class KeycloakService implements IdentityClient {
     var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGOUT);
     try {
       var response = restTemplate.postForEntity(url, request, Void.class);
-      return wasLogoutSuccessful(response, refreshToken);
+      return wasLogoutSuccessful(response);
     } catch (Exception ex) {
-      log.error("Keycloak error: Could not log out user with refresh token {}", refreshToken, ex);
+      log.error("Keycloak error: Could not log out user", ex);
 
       return false;
     }
   }
 
-  private boolean wasLogoutSuccessful(ResponseEntity<Void> responseEntity, String refreshToken) {
+  private boolean wasLogoutSuccessful(ResponseEntity<Void> responseEntity) {
     if (!responseEntity.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
-      log.error("Keycloak error: Could not log out user with refresh token {}", refreshToken);
+      log.error("Keycloak error: Could not log out user");
 
       return false;
     }
     return true;
+  }
+
+  private static final class SensitiveKeycloakFormData extends LinkedMultiValueMap<String, String> {
+
+    private static final String REDACTED = "[REDACTED]";
+
+    @Override
+    public String toString() {
+      var sanitized = new LinkedMultiValueMap<>(this);
+      if (sanitized.containsKey(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN)) {
+        sanitized.put(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, Collections.singletonList(REDACTED));
+      }
+      if (sanitized.containsKey(BODY_KEY_PASSWORD)) {
+        sanitized.put(BODY_KEY_PASSWORD, Collections.singletonList(REDACTED));
+      }
+      return sanitized.toString();
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatCredentialsProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatCredentialsProvider.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.LoginRespons
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.logout.LogoutResponseDTO;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatUserNotInitializedException;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
@@ -31,6 +32,9 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @RequiredArgsConstructor
 public class RocketChatCredentialsProvider {
+
+  private static final String BODY_KEY_PASSWORD = "password";
+  private static final String BODY_KEY_USERNAME = "username";
 
   @Value("${rocket.technical.username}")
   private String technicalUsername;
@@ -196,9 +200,9 @@ public class RocketChatCredentialsProvider {
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-      MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-      map.add("username", username);
-      map.add("password", password);
+      MultiValueMap<String, String> map = new SensitiveRocketChatFormData();
+      map.add(BODY_KEY_USERNAME, username);
+      map.add(BODY_KEY_PASSWORD, password);
 
       HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
 
@@ -207,6 +211,21 @@ public class RocketChatCredentialsProvider {
     } catch (Exception ex) {
       throw new RocketChatLoginException(
           String.format("Could not login user (%s) in Rocket.Chat", username));
+    }
+  }
+
+  private static final class SensitiveRocketChatFormData
+      extends LinkedMultiValueMap<String, String> {
+
+    private static final String REDACTED = "[REDACTED]";
+
+    @Override
+    public String toString() {
+      var sanitized = new LinkedMultiValueMap<>(this);
+      if (sanitized.containsKey(BODY_KEY_PASSWORD)) {
+        sanitized.put(BODY_KEY_PASSWORD, Collections.singletonList(REDACTED));
+      }
+      return sanitized.toString();
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/SensitiveRequestBodyLoggingAdvice.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/SensitiveRequestBodyLoggingAdvice.java
@@ -1,0 +1,59 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordDTO;
+import java.lang.reflect.Type;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+
+@ControllerAdvice
+public class SensitiveRequestBodyLoggingAdvice extends RequestBodyAdviceAdapter {
+
+  private static final String REDACTED = "[REDACTED]";
+
+  @Override
+  public boolean supports(
+      MethodParameter methodParameter,
+      Type targetType,
+      Class<? extends HttpMessageConverter<?>> converterType) {
+    return PasswordDTO.class.equals(targetType);
+  }
+
+  @Override
+  public Object afterBodyRead(
+      Object body,
+      HttpInputMessage inputMessage,
+      MethodParameter parameter,
+      Type targetType,
+      Class<? extends HttpMessageConverter<?>> converterType) {
+    if (body instanceof PasswordDTO) {
+      var passwordDTO = (PasswordDTO) body;
+      return RedactedPasswordDTO.from(passwordDTO);
+    }
+    return body;
+  }
+
+  static final class RedactedPasswordDTO extends PasswordDTO {
+
+    static RedactedPasswordDTO from(PasswordDTO passwordDTO) {
+      var redactedPasswordDTO = new RedactedPasswordDTO();
+      redactedPasswordDTO.setOldPassword(passwordDTO.getOldPassword());
+      redactedPasswordDTO.setNewPassword(passwordDTO.getNewPassword());
+      return redactedPasswordDTO;
+    }
+
+    @Override
+    public String toString() {
+      return "class PasswordDTO {\n"
+          + "    oldPassword: "
+          + REDACTED
+          + "\n"
+          + "    newPassword: "
+          + REDACTED
+          + "\n"
+          + "}";
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacade.java
@@ -127,10 +127,7 @@ public class CreateUserChatRelationFacade {
     String rcUserId = obtainValidRcUserId(dataDTO, rocketChatCredentials);
 
     log.info(
-        "Validating RocketChat credentials for user {}: token={}, userId={}",
-        user.getUsername(),
-        rcUserToken,
-        rcUserId);
+        "Validating RocketChat credentials for user {}: userId={}", user.getUsername(), rcUserId);
 
     if (isBlank(rcUserToken) || isBlank(rcUserId)) {
       log.warn("RocketChat credentials are blank for user {}, rolling back", user.getUsername());

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -182,7 +182,7 @@ public class MatrixEventListenerService {
       // Update sync token for next request
       if (syncResult != null && syncResult.containsKey("next_batch")) {
         syncToken = (String) syncResult.get("next_batch");
-        log.debug("🔷 Sync token updated: {}", syncToken);
+        log.debug("🔷 Matrix sync cursor updated");
       }
 
       return syncResult;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
@@ -1,0 +1,145 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakServiceLoggingTest {
+
+  private static final String REFRESH_TOKEN = "secret-refresh-token-value";
+  private static final String PASSWORD = "secret-password-value";
+  private static final String USERNAME = "user";
+
+  @Mock private RestTemplate restTemplate;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private UserAccountInputValidator userAccountInputValidator;
+  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private KeycloakClient keycloakClient;
+  @Mock private KeycloakMapper keycloakMapper;
+  @Mock private UserHelper userHelper;
+
+  private KeycloakService keycloakService;
+  private Logger logger;
+  private ListAppender<ILoggingEvent> listAppender;
+
+  @BeforeEach
+  void setUp() {
+    keycloakService =
+        new KeycloakService(
+            restTemplate,
+            authenticatedUser,
+            userAccountInputValidator,
+            identityClientConfig,
+            keycloakClient,
+            keycloakMapper,
+            userHelper);
+    setField(keycloakService, "keycloakClientId", "app");
+
+    lenient().when(authenticatedUser.getAccessToken()).thenReturn("access-token");
+    lenient()
+        .when(identityClientConfig.getOpenIdConnectUrl(anyString()))
+        .thenReturn("https://keycloak/logout");
+
+    logger = (Logger) LoggerFactory.getLogger(KeycloakService.class);
+    listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(listAppender);
+  }
+
+  @Test
+  void loginUser_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging() {
+    var loginResponse = new KeycloakLoginResponseDTO();
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
+
+    assertThat(keycloakService.loginUser(USERNAME, PASSWORD)).isSameAs(loginResponse);
+
+    var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .postForEntity(anyString(), requestCaptor.capture(), eq(KeycloakLoginResponseDTO.class));
+    @SuppressWarnings("unchecked")
+    var request = (HttpEntity<MultiValueMap<String, String>>) requestCaptor.getValue();
+
+    assertThat(request.getBody().getFirst("password")).isEqualTo(PASSWORD);
+    assertThat(request.getBody().toString()).doesNotContain(PASSWORD);
+    assertThat(request.getBody().toString()).contains("[REDACTED]");
+  }
+
+  @Test
+  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutThrowsException() {
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenThrow(new RestClientException("keycloak unavailable"));
+
+    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+
+    assertRefreshTokenWasNotLogged();
+  }
+
+  @Test
+  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutReturnsUnexpectedStatus() {
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
+
+    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+
+    assertRefreshTokenWasNotLogged();
+  }
+
+  @Test
+  void logoutUser_ShouldRedactRefreshToken_WhenRequestBodyIsRenderedForDebugLogging() {
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isTrue();
+
+    var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate).postForEntity(anyString(), requestCaptor.capture(), eq(Void.class));
+    @SuppressWarnings("unchecked")
+    var request = (HttpEntity<MultiValueMap<String, String>>) requestCaptor.getValue();
+
+    assertThat(request.getBody().getFirst("refresh_token")).isEqualTo(REFRESH_TOKEN);
+    assertThat(request.getBody().toString()).doesNotContain(REFRESH_TOKEN);
+    assertThat(request.getBody().toString()).contains("[REDACTED]");
+  }
+
+  private void assertRefreshTokenWasNotLogged() {
+    assertThat(listAppender.list).isNotEmpty();
+    assertThat(listAppender.list)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .noneMatch(message -> message.contains(REFRESH_TOKEN));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -184,7 +184,7 @@ public class KeycloakServiceTest {
     boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
 
     assertFalse(response);
-    verify(logger, atLeastOnce()).error(anyString(), anyString(), any(Exception.class));
+    verify(logger, atLeastOnce()).error(anyString(), any(Exception.class));
   }
 
   @Test
@@ -196,7 +196,7 @@ public class KeycloakServiceTest {
     boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
 
     assertFalse(response);
-    verify(logger, atLeastOnce()).error(anyString(), anyString());
+    verify(logger, atLeastOnce()).error(anyString());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/SensitiveRequestBodyLoggingAdviceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/SensitiveRequestBodyLoggingAdviceTest.java
@@ -1,0 +1,36 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordDTO;
+import org.junit.jupiter.api.Test;
+
+class SensitiveRequestBodyLoggingAdviceTest {
+
+  private static final String OLD_PASSWORD = "old-secret-password";
+  private static final String NEW_PASSWORD = "new-secret-password";
+
+  private final SensitiveRequestBodyLoggingAdvice advice = new SensitiveRequestBodyLoggingAdvice();
+
+  @Test
+  void afterBodyRead_ShouldPreservePasswordValuesButRedactToString_ForPasswordDto() {
+    var passwordDTO = new PasswordDTO();
+    passwordDTO.setOldPassword(OLD_PASSWORD);
+    passwordDTO.setNewPassword(NEW_PASSWORD);
+
+    var result =
+        (PasswordDTO) advice.afterBodyRead(passwordDTO, null, null, PasswordDTO.class, null);
+
+    assertThat(result.getOldPassword()).isEqualTo(OLD_PASSWORD);
+    assertThat(result.getNewPassword()).isEqualTo(NEW_PASSWORD);
+    assertThat(result.toString()).doesNotContain(OLD_PASSWORD, NEW_PASSWORD);
+    assertThat(result.toString()).contains("[REDACTED]");
+  }
+
+  @Test
+  void afterBodyRead_ShouldLeaveOtherBodiesUnchanged() {
+    var body = new Object();
+
+    assertThat(advice.afterBodyRead(body, null, null, Object.class, null)).isSameAs(body);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/helper/RocketChatCredentialsProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/helper/RocketChatCredentialsProviderTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -139,6 +140,31 @@ public class RocketChatCredentialsProviderTest {
 
     rocketChatConfig.setBaseUrl("http://localhost/api/v1");
     setField(rcCredentialHelper, "rocketChatConfig", rocketChatConfig);
+  }
+
+  @Test
+  public void loginUser_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging()
+      throws Exception {
+    when(restTemplate.postForEntity(
+            ArgumentMatchers.eq(RC_URL_CHAT_USER_LOGIN),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.<Class<LoginResponseDTO>>any()))
+        .thenReturn(new ResponseEntity<>(LOGIN_RESPONSE_DTO_TECHNICAL_USER_A, HttpStatus.OK));
+
+    rcCredentialHelper.loginUser(TECHNICAL_USER_USERNAME, TECHNICAL_USER_PW);
+
+    var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .postForEntity(
+            ArgumentMatchers.eq(RC_URL_CHAT_USER_LOGIN),
+            requestCaptor.capture(),
+            ArgumentMatchers.<Class<LoginResponseDTO>>any());
+    @SuppressWarnings("unchecked")
+    var request = (HttpEntity<MultiValueMap<String, String>>) requestCaptor.getValue();
+
+    assertEquals(TECHNICAL_USER_PW, request.getBody().getFirst("password"));
+    assertFalse(request.getBody().toString().contains(TECHNICAL_USER_PW));
+    assertTrue(request.getBody().toString().contains("[REDACTED]"));
   }
 
   /** Method: updateCredentials */


### PR DESCRIPTION
## Summary

Fixes US-H03: Keycloak refresh token was logged in plaintext in Keycloak logout error/debug flows.

### Main fix

- Removed refresh token values from Keycloak logout error logs.
- Redacted Keycloak logout form data so DEBUG request logging prints `refresh_token=[[REDACTED]]` instead of the actual refresh token.

### Additional hardening

While checking the same logging area, I also fixed nearby sensitive logging risks:

- Redacted Keycloak login form password logging: `password=[[REDACTED]]`
- Redacted password-change request body logging: `oldPassword: [REDACTED]`, `newPassword: [REDACTED]`
- Removed RocketChat token value from a validation log line.
- Redacted RocketChat login form password logging.
- Avoided logging the raw Matrix sync cursor value.

No API changes, no database changes, and no behavior changes are intended.

## Manual Verification

I verified the password-change logging flow locally through Admin app/Postman using an authenticated Keycloak token.

Request: `PUT /users/password/change`

I used an intentionally invalid `oldPassword`, so the password was not changed.

Expected result: `400 BAD_REQUEST`

The attached screenshot shows the backend console output for this request. It confirms that sensitive values are redacted in logs:

<img width="1393" height="354" alt="image" src="https://github.com/user-attachments/assets/07dcbc23-389c-4ee1-a9d0-2797a0bebac0" />


```text
oldPassword: [REDACTED]
newPassword: [REDACTED]
password=[[REDACTED]]

Note: I did not manually test the Keycloak logout flow through Postman because it is not exposed as a public UserService API endpoint. It is an internal backend method used by validation/login flows. The refresh-token redaction for that path is covered by unit tests.

Tests: 
mvn -Dtest=KeycloakServiceLoggingTest,SensitiveRequestBodyLoggingAdviceTest,UserAccountValidatorTest,RocketChatCredentialsProviderTest#loginUser_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging -Dspotless.check.skip=true test
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0

mvn -DskipTests spotless:check
Result: BUILD SUCCESS

mvn -DskipTests -Dspotless.check.skip=true compile
Result: BUILD SUCCESS