### PR TITLE
fix: replace contains() with startsWith() in CSRF whitelist check

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -109,8 +109,9 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
       List<String> csrfWhitelist =
           new ArrayList<>(Arrays.asList(csrfSecurityProperties.getWhitelist().getConfigUris()));
       csrfWhitelist.addAll(Arrays.asList(csrfSecurityProperties.getWhitelist().getAdminUris()));
+      final String requestUri = request.getRequestURI().toLowerCase();
       return csrfWhitelist.parallelStream()
-          .anyMatch(request.getRequestURI().toLowerCase()::contains);
+          .anyMatch(whitelistUri -> requestUri.startsWith(whitelistUri.toLowerCase()));
     }
 
     private boolean isWhiteListHeader(HttpServletRequest request) {


### PR DESCRIPTION
## What
- Changed anyMatch(request.getRequestURI().toLowerCase()::contains) to anyMatch(whitelistUri -> requestUri.startsWith(whitelistUri.toLowerCase())) in StatelessCsrfFilter.java

## Why
Closes #127 — the contains() check treated whitelist entries as substrings to search for anywhere in the request URI. An attacker could craft a URI like /api/evil/../whitelisted-path to bypass CSRF validation entirely. startsWith() restricts matching to URIs that actually begin with the whitelisted prefix.

## Test
- [ ] Confirm existing whitelisted paths (configUris, adminUris) still pass CSRF check
- [ ] Confirm a crafted URI containing a whitelist entry as a substring but not a prefix is now rejected