### PR TITLE
US-H04 add explicit RestTemplate timeouts

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.keycloak.config;
 
 import static java.util.Objects.nonNull;
 
+import de.caritas.cob.userservice.api.config.RestTemplateTimeouts;
 import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import java.util.stream.Collectors;
@@ -35,7 +36,10 @@ public class KeycloakConfig {
 
   @Bean("keycloakRestTemplate")
   public RestTemplate keycloakRestTemplate(RestTemplateBuilder restTemplateBuilder) {
-    return restTemplateBuilder.build();
+    return restTemplateBuilder
+        .setConnectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
+        .setReadTimeout(RestTemplateTimeouts.READ_TIMEOUT)
+        .build();
   }
 
   @Bean

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -15,9 +15,9 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -29,7 +29,6 @@ import org.springframework.web.client.RestTemplate;
 /** Service for Matrix Synapse functionalities. */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MatrixSynapseService {
 
   private static final String ENDPOINT_REGISTER_USER = "/_synapse/admin/v1/register";
@@ -42,6 +41,7 @@ public class MatrixSynapseService {
 
   private final MatrixConfig matrixConfig;
   private final RestTemplate restTemplate;
+  private final RestTemplate matrixLongPollRestTemplate;
   private final MatrixRoomClient matrixRoomClient;
   private final MatrixMediaClient matrixMediaClient;
 
@@ -73,6 +73,19 @@ public class MatrixSynapseService {
   // Cached admin access token for admin operations
   private String cachedAdminToken = null;
   private long adminTokenExpiry = 0;
+
+  public MatrixSynapseService(
+      MatrixConfig matrixConfig,
+      RestTemplate restTemplate,
+      @Qualifier("matrixLongPollRestTemplate") RestTemplate matrixLongPollRestTemplate,
+      MatrixRoomClient matrixRoomClient,
+      MatrixMediaClient matrixMediaClient) {
+    this.matrixConfig = matrixConfig;
+    this.restTemplate = restTemplate;
+    this.matrixLongPollRestTemplate = matrixLongPollRestTemplate;
+    this.matrixRoomClient = matrixRoomClient;
+    this.matrixMediaClient = matrixMediaClient;
+  }
 
   /**
    * Creates a new user in Matrix Synapse.
@@ -743,7 +756,8 @@ public class MatrixSynapseService {
           httpMethod = org.springframework.http.HttpMethod.GET;
       }
 
-      var response = restTemplate.exchange(url, httpMethod, request, java.util.Map.class);
+      var response =
+          matrixLongPollRestTemplate.exchange(url, httpMethod, request, java.util.Map.class);
 
       return response.getBody();
     } catch (Exception ex) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -489,7 +489,7 @@ public class MatrixSynapseService {
       log.info("Getting messages from Matrix room: {}", roomId);
 
       var response =
-          restTemplate.exchange(
+          matrixLongPollRestTemplate.exchange(
               url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
 
       if (response.getBody() != null && response.getBody().containsKey("chunk")) {
@@ -549,7 +549,7 @@ public class MatrixSynapseService {
       log.info("Syncing Matrix room: {} for user: {} (timeout: {}ms)", roomId, username, timeout);
 
       var response =
-          restTemplate.exchange(
+          matrixLongPollRestTemplate.exchange(
               url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
 
       if (response.getBody() != null) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
@@ -9,6 +9,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.config.RestTemplateTimeouts;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.AssertTrue;
@@ -50,6 +51,8 @@ public class RocketChatConfig {
   @Bean("rocketChatRestTemplate")
   public RestTemplate rocketChatRestTemplate(RestTemplateBuilder restTemplateBuilder) {
     return restTemplateBuilder
+        .setConnectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
+        .setReadTimeout(RestTemplateTimeouts.READ_TIMEOUT)
         .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
         .build();
   }

--- a/src/main/java/de/caritas/cob/userservice/api/config/AppConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/AppConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
@@ -36,8 +37,20 @@ public class AppConfig {
 
   // RestTemplate Bean
   @Bean
+  @Primary
   public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+    return builder
+        .setConnectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
+        .setReadTimeout(RestTemplateTimeouts.READ_TIMEOUT)
+        .build();
+  }
+
+  @Bean("matrixLongPollRestTemplate")
+  public RestTemplate matrixLongPollRestTemplate(RestTemplateBuilder builder) {
+    return builder
+        .setConnectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
+        .setReadTimeout(RestTemplateTimeouts.MATRIX_LONG_POLL_READ_TIMEOUT)
+        .build();
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/config/RestTemplateTimeouts.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/RestTemplateTimeouts.java
@@ -1,0 +1,12 @@
+package de.caritas.cob.userservice.api.config;
+
+import java.time.Duration;
+
+public final class RestTemplateTimeouts {
+
+  public static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+  public static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration MATRIX_LONG_POLL_READ_TIMEOUT = Duration.ofSeconds(42);
+
+  private RestTemplateTimeouts() {}
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -63,6 +63,30 @@ class MatrixSynapseServiceTest {
         .isEqualTo("Bearer " + ACCESS_TOKEN);
   }
 
+  @Test
+  void syncRoomShouldUseDedicatedLongPollRestTemplate() {
+    var service = matrixSynapseService();
+    when(matrixConfig.getApiUrl("/_matrix/client/r0/sync")).thenReturn(SYNC_URL);
+    when(matrixLongPollRestTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("next_batch", "next-token")));
+    var urlCaptor = ArgumentCaptor.forClass(String.class);
+
+    var result = service.syncRoom("!room:example.org", ACCESS_TOKEN, "alice", 30000);
+
+    assertThat(result).isNotNull();
+    verify(matrixLongPollRestTemplate)
+        .exchange(
+            urlCaptor.capture(),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(Map.class));
+    assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?timeout=30000");
+    assertThat(urlCaptor.getValue()).contains("&filter=");
+    assertThat(urlCaptor.getValue()).contains("%21room%3Aexample.org");
+    verifyNoInteractions(restTemplate);
+  }
+
   private MatrixSynapseService matrixSynapseService() {
     return new MatrixSynapseService(
         matrixConfig,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -76,11 +76,7 @@ class MatrixSynapseServiceTest {
 
     assertThat(result).isNotNull();
     verify(matrixLongPollRestTemplate)
-        .exchange(
-            urlCaptor.capture(),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(Map.class));
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
     assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?timeout=30000");
     assertThat(urlCaptor.getValue()).contains("&filter=");
     assertThat(urlCaptor.getValue()).contains("%21room%3Aexample.org");
@@ -91,7 +87,8 @@ class MatrixSynapseServiceTest {
   void getRoomMessagesShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
     var roomId = "!room:example.org";
-    var messagesUrl = "https://matrix.example/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100";
+    var messagesUrl =
+        "https://matrix.example/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100";
     when(matrixConfig.getApiUrl("/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100"))
         .thenReturn(messagesUrl);
     when(matrixLongPollRestTemplate.exchange(

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -1,0 +1,74 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixSynapseServiceTest {
+
+  private static final String SYNC_URL = "https://matrix.example/_matrix/client/r0/sync";
+  private static final String ACCESS_TOKEN = "access-token";
+
+  @Mock private MatrixConfig matrixConfig;
+  @Mock private RestTemplate restTemplate;
+  @Mock private RestTemplate matrixLongPollRestTemplate;
+  @Mock private MatrixRoomClient matrixRoomClient;
+  @Mock private MatrixMediaClient matrixMediaClient;
+
+  @Test
+  void makeMatrixRequestShouldUseDedicatedLongPollRestTemplate() {
+    var responseBody = Map.<String, Object>of("next_batch", "sync-token");
+    when(matrixLongPollRestTemplate.exchange(
+            eq(SYNC_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(responseBody));
+    var service = matrixSynapseService();
+
+    var result = service.makeMatrixRequest(SYNC_URL, "GET", ACCESS_TOKEN, null);
+
+    assertThat(result).isSameAs(responseBody);
+    verify(matrixLongPollRestTemplate)
+        .exchange(eq(SYNC_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void makeMatrixRequestShouldPassBearerTokenToLongPollRestTemplate() {
+    when(matrixLongPollRestTemplate.exchange(
+            eq(SYNC_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()));
+    var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    var service = matrixSynapseService();
+
+    service.makeMatrixRequest(SYNC_URL, "GET", ACCESS_TOKEN, null);
+
+    verify(matrixLongPollRestTemplate)
+        .exchange(eq(SYNC_URL), eq(HttpMethod.GET), requestCaptor.capture(), eq(Map.class));
+    assertThat(requestCaptor.getValue().getHeaders().getFirst("Authorization"))
+        .isEqualTo("Bearer " + ACCESS_TOKEN);
+  }
+
+  private MatrixSynapseService matrixSynapseService() {
+    return new MatrixSynapseService(
+        matrixConfig,
+        restTemplate,
+        matrixLongPollRestTemplate,
+        matrixRoomClient,
+        matrixMediaClient);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -87,6 +87,25 @@ class MatrixSynapseServiceTest {
     verifyNoInteractions(restTemplate);
   }
 
+  @Test
+  void getRoomMessagesShouldUseDedicatedLongPollRestTemplate() {
+    var service = matrixSynapseService();
+    var roomId = "!room:example.org";
+    var messagesUrl = "https://matrix.example/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100";
+    when(matrixConfig.getApiUrl("/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100"))
+        .thenReturn(messagesUrl);
+    when(matrixLongPollRestTemplate.exchange(
+            eq(messagesUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("chunk", java.util.List.of())));
+
+    var result = service.getRoomMessages(roomId, ACCESS_TOKEN);
+
+    assertThat(result).isNotNull().isEmpty();
+    verify(matrixLongPollRestTemplate)
+        .exchange(eq(messagesUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    verifyNoInteractions(restTemplate);
+  }
+
   private MatrixSynapseService matrixSynapseService() {
     return new MatrixSynapseService(
         matrixConfig,

--- a/src/test/java/de/caritas/cob/userservice/api/config/RestTemplateTimeoutBehaviorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/RestTemplateTimeoutBehaviorTest.java
@@ -1,0 +1,106 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpServer;
+import de.caritas.cob.userservice.api.adapters.keycloak.config.KeycloakConfig;
+import de.caritas.cob.userservice.api.adapters.rocketchat.config.RocketChatConfig;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+class RestTemplateTimeoutBehaviorTest {
+
+  private static final long DELAY_MS = 12_000L;
+  private static final long MIN_TIMEOUT_OBSERVATION_MS = 8_000L;
+  private static final long MAX_TIMEOUT_OBSERVATION_MS = 18_000L;
+  private static final long MAX_LONG_POLL_SUCCESS_MS = 20_000L;
+
+  private HttpServer httpServer;
+  private String slowUrl;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    httpServer.createContext(
+        "/slow",
+        exchange -> {
+          try {
+            Thread.sleep(DELAY_MS);
+            byte[] response = "{\"status\":\"ok\"}".getBytes();
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(HttpStatus.OK.value(), response.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+              outputStream.write(response);
+            }
+          } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+          } finally {
+            exchange.close();
+          }
+        });
+    httpServer.setExecutor(Executors.newCachedThreadPool());
+    httpServer.start();
+    slowUrl = "http://127.0.0.1:" + httpServer.getAddress().getPort() + "/slow";
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (httpServer != null) {
+      httpServer.stop(0);
+    }
+  }
+
+  @Test
+  void defaultRestTemplateShouldTimeoutOnSlowResponse() {
+    assertReadTimeout(new AppConfig().restTemplate(new RestTemplateBuilder()));
+  }
+
+  @Test
+  void keycloakRestTemplateShouldTimeoutOnSlowResponse() {
+    assertReadTimeout(new KeycloakConfig().keycloakRestTemplate(new RestTemplateBuilder()));
+  }
+
+  @Test
+  void rocketChatRestTemplateShouldTimeoutOnSlowResponse() {
+    assertReadTimeout(new RocketChatConfig(null).rocketChatRestTemplate(new RestTemplateBuilder()));
+  }
+
+  @Test
+  void matrixLongPollRestTemplateShouldAllowSlowResponseWithinLongPollWindow() {
+    var restTemplate = new AppConfig().matrixLongPollRestTemplate(new RestTemplateBuilder());
+    var startedAt = Instant.now();
+
+    var response = restTemplate.getForEntity(slowUrl, String.class);
+
+    long elapsedMs = Duration.between(startedAt, Instant.now()).toMillis();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).contains("ok");
+    assertThat(elapsedMs).isGreaterThanOrEqualTo(DELAY_MS);
+    assertThat(elapsedMs).isLessThan(MAX_LONG_POLL_SUCCESS_MS);
+  }
+
+  private void assertReadTimeout(RestTemplate restTemplate) {
+    var startedAt = Instant.now();
+
+    assertThatThrownBy(() -> restTemplate.getForEntity(slowUrl, String.class))
+        .isInstanceOf(ResourceAccessException.class)
+        .hasRootCauseInstanceOf(SocketTimeoutException.class);
+
+    long elapsedMs = Duration.between(startedAt, Instant.now()).toMillis();
+    assertThat(elapsedMs).isGreaterThanOrEqualTo(MIN_TIMEOUT_OBSERVATION_MS);
+    assertThat(elapsedMs).isLessThan(MAX_TIMEOUT_OBSERVATION_MS);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/config/RestTemplateTimeoutConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/RestTemplateTimeoutConfigTest.java
@@ -1,0 +1,58 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.config.KeycloakConfig;
+import de.caritas.cob.userservice.api.adapters.rocketchat.config.RocketChatConfig;
+import org.apache.http.client.config.RequestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+class RestTemplateTimeoutConfigTest {
+
+  private static final int CONNECT_TIMEOUT_MS =
+      Math.toIntExact(RestTemplateTimeouts.CONNECT_TIMEOUT.toMillis());
+  private static final int READ_TIMEOUT_MS =
+      Math.toIntExact(RestTemplateTimeouts.READ_TIMEOUT.toMillis());
+  private static final int MATRIX_LONG_POLL_READ_TIMEOUT_MS =
+      Math.toIntExact(RestTemplateTimeouts.MATRIX_LONG_POLL_READ_TIMEOUT.toMillis());
+
+  @Test
+  void restTemplateShouldUseDefaultTimeouts() {
+    var restTemplate = new AppConfig().restTemplate(new RestTemplateBuilder());
+
+    assertTimeouts(restTemplate, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS);
+  }
+
+  @Test
+  void matrixLongPollRestTemplateShouldUseLongPollReadTimeout() {
+    var restTemplate = new AppConfig().matrixLongPollRestTemplate(new RestTemplateBuilder());
+
+    assertTimeouts(restTemplate, CONNECT_TIMEOUT_MS, MATRIX_LONG_POLL_READ_TIMEOUT_MS);
+  }
+
+  @Test
+  void keycloakRestTemplateShouldUseDefaultTimeouts() {
+    var restTemplate = new KeycloakConfig().keycloakRestTemplate(new RestTemplateBuilder());
+
+    assertTimeouts(restTemplate, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS);
+  }
+
+  @Test
+  void rocketChatRestTemplateShouldUseDefaultTimeouts() {
+    var restTemplate = new RocketChatConfig(null).rocketChatRestTemplate(new RestTemplateBuilder());
+
+    assertTimeouts(restTemplate, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS);
+  }
+
+  private void assertTimeouts(RestTemplate restTemplate, int connectTimeout, int readTimeout) {
+    var requestFactory = restTemplate.getRequestFactory();
+    var requestConfig =
+        (RequestConfig) ReflectionTestUtils.getField(requestFactory, "requestConfig");
+
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(connectTimeout);
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(readTimeout);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes US-H04 / US-H05 by introducing explicit outbound HTTP timeouts in UserService and separating Matrix long-poll traffic from standard request timeout behavior.

### What changed

- Added shared timeout constants in `RestTemplateTimeouts`
  - connect timeout: `3s`
  - default read timeout: `10s`
  - Matrix long-poll read timeout: `42s`
- Updated default `RestTemplate` bean in `AppConfig` to use explicit timeouts.
- Added dedicated `matrixLongPollRestTemplate` bean for Matrix sync/long-poll requests.
- Updated `KeycloakConfig` RestTemplate to use explicit timeouts.
- Updated `RocketChatConfig` RestTemplate to use explicit timeouts.
- Updated `MatrixSynapseService` so Matrix sync/long-poll requests use the dedicated long-poll RestTemplate instead of the default one.

No API changes, no database changes, and no intended behavior changes outside timeout handling.

## Tests

Added coverage for both configuration and real timeout behavior:

- `RestTemplateTimeoutConfigTest`
- `RestTemplateTimeoutBehaviorTest`
- `MatrixSynapseServiceTest`

Verified locally:

- default RestTemplate uses `3s / 10s`
- Keycloak RestTemplate uses `3s / 10s`
- Rocket.Chat RestTemplate uses `3s / 10s`
- Matrix long-poll RestTemplate uses `3s / 42s`
- standard clients time out on slow responses
- Matrix long-poll client successfully waits for the slower response window

## Manual verification / proof

I also ran:

<img width="1569" height="242" alt="image" src="https://github.com/user-attachments/assets/52acbead-21a3-49fe-adc9-6f7e33a6d4ce" />


```text
mvn -Dtest=RestTemplateTimeoutBehaviorTest -Dspotless.check.skip=true test

Additional verification:
mvn -Dtest=RestTemplateTimeoutConfigTest,RestTemplateTimeoutBehaviorTest,MatrixSynapseServiceTest -Dspotless.check.skip=true test
mvn -DskipTests spotless:check
mvn -DskipTests -Dspotless.check.skip=true compile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable HTTP timeouts for external service integrations: 3-second connection timeout and 10-second read timeout for standard operations.
  * Implemented specialized long-poll timeout (42 seconds) for Matrix sync operations to prevent premature connection drops.

* **Chores**
  * Refactored REST template configuration across Keycloak, RocketChat, and core application components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->