### PR TITLE
US-M31 add graceful shutdown handling

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java
+++ b/src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java
@@ -47,6 +47,8 @@ public class UserServiceApplication {
     executor.setMaxPoolSize(THREAD_MAX_POOL_SIZE);
     executor.setQueueCapacity(THREAD_QUEUE_CAPACITY);
     executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(25);
     executor.initialize();
     return executor;
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,8 @@ server.port=8082
 server.host=http://localhost
 app.base.url=http://localhost:8082
 system.notification.frontend.base-url=${SYSTEM_NOTIFICATION_FRONTEND_BASE_URL:https://app.oriso.org}
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=30s
 
 # Tomcat thread pool - Scaled for 5000 concurrent users
 server.tomcat.threads.max=1000

--- a/src/test/java/de/caritas/cob/userservice/api/UserServiceApplicationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/UserServiceApplicationTest.java
@@ -1,0 +1,72 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class UserServiceApplicationTest {
+
+  @Test
+  void applicationPropertiesShouldEnableGracefulShutdown() throws Exception {
+    Properties properties = new Properties();
+    try (InputStream inputStream =
+        new ClassPathResource("application.properties").getInputStream()) {
+      properties.load(inputStream);
+    }
+
+    assertThat(properties.getProperty("server.shutdown")).isEqualTo("graceful");
+    assertThat(properties.getProperty("spring.lifecycle.timeout-per-shutdown-phase"))
+        .isEqualTo("30s");
+  }
+
+  @Test
+  void taskExecutorShouldWaitForQueuedTasksOnShutdown() throws Exception {
+    UserServiceApplication application = new UserServiceApplication();
+    ReflectionTestUtils.setField(application, "THREAD_CORE_POOL_SIZE", 1);
+    ReflectionTestUtils.setField(application, "THREAD_MAX_POOL_SIZE", 1);
+    ReflectionTestUtils.setField(application, "THREAD_QUEUE_CAPACITY", 1);
+    ReflectionTestUtils.setField(application, "THREAD_NAME_PREFIX", "test-");
+
+    Executor executor = application.taskExecutor();
+
+    assertThat(executor).isInstanceOf(ThreadPoolTaskExecutor.class);
+    ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) executor;
+    CountDownLatch taskStarted = new CountDownLatch(1);
+    CountDownLatch releaseTask = new CountDownLatch(1);
+    AtomicBoolean shutdownReturned = new AtomicBoolean(false);
+
+    taskExecutor.execute(
+        () -> {
+          taskStarted.countDown();
+          try {
+            releaseTask.await();
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
+        });
+    assertThat(taskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+    Thread shutdownThread =
+        new Thread(
+            () -> {
+              taskExecutor.shutdown();
+              shutdownReturned.set(true);
+            });
+    shutdownThread.start();
+
+    TimeUnit.MILLISECONDS.sleep(100);
+    assertThat(shutdownReturned).isFalse();
+    releaseTask.countDown();
+    shutdownThread.join(1000);
+    assertThat(shutdownReturned).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

Implements the UserService application-side part of US-M31.

- Enabled Spring graceful shutdown:
  - `server.shutdown=graceful`
  - `spring.lifecycle.timeout-per-shutdown-phase=30s`
- Updated the async `taskExecutor` to wait for active/queued tasks during shutdown:
  - `setWaitForTasksToCompleteOnShutdown(true)`
  - `setAwaitTerminationSeconds(25)`
- Added test coverage for:
  - graceful shutdown properties being present in `application.properties`
  - executor shutdown waiting for an active task before returning

No API changes and no database changes.

## Testing

- `mvn -Dtest=UserServiceApplicationTest -Dspotless.check.skip=true test`
  - Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
- `mvn -DskipTests spotless:check`
  - BUILD SUCCESS
- `mvn -DskipTests -Dspotless.check.skip=true compile`
  - BUILD SUCCESS
- `git diff --check`
  - passed

## Note

This covers the local/application-side behavior. A real rolling-deploy E2E still needs Kubernetes because the issue is specifically about pod termination during rollout.