### PR TITLE
disable OSIV to prevent DB connections held open during external HTTP calls

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.application.name=user-service
 spring.profiles.active=@activeSpringProfile@
 spring.main.allow-bean-definition-overriding=true
-spring.jpa.open-in-view=true
+spring.jpa.open-in-view=false
 spring.jpa.hibernate.ddl-auto=none
 spring.data.jpa.repositories.bootstrap-mode=default
 spring.main.banner-mode=off


### PR DESCRIPTION
## What
- Set `spring.jpa.open-in-view=false` in `application.properties`

## Why
Fixes audit finding US-H07 — OSIV held a DB connection open for the entire request lifecycle, including across all external HTTP calls (Keycloak, Matrix, RocketChat) which have no timeout. With 80 Hikari connections vs 1000 request threads, a single slow external service could exhaust the pool.
Closes #169

## Test
- [ ] Service starts cleanly after deploy
- [ ] No LazyInitializationException in logs for normal counseling session flows
- [ ] Connection pool metrics remain stable under normal load

## Reviewer checklist
- [ ] `application.properties` line 5: `spring.jpa.open-in-view=false`
- [ ] No LazyInitializationException in startup or basic request paths