### PR TITLE
Feat fetch smtp credential from applicationsettings for test email

### DIFF
--- a/services/applicationsettingsservice.yaml
+++ b/services/applicationsettingsservice.yaml
@@ -29,6 +29,28 @@ paths:
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
 
+  /settingsadmin/smtp-credentials:
+    get:
+      tags:
+        - applicationsettings-controller
+      summary: 'Get global SMTP credentials (super admin only)'
+      operationId: getGlobalSmtpCredentials
+      responses:
+        200:
+          description: OK - successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationSettingsSmtpCredentialsDTO'
+        204:
+          description: NO CONTENT - no content found
+        401:
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        403:
+          description: FORBIDDEN - insufficient permissions
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+
 components:
   schemas:
     ApplicationSettingsDTO:
@@ -91,3 +113,10 @@ components:
         readOnly:
           type: boolean
           example: false
+    ApplicationSettingsSmtpCredentialsDTO:
+      type: object
+      properties:
+        globalSmtpUsername:
+          type: string
+        globalSmtpPassword:
+          type: string

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/GlobalSmtpTestEmailController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/GlobalSmtpTestEmailController.java
@@ -32,9 +32,11 @@ public class GlobalSmtpTestEmailController {
     } catch (Exception ex) {
       log.warn("Global SMTP test email failed", ex);
       String reason = "SMTP test mail could not be sent. Please verify your SMTP settings.";
-      if (ex instanceof AuthenticationFailedException) {
+      if (ex instanceof IllegalStateException) {
+        reason = ex.getMessage();
+      } else if (ex instanceof AuthenticationFailedException) {
         reason =
-            "SMTP authentication failed. Please verify username/password and provider auth policy.";
+            "SMTP authentication failed. Please verify stored SMTP credentials and provider auth policy.";
       }
       return ResponseEntity.badRequest().body(Map.of("message", reason));
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/GlobalSmtpTestEmailDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/GlobalSmtpTestEmailDTO.java
@@ -19,10 +19,6 @@ public class GlobalSmtpTestEmailDTO {
 
   @NotNull private Boolean secure;
 
-  @NotBlank private String username;
-
-  @NotBlank private String password;
-
   @NotBlank @Email private String from;
 
   @NotBlank @Email private String recipientEmail;

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.userservice.api.service.consultingtype;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import de.caritas.cob.userservice.api.config.CacheManagerConfig;
 import de.caritas.cob.userservice.api.config.apiclient.ApplicationSettingsApiControllerFactory;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -7,10 +9,14 @@ import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.applicationsettingsservice.generated.ApiClient;
 import de.caritas.cob.userservice.applicationsettingsservice.generated.web.ApplicationsettingsControllerApi;
 import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTO;
+import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model.ApplicationSettingsSmtpCredentialsDTO;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 
 /** Service class to communicate with the ConsultingTypeService. */
 @Component
@@ -28,6 +34,27 @@ public class ApplicationSettingsService {
         applicationSettingsApiControllerFactory.createControllerApi();
     addDefaultHeaders(controllerApi.getApiClient());
     return controllerApi.getApplicationSettings();
+  }
+
+  public Optional<ApplicationSettingsSmtpCredentialsDTO> getGlobalSmtpCredentials() {
+    try {
+      ApplicationsettingsControllerApi controllerApi =
+          applicationSettingsApiControllerFactory.createControllerApi();
+      HttpHeaders headers = this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+      tenantHeaderSupplier.addTenantHeader(headers);
+      headers.forEach(
+          (key, value) ->
+              controllerApi.getApiClient().addDefaultHeader(key, value.iterator().next()));
+      ApplicationSettingsSmtpCredentialsDTO credentials = controllerApi.getGlobalSmtpCredentials();
+      if (credentials == null
+          || isBlank(credentials.getGlobalSmtpUsername())
+          || isBlank(credentials.getGlobalSmtpPassword())) {
+        return Optional.empty();
+      }
+      return Optional.of(credentials);
+    } catch (RestClientException ex) {
+      return Optional.empty();
+    }
   }
 
   private void addDefaultHeaders(ApiClient apiClient) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/GlobalSmtpTestEmailService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/GlobalSmtpTestEmailService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.service.notification;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.GlobalSmtpTestEmailDTO;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Properties;
@@ -12,14 +13,26 @@ import javax.mail.PasswordAuthentication;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class GlobalSmtpTestEmailService {
 
+  private final @NonNull ApplicationSettingsService applicationSettingsService;
+
   public void sendTestEmail(GlobalSmtpTestEmailDTO dto) throws Exception {
+    var credentials =
+        applicationSettingsService
+            .getGlobalSmtpCredentials()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "SMTP credentials are not configured in application settings."));
     Properties props = new Properties();
     props.put("mail.smtp.auth", "true");
     props.put("mail.smtp.host", dto.getHost());
@@ -36,7 +49,8 @@ public class GlobalSmtpTestEmailService {
             new Authenticator() {
               @Override
               protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication(dto.getUsername(), dto.getPassword());
+                return new PasswordAuthentication(
+                    credentials.getGlobalSmtpUsername(), credentials.getGlobalSmtpPassword());
               }
             });
 


### PR DESCRIPTION
## Feat: Fetch global SMTP credentials from application settings for test email

#### Related Issue: https://github.com/OpenResilienceInitiative/ORISO-ConsultingTypeService/issues/7
#### Related PR: [Admin #138](https://github.com/OpenResilienceInitiative/ORISO-Admin/pull/138) & [ConsultingTypeService #138](https://github.com/OpenResilienceInitiative/ORISO-ConsultingTypeService/pull/9)

## Summary
- Remove `username` and `password` from `GlobalSmtpTestEmailDTO`; the test email endpoint no longer accepts SMTP credentials in the request body.
- Add `GET /settingsadmin/smtp-credentials` to the application settings OpenAPI client and expose it via `ApplicationSettingsService.getGlobalSmtpCredentials()`.
- Update `GlobalSmtpTestEmailService` to load credentials from application settings (with the caller's Keycloak token) before sending the test email.
- Improve error responses when credentials are missing or SMTP authentication fails.

## Test plan
- `mvn compile` succeeds (regenerates application settings client if needed)
- `POST /service/users/system-notification-emails/test` with valid admin token, CSRF headers, and body (`host`, `port`, `secure`, `from`, `recipientEmail`) returns **200** when SMTP settings and stored credentials are configured
- Same request without configured credentials returns **400** with a clear message
- Request without `username`/`password` in body still works (credentials come from `/settingsadmin/smtp-credentials`)
- Request without CSRF token is rejected with **403** (expected existing behavior)