### PR TITLE
US-M18 secure public user and statistics endpoints

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -270,7 +270,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .antMatchers("/users/sessions/{sessionId:[0-9]+}/dearchive", "/users/mails/reassignment")
         .hasAnyAuthority(USER_DEFAULT, CONSULTANT_DEFAULT)
         .antMatchers("/userstatistics", "/userstatistics/**")
-        .permitAll()
+        .hasAuthority(TECHNICAL_DEFAULT)
         .antMatchers(HttpMethod.DELETE, "/useradmin/consultants/{consultantId:[0-9]+}/delete")
         .hasAnyAuthority(USER_ADMIN, RESTRICTED_AGENCY_ADMIN)
         .antMatchers(HttpMethod.GET, "/actuator/health")
@@ -284,7 +284,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .mvcMatchers(HttpMethod.GET, "/users/availability/{username}")
         .permitAll()
         .mvcMatchers(HttpMethod.GET, "/users/{username}")
-        .permitAll()
+        .hasAuthority(TECHNICAL_DEFAULT)
         .anyRequest()
         .denyAll();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -54,6 +54,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.userservice.api.IdentityManager;
+import de.caritas.cob.userservice.api.Messenger;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MobileTokenDTO;
@@ -103,16 +104,42 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:user-controller-auth;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=sa",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.jpa.hibernate.ddl-auto=none",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "keycloak.auth-server-url=https://auth.testing",
+      "keycloak.realm=testing",
+      "keycloak.config.admin-username=admin",
+      "keycloak.config.admin-password=secret",
+      "identity.openid-connect-url=https://auth.testing/realms/testing/protocol/openid-connect",
+      "rocket.technical.username=technical",
+      "rocket.technical.password=secret",
+      "rocket-chat.base-url=https://testing.com/api/v1",
+      "rocket-chat.mongo-url=mongodb://localhost:27017/testing",
+      "consulting.type.service.api.url=https://consulting-type.testing/service",
+      "tenant.service.api.url=https://tenant.testing/service",
+      "matrix.apiUrl=https://matrix.testing",
+      "matrix.registrationSharedSecret=secret"
+    })
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
 @ActiveProfiles("testing")
 class UserControllerAuthorizationIT {
 
@@ -164,6 +191,10 @@ class UserControllerAuthorizationIT {
   @SuppressWarnings("unused")
   private Messaging messenger;
 
+  @MockBean
+  @SuppressWarnings("unused")
+  private Messenger concreteMessenger;
+
   /** POST on /users/askers/new */
   @Test
   void registerUser_Should_ReturnForbiddenAndCallNoMethods_WhenNoCsrfTokens() throws Exception {
@@ -192,6 +223,39 @@ class UserControllerAuthorizationIT {
         .andExpect(status().isUnauthorized());
 
     verifyNoMoreInteractions(authenticatedUser, sessionService, sessionRepository);
+  }
+
+  @Test
+  void userExists_Should_ReturnUnauthorized_WhenNoKeycloakAuthorization() throws Exception {
+    var username = "john@doe.com";
+
+    mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(identityClient);
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TECHNICAL_DEFAULT})
+  void userExists_Should_ReturnNotFound_WhenTechnicalUserIsAuthorized() throws Exception {
+    var username = "john@doe.com";
+    when(identityClient.isUsernameAvailable(username)).thenReturn(true);
+
+    mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+
+    verify(identityClient).isUsernameAvailable(username);
+  }
+
+  @Test
+  void usernameAvailability_Should_StayPublic_WhenNoKeycloakAuthorization() throws Exception {
+    var username = "john@doe.com";
+    when(identityClient.isUsernameAvailable(username)).thenReturn(true);
+
+    mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(identityClient).isUsernameAvailable(username);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserStatisticsControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserStatisticsControllerAuthorizationIT.java
@@ -1,0 +1,85 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
+import de.caritas.cob.userservice.api.service.statistics.SessionStatisticsService;
+import de.caritas.cob.userservice.api.statistics.model.SessionStatisticsResultDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.datasource.url=jdbc:h2:mem:userstatistics-auth;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=sa",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.jpa.hibernate.ddl-auto=none",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "keycloak.auth-server-url=https://auth.testing",
+      "keycloak.realm=testing",
+      "keycloak.config.admin-username=admin",
+      "keycloak.config.admin-password=secret",
+      "identity.openid-connect-url=https://auth.testing/realms/testing/protocol/openid-connect",
+      "rocket.technical.username=technical",
+      "rocket.technical.password=secret",
+      "rocket-chat.base-url=https://testing.com/api/v1",
+      "rocket-chat.mongo-url=mongodb://localhost:27017/testing",
+      "consulting.type.service.api.url=https://consulting-type.testing/service",
+      "tenant.service.api.url=https://tenant.testing/service",
+      "matrix.apiUrl=https://matrix.testing",
+      "matrix.registrationSharedSecret=secret"
+    })
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+@ActiveProfiles("testing")
+class UserStatisticsControllerAuthorizationIT {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private SessionStatisticsService sessionStatisticsService;
+
+  @MockBean SessionTopicEnrichmentService sessionTopicEnrichmentService;
+
+  @Test
+  void getSessionStatistics_Should_ReturnUnauthorized_WhenNoKeycloakAuthorization()
+      throws Exception {
+    mvc.perform(get("/userstatistics/sessions").param("sessionId", "1"))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(sessionStatisticsService);
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_DEFAULT})
+  void getSessionStatistics_Should_ReturnForbidden_WhenNoTechnicalAuthority() throws Exception {
+    mvc.perform(get("/userstatistics/sessions").param("sessionId", "1"))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(sessionStatisticsService);
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TECHNICAL_DEFAULT})
+  void getSessionStatistics_Should_ReturnOk_WhenTechnicalUserIsAuthorized() throws Exception {
+    when(sessionStatisticsService.retrieveSession(1L, null))
+        .thenReturn(new SessionStatisticsResultDTO());
+
+    mvc.perform(get("/userstatistics/sessions").param("sessionId", "1")).andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes US-M18: public username lookup and user statistics endpoints were accessible without authentication.

## Changes

- Restricted `GET /users/{username}` to `TECHNICAL_DEFAULT`.
- Restricted `/userstatistics` and `/userstatistics/**` to `TECHNICAL_DEFAULT`.
- Kept `GET /users/availability/{username}` public so registration username availability checks continue to work.
- Added authorization regression tests for:
  - anonymous `/users/{username}` access
  - technical `/users/{username}` access
  - public `/users/availability/{username}` access
  - anonymous/user/technical `/userstatistics/sessions` access

## Verification

Automated:
- `UserStatisticsControllerAuthorizationIT` -> 3 tests passed
- Targeted `UserControllerAuthorizationIT` auth tests -> 3 tests passed
- `mvn -DskipTests spotless:check` -> BUILD SUCCESS
- `mvn -DskipTests -Dspotless.check.skip=true compile` -> BUILD SUCCESS
- `git diff --check` -> clean

Manual Postman:
- `GET /users/test@example.com` without token -> `401 Unauthorized`
- `GET /users/availability/test@example.com` without token -> `204 No Content`
- `GET /userstatistics/sessions?sessionId=1` without token -> `401 Unauthorized`

No API or database changes.
 
 
<img width="975" height="548" alt="image" src="https://github.com/user-attachments/assets/1a299e05-6f89-491e-9371-2007fa86c08c" />

<img width="975" height="548" alt="image" src="https://github.com/user-attachments/assets/f1a43a26-0fdf-4761-8d62-d88dc75e60be" />

<img width="975" height="548" alt="image" src="https://github.com/user-attachments/assets/1ae60c42-3591-4cb7-bbf9-9a6eba79d879" />
