### PR TITLE
Fix Matrix enquiry creation without Rocket.Chat headers

### DIFF
--- a/api/appointmentservice.yaml
+++ b/api/appointmentservice.yaml
@@ -187,12 +187,12 @@ paths:
             format: int64
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: RCUserId
           in: header
-          required: true
+          required: false
           schema:
             type: string
       requestBody:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -56,12 +56,12 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: RCUserId
           in: header
-          required: true
+          required: false
           schema:
             type: string
       requestBody:
@@ -100,12 +100,12 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: RCUserId
           in: header
-          required: true
+          required: false
           schema:
             type: string
       requestBody:
@@ -151,12 +151,12 @@ paths:
             format: int64
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: RCUserId
           in: header
-          required: true
+          required: false
           schema:
             type: string
       requestBody:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentController.java
@@ -174,9 +174,9 @@ public class AppointmentController implements AppointmentsApi {
   @Override
   public ResponseEntity<CreateEnquiryMessageResponseDTO> createEnquiryAppointment(
       @PathVariable Long sessionId,
-      @RequestHeader String rcToken,
-      @RequestHeader String rcUserId,
-      @RequestBody EnquiryAppointmentDTO enquiryAppointmentDTO) {
+      @RequestBody EnquiryAppointmentDTO enquiryAppointmentDTO,
+      @RequestHeader(value = "RCToken", required = false) String rcToken,
+      @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
 
     var user = this.userAccountProvider.retrieveValidatedUser();
     var rocketChatCredentials =

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -244,16 +244,16 @@ public class UserController implements UsersApi {
   /**
    * Creates a new session or chat-agency relation depending on the provided consulting type.
    *
-   * @param rcToken Rocket.Chat token (required)
-   * @param rcUserId Rocket.Chat user ID (required)
+   * @param rcToken Rocket.Chat token (optional for Matrix-backed sessions)
+   * @param rcUserId Rocket.Chat user ID (optional for Matrix-backed sessions)
    * @param newRegistrationDto {@link NewRegistrationDto}
    * @return {@link ResponseEntity} containing {@link NewRegistrationResponseDto}
    */
   @Override
   public ResponseEntity<NewRegistrationResponseDto> registerNewConsultingType(
-      @RequestHeader String rcToken,
-      @RequestHeader String rcUserId,
-      @Valid @RequestBody NewRegistrationDto newRegistrationDto) {
+      @Valid @RequestBody NewRegistrationDto newRegistrationDto,
+      @RequestHeader(value = "RCToken", required = false) String rcToken,
+      @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
 
     var user = this.userAccountProvider.retrieveValidatedUser();
     var rocketChatCredentials =
@@ -272,16 +272,16 @@ public class UserController implements UsersApi {
   /**
    * Creates a new session or chat-agency relation depending on the provided topic.
    *
-   * @param rcToken Rocket.Chat token (required)
-   * @param rcUserId Rocket.Chat user ID (required)
+   * @param rcToken Rocket.Chat token (optional for Matrix-backed sessions)
+   * @param rcUserId Rocket.Chat user ID (optional for Matrix-backed sessions)
    * @param newRegistrationDto {@link NewRegistrationDto}
    * @return {@link ResponseEntity} containing {@link NewRegistrationResponseDto}
    */
   @Override
   public ResponseEntity<NewRegistrationResponseDto> registerNewSession(
-      @RequestHeader String rcToken,
-      @RequestHeader(value = "RCUserId", required = true) String rcUserId,
-      de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto newRegistrationDto) {
+      de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto newRegistrationDto,
+      @RequestHeader(value = "RCToken", required = false) String rcToken,
+      @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
     var user = this.userAccountProvider.retrieveValidatedUser();
     var rocketChatCredentials =
         RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
@@ -327,17 +327,17 @@ public class UserController implements UsersApi {
 
   /**
    * @param sessionId Session Id (required)
-   * @param rcToken Rocket.Chat token (required)
-   * @param rcUserId Rocket.Chat user ID (required)
+   * @param rcToken Rocket.Chat token (optional for Matrix-backed sessions)
+   * @param rcUserId Rocket.Chat user ID (optional for Matrix-backed sessions)
    * @param enquiryMessage Enquiry message (required)
    * @return {@link ResponseEntity} containing {@link CreateEnquiryMessageResponseDTO}
    */
   @Override
   public ResponseEntity<CreateEnquiryMessageResponseDTO> createEnquiryMessage(
       @PathVariable Long sessionId,
-      @RequestHeader String rcToken,
-      @RequestHeader String rcUserId,
-      @RequestBody EnquiryMessageDTO enquiryMessage) {
+      @RequestBody EnquiryMessageDTO enquiryMessage,
+      @RequestHeader(value = "RCToken", required = false) String rcToken,
+      @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
 
     var user = this.userAccountProvider.retrieveValidatedUser();
     var rocketChatCredentials =

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -3,8 +3,10 @@ package de.caritas.cob.userservice.api.facade;
 import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
 import static de.caritas.cob.userservice.api.model.Session.RegistrationType.ANONYMOUS;
 import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupResponseDTO;
@@ -35,6 +37,7 @@ import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationSe
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.message.RocketChatData;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -56,8 +59,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CreateEnquiryMessageFacade {
 
+  private static final String MATRIX_MIGRATION_DUMMY_RC_USER_ID = "matrix-migration-dummy-user";
+
   private final @NonNull SessionService sessionService;
   private final @NonNull RocketChatService rocketChatService;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull EmailNotificationFacade emailNotificationFacade;
   private final @NonNull MessageServiceProvider messageServiceProvider;
   private final @NonNull ConsultantAgencyService consultantAgencyService;
@@ -67,6 +73,7 @@ public class CreateEnquiryMessageFacade {
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final @NonNull EventNotificationService eventNotificationService;
+  private final @NonNull AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
   private final RocketChatRoomNameGenerator rocketChatRoomNameGenerator =
       new RocketChatRoomNameGenerator();
 
@@ -81,8 +88,11 @@ public class CreateEnquiryMessageFacade {
    */
   public CreateEnquiryMessageResponseDTO createEnquiryMessage(EnquiryData enquiryData) {
     try {
-      checkIfKeycloakAndRocketChatUsernamesMatch(
-          enquiryData.getRocketChatCredentials().getRocketChatUserId(), enquiryData.getUser());
+      var hasRocketChatCredentials = hasUsableRocketChatCredentials(enquiryData);
+      if (hasRocketChatCredentials) {
+        checkIfKeycloakAndRocketChatUsernamesMatch(
+            enquiryData.getRocketChatCredentials().getRocketChatUserId(), enquiryData.getUser());
+      }
 
       var session =
           fetchSessionForEnquiryMessage(enquiryData.getSessionId(), enquiryData.getUser());
@@ -92,6 +102,11 @@ public class CreateEnquiryMessageFacade {
       var extendedConsultingTypeResponseDTO =
           consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId());
       List<ConsultantAgency> agencyList = resolveConsultantAgenciesForEnquiry(session);
+
+      if (!hasRocketChatCredentials) {
+        return createMatrixEnquiryMessage(enquiryData, session, agencyList);
+      }
+
       String rcGroupId =
           createRocketChatRoomAndAddUsers(
               session, agencyList, enquiryData.getRocketChatCredentials());
@@ -132,19 +147,7 @@ public class CreateEnquiryMessageFacade {
       updateSession(
           session, enquiryData.getLanguage(), rcGroupId, createEnquiryExceptionInformation);
 
-      if (session.getIsConsultantDirectlySet()) {
-        emailNotificationFacade.sendNewDirectEnquiryEmailNotification(
-            session.getConsultant().getId(),
-            session.getAgencyId(),
-            session.getPostcode(),
-            TenantContext.getCurrentTenantData());
-      } else {
-        emailNotificationFacade.sendNewEnquiryEmailNotification(
-            session, TenantContext.getCurrentTenantData());
-      }
-
-      notifyEligibleConsultantsAboutLiveChatEnquiry(session);
-      persistNewClientRequestNotifications(session, agencyList);
+      sendEnquiryNotifications(session, agencyList);
 
       return new CreateEnquiryMessageResponseDTO()
           .rcGroupId(rcGroupId)
@@ -156,6 +159,94 @@ public class CreateEnquiryMessageFacade {
       log.error("CreateEnquiryMessageFacade error: ", exception);
       throw new InternalServerErrorException(exception.getMessage(), exception);
     }
+  }
+
+  private boolean hasUsableRocketChatCredentials(EnquiryData enquiryData) {
+    var credentials = enquiryData.getRocketChatCredentials();
+    if (credentials == null) {
+      return false;
+    }
+    var rcUserId = credentials.getRocketChatUserId();
+    return !isBlank(rcUserId) && !MATRIX_MIGRATION_DUMMY_RC_USER_ID.equals(rcUserId);
+  }
+
+  private CreateEnquiryMessageResponseDTO createMatrixEnquiryMessage(
+      EnquiryData enquiryData, Session session, List<ConsultantAgency> agencyList)
+      throws CreateEnquiryException {
+
+    String matrixRoomId = ensureMatrixRoomForEnquiry(session, enquiryData.getUser());
+    if (isBlank(enquiryData.getUser().getMatrixUserId())) {
+      throw new InternalServerErrorException(
+          String.format(
+              "Enquiry user %s has no Matrix account", enquiryData.getUser().getUserId()));
+    }
+    var matrixMessageEventId = "";
+    if (!isAppointmentEnquiryMessage(enquiryData)) {
+      String matrixAccessToken =
+          matrixSynapseService.loginAsUserAccessToken(enquiryData.getUser().getMatrixUserId());
+      if (isBlank(matrixAccessToken)) {
+        throw new InternalServerErrorException(
+            String.format(
+                "Could not create Matrix token for enquiry user %s",
+                enquiryData.getUser().getUserId()));
+      }
+
+      var matrixResponse =
+          matrixSynapseService.sendMessage(
+              matrixRoomId, enquiryData.getMessage(), matrixAccessToken);
+      if (matrixResponse == null || matrixResponse.containsKey("error")) {
+        throw new InternalServerErrorException(
+            String.format(
+                "Could not post Matrix enquiry message to room %s for session %s",
+                matrixRoomId, session.getId()));
+      }
+      matrixMessageEventId = String.valueOf(matrixResponse.getOrDefault("event_id", ""));
+    }
+
+    var createEnquiryExceptionInformation =
+        CreateEnquiryExceptionInformation.builder()
+            .session(session)
+            .rcGroupId(matrixRoomId)
+            .build();
+    updateMatrixSession(
+        session, enquiryData.getLanguage(), matrixRoomId, createEnquiryExceptionInformation);
+
+    sendEnquiryNotifications(session, agencyList);
+
+    return new CreateEnquiryMessageResponseDTO()
+        .rcGroupId(matrixRoomId)
+        .sessionId(enquiryData.getSessionId())
+        .t(matrixMessageEventId);
+  }
+
+  private String ensureMatrixRoomForEnquiry(Session session, User user) {
+    if (!isBlank(session.getMatrixRoomId())) {
+      return session.getMatrixRoomId();
+    }
+
+    agencyPreAssignmentRoomService.ensureHoldingRoom(session, user);
+    if (!isBlank(session.getMatrixRoomId())) {
+      return session.getMatrixRoomId();
+    }
+
+    throw new InternalServerErrorException(
+        String.format("Could not create Matrix room for enquiry session %s", session.getId()));
+  }
+
+  private void sendEnquiryNotifications(Session session, List<ConsultantAgency> agencyList) {
+    if (session.getIsConsultantDirectlySet()) {
+      emailNotificationFacade.sendNewDirectEnquiryEmailNotification(
+          session.getConsultant().getId(),
+          session.getAgencyId(),
+          session.getPostcode(),
+          TenantContext.getCurrentTenantData());
+    } else {
+      emailNotificationFacade.sendNewEnquiryEmailNotification(
+          session, TenantContext.getCurrentTenantData());
+    }
+
+    notifyEligibleConsultantsAboutLiveChatEnquiry(session);
+    persistNewClientRequestNotifications(session, agencyList);
   }
 
   private boolean isAppointmentEnquiryMessage(EnquiryData enquiryData) {
@@ -391,6 +482,32 @@ public class CreateEnquiryMessageFacade {
     } catch (InternalServerErrorException exception) {
       throw new CreateEnquiryException(
           String.format("Could not update session %s with groupId %s", session.getId(), rcGroupId),
+          exception,
+          createEnquiryExceptionInformation);
+    }
+  }
+
+  private void updateMatrixSession(
+      Session session,
+      String language,
+      String matrixRoomId,
+      CreateEnquiryExceptionInformation createEnquiryExceptionInformation)
+      throws CreateEnquiryException {
+
+    try {
+      session.setGroupId(matrixRoomId);
+      session.setMatrixRoomId(matrixRoomId);
+      session.setStatus(SessionStatus.NEW);
+      session.setEnquiryMessageDate(nowInUtc());
+      if (nonNull(language)) {
+        session.setLanguageCode(LanguageCode.getByCode(language));
+      }
+      setSessionStatusInProgressIfConsultantIsAlreadyAssigned(session);
+      sessionService.saveSession(session);
+    } catch (InternalServerErrorException exception) {
+      throw new CreateEnquiryException(
+          String.format(
+              "Could not update session %s with Matrix room %s", session.getId(), matrixRoomId),
           exception,
           createEnquiryExceptionInformation);
     }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupDTO;
@@ -77,6 +78,7 @@ import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationSe
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.message.RocketChatData;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
@@ -86,6 +88,7 @@ import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.Welc
 import de.caritas.cob.userservice.messageservice.generated.web.model.MessageResponseDTO;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.jeasy.random.EasyRandom;
@@ -170,6 +173,8 @@ class CreateEnquiryMessageFacadeTest {
 
   @Mock private RocketChatService rocketChatService;
 
+  @Mock private MatrixSynapseService matrixSynapseService;
+
   @Mock private MessageServiceProvider messageServiceProvider;
 
   @Mock private ConsultantAgencyService consultantAgencyService;
@@ -187,6 +192,8 @@ class CreateEnquiryMessageFacadeTest {
   @Mock private LiveEventNotificationService liveEventNotificationService;
 
   @Mock private EventNotificationService eventNotificationService;
+
+  @Mock private AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
 
   private Session session;
   private User user;
@@ -232,6 +239,90 @@ class CreateEnquiryMessageFacadeTest {
     this.rocketChatCredentials = RocketChatCredentials.builder().build();
     RequestContextHolder.setRequestAttributes(
         new ServletRequestAttributes(Mockito.mock(HttpServletRequest.class)));
+    resetRequestAttributes();
+  }
+
+  @Test
+  void createEnquiryMessage_Should_PostMatrixEnquiry_When_RocketChatCredentialsAreMissing()
+      throws Exception {
+    var matrixRoomId = "!session-room:oriso.org";
+    var matrixUserId = "@asker:oriso.org";
+    var matrixToken = "matrix-token";
+    var matrixEventId = "$event";
+    user.setMatrixUserId(matrixUserId);
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setIsConsultantDirectlySet(false);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(matrixRoomId);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId()))
+        .thenReturn(extendedConsultingTypeResponseDTO);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+    when(matrixSynapseService.loginAsUserAccessToken(matrixUserId)).thenReturn(matrixToken);
+    when(matrixSynapseService.sendMessage(matrixRoomId, MESSAGE, matrixToken))
+        .thenReturn(Map.of("event_id", matrixEventId));
+
+    final var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(user, SESSION_ID, MESSAGE, null, null));
+
+    verify(rocketChatService, never()).getUserInfo(anyString());
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+    verify(messageServiceProvider, never())
+        .postEnquiryMessage(
+            any(RocketChatData.class), any(CreateEnquiryExceptionInformation.class));
+    verify(agencyPreAssignmentRoomService, never()).ensureHoldingRoom(any(), any());
+    verify(sessionService).saveSession(session);
+    assertEquals(SESSION_ID, response.getSessionId());
+    assertEquals(matrixRoomId, response.getRcGroupId());
+    assertEquals(matrixEventId, response.getT());
+    assertEquals(matrixRoomId, session.getGroupId());
+    assertEquals(matrixRoomId, session.getMatrixRoomId());
+    assertEquals(SessionStatus.NEW, session.getStatus());
+    assertNotNull(session.getEnquiryMessageDate());
+    resetRequestAttributes();
+  }
+
+  @Test
+  void createEnquiryMessage_Should_CreateMatrixEnquiryWithoutMessage_When_AppointmentEnquiry()
+      throws Exception {
+    var matrixRoomId = "!appointment-room:oriso.org";
+    var matrixUserId = "@asker:oriso.org";
+    user.setMatrixUserId(matrixUserId);
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setIsConsultantDirectlySet(false);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(matrixRoomId);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId()))
+        .thenReturn(extendedConsultingTypeResponseDTO);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+
+    final var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(user, SESSION_ID, null, null, null, null, EMAIL));
+
+    verify(matrixSynapseService, never()).loginAsUserAccessToken(anyString());
+    verify(matrixSynapseService, never()).sendMessage(anyString(), any(), anyString());
+    verify(messageServiceProvider, never()).assignUserToRocketChatGroup(anyString(), any());
+    verify(sessionService).saveSession(session);
+    assertEquals(SESSION_ID, response.getSessionId());
+    assertEquals(matrixRoomId, response.getRcGroupId());
+    assertEquals("", response.getT());
+    assertEquals(matrixRoomId, session.getGroupId());
+    assertEquals(matrixRoomId, session.getMatrixRoomId());
+    assertEquals(SessionStatus.NEW, session.getStatus());
+    assertNotNull(session.getEnquiryMessageDate());
     resetRequestAttributes();
   }
 


### PR DESCRIPTION
## Problem
After the Matrix migration, the frontend no longer has Rocket.Chat cookies for newly registered advice seekers. The enquiry endpoint still required Rocket.Chat headers and always tried to create/post to a Rocket.Chat room, which can break the registration -> agency -> first message flow before a Matrix conversation is created.

## Solution
- Make Rocket.Chat headers optional in the user and appointment enquiry OpenAPI contracts.
- Keep the legacy Rocket.Chat path when real Rocket.Chat credentials are present.
- Route cookie-less/dummy-header enquiries through Matrix holding-room creation and Matrix message sending.
- Persist the Matrix room id on the session and reuse the existing notification flow.
- Keep appointment enquiries room-only when no message body is submitted.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -Dtest=CreateEnquiryMessageFacadeTest test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw test` (1541 tests, 0 failures, 0 errors, 7 skipped)

## Companion PR
- OpenResilienceInitiative/ORISO-Frontend#276

🤖 Generated with [Claude Code](https://claude.com/claude-code)