### PR TITLE
Fix(US-C05): harden redis debug message mirror against prod plaintext leaks

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import java.util.Optional;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.NonNull;
@@ -26,7 +27,7 @@ public class EventNotificationController {
 
   private final @NonNull EventNotificationService eventNotificationService;
   private final @NonNull AuthenticatedUser authenticatedUser;
-  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
+  private final Optional<RedisMessageMirrorService> redisMessageMirrorService;
 
   @GetMapping
   public ResponseEntity<EventNotificationService.NotificationFeedResponse> getFeed(
@@ -92,13 +93,16 @@ public class EventNotificationController {
     }
 
     // Debug-only mirror to Redis for Redis Commander verification of outgoing preview flow.
-    redisMessageMirrorService.mirrorOutgoingMessage(
-        null,
-        request.getRoomId(),
-        authenticatedUser.getUsername(),
-        authenticatedUser.getRoles() != null && authenticatedUser.getRoles().contains("consultant"),
-        request.getMessagePreview(),
-        null);
+    redisMessageMirrorService.ifPresent(
+        mirror ->
+            mirror.mirrorOutgoingMessage(
+                null,
+                request.getRoomId(),
+                authenticatedUser.getUsername(),
+                authenticatedUser.getRoles() != null
+                    && authenticatedUser.getRoles().contains("consultant"),
+                request.getMessagePreview(),
+                null));
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.Map;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,7 @@ public class MatrixMessageController {
   private final @NonNull ConsultantService consultantService;
   private final @NonNull UserService userService;
   private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
-  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
+  private final Optional<RedisMessageMirrorService> redisMessageMirrorService;
 
   /**
    * Send a message to a Matrix room.
@@ -127,13 +128,15 @@ public class MatrixMessageController {
       var response = matrixSynapseService.sendMessage(roomId, message, accessToken);
       Object eventId = response != null ? response.get("event_id") : null;
 
-      redisMessageMirrorService.mirrorOutgoingMessage(
-          sessionId,
-          roomId,
-          keycloakUsername,
-          isConsultant,
-          message,
-          eventId == null ? null : String.valueOf(eventId));
+      redisMessageMirrorService.ifPresent(
+          mirror ->
+              mirror.mirrorOutgoingMessage(
+                  sessionId,
+                  roomId,
+                  keycloakUsername,
+                  isConsultant,
+                  message,
+                  eventId == null ? null : String.valueOf(eventId)));
 
       log.info("Message sent to room {} by {}", roomId, matrixUsername);
       return ResponseEntity.ok(Map.of("success", true));

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -31,7 +31,7 @@ public class MatrixEventListenerService {
   private final @NonNull SessionService sessionService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final @NonNull EventNotificationService eventNotificationService;
-  private final @NonNull RedisMessageMirrorService redisMessageMirrorService;
+  private final Optional<RedisMessageMirrorService> redisMessageMirrorService;
   private final @NonNull UserRepository userRepository;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionRepository sessionRepository;
@@ -314,13 +314,15 @@ public class MatrixEventListenerService {
     // Debug mirror: capture actual Matrix timeline messages so Redis Commander can show them.
     // This is feature-flagged/TTL-bound in RedisMessageMirrorService.
     Long sessionId = roomToSessionMap.get(roomId);
-    redisMessageMirrorService.mirrorOutgoingMessage(
-        sessionId,
-        roomId,
-        senderId,
-        senderDomainUserId != null && senderDomainUserId.startsWith("consultant"),
-        messageBody,
-        event.get("event_id") != null ? String.valueOf(event.get("event_id")) : null);
+    redisMessageMirrorService.ifPresent(
+        mirror ->
+            mirror.mirrorOutgoingMessage(
+                sessionId,
+                roomId,
+                senderId,
+                senderDomainUserId != null && senderDomainUserId.startsWith("consultant"),
+                messageBody,
+                event.get("event_id") != null ? String.valueOf(event.get("event_id")) : null));
 
     // Get users who should receive notification (exclude sender)
     Set<String> userIds = getRecipientCandidatesForRoom(roomId);

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorService.java
@@ -2,15 +2,19 @@ package de.caritas.cob.userservice.api.service.matrix;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -22,8 +26,11 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @Slf4j
-@RequiredArgsConstructor
+@Profile("!prod")
+@ConditionalOnExpression("${debug.redis.message.mirror.enabled:false}")
 public class RedisMessageMirrorService {
+
+  private static final int MESSAGE_HASH_HEX_CHARS = 8;
 
   private final ObjectProvider<StringRedisTemplate> redisTemplateProvider;
   private final ObjectMapper objectMapper;
@@ -39,6 +46,13 @@ public class RedisMessageMirrorService {
 
   @Value("${debug.redis.message.mirror.keyPrefix:debug:msgmirror}")
   private String keyPrefix;
+
+  public RedisMessageMirrorService(
+      ObjectProvider<StringRedisTemplate> redisTemplateProvider, ObjectMapper objectMapper) {
+    this.redisTemplateProvider = redisTemplateProvider;
+    this.objectMapper = objectMapper;
+    log.warn("RedisMessageMirrorService active — debug only, must never run in prod");
+  }
 
   public void mirrorOutgoingMessage(
       Long sessionId,
@@ -77,10 +91,8 @@ public class RedisMessageMirrorService {
     payload.put("ts", Instant.now().toString());
     payload.put("sessionId", sessionId);
     payload.put("roomId", roomId);
-    payload.put("sender", senderUsername);
-    payload.put("senderRole", consultantSender ? "consultant" : "user");
-    payload.put("eventId", matrixEventId == null ? "" : matrixEventId);
-    payload.put("message", safeBody);
+    payload.put("messageLength", safeBody.length());
+    payload.put("messageHash", sha256Prefix(safeBody, MESSAGE_HASH_HEX_CHARS));
 
     try {
       String serializedPayload = objectMapper.writeValueAsString(payload);
@@ -91,6 +103,20 @@ public class RedisMessageMirrorService {
       log.warn("Failed to serialize Redis message mirror payload: {}", e.getMessage());
     } catch (Exception e) {
       log.warn("Failed writing mirrored message to Redis: {}", e.getMessage());
+    }
+  }
+
+  private static String sha256Prefix(String input, int hexChars) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(hash.length * 2);
+      for (byte value : hash) {
+        hex.append(String.format("%02x", value));
+      }
+      return hex.substring(0, hexChars);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
     }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
@@ -1,0 +1,126 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RedisMessageMirrorServiceTest {
+
+  private static final String SENSITIVE_MESSAGE = "super-secret counselling text";
+  private static final String SENDER_USERNAME = "alice.user";
+
+  @Mock private ObjectProvider<StringRedisTemplate> redisTemplateProvider;
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOperations;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private RedisMessageMirrorService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new RedisMessageMirrorService(redisTemplateProvider, objectMapper);
+    ReflectionTestUtils.setField(service, "enabled", false);
+    ReflectionTestUtils.setField(service, "ttlSeconds", 900L);
+    ReflectionTestUtils.setField(service, "maxBodyLength", 500);
+    ReflectionTestUtils.setField(service, "keyPrefix", "debug:msgmirror");
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldNotWriteToRedisWhenDisabled() {
+    assertThatCode(
+            () ->
+                service.mirrorOutgoingMessage(
+                    42L,
+                    "!room:example.org",
+                    SENDER_USERNAME,
+                    true,
+                    SENSITIVE_MESSAGE,
+                    "$event123"))
+        .doesNotThrowAnyException();
+
+    verifyNoInteractions(redisTemplateProvider);
+    verifyNoInteractions(redisTemplate);
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldStoreMetadataOnlyWhenEnabled() throws Exception {
+    ReflectionTestUtils.setField(service, "enabled", true);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    service.mirrorOutgoingMessage(
+        42L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$event123");
+
+    ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).set(anyString(), payloadCaptor.capture(), any(Duration.class));
+
+    String serializedPayload = payloadCaptor.getValue();
+    JsonNode payload = objectMapper.readTree(serializedPayload);
+
+    assertThat(payload.has("sessionId")).isTrue();
+    assertThat(payload.get("sessionId").asLong()).isEqualTo(42L);
+    assertThat(payload.has("messageLength")).isTrue();
+    assertThat(payload.get("messageLength").asInt()).isEqualTo(SENSITIVE_MESSAGE.length());
+    assertThat(payload.has("messageHash")).isTrue();
+    assertThat(payload.get("messageHash").asText()).isEqualTo(sha256Prefix(SENSITIVE_MESSAGE, 8));
+
+    assertThat(payload.has("message")).isFalse();
+    assertThat(payload.has("sender")).isFalse();
+    assertThat(payload.has("senderRole")).isFalse();
+    assertThat(serializedPayload).doesNotContain(SENSITIVE_MESSAGE);
+    assertThat(serializedPayload).doesNotContain(SENDER_USERNAME);
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldNotThrowWhenStringRedisTemplateUnavailable() {
+    ReflectionTestUtils.setField(service, "enabled", true);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(null);
+
+    assertThatCode(
+            () ->
+                service.mirrorOutgoingMessage(
+                    42L,
+                    "!room:example.org",
+                    SENDER_USERNAME,
+                    true,
+                    SENSITIVE_MESSAGE,
+                    "$event123"))
+        .doesNotThrowAnyException();
+
+    verify(redisTemplateProvider).getIfAvailable();
+    verify(redisTemplate, never()).opsForValue();
+  }
+
+  private static String sha256Prefix(String input, int hexChars) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+    StringBuilder hex = new StringBuilder(hash.length * 2);
+    for (byte value : hash) {
+      hex.append(String.format("%02x", value));
+    }
+    return hex.substring(0, hexChars);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [US-C05 / #134](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/134): the debug Redis message mirror was writing counselling message content to Redis and could be active in production via env/Helm config alone.

This PR adds **code-level** guards so the mirror cannot silently run in prod, stores **metadata only** in Redis (no plaintext message or sender identity), and makes all call sites tolerant when the bean is absent.

### Application changes
- **`RedisMessageMirrorService`**
  - `@Profile("!prod")` — bean excluded when `prod` profile is active
  - `@ConditionalOnExpression("${debug.redis.message.mirror.enabled:false}")` — bean only loads when explicitly enabled
  - Startup `log.warn` when the bean is instantiated
  - Redis payload: `ts`, `sessionId`, `roomId`, `messageLength`, `messageHash` (8-char SHA-256 prefix)
  - Removed from payload: `message`, `sender`, `senderRole`, `eventId`
  - Retained runtime `enabled` `@Value` + early return (defense in depth)
- **Call sites** (`MatrixMessageController`, `MatrixEventListenerService`, `EventNotificationController`)
  - `Optional<RedisMessageMirrorService>` injection + `.ifPresent(...)` so prod startup does not fail when the bean is missing
- **Tests**: `RedisMessageMirrorServiceTest` — disabled path, metadata-only payload, missing `StringRedisTemplate` handling

### Infra follow-up (not in this PR — needs Helm/ConfigMap access)
- [ ] Confirm prod ConfigMap sets `DEBUG_REDIS_MESSAGE_MIRROR_ENABLED=false`

Fixes OpenResilienceInitiative/ORISO-UserService#134

## Test

- `mvn test -Dtest=RedisMessageMirrorServiceTest` — 3/3 pass (JDK 17)
- Full module test suite run — no failures in mirror-related classes; pre-existing PowerMock/Mockito errors elsewhere unchanged
- Deploy to non-prod with `debug.redis.message.mirror.enabled=true` — confirm startup warning log appears
- Send a test message — confirm Redis keys contain metadata only (no `message` / `sender` fields)
- Deploy with `spring.profiles.active=prod` — confirm app starts without `RedisMessageMirrorService` bean
- Infra owner: apply Helm/ConfigMap changes above in prod