### PR TITLE
fix: decode base32-encoded username from JWT after Keycloak 26 upgrade

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -5,6 +5,7 @@ import static java.util.Objects.nonNull;
 import de.caritas.cob.userservice.api.config.RestTemplateTimeouts;
 import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotBlank;
@@ -56,7 +57,8 @@ public class KeycloakConfig {
 
   @Bean
   @Scope(scopeName = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
-  public AuthenticatedUser authenticatedUser(HttpServletRequest request) {
+  public AuthenticatedUser authenticatedUser(
+      HttpServletRequest request, UsernameTranscoder usernameTranscoder) {
     var userPrincipal = request.getUserPrincipal();
     var authenticatedUser = new AuthenticatedUser();
 
@@ -67,7 +69,8 @@ public class KeycloakConfig {
 
       try {
         if (claimMap.containsKey("username")) {
-          authenticatedUser.setUsername(claimMap.get("username").toString());
+          authenticatedUser.setUsername(
+              usernameTranscoder.decodeUsername(claimMap.get("username").toString()));
         }
         // Use the subject (sub) field for userId instead of otherClaims
         authenticatedUser.setUserId(securityContext.getToken().getSubject());

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -70,6 +70,8 @@ import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
@@ -171,6 +173,7 @@ public class UserController implements UsersApi {
 
   private final @NonNull SessionDeleteService sessionDeleteService;
   private final @NonNull EventNotificationService eventNotificationService;
+  private final @NonNull UsernameTranscoder usernameTranscoder;
 
   @Override
   public ResponseEntity<Void> userExists(String username) {
@@ -619,7 +622,8 @@ public class UserController implements UsersApi {
     }
     var otpInfoDTO =
         identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())
-            ? identityManager.getOtpCredential(authenticatedUser.getUsername())
+            ? identityManager.getOtpCredential(
+                usernameTranscoder.encodeUsername(authenticatedUser.getUsername()))
             : null;
 
     var fullUserData =
@@ -1041,7 +1045,9 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<Void> updatePassword(@RequestBody PasswordDTO passwordDTO) {
     var username = authenticatedUser.getUsername();
-    if (!identityManager.validatePasswordIgnoring2fa(username, passwordDTO.getOldPassword())) {
+    var encodedUsername = usernameTranscoder.encodeUsername(username);
+    if (!identityManager.validatePasswordIgnoring2fa(
+        encodedUsername, passwordDTO.getOldPassword())) {
       var message = String.format("Could not log in user %s into Keycloak", username);
       throw new BadRequestException(message);
     }
@@ -1286,7 +1292,8 @@ public class UserController implements UsersApi {
       @Valid DeleteUserAccountDTO deleteUserAccountDTO) {
     var username = authenticatedUser.getUsername();
     var password = deleteUserAccountDTO.getPassword();
-    if (!identityManager.validatePasswordIgnoring2fa(username, password)) {
+    var encodedUsername = usernameTranscoder.encodeUsername(username);
+    if (!identityManager.validatePasswordIgnoring2fa(encodedUsername, password)) {
       var message = String.format("Could not log in user %s into Keycloak", username);
       throw new BadRequestException(message);
     }
@@ -1360,7 +1367,7 @@ public class UserController implements UsersApi {
 
   @Override
   public ResponseEntity<Void> startTwoFactorAuthByEmailSetup(EmailDTO emailDTO) {
-    var username = authenticatedUser.getUsername();
+    var username = usernameTranscoder.encodeUsername(authenticatedUser.getUsername());
     var email = emailDTO.getEmail().toLowerCase();
 
     if (!identityManager.isEmailAvailableOrOwn(username, email)) {
@@ -1379,7 +1386,7 @@ public class UserController implements UsersApi {
 
   @Override
   public ResponseEntity<Void> finishTwoFactorAuthByEmailSetup(String tan) {
-    var username = authenticatedUser.getUsername();
+    var username = usernameTranscoder.encodeUsername(authenticatedUser.getUsername());
     var validationResult = identityManager.validateOneTimePassword(username, tan);
 
     if (Boolean.parseBoolean(validationResult.get("created"))) {
@@ -1424,7 +1431,7 @@ public class UserController implements UsersApi {
 
     var isValid =
         identityManager.setUpOneTimePassword(
-            authenticatedUser.getUsername(),
+            usernameTranscoder.encodeUsername(authenticatedUser.getUsername()),
             oneTimePasswordDTO.getOtp(),
             oneTimePasswordDTO.getSecret());
 
@@ -1438,7 +1445,8 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> deactivateTwoFactorAuthByApp() {
-    identityManager.deleteOneTimePassword(authenticatedUser.getUsername());
+    identityManager.deleteOneTimePassword(
+        usernameTranscoder.encodeUsername(authenticatedUser.getUsername()));
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -71,7 +71,6 @@ import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
-import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;


### PR DESCRIPTION
## Summary

Fixes the 500 error on `/service/users/data` after Keycloak 26.1.0 upgrade. Keycloak 26 stores usernames in base32-encoded form (`enc.MNUHKY3...`) — UserService's JWT entry point wasn't decoding them, causing downstream DB lookups to fail.

## Changes

- **`KeycloakConfig.java:66`** — decode username via `UsernameTranscoder.decodeUsername()` when mapping JWT claims to `AuthenticatedUser`
- **`UserController.java`** — re-encode at 7 Keycloak-facing `identityManager` call sites via `usernameTranscoder.encodeUsername()`
- Error messages and logging retain the decoded (plain) username

## Evidence

- Keycloak 26.1.0 confirmed live on oriso.org with base32-encoded usernames
- Username encoding verified: `enc.` prefix + `hi-base32` encoding used by frontend `encryptionHelpers.ts`
- Companion PRs on other services: AgencyService #27, TenantService #30, ConsultingTypeService #20

Refs: epic #72 (Keycloak Helm migration)