### PR TITLE
feat: add hasOtherIdentity to user list responses (multi-role badge data)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/AccountManager.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Consultant.ConsultantBase;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
@@ -44,6 +45,8 @@ import org.springframework.web.client.RestClientException;
 public class AccountManager implements AccountManaging {
 
   private final ConsultantRepository consultantRepository;
+
+  private final AdminRepository adminRepository;
 
   private final UserRepository userRepository;
 
@@ -148,8 +151,18 @@ public class AccountManager implements AccountManaging {
                     },
                     (existing, replacement) -> existing));
 
+    var consultantIdsWithAdminIdentity =
+        consultantIds.isEmpty()
+            ? java.util.Collections.<String>emptySet()
+            : adminRepository.findExistingIdsByIdIn(consultantIds);
+
     return userServiceMapper.mapOf(
-        consultantPage, fullConsultants, agencies, consultingAgencies, tenantIdsToNameMap);
+        consultantPage,
+        fullConsultants,
+        agencies,
+        consultingAgencies,
+        tenantIdsToNameMap,
+        consultantIdsWithAdminIdentity);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/UserServiceMapper.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -102,7 +103,8 @@ public class UserServiceMapper {
       List<Consultant> fullConsultants,
       List<AgencyDTO> agencyDTOS,
       List<ConsultantAgencyBase> consultantAgencies,
-      Map<Long, String> tenantIdsToNameMap) {
+      Map<Long, String> tenantIdsToNameMap,
+      Set<String> idsWithOtherIdentity) {
 
     var agencyLookupMap =
         agencyDTOS.stream().collect(Collectors.toMap(AgencyDTO::getId, Function.identity()));
@@ -122,7 +124,11 @@ public class UserServiceMapper {
               nonNull(fullConsultant)
                   ? mapOf(fullConsultant, agencyLookupMap, consultantAgencyLookupMap)
                   : new ArrayList<Map<String, Object>>();
-          var consultantMap = mapOf(consultantBase, fullConsultant, agencies, tenantIdsToNameMap);
+          var hasOtherIdentity =
+              nonNull(idsWithOtherIdentity)
+                  && idsWithOtherIdentity.contains(consultantBase.getId());
+          var consultantMap =
+              mapOf(consultantBase, fullConsultant, agencies, tenantIdsToNameMap, hasOtherIdentity);
           consultants.add(consultantMap);
         });
 
@@ -142,7 +148,8 @@ public class UserServiceMapper {
       List<Admin> fullAdmins,
       List<AgencyDTO> agencyDTOs,
       List<AdminAgencyBase> agenciesOfAdmin,
-      Map<Long, String> tenantIdsToNameMap) {
+      Map<Long, String> tenantIdsToNameMap,
+      Set<String> idsWithOtherIdentity) {
     var agencyLookupMap =
         agencyDTOs.stream().collect(Collectors.toMap(AgencyDTO::getId, Function.identity()));
 
@@ -157,7 +164,10 @@ public class UserServiceMapper {
         adminBase -> {
           var fullAdmin = fullAdminLookupMap.get(adminBase.getId());
           var agencies = mapOfAgencies(fullAdmin, agencyLookupMap, adminAgencyLookupMap);
-          var adminMap = mapOfAdmin(adminBase, fullAdmin, agencies, tenantIdsToNameMap);
+          var hasOtherIdentity =
+              nonNull(idsWithOtherIdentity) && idsWithOtherIdentity.contains(adminBase.getId());
+          var adminMap =
+              mapOfAdmin(adminBase, fullAdmin, agencies, tenantIdsToNameMap, hasOtherIdentity);
           admins.add(adminMap);
         });
 
@@ -241,7 +251,8 @@ public class UserServiceMapper {
       ConsultantBase consultantBase,
       Consultant fullConsultant,
       List<Map<String, Object>> agencies,
-      Map<Long, String> tenantIdsToNameMap) {
+      Map<Long, String> tenantIdsToNameMap,
+      boolean hasOtherIdentity) {
     var status =
         isNull(fullConsultant) || isNull(fullConsultant.getStatus())
             ? ConsultantStatus.ERROR.toString()
@@ -283,6 +294,7 @@ public class UserServiceMapper {
         tenantIdsToNameMap.containsKey(tenantId)
             ? tenantIdsToNameMap.get(tenantId)
             : StringUtils.EMPTY);
+    map.put("hasOtherIdentity", hasOtherIdentity);
     return map;
   }
 
@@ -290,7 +302,8 @@ public class UserServiceMapper {
       AdminBase adminBase,
       Admin fullAdmin,
       List<Map<String, Object>> agencies,
-      Map<Long, String> tenantIdsToNameMap) {
+      Map<Long, String> tenantIdsToNameMap,
+      boolean hasOtherIdentity) {
 
     Map<String, Object> map = new HashMap<>();
     map.put("id", adminBase.getId());
@@ -308,6 +321,7 @@ public class UserServiceMapper {
         "updatedAt",
         nonNull(fullAdmin.getUpdateDate()) ? fullAdmin.getUpdateDate().toString() : null);
     map.put("agencies", agencies);
+    map.put("hasOtherIdentity", hasOtherIdentity);
 
     return map;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -13,10 +13,13 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +42,7 @@ public class AgencyAdminUserService {
   private final @NonNull UserServiceMapper userServiceMapper;
   private final @NonNull AgencyService agencyService;
   private final @NonNull TenantService tenantService;
+  private final @NonNull ConsultantRepository consultantRepository;
 
   public AdminResponseDTO createNewAgencyAdmin(final CreateAdminDTO createAgencyAdminDTO) {
     final Admin newAdmin = createAdminService.createNewAgencyAdmin(createAgencyAdminDTO);
@@ -81,8 +85,18 @@ public class AgencyAdminUserService {
 
     var agencies = agencyService.getAgenciesWithoutCaching(agencyIds);
 
+    Set<String> idsWithConsultantIdentity =
+        adminIds.isEmpty()
+            ? Collections.emptySet()
+            : consultantRepository.findActiveIdsByIdIn(adminIds);
+
     return userServiceMapper.mapOfAdmin(
-        adminsPage, fullAdmins, agencies, agenciesOfAdmin, tenantIdsToNameMap);
+        adminsPage,
+        fullAdmins,
+        agencies,
+        agenciesOfAdmin,
+        tenantIdsToNameMap,
+        idsWithConsultantIdentity);
   }
 
   public AdminResponseDTO patchAgencyAdmin(String adminId, PatchAdminDTO patchAdminDTO) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -16,9 +16,12 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,7 @@ public class TenantAdminUserService {
   private final @NonNull UserServiceMapper userServiceMapper;
   private final @NonNull TenantService tenantService;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull ConsultantRepository consultantRepository;
 
   @Value("${multitenancy.enabled}")
   private boolean multiTenancyEnabled;
@@ -103,8 +107,18 @@ public class TenantAdminUserService {
 
     var tenantIdsToNameMap = tenantIdsToNameMap(fullAdmins);
 
+    Set<String> idsWithConsultantIdentity =
+        adminIds.isEmpty()
+            ? Collections.emptySet()
+            : consultantRepository.findActiveIdsByIdIn(adminIds);
+
     return userServiceMapper.mapOfAdmin(
-        adminsPage, fullAdmins, Lists.newArrayList(), Lists.newArrayList(), tenantIdsToNameMap);
+        adminsPage,
+        fullAdmins,
+        Lists.newArrayList(),
+        Lists.newArrayList(),
+        tenantIdsToNameMap,
+        idsWithConsultantIdentity);
   }
 
   private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface AdminRepository extends CrudRepository<Admin, String> {
 
@@ -40,4 +42,7 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
   List<Admin> findByType(Admin.AdminType type);
 
   List<Admin> findAllByIdIn(Set<String> adminIds);
+
+  @Query("SELECT a.id FROM Admin a WHERE a.id IN :ids")
+  Set<String> findExistingIdsByIdIn(@Param("ids") Collection<String> ids);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ConsultantRepository
     extends JpaRepository<Consultant, String>, JpaSpecificationExecutor<Consultant> {
@@ -34,6 +35,9 @@ public interface ConsultantRepository
   List<Consultant> findByDeleteDateIsNull();
 
   List<Consultant> findAllByIdIn(List<String> ids);
+
+  @Query("SELECT c.id FROM Consultant c WHERE c.id IN :ids AND c.deleteDate IS NULL")
+  Set<String> findActiveIdsByIdIn(@Param("ids") Collection<String> ids);
 
   @Query(
       value =

--- a/src/test/java/de/caritas/cob/userservice/api/AccountManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/AccountManagerTest.java
@@ -27,6 +27,8 @@ class AccountManagerTest {
 
   @Mock ConsultantRepository consultantRepository;
 
+  @Mock de.caritas.cob.userservice.api.port.out.AdminRepository adminRepository;
+
   @Mock ConsultantAgencyRepository consultantAgencyRepository;
 
   @Mock UserServiceMapper userServiceMapper;
@@ -79,7 +81,8 @@ class AccountManagerTest {
             Mockito.anyList(),
             Mockito.eq(List.of()),
             Mockito.anyList(),
-            Mockito.anyMap());
+            Mockito.anyMap(),
+            Mockito.any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperAdminIdentityTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperAdminIdentityTest.java
@@ -1,0 +1,130 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceMapperAdminIdentityTest {
+
+  @InjectMocks private UserServiceMapper userServiceMapper;
+
+  @Mock
+  @SuppressWarnings("unused")
+  private UsernameTranscoder usernameTranscoder;
+
+  private AdminBase adminBase(String id) {
+    return new AdminBase() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public String getFirstName() {
+        return "First";
+      }
+
+      @Override
+      public String getLastName() {
+        return "Last";
+      }
+
+      @Override
+      public String getEmail() {
+        return "admin@example.com";
+      }
+
+      @Override
+      public Long getTenantId() {
+        return 1L;
+      }
+
+      @Override
+      public Admin.AdminType getType() {
+        return Admin.AdminType.AGENCY;
+      }
+
+      @Override
+      public java.time.LocalDateTime getUpdateDate() {
+        return null;
+      }
+    };
+  }
+
+  private Admin fullAdmin(String id) {
+    return Admin.builder()
+        .id(id)
+        .username("admin-username")
+        .firstName("First")
+        .lastName("Last")
+        .email("admin@example.com")
+        .type(Admin.AdminType.AGENCY)
+        .tenantId(1L)
+        .build();
+  }
+
+  @Test
+  void mapOfAdminShouldSetHasOtherIdentityTrueWhenFlagIsTrue() {
+    var map =
+        userServiceMapper.mapOfAdmin(
+            adminBase("admin-1"),
+            fullAdmin("admin-1"),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            true);
+
+    assertThat(map).containsEntry("hasOtherIdentity", true);
+  }
+
+  @Test
+  void mapOfAdminShouldSetHasOtherIdentityFalseWhenFlagIsFalse() {
+    var map =
+        userServiceMapper.mapOfAdmin(
+            adminBase("admin-1"),
+            fullAdmin("admin-1"),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            false);
+
+    assertThat(map).containsEntry("hasOtherIdentity", false);
+  }
+
+  @Test
+  void mapOfAdminPagedShouldFlagOnlyAdminsWhoseIdIsInOtherIdentitySet() {
+    var firstBase = adminBase("admin-1");
+    var secondBase = adminBase("admin-2");
+    var adminsPage = new org.springframework.data.domain.PageImpl<>(List.of(firstBase, secondBase));
+
+    var fullAdmins = List.of(fullAdmin("admin-1"), fullAdmin("admin-2"));
+
+    var result =
+        userServiceMapper.mapOfAdmin(
+            adminsPage,
+            fullAdmins,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            java.util.Set.of("admin-1"));
+
+    @SuppressWarnings("unchecked")
+    var admins = (List<Map<String, Object>>) result.get("admins");
+    var first =
+        admins.stream().filter(a -> "admin-1".equals(a.get("id"))).findFirst().orElseThrow();
+    var second =
+        admins.stream().filter(a -> "admin-2".equals(a.get("id"))).findFirst().orElseThrow();
+
+    assertThat(first).containsEntry("hasOtherIdentity", true);
+    assertThat(second).containsEntry("hasOtherIdentity", false);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperConsultantIdentityTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperConsultantIdentityTest.java
@@ -1,0 +1,112 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Consultant.ConsultantBase;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceMapperConsultantIdentityTest {
+
+  @InjectMocks private UserServiceMapper userServiceMapper;
+
+  @Mock
+  @SuppressWarnings("unused")
+  private UsernameTranscoder usernameTranscoder;
+
+  private ConsultantBase consultantBase(String id) {
+    return new ConsultantBase() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public String getFirstName() {
+        return "First";
+      }
+
+      @Override
+      public String getLastName() {
+        return "Last";
+      }
+
+      @Override
+      public String getEmail() {
+        return "consultant@example.com";
+      }
+
+      @Override
+      public java.time.LocalDateTime getUpdateDate() {
+        return null;
+      }
+    };
+  }
+
+  @Test
+  void mapOfConsultantShouldSetHasOtherIdentityTrueWhenFlagIsTrue() {
+    var map =
+        userServiceMapper.mapOf(
+            consultantBase("consultant-1"),
+            null,
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            true);
+
+    assertThat(map).containsEntry("hasOtherIdentity", true);
+  }
+
+  @Test
+  void mapOfConsultantShouldSetHasOtherIdentityFalseWhenFlagIsFalse() {
+    var map =
+        userServiceMapper.mapOf(
+            consultantBase("consultant-1"),
+            null,
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            false);
+
+    assertThat(map).containsEntry("hasOtherIdentity", false);
+  }
+
+  @Test
+  void mapOfConsultantPagedShouldFlagOnlyConsultantsWhoseIdIsInOtherIdentitySet() {
+    var firstBase = consultantBase("consultant-1");
+    var secondBase = consultantBase("consultant-2");
+    var consultantPage =
+        new org.springframework.data.domain.PageImpl<>(List.of(firstBase, secondBase));
+
+    var result =
+        userServiceMapper.mapOf(
+            consultantPage,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            java.util.Set.of("consultant-1"));
+
+    @SuppressWarnings("unchecked")
+    var consultants = (List<Map<String, Object>>) result.get("consultants");
+    var first =
+        consultants.stream()
+            .filter(c -> "consultant-1".equals(c.get("id")))
+            .findFirst()
+            .orElseThrow();
+    var second =
+        consultants.stream()
+            .filter(c -> "consultant-2".equals(c.get("id")))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(first).containsEntry("hasOtherIdentity", true);
+    assertThat(second).containsEntry("hasOtherIdentity", false);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -50,6 +50,8 @@ class AgencyAdminUserServiceTest {
 
   @Mock private TenantService tenantService;
 
+  @Mock private de.caritas.cob.userservice.api.port.out.ConsultantRepository consultantRepository;
+
   @Test
   void findAgencyAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {
     // given
@@ -73,7 +75,12 @@ class AgencyAdminUserServiceTest {
     when(tenantService.getRestrictedTenantData(2L))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
     when(userServiceMapper.mapOfAdmin(
-            Mockito.any(), Mockito.anyList(), Mockito.anyList(), Mockito.anyList(), Mockito.any()))
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
         .thenReturn(new HashMap<>());
 
     // when
@@ -87,7 +94,8 @@ class AgencyAdminUserServiceTest {
             Mockito.eq(fullAdmins),
             Mockito.anyList(),
             Mockito.anyList(),
-            tenantNameMapCaptor.capture());
+            tenantNameMapCaptor.capture(),
+            Mockito.any());
     Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
   }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -68,6 +68,8 @@ class TenantAdminUserServiceTest {
 
   @Mock private AuthenticatedUser authenticatedUser;
 
+  @Mock private de.caritas.cob.userservice.api.port.out.ConsultantRepository consultantRepository;
+
   @Test
   void createNewTenantAdmin_Should_AllowPlatformTenantId_WhenAuthenticatedUserIsPlatformAdmin() {
     // given
@@ -169,7 +171,12 @@ class TenantAdminUserServiceTest {
     when(tenantService.getRestrictedTenantData(2L))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
     when(userServiceMapper.mapOfAdmin(
-            Mockito.any(), Mockito.anyList(), Mockito.anyList(), Mockito.anyList(), Mockito.any()))
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
         .thenReturn(new HashMap<>());
 
     // when
@@ -183,7 +190,8 @@ class TenantAdminUserServiceTest {
             Mockito.eq(fullAdmins),
             Mockito.anyList(),
             Mockito.anyList(),
-            tenantNameMapCaptor.capture());
+            tenantNameMapCaptor.capture(),
+            Mockito.any());
     Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
   }


### PR DESCRIPTION
## Why
Feature 2's admin-panel badge needs a cheap data source. This adds a `hasOtherIdentity` boolean to each row of the **agency-admin, tenant-admin, and consultant** list/search responses, marking users who also hold the other kind of identity (same Keycloak id in both `admin` and `consultant`).

## What
- `hasOtherIdentity` injected into the raw response map in `UserServiceMapper` for both admins and consultants — **no OpenAPI/DTO change** (these endpoints serialize a `Map<String,Object>`).
- Computed with **one batched query per page** (not per-row): `ConsultantRepository.findActiveIdsByIdIn` / `AdminRepository.findExistingIdsByIdIn`.
- Wired in `AgencyAdminUserService`, `TenantAdminUserService`, `AccountManager` (each guarded to skip the query for empty pages).

## Tests (TDD)
- `UserServiceMapperAdminIdentityTest` + `UserServiceMapperConsultantIdentityTest` — 6 unit tests, RED→GREEN.
- `./mvnw clean compile` green (proves every `mapOf`/`mapOfAdmin` caller was updated). Existing service tests updated for the new constructor deps.

## Deferred to CI / Pre-Dev
- Real list output (needs a user holding both identities) + H2 `deleteDate IS NULL` behavior. The 3 pre-existing service tests hit the known local Byte-Buddy/Lombok flake; CI runs them clean-env.

Pairs with the ORISO-Admin badge-column + grant-action PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)