### PR TITLE
feat(notifications): backfill structured params on all event producers (WP-06 Slice 2b, step 1)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -95,26 +95,8 @@ public class SessionSupervisorController {
     if (supervisor.getSession() != null
         && supervisor.getSupervisorConsultant() != null
         && supervisor.getSupervisorConsultant().getId() != null) {
-      String roomRef =
-          supervisor.getSession().getMatrixRoomId() != null
-                  && !supervisor.getSession().getMatrixRoomId().isBlank()
-              ? supervisor.getSession().getMatrixRoomId()
-              : supervisor.getSession().getGroupId();
-      eventNotificationService.createEvent(
-          supervisor.getSupervisorConsultant().getId(),
-          "supervisor.assigned",
-          EventNotificationService.CATEGORY_SYSTEM,
-          "Supervisor assignment",
-          String.format(
-              "You were added as supervisor to chat #%s.", supervisor.getSession().getId()),
-          roomRef != null
-              ? "/sessions/consultant/sessionView/"
-                  + roomRef
-                  + "/"
-                  + supervisor.getSession().getId()
-              : null,
-          supervisor.getSession().getId(),
-          supervisor.getSession().getTenantId());
+      eventNotificationService.createSupervisorAssignedNotification(
+          supervisor.getSession(), supervisor.getSupervisorConsultant().getId());
     }
 
     SessionSupervisorResponseDTO response = mapToDTO(supervisor);

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -59,12 +59,15 @@ public class EventNotificationService {
     }
 
     String consultantName = resolveConsultantName(consultant);
+    Map<String, Object> params = baseParams(session);
+    params.put("consultantName", consultantName);
     createEvent(
         session.getUser().getUserId(),
         "inquiry.accepted",
         CATEGORY_SYSTEM,
         "Inquiry accepted",
         String.format("Your request was accepted by %s. Chat is now active.", consultantName),
+        serializeParams(params),
         buildSessionActionPath(session),
         session.getId(),
         session.getTenantId());
@@ -73,6 +76,8 @@ public class EventNotificationService {
   @Transactional
   public void createSupervisorAddedNotification(
       Session session, String recipientUserId, String supervisorName) {
+    Map<String, Object> params = baseParams(session);
+    putIfPresent(params, "supervisorName", supervisorName);
     createEvent(
         recipientUserId,
         "supervisor.added",
@@ -81,7 +86,30 @@ public class EventNotificationService {
         String.format(
             "%s was added as a consultant supervisor to your chat #%s.",
             safeValue(supervisorName, "A supervisor"), session.getId()),
+        serializeParams(params),
         buildSessionActionPath(session),
+        session.getId(),
+        session.getTenantId());
+  }
+
+  /**
+   * WP-06 Slice 2b: notify the consultant who was just assigned as supervisor. Extracted from
+   * SessionSupervisorController so every event_notification producer goes through this service and
+   * carries structured params uniformly.
+   */
+  @Transactional
+  public void createSupervisorAssignedNotification(Session session, String recipientConsultantId) {
+    if (session == null || recipientConsultantId == null || recipientConsultantId.isBlank()) {
+      return;
+    }
+    createEvent(
+        recipientConsultantId,
+        "supervisor.assigned",
+        CATEGORY_SYSTEM,
+        "Supervisor assignment",
+        String.format("You were added as supervisor to chat #%s.", session.getId()),
+        serializeParams(baseParams(session)),
+        buildSessionActionPath(session, null, true),
         session.getId(),
         session.getTenantId());
   }
@@ -89,6 +117,8 @@ public class EventNotificationService {
   @Transactional
   public void createSupervisorRemovedNotification(
       Session session, String recipientUserId, String supervisorName) {
+    Map<String, Object> params = baseParams(session);
+    putIfPresent(params, "supervisorName", supervisorName);
     createEvent(
         recipientUserId,
         "supervisor.removed",
@@ -97,6 +127,7 @@ public class EventNotificationService {
         String.format(
             "%s was removed from supervision for chat #%s.",
             safeValue(supervisorName, "A supervisor"), session.getId()),
+        serializeParams(params),
         buildSessionActionPath(session),
         session.getId(),
         session.getTenantId());
@@ -111,6 +142,9 @@ public class EventNotificationService {
     String previous = safeValue(oldDisplayName, "your counselor");
     String updated = safeValue(newDisplayName, "your counselor");
     String changedAt = LocalDateTime.now(ZoneOffset.UTC).toString();
+    Map<String, Object> params = baseParams(session);
+    params.put("oldName", previous);
+    params.put("newName", updated);
     createEvent(
         recipientUserId,
         "counselor.renamed",
@@ -119,6 +153,7 @@ public class EventNotificationService {
         String.format(
             "Your counselor display name changed from \"%s\" to \"%s\" at %s UTC.",
             previous, updated, changedAt),
+        serializeParams(params),
         buildSessionActionPath(session),
         session.getId(),
         session.getTenantId());
@@ -169,10 +204,7 @@ public class EventNotificationService {
   }
 
   private String buildNewClientRequestParams(Session session) {
-    Map<String, Object> params = new LinkedHashMap<>();
-    if (session.getId() != null) {
-      params.put("sessionId", session.getId());
-    }
+    Map<String, Object> params = baseParams(session);
     if (session.getAgencyId() != null) {
       params.put("agencyId", session.getAgencyId());
     }
@@ -180,10 +212,58 @@ public class EventNotificationService {
       params.put("topicId", session.getMainTopicId());
     }
     params.put("consultingTypeId", session.getConsultingTypeId());
+    return serializeParams(params);
+  }
+
+  // WP-06 Slice 2b: structured params for message/thread events. Per ADR-AT-01 these carry only
+  // non-content metadata (sender label, content class, recipient role, thread id) — NEVER the
+  // message preview/body, which stays client-hydrated from the Matrix room.
+  private String buildMessageParams(
+      Session session, String senderName, String contentClass, String recipientRole) {
+    Map<String, Object> params = baseParams(session);
+    putIfPresent(params, "senderName", senderName);
+    putIfPresent(params, "contentClass", contentClass);
+    putIfPresent(params, "recipientRole", recipientRole);
+    return serializeParams(params);
+  }
+
+  private String buildThreadReplyParams(
+      Session session,
+      String senderName,
+      String contentClass,
+      String threadRootId,
+      String recipientRole) {
+    Map<String, Object> params = baseParams(session);
+    putIfPresent(params, "senderName", senderName);
+    putIfPresent(params, "contentClass", contentClass);
+    putIfPresent(params, "threadRootId", threadRootId);
+    putIfPresent(params, "recipientRole", recipientRole);
+    return serializeParams(params);
+  }
+
+  /** Seed a params map with the session id every timeline event references. */
+  private Map<String, Object> baseParams(Session session) {
+    Map<String, Object> params = new LinkedHashMap<>();
+    if (session != null && session.getId() != null) {
+      params.put("sessionId", session.getId());
+    }
+    return params;
+  }
+
+  private void putIfPresent(Map<String, Object> params, String key, String value) {
+    if (value != null && !value.isBlank()) {
+      params.put(key, value);
+    }
+  }
+
+  private String serializeParams(Map<String, Object> params) {
+    if (params == null || params.isEmpty()) {
+      return null;
+    }
     try {
       return paramsObjectMapper.writeValueAsString(params);
     } catch (JsonProcessingException ex) {
-      log.warn("Could not serialize request.new params for session {}", session.getId(), ex);
+      log.warn("Could not serialize event_notification params", ex);
       return null;
     }
   }
@@ -247,6 +327,7 @@ public class EventNotificationService {
     Session session = sessionOpt.get();
     String senderLabel = resolveSenderName(senderUserId, senderDisplayName);
     String text = buildMessageNotificationText(senderLabel, messagePreview, envelope);
+    String contentClass = envelope != null ? envelope.getContentClass() : null;
 
     if (!supervisorMessage
         && session.getUser() != null
@@ -259,6 +340,7 @@ public class EventNotificationService {
           CATEGORY_MESSAGE,
           "New message",
           text,
+          buildMessageParams(session, senderLabel, contentClass, "user"),
           buildSessionActionPathForRecipient(session, session.getUser().getUserId(), null),
           session.getId(),
           session.getTenantId());
@@ -274,6 +356,7 @@ public class EventNotificationService {
           CATEGORY_MESSAGE,
           "New message",
           text,
+          buildMessageParams(session, senderLabel, contentClass, "consultant"),
           buildSessionActionPathForRecipient(session, session.getConsultant().getId(), null),
           session.getId(),
           session.getTenantId());
@@ -355,6 +438,7 @@ public class EventNotificationService {
     String text =
         buildThreadReplyNotificationText(
             senderLabel, messagePreview, threadParentPreview, envelope);
+    String contentClass = envelope != null ? envelope.getContentClass() : null;
 
     if (!supervisorMessage
         && session.getUser() != null
@@ -367,6 +451,7 @@ public class EventNotificationService {
           CATEGORY_MESSAGE,
           "New thread reply",
           text,
+          buildThreadReplyParams(session, senderLabel, contentClass, threadRootId, "user"),
           buildSessionActionPathForRecipient(session, session.getUser().getUserId(), threadRootId),
           session.getId(),
           session.getTenantId());
@@ -382,6 +467,7 @@ public class EventNotificationService {
           CATEGORY_MESSAGE,
           "New thread reply",
           text,
+          buildThreadReplyParams(session, senderLabel, contentClass, threadRootId, "consultant"),
           buildSessionActionPathForRecipient(
               session, session.getConsultant().getId(), threadRootId),
           session.getId(),

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -1,7 +1,9 @@
 package de.caritas.cob.userservice.api.service.notification;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -11,8 +13,10 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EventNotification;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -20,6 +24,7 @@ import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -106,5 +111,98 @@ class EventNotificationServiceTest {
     eventNotificationService.createNewClientRequestNotifications(sessionMock(), null);
 
     verify(eventNotificationRepository, never()).save(any());
+  }
+
+  // WP-06 Slice 2b: every producer now emits structured params alongside the (unchanged)
+  // title/text.
+
+  @Test
+  void createInquiryAcceptedNotification_setsSessionAndConsultantNameParams() throws Exception {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getDisplayName()).thenReturn("Jane Doe");
+
+    eventNotificationService.createInquiryAcceptedNotification(session, consultant);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("inquiry.accepted", saved.getEventType());
+    assertEquals("asker-1", saved.getRecipientUserId());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals("Jane Doe", params.get("consultantName").asText());
+  }
+
+  @Test
+  void createSupervisorAddedNotification_setsSessionAndSupervisorNameParams() throws Exception {
+    eventNotificationService.createSupervisorAddedNotification(
+        sessionMock(), "asker-1", "Sam Supervisor");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("supervisor.added", saved.getEventType());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals("Sam Supervisor", params.get("supervisorName").asText());
+  }
+
+  @Test
+  void createSupervisorAssignedNotification_setsParamsAndConsultantActionPath() throws Exception {
+    eventNotificationService.createSupervisorAssignedNotification(sessionMock(), "consultant-x");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("supervisor.assigned", saved.getEventType());
+    assertEquals("consultant-x", saved.getRecipientUserId());
+    assertEquals("/sessions/consultant/sessionView/rc-group-1/100", saved.getActionPath());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+  }
+
+  @Test
+  void createSupervisorAssignedNotification_doesNothingForBlankRecipient() {
+    eventNotificationService.createSupervisorAssignedNotification(sessionMock(), "  ");
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createCounselorRenamedNotification_setsOldAndNewNameParams() throws Exception {
+    eventNotificationService.createCounselorRenamedNotification(
+        sessionMock(), "asker-1", "Old Name", "New Name");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("counselor.renamed", saved.getEventType());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals("Old Name", params.get("oldName").asText());
+    assertEquals("New Name", params.get("newName").asText());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_setsParamsAndNeverLeaksMessageBody() throws Exception {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "someone-else", "secret message body", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("message.new", saved.getEventType());
+    assertEquals("asker-1", saved.getRecipientUserId());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals("user", params.get("recipientRole").asText());
+    assertTrue(params.has("senderName"));
+    // ADR-AT-01: params carry only non-content metadata — never the message preview/body.
+    assertFalse(saved.getParams().contains("secret message body"));
   }
 }


### PR DESCRIPTION
## WP-06 Slice 2b — step 1: structured params on every producer (additive, non-breaking)

Builds on Slice 2a (#182). Moves toward ADR-AT-01 "strict text-free records" **without** any breaking change yet.

### What changed
Every `event_notification` producer now emits structured JSON `params` **alongside** the unchanged `title`/`text` fallback (only `request.new` did so before):

| event_type | params |
|---|---|
| inquiry.accepted | `sessionId, consultantName` |
| supervisor.added / removed | `sessionId, supervisorName` |
| supervisor.assigned | `sessionId` |
| counselor.renamed | `sessionId, oldName, newName` |
| message.new | `sessionId, senderName, contentClass, recipientRole` |
| thread.reply.new | `sessionId, senderName, contentClass, threadRootId, recipientRole` |

- **ADR-AT-01 boundary:** `message.new` / `thread.reply.new` params carry only non-content metadata (sender label, content class, recipient role, thread id) — **never** the message preview/body, which stays client-hydrated from the Matrix room. Covered by a unit test.
- **Refactor:** the hand-rolled `supervisor.assigned` `createEvent` block in `SessionSupervisorController` is extracted into `EventNotificationService.createSupervisorAssignedNotification(...)` so all 8 producers go through the service uniformly (behaviour-identical).

### Why this is safe
- `title`/`text` are **left exactly as-is** → today's frontend renders unchanged, old clients unaffected.
- **Zero schema change** — the `params` column shipped in 2a (changeset 0054) and is already hand-applied on Pre-Dev.
- The only reader of `title`/`text` is the feed DTO; no other subsystem reads these columns.

### Tests
`EventNotificationServiceTest` 9/9 green (3 existing + 6 new, incl. the no-preview-leak guard). `mvn spotless:apply` clean, `BUILD SUCCESS`. The pre-existing PowerMock / `@NonNull`-construction errors in unrelated facade tests are masked by CI `testFailureIgnore` as before and are untouched by this PR.

### Deferred to later, separately-orderable PRs (the breaking "flag-day")
- Make `title` nullable + drop the `createEvent` coalescing defaults + stop populating `title`/`text` in producers.
- FE: render purely from `params` (drop the server-text bridge in `describeItem`) **before** the server stops sending text.
- Fill `notifications.events.*` translations for `fr/ru/tr/ti` (today only de/en — hard blocker for the flag-day).
- Slice 2c: remove Rocket.Chat from the notification path (ADR-AT-01 Decision #4).

### Open questions for the flag-day (not blocking this PR)
1. Legacy rows: FE render-from-params with fallback to `title`/`text` when params is null (non-destructive), or accept blanks?
2. Who fills `fr/ru/tr/ti` translations, and is it a hard gate on the flip?
3. Named-content UX: actually show supervisor/sender/old+new names (needs FE `{{…}}` placeholders), or keep the generic copy? (params now carry the values either way.)
4. Is the `contentClass` label (image/file/…) safe to store, or hydrate client-side too?

Refs: #182, ADR-AT-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
