### PR TITLE
Fix: add PlainCredentialsCleanUpFilter as ThreadLocal safety net (US-M01)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/PlainCredentialsCleanupFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/PlainCredentialsCleanupFilter.java
@@ -1,0 +1,28 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import de.caritas.cob.userservice.api.helper.PlainCredentialsHolder;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class PlainCredentialsCleanupFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      PlainCredentialsHolder.clear();
+      log.debug(
+          "Cleared PlainCredentialsHolder ThreadLocal for request {}", request.getRequestURI());
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/PlainCredentialsCleanupFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/PlainCredentialsCleanupFilterTest.java
@@ -1,0 +1,68 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.helper.PlainCredentialsHolder;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlainCredentialsCleanupFilterTest {
+
+  private PlainCredentialsCleanupFilter cleanupFilter;
+
+  @Mock private HttpServletRequest request;
+
+  @Mock private HttpServletResponse response;
+
+  @Mock private FilterChain filterChain;
+
+  @BeforeEach
+  void setup() {
+    cleanupFilter = new PlainCredentialsCleanupFilter();
+  }
+
+  @AfterEach
+  void tearDown() {
+    PlainCredentialsHolder.clear();
+  }
+
+  @Test
+  void doFilterInternal_shouldClearPlainCredentialsHolder_afterNormalFlow()
+      throws ServletException, IOException {
+    PlainCredentialsHolder.set("testuser", "testpassword");
+
+    cleanupFilter.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain, times(1)).doFilter(request, response);
+    assertNull(PlainCredentialsHolder.get());
+  }
+
+  @Test
+  void doFilterInternal_shouldClearPlainCredentialsHolder_whenFilterChainThrows()
+      throws ServletException, IOException {
+    PlainCredentialsHolder.set("testuser", "testpassword");
+    doThrow(new ServletException("deserialization failed"))
+        .when(filterChain)
+        .doFilter(request, response);
+
+    assertThrows(
+        ServletException.class,
+        () -> cleanupFilter.doFilterInternal(request, response, filterChain));
+
+    assertNull(PlainCredentialsHolder.get());
+  }
+}


### PR DESCRIPTION
#### [Issue #143](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/143)

## Summary

Partial fix for US-M01: adds `PlainCredentialsCleanupFilter` as a
safety net to ensure `PlainCredentialsHolder` ThreadLocal is always
cleared at the end of every request, regardless of exit path.

## Problem

`PlainCredentialsHolder` stores plain username and decoded password
during Jackson deserialization. It was only cleared in `finally` blocks
in `CreateUserFacade` and `CreateConsultantSaga` — meaning any request
that aborted before reaching those methods (e.g. `BadRequestException`
during deserialization) left credentials in thread memory until the next
request on the same Tomcat thread overwrote them.

## Changes Made

- Added `PlainCredentialsCleanupFilter` (`OncePerRequestFilter`,
  `@Component`) in `...adapters.web.controller.interceptor` — wraps
  every request in `try-finally`, calls `PlainCredentialsHolder.clear()`
  unconditionally on completion
- Registered via `@Component` only (not `SecurityConfig`) so it covers
  `/users/askers/new` which is in `web.ignoring()`
- Existing `clear()` calls in `CreateUserFacade` and
  `CreateConsultantSaga` left in place — now redundant but harmless

## Out of scope (longer term, not in this PR)

Full ThreadLocal removal — passing credentials as explicit method
parameters through the call chain and adding `@JsonIgnore` DTO fields.
This requires touching 4 write sites, 2 read sites, and all callers,
with careful per-path regression testing. Tracked as follow-up.

## Testing

- 2 new unit tests in `PlainCredentialsCleanupFilterTest`:
  normal flow clears ThreadLocal, exception flow clears ThreadLocal
- Both pass (2/2)
- Zero regressions — 493 pre-existing failures in full suite are
  unrelated (Mockito setup issues, confirmed pre-existing)