### PR TITLE
Fix Keycloak identity claim persistence

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
@@ -883,7 +884,9 @@ public class KeycloakService implements IdentityClient {
   @Override
   public List<String> getRealmRoles(String userId) {
     try {
-      return getUserRoles(userId).stream().map(RoleRepresentation::getName).toList();
+      return getUserRoles(userId).stream()
+          .map(RoleRepresentation::getName)
+          .collect(Collectors.toList());
     } catch (Exception ex) {
       var error = String.format("Could not get roles for user id %s", userId);
       log.error("Keycloak error: " + error, ex);

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -83,6 +83,8 @@ public class KeycloakService implements IdentityClient {
   private static final String LOCALE = "locale";
   private static final String TENANT_ID_ATTRIBUTE = "tenantId";
   private static final String USER_ID_ATTRIBUTE = "userId";
+  private static final String USERNAME_ATTRIBUTE = "username";
+  private static final String LEGACY_USERNAME_ATTRIBUTE = "userName";
 
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull AuthenticatedUser authenticatedUser;
@@ -504,9 +506,19 @@ public class KeycloakService implements IdentityClient {
     }
     kcUser.setEnabled(true);
 
+    putUsernameAttributes(user, kcUser);
     updateTenantId(user, kcUser);
 
     return kcUser;
+  }
+
+  private void putUsernameAttributes(UserDTO userDTO, UserRepresentation kcUser) {
+    Map<String, List<String>> attributes =
+        kcUser.getAttributes() == null ? new HashMap<>() : new HashMap<>(kcUser.getAttributes());
+    var decodedUsername = usernameTranscoder.decodeUsername(userDTO.getUsername());
+    attributes.put(USERNAME_ATTRIBUTE, Collections.singletonList(decodedUsername));
+    attributes.put(LEGACY_USERNAME_ATTRIBUTE, Collections.singletonList(decodedUsername));
+    kcUser.setAttributes(attributes);
   }
 
   private void updateTenantId(UserDTO userDTO, UserRepresentation kcUser) {
@@ -530,6 +542,9 @@ public class KeycloakService implements IdentityClient {
             : new LinkedHashMap<>(representation.getAttributes());
 
     attributes.put(USER_ID_ATTRIBUTE, Collections.singletonList(keycloakUserId));
+    var decodedUsername = usernameTranscoder.decodeUsername(userDTO.getUsername());
+    attributes.put(USERNAME_ATTRIBUTE, Collections.singletonList(decodedUsername));
+    attributes.put(LEGACY_USERNAME_ATTRIBUTE, Collections.singletonList(decodedUsername));
     var tenantId = resolveTenantId(userDTO);
     if (tenantId != null) {
       attributes.put(TENANT_ID_ATTRIBUTE, Collections.singletonList(tenantId.toString()));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -63,9 +63,9 @@ public class KeycloakConfig {
           String usernameClaim =
               resolveUsernameClaim(
                   claimMap,
-                  resolveClaimValue(claimMap.getOrDefault(principalAttribute, authToken.getName())));
-          authenticatedUser.setUsername(
-              usernameTranscoder.decodeUsername(usernameClaim));
+                  resolveClaimValue(
+                      claimMap.getOrDefault(principalAttribute, authToken.getName())));
+          authenticatedUser.setUsername(usernameTranscoder.decodeUsername(usernameClaim));
           authenticatedUser.setUserId(jwt.getSubject());
           authenticatedUser.setAccessToken(jwt.getTokenValue());
           authenticatedUser.setRoles(extractRealmRoles(jwt));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -37,6 +37,9 @@ import org.springframework.web.context.WebApplicationContext;
 @ConfigurationProperties(prefix = "keycloak")
 public class KeycloakConfig {
 
+  private static final String USERNAME_CLAIM = "username";
+  private static final String TENANT_ID_CLAIM = "tenantId";
+
   @Bean("keycloakRestTemplate")
   public RestTemplate keycloakRestTemplate(RestTemplateBuilder restTemplateBuilder) {
     return restTemplateBuilder
@@ -57,16 +60,18 @@ public class KeycloakConfig {
         if (userPrincipal instanceof JwtAuthenticationToken authToken) {
           Jwt jwt = authToken.getToken();
           Map<String, Object> claimMap = jwt.getClaims();
-          Object usernameClaim =
-              claimMap.getOrDefault(
-                  "username", claimMap.getOrDefault(principalAttribute, authToken.getName()));
+          String usernameClaim =
+              resolveUsernameClaim(
+                  claimMap,
+                  resolveClaimValue(claimMap.getOrDefault(principalAttribute, authToken.getName())));
           authenticatedUser.setUsername(
-              usernameTranscoder.decodeUsername(usernameClaim.toString()));
+              usernameTranscoder.decodeUsername(usernameClaim));
           authenticatedUser.setUserId(jwt.getSubject());
           authenticatedUser.setAccessToken(jwt.getTokenValue());
           authenticatedUser.setRoles(extractRealmRoles(jwt));
-          if (claimMap.containsKey("tenantId")) {
-            authenticatedUser.setTenantId(Long.valueOf(claimMap.get("tenantId").toString()));
+          var tenantIdClaim = resolveTenantIdClaim(claimMap);
+          if (nonNull(tenantIdClaim)) {
+            authenticatedUser.setTenantId(Long.valueOf(tenantIdClaim));
           }
         }
       } catch (Exception exception) {
@@ -93,6 +98,27 @@ public class KeycloakConfig {
       }
     }
     return new HashSet<>();
+  }
+
+  String resolveUsernameClaim(Map<String, Object> claimMap, String preferredUsername) {
+    var username = resolveClaimValue(claimMap.get(USERNAME_CLAIM));
+    return hasText(username) ? username : resolveClaimValue(preferredUsername);
+  }
+
+  String resolveTenantIdClaim(Map<String, Object> claimMap) {
+    return resolveClaimValue(claimMap.get(TENANT_ID_CLAIM));
+  }
+
+  private String resolveClaimValue(Object claimValue) {
+    if (claimValue instanceof Collection<?>) {
+      return ((Collection<?>) claimValue)
+          .stream().map(this::resolveClaimValue).filter(this::hasText).findFirst().orElse(null);
+    }
+    return claimValue == null ? null : claimValue.toString();
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 
   @Bean

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -40,6 +40,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import javax.ws.rs.BadRequestException;
@@ -114,6 +115,7 @@ public class KeycloakServiceTest {
     setField(keycloakService, "usernameTranscoder", usernameTranscoder);
     setField(keycloakService, "multiTenancyEnabled", false);
     logCaptor = LogbackCaptor.forClass(KeycloakService.class);
+    when(usernameTranscoder.decodeUsername(any())).thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterEach
@@ -345,11 +347,13 @@ public class KeycloakServiceTest {
     // via getUsersResource().get(id).toRepresentation() (updateIdentityAttributesAfterCreate).
     givenAUserResourceForCreatedUser(usersResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    givenPostCreateAttributeUpdate(usersResource, response, USER_ID);
 
     KeycloakCreateUserResponseDTO keycloakUser = this.keycloakService.createKeycloakUser(userDTO);
 
     assertThat(keycloakUser, notNullValue());
     assertThat(keycloakUser.getStatus(), is(HttpStatus.CREATED));
+    assertThat(keycloakUser.getUserId(), is(USER_ID));
   }
 
   @Test
@@ -368,6 +372,7 @@ public class KeycloakServiceTest {
     // via getUsersResource().get(id).toRepresentation() (updateIdentityAttributesAfterCreate).
     givenAUserResourceForCreatedUser(usersResource);
     when(this.keycloakClient.getUsersResource()).thenReturn(usersResource);
+    givenPostCreateAttributeUpdate(usersResource, response, USER_ID);
 
     KeycloakCreateUserResponseDTO keycloakUser = this.keycloakService.createKeycloakUser(userDTO);
 
@@ -386,6 +391,44 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void createKeycloakUser_Should_updateIdentityAttributes_When_keycloakReturnsCreated() {
+    TenantContext.setCurrentTenant(7L);
+    setField(keycloakService, "multiTenancyEnabled", true);
+
+    var userDTO = new UserDTO();
+    userDTO.setUsername("encoded-user");
+    userDTO.setEmail("user@example.org");
+    userDTO.setTenantId(7L);
+    when(usernameTranscoder.decodeUsername("encoded-user")).thenReturn("decoded-user");
+
+    var usersResource = mock(UsersResource.class);
+    var userResource = mock(UserResource.class);
+    var response = mock(Response.class);
+    var storedRepresentation = new UserRepresentation();
+    storedRepresentation.setAttributes(new HashMap<>());
+    when(response.getStatus()).thenReturn(HttpStatus.CREATED.value());
+    when(response.getLocation()).thenReturn(createdUserLocation(USER_ID));
+    when(usersResource.create(any())).thenReturn(response);
+    when(usersResource.get(USER_ID)).thenReturn(userResource);
+    when(userResource.toRepresentation()).thenReturn(storedRepresentation);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    var keycloakUser = this.keycloakService.createKeycloakUser(userDTO);
+
+    assertThat(keycloakUser.getUserId(), is(USER_ID));
+
+    var representationCaptor = ArgumentCaptor.forClass(UserRepresentation.class);
+    verify(userResource).update(representationCaptor.capture());
+    var attributes = representationCaptor.getValue().getAttributes();
+    assertThat(attributes.get("userId").get(0), is(USER_ID));
+    assertThat(attributes.get("tenantId").get(0), is("7"));
+    assertThat(attributes.get("username").get(0), is("decoded-user"));
+    assertThat(attributes.get("userName").get(0), is("decoded-user"));
+
+    TenantContext.clear();
+  }
+
+  @Test
   public void createKeycloakUser_Should_createUserWithDefaultLocale() {
     var userDTO = easyRandom.nextObject(UserDTO.class);
     userDTO.setPreferredLanguage(null);
@@ -397,6 +440,7 @@ public class KeycloakServiceTest {
     // via getUsersResource().get(id).toRepresentation() (updateIdentityAttributesAfterCreate).
     givenAUserResourceForCreatedUser(usersResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    givenPostCreateAttributeUpdate(usersResource, response, USER_ID);
 
     var keycloakUser = keycloakService.createKeycloakUser(userDTO);
 
@@ -407,6 +451,21 @@ public class KeycloakServiceTest {
 
     var locales = argumentCaptor.getValue().getAttributes().get("locale");
     assertEquals("de", locales.get(0));
+  }
+
+  private UserResource givenPostCreateAttributeUpdate(
+      UsersResource usersResource, Response response, String userId) {
+    var userResource = mock(UserResource.class);
+    var storedRepresentation = new UserRepresentation();
+    storedRepresentation.setAttributes(new HashMap<>());
+    when(response.getLocation()).thenReturn(createdUserLocation(userId));
+    when(usersResource.get(userId)).thenReturn(userResource);
+    when(userResource.toRepresentation()).thenReturn(storedRepresentation);
+    return userResource;
+  }
+
+  private URI createdUserLocation(String userId) {
+    return URI.create("http://keycloak/admin/realms/online-beratung/users/" + userId);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -115,7 +115,8 @@ public class KeycloakServiceTest {
     setField(keycloakService, "usernameTranscoder", usernameTranscoder);
     setField(keycloakService, "multiTenancyEnabled", false);
     logCaptor = LogbackCaptor.forClass(KeycloakService.class);
-    when(usernameTranscoder.decodeUsername(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(usernameTranscoder.decodeUsername(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @AfterEach

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
@@ -11,7 +11,8 @@ class KeycloakConfigTest {
 
   @Test
   void resolveUsernameClaim_ShouldPreferMappedUsernameClaim_WhenPresent() {
-    var usernameClaim = keycloakConfig.resolveUsernameClaim(Map.of("username", "mapped"), "preferred");
+    var usernameClaim =
+        keycloakConfig.resolveUsernameClaim(Map.of("username", "mapped"), "preferred");
 
     assertThat(usernameClaim).isEqualTo("mapped");
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
@@ -1,0 +1,25 @@
+package de.caritas.cob.userservice.api.adapters.keycloak.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class KeycloakConfigTest {
+
+  private final KeycloakConfig keycloakConfig = new KeycloakConfig();
+
+  @Test
+  void resolveUsernameClaim_ShouldPreferMappedUsernameClaim_WhenPresent() {
+    var usernameClaim = keycloakConfig.resolveUsernameClaim(Map.of("username", "mapped"), "preferred");
+
+    assertThat(usernameClaim).isEqualTo("mapped");
+  }
+
+  @Test
+  void resolveUsernameClaim_ShouldFallbackToPreferredUsername_WhenMappedClaimIsMissing() {
+    var usernameClaim = keycloakConfig.resolveUsernameClaim(Map.of(), "preferred");
+
+    assertThat(usernameClaim).isEqualTo("preferred");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfigTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.keycloak.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -22,5 +23,27 @@ class KeycloakConfigTest {
     var usernameClaim = keycloakConfig.resolveUsernameClaim(Map.of(), "preferred");
 
     assertThat(usernameClaim).isEqualTo("preferred");
+  }
+
+  @Test
+  void resolveUsernameClaim_ShouldUseFirstTextValue_WhenMappedClaimIsCollection() {
+    var usernameClaim =
+        keycloakConfig.resolveUsernameClaim(Map.of("username", List.of("", "mapped")), "preferred");
+
+    assertThat(usernameClaim).isEqualTo("mapped");
+  }
+
+  @Test
+  void resolveUsernameClaim_ShouldFallbackToPreferredUsername_WhenMappedClaimIsBlank() {
+    var usernameClaim = keycloakConfig.resolveUsernameClaim(Map.of("username", ""), "preferred");
+
+    assertThat(usernameClaim).isEqualTo("preferred");
+  }
+
+  @Test
+  void resolveTenantIdClaim_ShouldUseFirstTextValue_WhenMappedClaimIsCollection() {
+    var tenantIdClaim = keycloakConfig.resolveTenantIdClaim(Map.of("tenantId", List.of("", "7")));
+
+    assertThat(tenantIdClaim).isEqualTo("7");
   }
 }


### PR DESCRIPTION
## Summary
- Persist mandatory Keycloak identity attributes after user creation.
- Keep legacy userName while resolving username from the mapped claim or preferred_username.
- Add focused tests for attribute persistence and username fallback.

## Validation
- ./mvnw -Dtest=KeycloakServiceTest,KeycloakConfigTest test (blocked locally: JDK 25 prevents Lombok-generated methods/builders/log fields from compiling across the repo)
- Live verification: app.oriso.org consultant login for the affected account reaches /sessions/consultant/sessionPreview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)