### PR TITLE
fix: clean up UserService Dockerfile JDWP toggle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM eclipse-temurin:17-jre
 VOLUME ["/tmp","/log"]
-EXPOSE 8080
+EXPOSE 8082
 ARG JAR_FILE
-ENV JAVA_UPPER_VERSION=eclipse-temurin:21-jre
-ENV ENABLE_JDWP=false
+ENV JAVA_UPPER_VERSION=eclipse-temurin:17-jre
 COPY ./target/UserService.jar app.jar
-ENTRYPOINT ["sh","-c","if [ \"$ENABLE_JDWP\" = \"true\" ]; then DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'; else DEBUG_OPTS=''; fi; exec java $DEBUG_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-XX:MaxRAMPercentage=75","-jar","/app.jar"]


### PR DESCRIPTION
## Summary
- remove the conditional JDWP/`ENABLE_JDWP` path from the standard UserService Dockerfile
- correct Dockerfile `EXPOSE` from `8080` to the actual UserService port `8082`
- align `JAVA_UPPER_VERSION` metadata with the Java 17 base image
- add `-XX:MaxRAMPercentage=75` consistently with the sibling service JDWP cleanup PRs

Closes #136

## Verification
- `git diff --check`
- `rg -n "jdwp|agentlib|ENABLE_JDWP|5005" Dockerfile || true` returns no matches

## Post-merge deployment check
After redeploying dev, verify `/proc/1/cmdline` in the UserService pod has no JDWP flag and port 5005 is not listening.