### PR TITLE
US-M22 lock actuator health details behind auth

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -274,7 +274,7 @@ feature.video.group.chats.enabled=true
 
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when-authorized
 management.endpoints.web.exposure.include=health,loggers
 management.endpoint.health.probes.enabled=true
 management.endpoint.loggers.enabled=true


### PR DESCRIPTION
## What
- Changed `management.endpoint.health.show-details=always` → `when-authorized` in `application.properties`

## Why
Unauthenticated callers (public internet) could query `/actuator/health` and see internal component details including database connection state, disk space, and dependency health — useful for reconnaissance.

`when-authorized` returns `{status:UP}` only to unauthenticated callers (K8s probes continue to work) and full details only to authenticated users.

**Security note:** Spring Security already excludes `/actuator/**` from the filter chain entirely (`SecurityConfig.java:299`) so probes are unaffected — `when-authorized` hides component details but does not return 401.

## Audit
**ID:** US-M22
**Severity:** Medium
**Batch:** B

## Test
- [ ] `GET /actuator/health` without auth token → `{status:UP}` only, no component details
- [ ] `GET /actuator/health` with valid Keycloak JWT → full details (db, diskSpace, etc.)
- [ ] K8s liveness/readiness probes still pass after deploy

Closes #164