### PR TITLE
Require identity technical user secret

### DIFF
--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -16,6 +16,8 @@ export CONSULTING_TYPE_SERVICE_API_URL="https://api.oriso.org/service"
 export AGENCY_SERVICE_API_URL="https://api.oriso.org/service"
 export TENANT_SERVICE_API_URL="https://api.oriso.org/service"
 export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso.org"
+export IDENTITY_TECHNICAL_USER_USERNAME="technical"
+export IDENTITY_TECHNICAL_USER_PASSWORD='CHANGE_ME'
 
 export ROCKET_CHAT_BASE_URL="http://localhost:3000/api/v1"
 export ROCKET_CHAT_MONGO_URL="mongodb://localhost:27017/rocketchat?retryWrites=false"

--- a/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
@@ -31,6 +31,12 @@ public class ConfigurationValidator {
   @Value("${identity.openid-connect-url:}")
   private String identityOpenIdConnectUrl;
 
+  @Value("${identity.technical-user.username:}")
+  private String identityTechnicalUsername;
+
+  @Value("${identity.technical-user.password:}")
+  private String identityTechnicalPassword;
+
   @Value("${rocket-chat.base-url:}")
   private String rocketChatBaseUrl;
 
@@ -76,6 +82,12 @@ public class ConfigurationValidator {
     }
     if (isEmpty(identityOpenIdConnectUrl)) {
       missingConfigs.add("identity.openid-connect-url (IDENTITY_OPENID_CONNECT_URL)");
+    }
+    if (isEmpty(identityTechnicalUsername)) {
+      missingConfigs.add("identity.technical-user.username (IDENTITY_TECHNICAL_USER_USERNAME)");
+    }
+    if (isEmpty(identityTechnicalPassword)) {
+      missingConfigs.add("identity.technical-user.password (IDENTITY_TECHNICAL_USER_PASSWORD)");
     }
     if (isEmpty(rocketChatBaseUrl)) {
       missingConfigs.add("rocket-chat.base-url (ROCKET_CHAT_BASE_URL)");

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -18,6 +18,10 @@ keycloak.config.admin-password=${KEYCLOAK_CONFIG_ADMIN_PASSWORD:}
 keycloak.config.admin-client-id=admin-cli
 keycloak.config.app-client-id=app
 
+# ---------------- Identity Management ----------------
+identity.technical-user.username=test-technical-user
+identity.technical-user.password=test-technical-user-password
+
 # ---------------- MariaDB ----------------
 # Scaled for 5000 concurrent users
 # Configuration must be provided via ConfigMap/Secrets (environment variables)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,8 +76,8 @@ inactive.account.notification.app-base-url=${app.base.url}
 
 # ---------------- Identity Management ----------------
 identity.email-dummy-suffix=@beratungcaritas.de
-identity.technical-user.username=technical
-identity.technical-user.password=technical
+identity.technical-user.username=${IDENTITY_TECHNICAL_USER_USERNAME:}
+identity.technical-user.password=${IDENTITY_TECHNICAL_USER_PASSWORD:}
 identity.error-message-duplicated-email=User exists with same email
 identity.error-message-duplicated-username=User exists with same username
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080/realms/online-beratung/protocol/openid-connect

--- a/src/test/java/de/caritas/cob/userservice/api/config/ConfigurationValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/ConfigurationValidatorTest.java
@@ -1,0 +1,63 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationValidatorTest {
+
+  private ConfigurationValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = new ConfigurationValidator();
+    givenAllRequiredConfigurationValues();
+  }
+
+  @Test
+  void validateConfigurationShouldPassWhenAllRequiredValuesArePresent() {
+    assertThatCode(validator::validateConfiguration).doesNotThrowAnyException();
+  }
+
+  @Test
+  void validateConfigurationShouldRejectMissingIdentityTechnicalUsername() {
+    setField(validator, "identityTechnicalUsername", "");
+
+    assertThatThrownBy(validator::validateConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "identity.technical-user.username (IDENTITY_TECHNICAL_USER_USERNAME)");
+  }
+
+  @Test
+  void validateConfigurationShouldRejectMissingIdentityTechnicalPassword() {
+    setField(validator, "identityTechnicalPassword", " ");
+
+    assertThatThrownBy(validator::validateConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "identity.technical-user.password (IDENTITY_TECHNICAL_USER_PASSWORD)");
+  }
+
+  private void givenAllRequiredConfigurationValues() {
+    setField(validator, "datasourceUrl", "jdbc:mariadb://mariadb/userservice");
+    setField(validator, "datasourceUsername", "userservice");
+    setField(validator, "datasourcePassword", "secret");
+    setField(validator, "keycloakAuthServerUrl", "https://auth.example");
+    setField(validator, "keycloakRealm", "online-beratung");
+    setField(validator, "identityOpenIdConnectUrl", "https://auth.example/openid-connect");
+    setField(validator, "identityTechnicalUsername", "technical-user");
+    setField(validator, "identityTechnicalPassword", "secret");
+    setField(validator, "rocketChatBaseUrl", "https://rocket.example/api/v1");
+    setField(validator, "rocketChatMongoUrl", "mongodb://mongodb/rocketchat");
+    setField(validator, "rocketTechnicalUsername", "rocket-technical-user");
+    setField(validator, "rocketTechnicalPassword", "secret");
+    setField(validator, "consultingTypeServiceApiUrl", "https://consulting-type.example/service");
+    setField(validator, "tenantServiceApiUrl", "https://tenant.example/service");
+    setField(validator, "matrixApiUrl", "https://matrix.example");
+    setField(validator, "matrixRegistrationSharedSecret", "secret");
+  }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `identity.technical-user` credentials with environment-backed placeholders.
- Validate identity technical username/password on startup.
- Add test coverage and local example values without a real default password.

## Verification
- `./mvnw.cmd -Dtest=ConfigurationValidatorTest test`
- `./mvnw.cmd -Dtest=ConfigurationValidatorTest,UserStatisticsControllerAuthorizationIT test`
- Local smoke: `/actuator/health`, `/actuator/health/liveness`, and `/actuator/health/readiness` return `UP`.

## Deploy Note
Requires `IDENTITY_TECHNICAL_USER_USERNAME` and `IDENTITY_TECHNICAL_USER_PASSWORD` to be configured before rollout.

<img width="975" height="548" alt="image" src="https://github.com/user-attachments/assets/3e30755c-3cc5-4ba8-898a-bb8e65bfb93b" />
