### PR TITLE
Fix Matrix URL encoding

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -21,6 +21,10 @@ import org.springframework.web.multipart.MultipartFile;
 public class MatrixMediaClient {
 
   private static final String ENDPOINT_MEDIA_UPLOAD = "/_matrix/media/r0/upload";
+  private static final String ENDPOINT_MEDIA_DOWNLOAD =
+      "/_matrix/media/r0/download/{serverName}/{mediaId}";
+  private static final String ENDPOINT_SEND_MESSAGE =
+      "/_matrix/client/r0/rooms/{roomId}/send/m.room.message/{txnId}";
 
   private final MatrixConfig matrixConfig;
   private final RestTemplate restTemplate;
@@ -72,7 +76,11 @@ public class MatrixMediaClient {
   }
 
   public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
-    String url = matrixConfig.getApiUrl("/_matrix/media/r0/download/" + serverName + "/" + mediaId);
+    String url =
+        MatrixUrlBuilder.buildUrl(
+            matrixConfig,
+            ENDPOINT_MEDIA_DOWNLOAD,
+            Map.of("serverName", serverName, "mediaId", mediaId));
     log.info("📥 Downloading file from Matrix: {}/{}", serverName, mediaId);
 
     HttpHeaders headers = new HttpHeaders();
@@ -134,8 +142,8 @@ public class MatrixMediaClient {
 
       String txnId = UUID.randomUUID().toString();
       var url =
-          matrixConfig.getApiUrl(
-              "/_matrix/client/r0/rooms/" + roomId + "/send/m.room.message/" + txnId);
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_SEND_MESSAGE, Map.of("roomId", roomId, "txnId", txnId));
 
       log.info("📨 Sending file message to Matrix room: {} (type: {})", roomId, msgtype);
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -21,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
@@ -256,16 +255,10 @@ public class MatrixRoomClient {
   }
 
   private String buildUrl(String endpoint) {
-    return UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint))
-        .build()
-        .encode()
-        .toUriString();
+    return MatrixUrlBuilder.buildUrl(matrixConfig, endpoint);
   }
 
   private String buildUrl(String endpoint, Map<String, ?> uriVariables) {
-    return UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint))
-        .buildAndExpand(uriVariables)
-        .encode()
-        .toUriString();
+    return MatrixUrlBuilder.buildUrl(matrixConfig, endpoint, uriVariables);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -44,6 +44,9 @@ public class MatrixSynapseService {
   private static final String ENDPOINT_PURGE_ROOM = "/_synapse/admin/v2/rooms/{roomId}";
   private static final String ENDPOINT_JOINED_ROOMS = "/_matrix/client/r0/joined_rooms";
   private static final String ENDPOINT_PRESENCE = "/_matrix/client/r0/presence/{userId}/status";
+  private static final String ENDPOINT_SEND_MESSAGE =
+      "/_matrix/client/r0/rooms/{roomId}/send/m.room.message/{txnId}";
+  private static final String ENDPOINT_ROOM_MESSAGES = "/_matrix/client/r0/rooms/{roomId}/messages";
   private static final long PRESENCE_CACHE_TTL_MS = 10_000L;
 
   private final MatrixConfig matrixConfig;
@@ -397,7 +400,8 @@ public class MatrixSynapseService {
 
       // Update display name using Synapse ADMIN v2 API
       String url =
-          matrixConfig.getApiUrl(ENDPOINT_UPDATE_USER_ADMIN.replace("{userId}", matrixUserId));
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
 
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -440,7 +444,8 @@ public class MatrixSynapseService {
       }
 
       String url =
-          matrixConfig.getApiUrl(ENDPOINT_DEACTIVATE_USER.replace("{userId}", matrixUserId));
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_DEACTIVATE_USER, java.util.Map.of("userId", matrixUserId));
 
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -478,7 +483,9 @@ public class MatrixSynapseService {
         return false;
       }
 
-      String url = matrixConfig.getApiUrl(ENDPOINT_PURGE_ROOM.replace("{roomId}", matrixRoomId));
+      String url =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_PURGE_ROOM, java.util.Map.of("roomId", matrixRoomId));
 
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -704,8 +711,10 @@ public class MatrixSynapseService {
 
       String txnId = java.util.UUID.randomUUID().toString();
       var url =
-          matrixConfig.getApiUrl(
-              "/_matrix/client/r0/rooms/" + roomId + "/send/m.room.message/" + txnId);
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig,
+              ENDPOINT_SEND_MESSAGE,
+              java.util.Map.of("roomId", roomId, "txnId", txnId));
 
       log.info("Sending message to Matrix room: {}", roomId);
 
@@ -736,8 +745,11 @@ public class MatrixSynapseService {
       HttpEntity<Void> request = new HttpEntity<>(headers);
 
       var url =
-          matrixConfig.getApiUrl(
-              "/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100");
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig,
+              ENDPOINT_ROOM_MESSAGES,
+              java.util.Map.of("roomId", roomId),
+              java.util.Map.of("dir", "b", "limit", 100));
 
       log.info("Getting messages from Matrix room: {}", roomId);
 
@@ -785,19 +797,16 @@ public class MatrixSynapseService {
       // Get the last sync token if available
       String since = syncTokenCache.getOrDefault(username, "");
 
-      // Build sync URL with room filter
-      String filter =
-          java.net.URLEncoder.encode(
-              "{\"room\":{\"timeline\":{\"limit\":50},\"rooms\":[\"" + roomId + "\"]}}",
-              java.nio.charset.StandardCharsets.UTF_8);
+      String filter = "{\"room\":{\"timeline\":{\"limit\":50},\"rooms\":[\"" + roomId + "\"]}}";
+      var queryParams = new java.util.LinkedHashMap<String, Object>();
+      queryParams.put("timeout", timeout);
+      if (!since.isEmpty()) {
+        queryParams.put("since", since);
+      }
+      queryParams.put("filter", filter);
 
       String url =
-          matrixConfig.getApiUrl(ENDPOINT_SYNC)
-              + "?timeout="
-              + timeout
-              + (since.isEmpty() ? "" : "&since=" + since)
-              + "&filter="
-              + filter;
+          MatrixUrlBuilder.buildUrl(matrixConfig, ENDPOINT_SYNC, java.util.Map.of(), queryParams);
 
       log.info("Syncing Matrix room: {} for user: {} (timeout: {}ms)", roomId, username, timeout);
 
@@ -1190,7 +1199,9 @@ public class MatrixSynapseService {
     }
 
     try {
-      String url = matrixConfig.getApiUrl(ENDPOINT_PRESENCE.replace("{userId}", matrixUserId));
+      String url =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_PRESENCE, java.util.Map.of("userId", matrixUserId));
       HttpEntity<Void> request = new HttpEntity<>(getClientHttpHeaders(adminToken));
 
       var response =

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
@@ -1,0 +1,38 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.Map;
+import org.springframework.web.util.UriComponentsBuilder;
+
+final class MatrixUrlBuilder {
+
+  private MatrixUrlBuilder() {}
+
+  static String buildUrl(MatrixConfig matrixConfig, String endpoint) {
+    return buildUrl(matrixConfig, endpoint, Map.of(), Map.of());
+  }
+
+  static String buildUrl(MatrixConfig matrixConfig, String endpoint, Map<String, ?> uriVariables) {
+    return buildUrl(matrixConfig, endpoint, uriVariables, Map.of());
+  }
+
+  static String buildUrl(
+      MatrixConfig matrixConfig,
+      String endpoint,
+      Map<String, ?> uriVariables,
+      Map<String, ?> queryParams) {
+    String url =
+        UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint))
+            .buildAndExpand(uriVariables)
+            .encode()
+            .toUriString();
+    var builder = UriComponentsBuilder.fromUriString(url);
+    queryParams.forEach(
+        (name, value) -> {
+          if (value != null) {
+            builder.queryParam(name, value);
+          }
+        });
+    return builder.build().encode().toUriString();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
@@ -21,18 +21,13 @@ final class MatrixUrlBuilder {
       String endpoint,
       Map<String, ?> uriVariables,
       Map<String, ?> queryParams) {
-    String url =
-        UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint))
-            .buildAndExpand(uriVariables)
-            .encode()
-            .toUriString();
-    var builder = UriComponentsBuilder.fromUriString(url);
+    var builder = UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint));
     queryParams.forEach(
         (name, value) -> {
           if (value != null) {
             builder.queryParam(name, value);
           }
         });
-    return builder.build().encode().toUriString();
+    return builder.buildAndExpand(uriVariables).encode().toUriString();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -90,7 +90,7 @@ class MatrixSynapseServiceTest {
         .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
     assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?timeout=30000");
     assertThat(urlCaptor.getValue()).contains("&filter=");
-    assertThat(urlCaptor.getValue()).contains("%21room%3Aexample.org");
+    assertThat(urlCaptor.getValue()).contains("%22!room:example.org%22");
     verifyNoInteractions(restTemplate);
   }
 
@@ -98,19 +98,23 @@ class MatrixSynapseServiceTest {
   void getRoomMessagesShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
     var roomId = "!room:example.org";
-    var messagesUrl =
-        "https://matrix.example/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100";
-    when(matrixConfig.getApiUrl("/_matrix/client/r0/rooms/" + roomId + "/messages?dir=b&limit=100"))
-        .thenReturn(messagesUrl);
+    when(matrixConfig.getApiUrl(any(String.class)))
+        .thenAnswer(
+            invocation -> "https://matrix.example" + invocation.getArgument(0, String.class));
     when(matrixLongPollRestTemplate.exchange(
-            eq(messagesUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("chunk", java.util.List.of())));
+    var urlCaptor = ArgumentCaptor.forClass(String.class);
 
     var result = service.getRoomMessages(roomId, ACCESS_TOKEN);
 
     assertThat(result).isNotNull().isEmpty();
     verify(matrixLongPollRestTemplate)
-        .exchange(eq(messagesUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    assertThat(urlCaptor.getValue())
+        .startsWith("https://matrix.example/_matrix/client/r0/rooms/" + roomId + "/messages?");
+    assertThat(urlCaptor.getValue()).contains("dir=b");
+    assertThat(urlCaptor.getValue()).contains("limit=100");
     verifyNoInteractions(restTemplate);
   }
 


### PR DESCRIPTION
## What changed
- Added a shared Matrix URL builder using UriComponentsBuilder for path-template expansion and query encoding.
- Replaced unsafe Matrix URL string replacement/concatenation in MatrixSynapseService and MatrixMediaClient.
- Reused the shared helper from MatrixRoomClient.
- Kept the admin login-as-user URI path on the existing pre-encoded URI.create(...) flow to avoid %2540 double-encoding.

## Why
Matrix user IDs, room IDs, media IDs, and room IDs can contain reserved URI characters such as @, :, and !. Building those URLs with string concatenation or .replace(...) risks malformed URLs or inconsistent encoding.

## Validation
- ./mvnw -Dtest=MatrixSynapseServiceTest,MatrixMediaClientTest,MatrixRoomClientTest test