### PR TITLE
Fix consultant login profile relation loading

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
@@ -27,6 +27,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientResponseException;
 
 /** Provider for consultant information. */
@@ -48,6 +49,7 @@ public class ConsultantDataProvider {
    * @param consultant a {@link Consultant} instance
    * @return the user data
    */
+  @Transactional(readOnly = true)
   public UserDataResponseDTO retrieveData(Consultant consultant) {
     if (isEmpty(consultant.getConsultantAgencies())) {
       throw new InternalServerErrorException(

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,7 @@ import org.springframework.data.repository.query.Param;
 public interface ConsultantRepository
     extends JpaRepository<Consultant, String>, JpaSpecificationExecutor<Consultant> {
 
+  @EntityGraph(attributePaths = {"consultantAgencies", "languages"})
   Optional<Consultant> findByIdAndDeleteDateIsNull(String id);
 
   Optional<Consultant> findByRocketChatIdAndDeleteDateIsNull(String id);

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryTest.java
@@ -1,0 +1,21 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.EntityGraph;
+
+class ConsultantRepositoryTest {
+
+  @Test
+  void findByIdAndDeleteDateIsNullShouldFetchLoginProfileRelations() throws Exception {
+    var method = ConsultantRepository.class.getMethod("findByIdAndDeleteDateIsNull", String.class);
+
+    var entityGraph = method.getAnnotation(EntityGraph.class);
+
+    assertNotNull(entityGraph);
+    assertArrayEquals(
+        new String[] {"consultantAgencies", "languages"}, entityGraph.attributePaths());
+  }
+}


### PR DESCRIPTION
## Problem
Newly created consultants can authenticate, but `GET /service/users/data` can return HTTP 500 while building the consultant login profile. This is consistent with lazy `consultantAgencies` / `languages` access after OSIV was disabled.

## Solution
- Fetch consultant login profile relations with an `@EntityGraph` on `findByIdAndDeleteDateIsNull`.
- Keep consultant user-data mapping inside a read-only transactional boundary.
- Add a focused regression test that locks the repository method to the required login-profile relation graph.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./mvnw -Dtest=ConsultantDataProviderTest,ConsultantRepositoryTest -Dspotless.check.skip=true test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./mvnw spotless:check -DskipTests`

## Deployment note
This still needs a UserService deploy to `oriso.org` after merge. The documented SSH key is currently rejected by both `oriso.org` and Pre-Dev, so I could not restart the running service from here.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)