### PR TITLE
fix(keycloak): gracefully handle user not found during deletion

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -804,7 +805,11 @@ public class KeycloakService implements IdentityClient {
    * @param userId the userId
    */
   public void deleteUser(String userId) {
-    keycloakClient.getUsersResource().get(userId).remove();
+    try {
+      keycloakClient.getUsersResource().get(userId).remove();
+    } catch (NotFoundException e) {
+      log.warn("User {} not found in Keycloak, skipping deletion.", userId);
+    }
   }
 
   /**


### PR DESCRIPTION
Re-applies the fix from #181 on current `dev`. The original #181 branch was rooted in `main`, so retargeting it to `dev` surfaced the entire main↔dev divergence (Matrix migration, MatrixIds util) as unrelated conflicts and could not merge cleanly.

This is the same minimal change: wrap `deleteUser`'s `remove()` in a `try/catch (NotFoundException)` so deleting an already-absent Keycloak user is a logged no-op instead of a propagated 404.

Supersedes #181.