### PR TITLE
feat(notifications): event_notification params + persist "New client request" (WP-06 Slice 2a)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -34,6 +34,7 @@ import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRout
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.message.RocketChatData;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -65,6 +66,7 @@ public class CreateEnquiryMessageFacade {
   private final @NonNull UserService userService;
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
+  private final @NonNull EventNotificationService eventNotificationService;
   private final RocketChatRoomNameGenerator rocketChatRoomNameGenerator =
       new RocketChatRoomNameGenerator();
 
@@ -142,6 +144,7 @@ public class CreateEnquiryMessageFacade {
       }
 
       notifyEligibleConsultantsAboutLiveChatEnquiry(session);
+      persistNewClientRequestNotifications(session, agencyList);
 
       return new CreateEnquiryMessageResponseDTO()
           .rcGroupId(rcGroupId)
@@ -174,6 +177,26 @@ public class CreateEnquiryMessageFacade {
     }
 
     return consultantAgencyService.findConsultantsByAgencyId(session.getAgencyId());
+  }
+
+  /**
+   * WP-06 Slice 2 (Tier 1): persist a "New client request" Activity Timeline event for every
+   * eligible consultant of this enquiry (the same population the email notification targets).
+   * Best-effort — a notification failure must never break enquiry creation, so any error is
+   * swallowed and logged.
+   */
+  private void persistNewClientRequestNotifications(
+      Session session, List<ConsultantAgency> agencyList) {
+    try {
+      List<String> consultantIds =
+          agencyList.stream()
+              .map(agency -> agency.getConsultant() != null ? agency.getConsultant().getId() : null)
+              .filter(id -> id != null && !id.isBlank())
+              .collect(Collectors.toList());
+      eventNotificationService.createNewClientRequestNotifications(session, consultantIds);
+    } catch (RuntimeException ex) {
+      log.warn("Could not persist request.new notifications for session {}", session.getId(), ex);
+    }
   }
 
   private void notifyEligibleConsultantsAboutLiveChatEnquiry(Session session) {

--- a/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
@@ -55,6 +55,15 @@ public class EventNotification implements TenantAware {
   @Column(name = "text", columnDefinition = "text")
   private String text;
 
+  /**
+   * WP-06 / ADR-AT-01: structured params (JSON) the client uses to render the event's visible
+   * strings from i18n templates instead of server-stored text. Additive for now — populated
+   * alongside {@code title}/{@code text} until the frontend renders purely from params and the
+   * display-text columns are dropped.
+   */
+  @Column(name = "params", columnDefinition = "text")
+  private String params;
+
   @Column(name = "action_path", length = 512)
   private String actionPath;
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -2,6 +2,8 @@ package de.caritas.cob.userservice.api.service.notification;
 
 import static java.util.Objects.nonNull;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EventNotification;
 import de.caritas.cob.userservice.api.model.Session;
@@ -12,6 +14,8 @@ import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,11 +25,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventNotificationService {
@@ -41,6 +47,7 @@ public class EventNotificationService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull IdentityTombstoneService identityTombstoneService;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
+  private final ObjectMapper paramsObjectMapper = new ObjectMapper();
 
   @Value("${privacy.notificationPreviewMode:NONE}")
   private String notificationPreviewMode;
@@ -115,6 +122,70 @@ public class EventNotificationService {
         buildSessionActionPath(session),
         session.getId(),
         session.getTenantId());
+  }
+
+  /**
+   * WP-06 Slice 2 (Tier 1): persist a "New client request" timeline event ({@code request.new}) for
+   * each eligible consultant when a new enquiry is created. The recipient population mirrors the
+   * consultants already notified by email — the Activity Timeline is the consultant's inbox.
+   *
+   * <p>Carries structured params (ADR-AT-01) for client-side rendering, plus a title/text fallback
+   * so today's frontend renders the same card until it reads params. Best-effort: persisting a
+   * notification must never break enquiry creation, so per-recipient failures are swallowed and
+   * logged.
+   */
+  @Transactional
+  public void createNewClientRequestNotifications(
+      Session session, Collection<String> recipientConsultantIds) {
+    if (session == null || recipientConsultantIds == null) {
+      return;
+    }
+    String actionPath = buildSessionActionPath(session, null, true);
+    String params = buildNewClientRequestParams(session);
+    recipientConsultantIds.stream()
+        .filter(id -> id != null && !id.isBlank())
+        .distinct()
+        .forEach(
+            consultantId -> {
+              try {
+                createEvent(
+                    consultantId,
+                    "request.new",
+                    CATEGORY_SYSTEM,
+                    "New client request",
+                    "A new client request is waiting.",
+                    params,
+                    actionPath,
+                    session.getId(),
+                    session.getTenantId());
+              } catch (RuntimeException ex) {
+                log.warn(
+                    "Could not persist request.new notification for consultant {} (session {})",
+                    consultantId,
+                    session.getId(),
+                    ex);
+              }
+            });
+  }
+
+  private String buildNewClientRequestParams(Session session) {
+    Map<String, Object> params = new LinkedHashMap<>();
+    if (session.getId() != null) {
+      params.put("sessionId", session.getId());
+    }
+    if (session.getAgencyId() != null) {
+      params.put("agencyId", session.getAgencyId());
+    }
+    if (session.getMainTopicId() != null) {
+      params.put("topicId", session.getMainTopicId());
+    }
+    params.put("consultingTypeId", session.getConsultingTypeId());
+    try {
+      return paramsObjectMapper.writeValueAsString(params);
+    } catch (JsonProcessingException ex) {
+      log.warn("Could not serialize request.new params for session {}", session.getId(), ex);
+      return null;
+    }
   }
 
   @Transactional
@@ -396,6 +467,34 @@ public class EventNotificationService {
       String actionPath,
       Long sourceSessionId,
       Long tenantId) {
+    createEvent(
+        recipientUserId,
+        eventType,
+        category,
+        title,
+        text,
+        null,
+        actionPath,
+        sourceSessionId,
+        tenantId);
+  }
+
+  /**
+   * Low-level builder. WP-06 / ADR-AT-01: {@code params} carries structured JSON the client renders
+   * visible strings from; {@code title}/{@code text} remain a fallback until the frontend renders
+   * purely from params.
+   */
+  @Transactional
+  public void createEvent(
+      String recipientUserId,
+      String eventType,
+      String category,
+      String title,
+      String text,
+      String params,
+      String actionPath,
+      Long sourceSessionId,
+      Long tenantId) {
     if (recipientUserId == null || recipientUserId.isBlank()) {
       return;
     }
@@ -406,6 +505,7 @@ public class EventNotificationService {
             .category(nonNull(category) ? category : CATEGORY_SYSTEM)
             .title(nonNull(title) ? title : "Notification")
             .text(nonNull(text) ? text : "")
+            .params(params)
             .actionPath(actionPath)
             .sourceSessionId(sourceSessionId)
             .readDate(null)
@@ -422,6 +522,7 @@ public class EventNotificationService {
         .category(item.getCategory())
         .title(item.getTitle())
         .text(item.getText())
+        .params(item.getParams())
         .actionPath(item.getActionPath())
         .sourceSessionId(item.getSourceSessionId())
         .readAt(
@@ -680,6 +781,10 @@ public class EventNotificationService {
     private final String category;
     private final String title;
     private final String text;
+
+    /** WP-06 / ADR-AT-01: structured JSON params for client-side string rendering. */
+    private final String params;
+
     private final String actionPath;
     private final Long sourceSessionId;
     private final String createdAt;

--- a/src/main/resources/db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+  <changeSet author="caritas" id="addEventNotificationParams">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="event_notification"/>
+    </preConditions>
+    <sqlFile
+      path="db/changelog/changeset/0054_event_notification_params/addEventNotificationParams.sql"
+      stripComments="true"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0054_event_notification_params/addEventNotificationParams.sql
+++ b/src/main/resources/db/changelog/changeset/0054_event_notification_params/addEventNotificationParams.sql
@@ -1,0 +1,8 @@
+-- WP-06 Activity Timeline (Slice 2, ADR-AT-01): event_notification records carry
+-- structured params (JSON) so visible strings can be rendered client-side from
+-- i18n templates instead of server-stored display text. This first, additive
+-- step only ADDS the nullable column; producers start populating it alongside
+-- the existing title/text. Dropping title/text follows once the frontend renders
+-- purely from params. Idempotent so it is safe whether applied by Liquibase or
+-- by hand on environments where Liquibase is disabled.
+ALTER TABLE event_notification ADD COLUMN IF NOT EXISTS params TEXT NULL;

--- a/src/main/resources/db/changelog/userservice-prod-master.xml
+++ b/src/main/resources/db/changelog/userservice-prod-master.xml
@@ -58,4 +58,5 @@
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-staging-master.xml
+++ b/src/main/resources/db/changelog/userservice-staging-master.xml
@@ -56,4 +56,5 @@
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -78,6 +78,7 @@ import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRout
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.message.RocketChatData;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
@@ -190,6 +191,8 @@ class CreateEnquiryMessageFacadeTest {
 
   @Mock private LiveEventNotificationService liveEventNotificationService;
 
+  @Mock private EventNotificationService eventNotificationService;
+
   private Session session;
   private User user;
   private ExtendedConsultingTypeResponseDTO extendedConsultingTypeResponseDTO;
@@ -285,6 +288,8 @@ class CreateEnquiryMessageFacadeTest {
         .postWelcomeMessageIfConfigured(any(), any(), any(), any());
     verify(sessionService, atLeastOnce()).saveSession(any());
     verify(emailNotificationFacade, atLeastOnce()).sendNewEnquiryEmailNotification(any(), any());
+    verify(eventNotificationService, atLeastOnce())
+        .createNewClientRequestNotifications(Mockito.eq(session), any());
     assertEquals(SESSION_ID, response.getSessionId());
     assertEquals(RC_GROUP_ID, response.getRcGroupId());
     assertEquals(response.getT(), messageResponse.getT());

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -1,0 +1,110 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.model.EventNotification;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * WP-06 Activity Timeline (Slice 2, Tier 1) — coverage for the persisted "New client request"
+ * ({@code request.new}) event and the structured params it carries (ADR-AT-01).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EventNotificationServiceTest {
+
+  @InjectMocks private EventNotificationService eventNotificationService;
+  @Mock private EventNotificationRepository eventNotificationRepository;
+  @Mock private SessionRepository sessionRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private IdentityTombstoneService identityTombstoneService;
+  @Captor private ArgumentCaptor<EventNotification> eventCaptor;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private Session sessionMock() {
+    Session session = mock(Session.class);
+    when(session.getId()).thenReturn(100L);
+    when(session.getTenantId()).thenReturn(7L);
+    when(session.getAgencyId()).thenReturn(42L);
+    when(session.getMainTopicId()).thenReturn(5L);
+    when(session.getConsultingTypeId()).thenReturn(1);
+    when(session.getMatrixRoomId()).thenReturn(null);
+    when(session.getGroupId()).thenReturn("rc-group-1");
+    return session;
+  }
+
+  @Test
+  void createNewClientRequestNotifications_persistsRequestNewEventPerRecipient() throws Exception {
+    Session session = sessionMock();
+
+    eventNotificationService.createNewClientRequestNotifications(
+        session, List.of("consultant-a", "consultant-b"));
+
+    verify(eventNotificationRepository, times(2)).save(eventCaptor.capture());
+    List<EventNotification> saved = eventCaptor.getAllValues();
+
+    EventNotification first = saved.get(0);
+    assertEquals("request.new", first.getEventType());
+    assertEquals(EventNotificationService.CATEGORY_SYSTEM, first.getCategory());
+    assertEquals("New client request", first.getTitle());
+    assertEquals("A new client request is waiting.", first.getText());
+    assertEquals(Long.valueOf(100L), first.getSourceSessionId());
+    assertEquals(Long.valueOf(7L), first.getTenantId());
+    assertEquals("/sessions/consultant/sessionView/rc-group-1/100", first.getActionPath());
+    assertEquals("consultant-a", first.getRecipientUserId());
+    assertEquals("consultant-b", saved.get(1).getRecipientUserId());
+
+    assertNotNull(first.getParams());
+    JsonNode params = objectMapper.readTree(first.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals(42L, params.get("agencyId").asLong());
+    assertEquals(5L, params.get("topicId").asLong());
+    assertEquals(1, params.get("consultingTypeId").asInt());
+  }
+
+  @Test
+  void createNewClientRequestNotifications_skipsBlankAndDeduplicatesRecipients() {
+    Session session = sessionMock();
+
+    eventNotificationService.createNewClientRequestNotifications(
+        session, Arrays.asList("consultant-a", null, "  ", "consultant-a", "consultant-b"));
+
+    // null/blank dropped, duplicate "consultant-a" collapsed -> 2 distinct recipients.
+    verify(eventNotificationRepository, times(2)).save(any());
+  }
+
+  @Test
+  void createNewClientRequestNotifications_doesNothingForNullInputs() {
+    eventNotificationService.createNewClientRequestNotifications(null, List.of("consultant-a"));
+    eventNotificationService.createNewClientRequestNotifications(sessionMock(), null);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+}


### PR DESCRIPTION
## WP-06 Activity Timeline — Slice 2a (backend, additive)

Backend groundwork for the strict text-free `event_notification` migration (ADR-AT-01), plus the first **Tier 1** persisted event type. **Additive and zero-regression**: nothing stops being written, so today's deployed frontend renders identically.

Tracking: OpenResilienceInitiative/ORISO-Frontend#251 · Plan: OrisoPlan *WP-06 — Activity Timeline*, *ADR-AT-01 — Storage & E2EE Boundary*.

### What this PR does
1. **`event_notification.params` column (additive).** New nullable `TEXT` column carrying structured JSON params so the client can render visible strings from i18n templates instead of server-stored text (ADR-AT-01). Producers will populate it *alongside* `title`/`text`; the display-text columns stay for now.
   - Changeset `0054_event_notification_params` (idempotent `ADD COLUMN IF NOT EXISTS` + a `tableExists event_notification` precondition with `onFail=MARK_RAN`), registered in `prod`/`staging` masters — mirroring exactly where the table-creating changeset `0048` is registered.
   - Entity field + DTO field (`NotificationItem.params`) + feed mapping.
2. **Persist "New client request" (`request.new`) — Tier 1.** A new enquiry already fires a live event + email but persisted **no** timeline row. We now persist a `request.new` event for **every eligible consultant** of the enquiry (the same population the email targets — the Activity Timeline is the consultant inbox), sourced from the already-resolved `agencyList` in `CreateEnquiryMessageFacade`.
   - The frontend registry already seeds a `request.new` descriptor + i18n (`New client request` / `A new client request is waiting.`) from Slice 0a, so this renders correctly on the **currently deployed** frontend with no FE change. A title/text fallback is also set as belt-and-suspenders.
   - Best-effort: wrapped so a notification failure can never break enquiry creation.

### What this PR deliberately does NOT do (deferred)
- **Stop populating `title`/`text`** (the strict switch) — that is a flag-day coupled to a frontend change that renders purely from `params`. Comes in a follow-up once the FE consumes `params`. `title` stays `NOT NULL` for now.
- **Pull Rocket.Chat out of the notification path** (ADR-AT-01 §4) — high blast radius (the new-message email path resolves recipients via RC group membership; the RC calls in `AssignEnquiryFacade` are room-setup, not notifications). Its own follow-up PR.

### Notes / things reviewers should know
- **Pre-existing changelog divergence (not introduced here):** `event_notification` (changeset 0048) is registered only in `prod`/`staging` masters, not `dev`/`local`/`testing`. The dev cluster runs Liquibase disabled and is hand-migrated; testing uses H2 `create-drop` from the entity. This PR follows the same registration as 0048 and is idempotent + precondition-guarded so it is safe wherever it runs. The dev DB column will be applied by hand at deploy time, as with the original table.
- **ORISO-Database** does not track `event_notification` (the original table wasn't mirrored there either), so no schema mirror is added.
- **Tests:** new `EventNotificationServiceTest` (3 tests, green on JDK 17) covers the `request.new` persistence, params JSON, dedup/blank-skipping, and null-input guards. `CreateEnquiryMessageFacadeTest` gains a mock + a verification, but note that class is **pre-existing-broken on JDK 17** (its `@BeforeEach` uses PowerMock `Whitebox.setInternalState`, which fails under JDK 17 — `testFailureIgnore=true` already hides this in CI). The meaningful new coverage is the standalone service test.

### Verification
- `mvn spotless:apply test-compile` — BUILD SUCCESS
- `EventNotificationServiceTest` — 3 run, 0 failures, 0 errors
- `mvn package -DskipTests` — green (CI runs `./mvnw -B package` on JDK 17; `testFailureIgnore=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
