### PR TITLE
US-M28 enable liquibase in dev profile

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -61,8 +61,9 @@ rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:}
 
 # ---------------- Liquibase ----------------
-spring.liquibase.enabled=false
-# Database already exists, skip Liquibase migration
+# Enabled in dev/local so new environments bootstrap automatically from changesets.
+# Prod stays false — schemas managed via ORISO-Database repo (platform-wide decision).
+spring.liquibase.enabled=true
 
 # ---------------- Local App Settings ----------------
 app.base.url=${APP_BASE_URL:http://localhost:8082}


### PR DESCRIPTION
## What
- Set `spring.liquibase.enabled=true` in `application-dev.properties`

## Why
Fixes audit finding US-M28 — Liquibase migrations were disabled in the dev profile, meaning schema changes were never validated against a real database during development.
Closes #165

## Test
- [ ] Service starts on dev profile without Liquibase errors
- [ ] `liquibase:update` runs cleanly against dev DB

## Reviewer checklist
- [ ] Only `application-dev.properties` changed — no prod or staging profiles touched
- [ ] No new changesets introduced — enabling the runner only