### PR TITLE
fix(keycloak,matrix): restore email update, guard duplicate-error NPE, fix Matrix sync URL

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -414,13 +414,12 @@ public class KeycloakService implements IdentityClient {
 
     String combinedError = rawResponse.toLowerCase();
 
-    if (combinedError.contains(identityClientConfig.getErrorMessageDuplicatedEmail().toLowerCase())
+    if (errorMatchesMarker(combinedError, identityClientConfig.getErrorMessageDuplicatedEmail())
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("email"))) {
       throw new CustomValidationHttpStatusException(EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
 
-    if (combinedError.contains(
-            identityClientConfig.getErrorMessageDuplicatedUsername().toLowerCase())
+    if (errorMatchesMarker(combinedError, identityClientConfig.getErrorMessageDuplicatedUsername())
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("username"))) {
       throw new CustomValidationHttpStatusException(USERNAME_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
@@ -432,6 +431,15 @@ public class KeycloakService implements IdentityClient {
             : String.format("Keycloak create-user failed with status %s", status);
 
     log.warn("Keycloak create-user failed. status={}, rawResponse={}", status, rawResponse);
+  }
+
+  /**
+   * Null-safe check whether the (lower-cased) Keycloak error response contains the configured
+   * duplicate-account marker. A missing/blank marker simply does not match (the status-based
+   * fallback still applies) instead of throwing an NPE that would mask a 409 CONFLICT as a 500.
+   */
+  private boolean errorMatchesMarker(String combinedError, String marker) {
+    return marker != null && !marker.isBlank() && combinedError.contains(marker.toLowerCase());
   }
 
   /**
@@ -772,16 +780,11 @@ public class KeycloakService implements IdentityClient {
    * @param emailAddress the email address to set
    */
   public void updateEmail(String userId, String emailAddress) {
-    // Temporarily bypass Keycloak email update for testing
-    log.info("Bypassing Keycloak email update for user: {} with email: {}", userId, emailAddress);
-    return;
-
-    // Original code (commented out):
-    // var userResource = keycloakClient.getUsersResource().get(userId);
-    // verifyEmail(userResource, emailAddress);
-    // UserRepresentation representation = userResource.toRepresentation();
-    // representation.setEmail(emailAddress);
-    // userResource.update(representation);
+    var userResource = keycloakClient.getUsersResource().get(userId);
+    verifyEmail(userResource, emailAddress);
+    UserRepresentation representation = userResource.toRepresentation();
+    representation.setEmail(emailAddress);
+    userResource.update(representation);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
@@ -1,8 +1,10 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 final class MatrixUrlBuilder {
 
@@ -21,13 +23,25 @@ final class MatrixUrlBuilder {
       String endpoint,
       Map<String, ?> uriVariables,
       Map<String, ?> queryParams) {
-    var builder = UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint));
+    // Expand path template variables on the endpoint FIRST, while no query params are present, so
+    // that query values containing literal braces (e.g. a JSON `filter`) are never mistaken for
+    // URI-template variables by buildAndExpand (which previously threw IllegalArgumentException and
+    // silently disabled the room long-poll sync).
+    String expandedUrl =
+        UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint))
+            .buildAndExpand(uriVariables)
+            .encode()
+            .toUriString();
+    var builder = UriComponentsBuilder.fromUriString(expandedUrl);
     queryParams.forEach(
         (name, value) -> {
           if (value != null) {
-            builder.queryParam(name, value);
+            builder.queryParam(
+                name, UriUtils.encodeQueryParam(value.toString(), StandardCharsets.UTF_8));
           }
         });
-    return builder.buildAndExpand(uriVariables).encode().toUriString();
+    // Components are already encoded (path via .encode(), query values via encodeQueryParam), so
+    // build with encoded=true and do not expand again.
+    return builder.build(true).toUriString();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -261,21 +261,24 @@ public class KeycloakServiceTest {
 
   @Test
   public void deleteEmailAddress_Should_useServicesCorrectly() {
-    // TODO(FLAG production): deleteEmailAddress -> updateDummyEmail(userId) -> updateEmail(...),
-    // and KeycloakService#updateEmail (KeycloakService.java:774-785) is a no-op (the real Keycloak
-    // update is commented out behind a "Bypassing Keycloak email update" log). The dummy email is
-    // therefore never persisted to Keycloak. This test asserts the CURRENT (bypassed) behavior:
-    // the user id is resolved and the dummy email computed, but no UserResource update happens.
-    // Restore the userResource.update(...) verification once the production bypass is removed.
+    // deleteEmailAddress -> updateDummyEmail(userId) -> updateEmail(...), which now persists the
+    // dummy email to Keycloak (verifyEmail + setEmail + userResource.update). Verify the dummy
+    // email
+    // is resolved and actually written via UserResource#update.
     var userId = random(16);
     when(authenticatedUser.getUserId()).thenReturn(userId);
     when(userHelper.getDummyEmail(userId)).thenReturn("dummy");
+    UserRepresentation userRepresentation = givenUserRepresentation("oldEmail");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
     keycloakService.deleteEmailAddress();
 
     verify(authenticatedUser).getUserId();
     verify(userHelper).getDummyEmail(userId);
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("dummy");
+    verify(userResource).update(userRepresentation);
   }
 
   @Test
@@ -497,6 +500,49 @@ public class KeycloakServiceTest {
 
           this.keycloakService.createKeycloakUser(userDTO);
         });
+  }
+
+  @Test
+  public void
+      createKeycloakUser_Should_notThrowNpe_When_duplicateMarkersAreNull_And_fallBackToStatus() {
+    // Guards the null-safe errorMatchesMarker(...): when the configured duplicate-email/username
+    // markers are unset (null), production must NOT NPE while lower-casing them. Instead it falls
+    // through to the status-based handling and still maps a 409 CONFLICT carrying "email" to a
+    // CustomValidationHttpStatusException (EMAIL_NOT_AVAILABLE), not an opaque 500.
+    UserDTO userDTO = new EasyRandom().nextObject(UserDTO.class);
+    Response response = mock(Response.class);
+    when(identityClientConfig.getErrorMessageDuplicatedEmail()).thenReturn(null);
+    when(identityClientConfig.getErrorMessageDuplicatedUsername()).thenReturn(null);
+    when(response.getStatus()).thenReturn(HttpStatus.CONFLICT.value());
+    when(response.readEntity(String.class)).thenReturn("User exists with same email");
+    when(usersResource.create(any())).thenReturn(response);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    CustomValidationHttpStatusException exception =
+        assertThrows(
+            CustomValidationHttpStatusException.class,
+            () -> this.keycloakService.createKeycloakUser(userDTO));
+
+    assertThat(
+        exception.getCustomHttpHeaders().get("X-Reason").get(0), is(EMAIL_NOT_AVAILABLE.name()));
+  }
+
+  @Test
+  public void
+      createKeycloakUser_Should_throwInternalServerError_When_duplicateMarkersAreNull_And_statusUnknown() {
+    // Same null-marker guard, but with a non-conflict status and an unrelated error body: the
+    // method must fall through to a generic InternalServerErrorException rather than NPE.
+    UserDTO userDTO = new EasyRandom().nextObject(UserDTO.class);
+    Response response = mock(Response.class);
+    when(identityClientConfig.getErrorMessageDuplicatedEmail()).thenReturn(null);
+    when(identityClientConfig.getErrorMessageDuplicatedUsername()).thenReturn(null);
+    when(response.getStatus()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    when(response.readEntity(String.class)).thenReturn("unexpected keycloak failure");
+    when(usersResource.create(any())).thenReturn(response);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    assertThrows(
+        InternalServerErrorException.class, () -> this.keycloakService.createKeycloakUser(userDTO));
   }
 
   @Test
@@ -724,18 +770,21 @@ public class KeycloakServiceTest {
 
   @Test
   public void updateDummyMail_id_Should_callServicesCorrectly() {
-    // TODO(FLAG production): updateDummyEmail(String) -> updateEmail(...), and
-    // KeycloakService#updateEmail (KeycloakService.java:774-785) is a no-op (the real Keycloak
-    // update is commented out behind a "Bypassing Keycloak email update" log). The dummy email is
-    // therefore never persisted to Keycloak. This test asserts the CURRENT (bypassed) behavior:
-    // the dummy email is computed but no UserResource update happens. Restore the
-    // userResource.update(...) verification once the production bypass is removed.
-    when(userHelper.getDummyEmail(anyString())).thenReturn("dummy");
+    // updateDummyEmail(String) -> updateEmail(...), which now persists the dummy email to Keycloak
+    // (verifyEmail + setEmail + userResource.update). Verify the dummy email is computed and
+    // written
+    // via UserResource#update.
+    when(userHelper.getDummyEmail("userId")).thenReturn("dummy");
+    UserRepresentation userRepresentation = givenUserRepresentation("oldEmail");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
     keycloakService.updateDummyEmail("userId");
 
     verify(userHelper).getDummyEmail("userId");
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("dummy");
+    verify(userResource).update(userRepresentation);
   }
 
   @Test
@@ -887,15 +936,20 @@ public class KeycloakServiceTest {
 
   @Test
   public void changeEmailAddress_Should_callServicesCorrectly_When_emailIsChangedAndAvailable() {
-    // TODO(FLAG production): KeycloakService#updateEmail (KeycloakService.java:774-785) is
-    // currently a no-op — it logs "Bypassing Keycloak email update" and returns, with the real
-    // Keycloak update commented out. As long as that bypass stands, no UserResource is touched and
-    // email changes are silently dropped. This test asserts the CURRENT (bypassed) behavior; once
-    // the production bypass is removed it must be restored to verify
-    // userRepresentation.setEmail(...) + userResource.update(...).
+    // KeycloakService#updateEmail now restores the real Keycloak update: it resolves the user,
+    // verifies email availability, sets the new email on the representation and persists it via
+    // UserResource#update. Verify the new email is set and the representation is written back.
+    UserRepresentation userRepresentation = givenUserRepresentation("oldEmail");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
     this.keycloakService.updateEmail("userId", "anotherEmail");
 
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("anotherEmail");
+    ArgumentCaptor<UserRepresentation> captor = ArgumentCaptor.forClass(UserRepresentation.class);
+    verify(userResource).update(captor.capture());
+    assertThat(captor.getValue(), is(userRepresentation));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MatrixSynapseServiceTest {
@@ -74,42 +76,50 @@ class MatrixSynapseServiceTest {
         .isEqualTo("Bearer " + ACCESS_TOKEN);
   }
 
-  // TODO(PRODUCTION BUG): syncRoom never reaches the long-poll RestTemplate.
+  // Regression test for the restored long-poll room sync.
   //
-  // MatrixSynapseService.syncRoom (src/main/.../matrix/MatrixSynapseService.java:790-872) builds
-  // its
-  // URL via MatrixUrlBuilder.buildUrl(...) (src/main/.../matrix/MatrixUrlBuilder.java:18-36). That
-  // helper appends the query params and then calls buildAndExpand(uriVariables).encode(). The
-  // "filter" query param is a JSON string ({"room":{"timeline":...}}). UriComponentsBuilder treats
-  // the embedded {"room"...} braces as a URI-template variable named "room", but uriVariables is
-  // empty (Map.of()), so buildAndExpand throws:
-  //     java.lang.IllegalArgumentException: Map has no value for '"room"'
-  // syncRoom catches it (line 868) and silently returns an empty result, so
-  // matrixLongPollRestTemplate
-  // is NEVER invoked. Consequence: the dedicated long-poll sync path is effectively dead in
-  // production and never fetches messages.
-  //
-  // Expected (once fixed): matrixLongPollRestTemplate.exchange(...) is called with a URL starting
-  // "...sync?timeout=30000" and containing the encoded room id; verifyNoInteractions(restTemplate).
-  // Actual (current behavior asserted below): zero interactions with matrixLongPollRestTemplate,
-  // result is the swallowed empty fallback {messages:[], next_batch:""}.
-  // Fix must land in src/main (MatrixUrlBuilder should not template-expand the JSON filter param,
-  // e.g. URI-encode query values directly instead of buildAndExpand) - out of scope for this
-  // test-only PR, so we pin the current (buggy) behavior here.
+  // MatrixSynapseService.syncRoom builds its URL via MatrixUrlBuilder.buildUrl(...). The "filter"
+  // query param is a JSON string ({"room":{"timeline":...}}). MatrixUrlBuilder now expands the path
+  // template vars first and then adds the query params with UriUtils.encodeQueryParam +
+  // build(true),
+  // so the embedded {"room"...} braces are no longer mistaken for URI-template variables. As a
+  // result the dedicated long-poll RestTemplate is actually invoked and messages are fetched.
   @Test
   void syncRoomShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
+    var roomId = "!room:example.org";
     when(matrixConfig.getApiUrl("/_matrix/client/r0/sync")).thenReturn(SYNC_URL);
+    var textMessage =
+        Map.<String, Object>of(
+            "type", "m.room.message", "content", Map.of("msgtype", "m.text", "body", "hello"));
+    var timeline = Map.<String, Object>of("events", java.util.List.of(textMessage));
+    var roomData = Map.<String, Object>of("timeline", timeline);
+    var join = Map.<String, Object>of(roomId, roomData);
+    var rooms = Map.<String, Object>of("join", join);
+    var responseBody = Map.<String, Object>of("next_batch", "s_token_42", "rooms", rooms);
+    when(matrixLongPollRestTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(responseBody));
+    var urlCaptor = ArgumentCaptor.forClass(String.class);
 
-    var result = service.syncRoom("!room:example.org", ACCESS_TOKEN, "alice", 30000);
+    var result = service.syncRoom(roomId, ACCESS_TOKEN, "alice", 30000);
 
-    // Bug: the JSON filter param breaks URL building, the exception is swallowed, and neither
-    // RestTemplate is ever touched. Assert that documented-broken behavior so the suite stays
-    // green.
+    verify(matrixLongPollRestTemplate)
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?");
+    assertThat(urlCaptor.getValue()).contains("timeout=30000");
+    // The JSON filter is URL-encoded (its braces survive as %7B/%7D) and the room id is present.
+    assertThat(urlCaptor.getValue()).contains("filter=");
+    assertThat(urlCaptor.getValue()).contains("timeline");
+    assertThat(urlCaptor.getValue())
+        .contains(UriUtils.encodeQueryParam(roomId, StandardCharsets.UTF_8));
+    // The parsed result reflects the body: the next_batch token and the single text message.
     assertThat(result).isNotNull();
-    assertThat(result).containsEntry("messages", new java.util.ArrayList<>());
-    assertThat(result).containsEntry("next_batch", "");
-    verifyNoInteractions(matrixLongPollRestTemplate);
+    assertThat(result).containsEntry("next_batch", "s_token_42");
+    @SuppressWarnings("unchecked")
+    var messages = (java.util.List<Map<String, Object>>) result.get("messages");
+    assertThat(messages).hasSize(1);
+    assertThat(messages.get(0)).isEqualTo(textMessage);
     verifyNoInteractions(restTemplate);
   }
 


### PR DESCRIPTION
Fixes the three production bugs surfaced by #126 (reported in #193). **Test-only + 3 small src/main changes; full JDK17 suite green: 1539 tests, 0 failures, 0 errors.**

### 1. `KeycloakService.updateEmail` was a silent no-op
Restored the real update (`verifyEmail` + `setEmail` + `userResource.update`). It was a leftover `"Temporarily bypass … for testing"` no-op from the repo-init commit, so `changeEmailAddress(email)` and `deleteEmailAddress()` never persisted the change to Keycloak. Safe: the technical user already calls `update()` in ~7 other methods (incl. the sibling `changeEmailAddress(username,email)`).

### 2. `handleCreateKeycloakUserError` NPE (409 → 500)
Added a null-safe `errorMatchesMarker(...)`; an unset duplicate-email/username config value no longer NPEs a duplicate-account 409 into an opaque 500. Two new tests prove no NPE on null markers.

### 3. `MatrixSynapseService.syncRoom` long-poll sync was dead
`MatrixUrlBuilder.buildUrl` ran `buildAndExpand` over query values, so the JSON `filter` param's braces were parsed as URI-template variables → `IllegalArgumentException`, swallowed by `syncRoom` → `matrixLongPollRestTemplate` never called, messages never fetched. Now expands path vars first, then adds query params with `UriUtils.encodeQueryParam` values + `build(true)`. The flipped test asserts the long-poll template IS called with the correctly-encoded sync URL and the response is parsed.

### Testing
- Unit: full suite green (1539/0/0); the previously-bypassed tests now assert the fixed behavior.
- ⚠️ **Recommend a dev-deploy smoke test** for #1 and #3 — unit tests prove the logic; live Keycloak (email change persists) and live Matrix (room sync actually fetches messages) prove the integration.

Closes #193.