### PR TITLE
[codex] Fix Matrix admin login URL encoding

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserRespon
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -264,9 +265,7 @@ public class MatrixSynapseService {
     }
 
     try {
-      String encodedMatrixUserId = encodeMatrixUserIdForAdminPath(matrixUserId);
-      String url =
-          matrixConfig.getApiUrl(String.format(ENDPOINT_ADMIN_LOGIN_AS_USER, encodedMatrixUserId));
+      URI uri = adminLoginAsUserUri(matrixUserId);
 
       var headers = getClientHttpHeaders(adminToken);
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -278,7 +277,7 @@ public class MatrixSynapseService {
 
       HttpEntity<java.util.Map<String, Object>> request = new HttpEntity<>(body, headers);
 
-      var response = restTemplate.postForEntity(url, request, java.util.Map.class);
+      var response = restTemplate.postForEntity(uri, request, java.util.Map.class);
 
       @SuppressWarnings("unchecked")
       java.util.Map<String, Object> responseBody =
@@ -309,6 +308,13 @@ public class MatrixSynapseService {
     } catch (IllegalArgumentException ex) {
       return UriUtils.encode(matrixUserId, StandardCharsets.UTF_8);
     }
+  }
+
+  private URI adminLoginAsUserUri(String matrixUserId) {
+    String encodedMatrixUserId = encodeMatrixUserIdForAdminPath(matrixUserId);
+    String url =
+        matrixConfig.getApiUrl(String.format(ENDPOINT_ADMIN_LOGIN_AS_USER, encodedMatrixUserId));
+    return URI.create(url);
   }
 
   public String loginAsUserAccessToken(String matrixUserId) {
@@ -526,10 +532,7 @@ public class MatrixSynapseService {
     }
 
     try {
-      String encodedUserId =
-          java.net.URLEncoder.encode(matrixUserId, StandardCharsets.UTF_8).replace("+", "%20");
-      String url =
-          matrixConfig.getApiUrl(String.format(ENDPOINT_ADMIN_LOGIN_AS_USER, encodedUserId));
+      URI uri = adminLoginAsUserUri(matrixUserId);
 
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -537,7 +540,7 @@ public class MatrixSynapseService {
 
       var response =
           restTemplate.postForEntity(
-              url, new HttpEntity<>(java.util.Map.of(), headers), java.util.Map.class);
+              uri, new HttpEntity<>(java.util.Map.of(), headers), java.util.Map.class);
 
       if (response.getBody() != null && response.getBody().containsKey("access_token")) {
         String accessToken = (String) response.getBody().get("access_token");

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -188,34 +189,58 @@ class MatrixSynapseServiceTest {
 
   @Test
   void loginAsUserShouldEncodeMatrixUserIdOnce() {
-    var expectedUrl = MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login";
-    stubAdminLogin(expectedUrl);
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminLogin(expectedUri);
     var service = matrixSynapseService();
 
     var accessToken = service.loginAsUserAccessToken("@alice:example.org");
 
     assertThat(accessToken).isEqualTo(MATRIX_USER_TOKEN);
-    verify(restTemplate).postForEntity(eq(expectedUrl), any(HttpEntity.class), eq(Map.class));
+    verify(restTemplate).postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class));
   }
 
   @Test
   void loginAsUserShouldNotDoubleEncodeMatrixUserId() {
-    var expectedUrl = MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login";
-    stubAdminLogin(expectedUrl);
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminLogin(expectedUri);
     var service = matrixSynapseService();
 
     var accessToken = service.loginAsUserAccessToken("%40alice%3Aexample.org");
 
     assertThat(accessToken).isEqualTo(MATRIX_USER_TOKEN);
-    verify(restTemplate).postForEntity(eq(expectedUrl), any(HttpEntity.class), eq(Map.class));
+    verify(restTemplate).postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class));
     verify(restTemplate, times(0))
         .postForEntity(
-            eq(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%2540alice%253Aexample.org/login"),
+            eq(
+                URI.create(
+                    MATRIX_BASE_URL + "/_synapse/admin/v1/users/%2540alice%253Aexample.org/login")),
             any(HttpEntity.class),
             eq(Map.class));
   }
 
-  private void stubAdminLogin(String expectedLoginAsUserUrl) {
+  @Test
+  void loginUserViaAdminShouldNotDoubleEncodeMatrixUserId() {
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminLogin(expectedUri);
+    var service = matrixSynapseService();
+
+    var accessToken = service.loginUserViaAdmin("@alice:example.org");
+
+    assertThat(accessToken).isEqualTo(MATRIX_USER_TOKEN);
+    verify(restTemplate).postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class));
+    verify(restTemplate, times(0))
+        .postForEntity(
+            eq(
+                URI.create(
+                    MATRIX_BASE_URL + "/_synapse/admin/v1/users/%2540alice%253Aexample.org/login")),
+            any(HttpEntity.class),
+            eq(Map.class));
+  }
+
+  private void stubAdminLogin(URI expectedLoginAsUserUri) {
     when(matrixConfig.getAdminUsername()).thenReturn("admin");
     when(matrixConfig.getAdminPassword()).thenReturn("admin-password");
     when(matrixConfig.getApiUrl(any(String.class)))
@@ -224,7 +249,7 @@ class MatrixSynapseServiceTest {
             eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_ADMIN_TOKEN)));
     when(restTemplate.postForEntity(
-            eq(expectedLoginAsUserUrl), any(HttpEntity.class), eq(Map.class)))
+            eq(expectedLoginAsUserUri), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_USER_TOKEN)));
   }
 


### PR DESCRIPTION
## Summary
- Use the `URI` RestTemplate overload for Synapse admin login-as-user calls so already encoded Matrix IDs are not encoded a second time.
- Route both `loginAsUser` and `loginUserViaAdmin` through one URI builder.
- Extend MatrixSynapseService tests to cover single-encoded and non-double-encoded admin login URLs.

## Root cause
Userservice encoded Matrix IDs such as `@alice:example.org` into `%40alice%3Aexample.org`, then passed the resulting URL as a `String` to RestTemplate. In real requests, Spring encoded the `%` characters again, producing `%2540alice%253Aexample.org`, which Synapse rejected with `Only local users can be logged in as`.

## Validation
- `./mvnw -Dtest=MatrixSynapseServiceTest test`
