### PR TITLE
fix: persist Keycloak email, guard duplicate-account NPE, repair Matrix sync URL (#193)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -6,6 +6,7 @@ import static de.caritas.cob.userservice.api.exception.httpresponses.customheade
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
@@ -375,6 +376,7 @@ public class KeycloakService implements IdentityClient {
     var locale =
         isNull(user.getPreferredLanguage()) ? "de" : user.getPreferredLanguage().toString();
     var kcUser = getUserRepresentation(user, firstName, lastName, locale);
+    String creationError = keycloakError;
     try (var response = keycloakClient.getUsersResource().create(kcUser)) {
       if (response.getStatus() == HttpStatus.CREATED.value()) {
         final String createdUserId = getCreatedUserId(response.getLocation());
@@ -394,14 +396,14 @@ public class KeycloakService implements IdentityClient {
         }
         return new KeycloakCreateUserResponseDTO(createdUserId);
       }
-      handleCreateKeycloakUserError(response);
+      creationError = handleCreateKeycloakUserError(response);
     }
     throw new InternalServerErrorException(
         String.format(
-            "Could not create Keycloak account for: %s %nKeycloak error: %s", user, keycloakError));
+            "Could not create Keycloak account for: %s %nKeycloak error: %s", user, creationError));
   }
 
-  private void handleCreateKeycloakUserError(Response response) {
+  private String handleCreateKeycloakUserError(Response response) {
     final int status = response.getStatus();
     String rawResponse = "";
 
@@ -414,24 +416,29 @@ public class KeycloakService implements IdentityClient {
 
     String combinedError = rawResponse.toLowerCase();
 
-    if (combinedError.contains(identityClientConfig.getErrorMessageDuplicatedEmail().toLowerCase())
+    String duplicatedEmailMarker = identityClientConfig.getErrorMessageDuplicatedEmail();
+    if ((isNotBlank(duplicatedEmailMarker)
+            && combinedError.contains(duplicatedEmailMarker.toLowerCase()))
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("email"))) {
       throw new CustomValidationHttpStatusException(EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
 
-    if (combinedError.contains(
-            identityClientConfig.getErrorMessageDuplicatedUsername().toLowerCase())
+    String duplicatedUsernameMarker = identityClientConfig.getErrorMessageDuplicatedUsername();
+    if ((isNotBlank(duplicatedUsernameMarker)
+            && combinedError.contains(duplicatedUsernameMarker.toLowerCase()))
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("username"))) {
       throw new CustomValidationHttpStatusException(USERNAME_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
 
-    // Preserve prior behavior but include status/raw details to avoid opaque 500s.
-    keycloakError =
+    // Build a local, non-opaque message; never mutate the injected keycloakError template (shared
+    // singleton field -> would clobber under concurrency).
+    String createUserError =
         !rawResponse.isBlank()
             ? String.format("Keycloak create-user failed with status %s: %s", status, rawResponse)
             : String.format("Keycloak create-user failed with status %s", status);
 
     log.warn("Keycloak create-user failed. status={}, rawResponse={}", status, rawResponse);
+    return createUserError;
   }
 
   /**
@@ -772,16 +779,11 @@ public class KeycloakService implements IdentityClient {
    * @param emailAddress the email address to set
    */
   public void updateEmail(String userId, String emailAddress) {
-    // Temporarily bypass Keycloak email update for testing
-    log.info("Bypassing Keycloak email update for user: {} with email: {}", userId, emailAddress);
-    return;
-
-    // Original code (commented out):
-    // var userResource = keycloakClient.getUsersResource().get(userId);
-    // verifyEmail(userResource, emailAddress);
-    // UserRepresentation representation = userResource.toRepresentation();
-    // representation.setEmail(emailAddress);
-    // userResource.update(representation);
+    var userResource = keycloakClient.getUsersResource().get(userId);
+    verifyEmail(userResource, emailAddress);
+    UserRepresentation representation = userResource.toRepresentation();
+    representation.setEmail(emailAddress);
+    userResource.update(representation);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -865,8 +865,19 @@ public class MatrixSynapseService {
       }
 
       return java.util.Map.of("messages", new java.util.ArrayList<>(), "next_batch", "");
-    } catch (Exception ex) {
-      log.error("Matrix Error: Could not sync room ({}). Reason: {}", roomId, ex.getMessage());
+    } catch (HttpStatusCodeException ex) {
+      // Transient/upstream HTTP failure: degrade gracefully so the long-poll endpoint keeps
+      // working.
+      log.error(
+          "Matrix Error: Could not sync room ({}). HTTP {} - {}",
+          roomId,
+          ex.getStatusCode(),
+          ex.getResponseBodyAsString());
+      return java.util.Map.of("messages", new java.util.ArrayList<>(), "next_batch", "");
+    } catch (RuntimeException ex) {
+      // Unexpected (e.g. URL-building / parsing bugs): log the full stack trace so the failure is
+      // not hidden as a silent "no messages forever" condition.
+      log.error("Matrix Error: Could not sync room ({}). Unexpected failure.", roomId, ex);
       return java.util.Map.of("messages", new java.util.ArrayList<>(), "next_batch", "");
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
@@ -1,10 +1,13 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.web.util.UriComponentsBuilder;
 
 final class MatrixUrlBuilder {
+
+  private static final String QUERY_VAR_PREFIX = "q__";
 
   private MatrixUrlBuilder() {}
 
@@ -16,18 +19,34 @@ final class MatrixUrlBuilder {
     return buildUrl(matrixConfig, endpoint, uriVariables, Map.of());
   }
 
+  /**
+   * Builds a fully-encoded Matrix API URL.
+   *
+   * <p>Query values are bound as URI variables (named {@code q__<paramName>}) instead of being
+   * appended literally. This stops {@link UriComponentsBuilder#buildAndExpand} from treating braces
+   * inside a value -- e.g. a JSON Matrix {@code filter} payload -- as URI-template placeholders,
+   * which previously threw an {@link IllegalArgumentException} and left the long-poll sync silently
+   * returning no messages.
+   *
+   * <p>Encoding runs after expansion, so each value is escaped per its URI component:
+   * reserved-but-legal characters such as {@code !} and {@code :} stay literal, while structural
+   * JSON characters are percent-encoded.
+   */
   static String buildUrl(
       MatrixConfig matrixConfig,
       String endpoint,
       Map<String, ?> uriVariables,
       Map<String, ?> queryParams) {
     var builder = UriComponentsBuilder.fromUriString(matrixConfig.getApiUrl(endpoint));
+    var allVariables = new LinkedHashMap<String, Object>(uriVariables);
     queryParams.forEach(
         (name, value) -> {
           if (value != null) {
-            builder.queryParam(name, value);
+            var varName = QUERY_VAR_PREFIX + name;
+            builder.queryParam(name, "{" + varName + "}");
+            allVariables.put(varName, value);
           }
         });
-    return builder.buildAndExpand(uriVariables).encode().toUriString();
+    return builder.buildAndExpand(allVariables).encode().toUriString();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -261,21 +261,22 @@ public class KeycloakServiceTest {
 
   @Test
   public void deleteEmailAddress_Should_useServicesCorrectly() {
-    // TODO(FLAG production): deleteEmailAddress -> updateDummyEmail(userId) -> updateEmail(...),
-    // and KeycloakService#updateEmail (KeycloakService.java:774-785) is a no-op (the real Keycloak
-    // update is commented out behind a "Bypassing Keycloak email update" log). The dummy email is
-    // therefore never persisted to Keycloak. This test asserts the CURRENT (bypassed) behavior:
-    // the user id is resolved and the dummy email computed, but no UserResource update happens.
-    // Restore the userResource.update(...) verification once the production bypass is removed.
+    // deleteEmailAddress -> updateDummyEmail(userId) -> updateEmail(userId, dummy) now persists the
+    // dummy address to Keycloak.
     var userId = random(16);
     when(authenticatedUser.getUserId()).thenReturn(userId);
     when(userHelper.getDummyEmail(userId)).thenReturn("dummy");
+    UserRepresentation userRepresentation = givenUserRepresentation("email");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
     keycloakService.deleteEmailAddress();
 
     verify(authenticatedUser).getUserId();
     verify(userHelper).getDummyEmail(userId);
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("dummy");
+    verify(userResource).update(userRepresentation);
   }
 
   @Test
@@ -497,6 +498,43 @@ public class KeycloakServiceTest {
 
           this.keycloakService.createKeycloakUser(userDTO);
         });
+  }
+
+  @Test
+  public void createKeycloakUser_Should_notThrowNpe_When_duplicatedMarkersUnsetAndErrorIsUnknown() {
+    // Issue #193: the configured duplicated-account markers are intentionally left unstubbed
+    // (null). An unset marker must not NPE on toLowerCase(); the unknown error must fall through to
+    // a generic InternalServerErrorException instead of an opaque 500.
+    UsersResource usersResource = mock(UsersResource.class);
+    Response response = mock(Response.class);
+    when(usersResource.create(any())).thenReturn(response);
+    when(response.readEntity(String.class)).thenReturn("some unrelated keycloak failure");
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    UserDTO userDTO = new EasyRandom().nextObject(UserDTO.class);
+
+    assertThrows(
+        InternalServerErrorException.class, () -> this.keycloakService.createKeycloakUser(userDTO));
+  }
+
+  @Test
+  public void
+      createKeycloakUser_Should_returnConflict_When_markersUnsetButStatusConflictAndBodyMentionsEmail() {
+    // Issue #193: even with the markers unset, a 409 with an "email" body must still map to the
+    // EMAIL_NOT_AVAILABLE conflict via the status fallback rather than NPE-ing into a 500.
+    UsersResource usersResource = mock(UsersResource.class);
+    Response response = mock(Response.class);
+    when(usersResource.create(any())).thenReturn(response);
+    when(response.getStatus()).thenReturn(HttpStatus.CONFLICT.value());
+    when(response.readEntity(String.class)).thenReturn("User exists with same email");
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    UserDTO userDTO = new EasyRandom().nextObject(UserDTO.class);
+
+    var exception =
+        assertThrows(
+            CustomValidationHttpStatusException.class,
+            () -> this.keycloakService.createKeycloakUser(userDTO));
+    assertThat(
+        exception.getCustomHttpHeaders().get("X-Reason").get(0), is(EMAIL_NOT_AVAILABLE.name()));
   }
 
   @Test
@@ -724,18 +762,19 @@ public class KeycloakServiceTest {
 
   @Test
   public void updateDummyMail_id_Should_callServicesCorrectly() {
-    // TODO(FLAG production): updateDummyEmail(String) -> updateEmail(...), and
-    // KeycloakService#updateEmail (KeycloakService.java:774-785) is a no-op (the real Keycloak
-    // update is commented out behind a "Bypassing Keycloak email update" log). The dummy email is
-    // therefore never persisted to Keycloak. This test asserts the CURRENT (bypassed) behavior:
-    // the dummy email is computed but no UserResource update happens. Restore the
-    // userResource.update(...) verification once the production bypass is removed.
+    // updateDummyEmail(String) -> updateEmail(userId, dummy) now persists the dummy address to
+    // Keycloak.
     when(userHelper.getDummyEmail(anyString())).thenReturn("dummy");
+    UserRepresentation userRepresentation = givenUserRepresentation("email");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
     keycloakService.updateDummyEmail("userId");
 
     verify(userHelper).getDummyEmail("userId");
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("dummy");
+    verify(userResource).update(userRepresentation);
   }
 
   @Test
@@ -887,15 +926,15 @@ public class KeycloakServiceTest {
 
   @Test
   public void changeEmailAddress_Should_callServicesCorrectly_When_emailIsChangedAndAvailable() {
-    // TODO(FLAG production): KeycloakService#updateEmail (KeycloakService.java:774-785) is
-    // currently a no-op — it logs "Bypassing Keycloak email update" and returns, with the real
-    // Keycloak update commented out. As long as that bypass stands, no UserResource is touched and
-    // email changes are silently dropped. This test asserts the CURRENT (bypassed) behavior; once
-    // the production bypass is removed it must be restored to verify
-    // userRepresentation.setEmail(...) + userResource.update(...).
+    UserRepresentation userRepresentation = givenUserRepresentation("email");
+    UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
     this.keycloakService.updateEmail("userId", "anotherEmail");
 
-    Mockito.verifyNoInteractions(keycloakClient);
+    verify(userRepresentation).setEmail("anotherEmail");
+    verify(userResource, times(1)).update(userRepresentation);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -74,43 +74,61 @@ class MatrixSynapseServiceTest {
         .isEqualTo("Bearer " + ACCESS_TOKEN);
   }
 
-  // TODO(PRODUCTION BUG): syncRoom never reaches the long-poll RestTemplate.
-  //
-  // MatrixSynapseService.syncRoom (src/main/.../matrix/MatrixSynapseService.java:790-872) builds
-  // its
-  // URL via MatrixUrlBuilder.buildUrl(...) (src/main/.../matrix/MatrixUrlBuilder.java:18-36). That
-  // helper appends the query params and then calls buildAndExpand(uriVariables).encode(). The
-  // "filter" query param is a JSON string ({"room":{"timeline":...}}). UriComponentsBuilder treats
-  // the embedded {"room"...} braces as a URI-template variable named "room", but uriVariables is
-  // empty (Map.of()), so buildAndExpand throws:
-  //     java.lang.IllegalArgumentException: Map has no value for '"room"'
-  // syncRoom catches it (line 868) and silently returns an empty result, so
-  // matrixLongPollRestTemplate
-  // is NEVER invoked. Consequence: the dedicated long-poll sync path is effectively dead in
-  // production and never fetches messages.
-  //
-  // Expected (once fixed): matrixLongPollRestTemplate.exchange(...) is called with a URL starting
-  // "...sync?timeout=30000" and containing the encoded room id; verifyNoInteractions(restTemplate).
-  // Actual (current behavior asserted below): zero interactions with matrixLongPollRestTemplate,
-  // result is the swallowed empty fallback {messages:[], next_batch:""}.
-  // Fix must land in src/main (MatrixUrlBuilder should not template-expand the JSON filter param,
-  // e.g. URI-encode query values directly instead of buildAndExpand) - out of scope for this
-  // test-only PR, so we pin the current (buggy) behavior here.
   @Test
   void syncRoomShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
     when(matrixConfig.getApiUrl("/_matrix/client/r0/sync")).thenReturn(SYNC_URL);
+    when(matrixLongPollRestTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("next_batch", "next-token")));
+    var urlCaptor = ArgumentCaptor.forClass(String.class);
 
     var result = service.syncRoom("!room:example.org", ACCESS_TOKEN, "alice", 30000);
 
-    // Bug: the JSON filter param breaks URL building, the exception is swallowed, and neither
-    // RestTemplate is ever touched. Assert that documented-broken behavior so the suite stays
-    // green.
+    // The JSON filter param is bound as a URI variable, so the URL builds correctly and the
+    // dedicated long-poll RestTemplate is actually invoked. The room id stays literal ('!' and ':'
+    // are query-legal) while the surrounding JSON quotes are percent-encoded (%22).
     assertThat(result).isNotNull();
-    assertThat(result).containsEntry("messages", new java.util.ArrayList<>());
-    assertThat(result).containsEntry("next_batch", "");
-    verifyNoInteractions(matrixLongPollRestTemplate);
+    verify(matrixLongPollRestTemplate)
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?timeout=30000");
+    assertThat(urlCaptor.getValue()).contains("&filter=");
+    assertThat(urlCaptor.getValue()).contains("%22!room:example.org%22");
     verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void syncRoomShouldReturnParsedMessagesAndResumeFromCachedToken() {
+    var service = matrixSynapseService();
+    var roomId = "!room:example.org";
+    when(matrixConfig.getApiUrl("/_matrix/client/r0/sync")).thenReturn(SYNC_URL);
+    var textEvent =
+        Map.<String, Object>of(
+            "type", "m.room.message", "content", Map.of("msgtype", "m.text", "body", "hello"));
+    var body =
+        Map.<String, Object>of(
+            "next_batch",
+            "batch-1",
+            "rooms",
+            Map.of(
+                "join",
+                Map.of(
+                    roomId, Map.of("timeline", Map.of("events", java.util.List.of(textEvent))))));
+    when(matrixLongPollRestTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(body));
+    var urlCaptor = ArgumentCaptor.forClass(String.class);
+
+    var first = service.syncRoom(roomId, ACCESS_TOKEN, "alice", 0);
+
+    assertThat((java.util.List<?>) first.get("messages")).hasSize(1);
+    assertThat(first).containsEntry("next_batch", "batch-1");
+
+    // a second sync resumes from the cached next_batch token
+    service.syncRoom(roomId, ACCESS_TOKEN, "alice", 0);
+    verify(matrixLongPollRestTemplate, times(2))
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    assertThat(urlCaptor.getAllValues().get(1)).contains("since=batch-1");
   }
 
   @Test


### PR DESCRIPTION
Fixes the three production bugs tracked in #193 (surfaced while removing `testFailureIgnore` in #126). Each was pinned to its current broken behavior with a `TODO(FLAG)` / `TODO(PRODUCTION BUG)` marker; this PR applies the real fix and flips the tests to assert it.

## 1. `updateEmail` was a silent no-op — email changes never reached Keycloak
`KeycloakService#updateEmail` logged *"Bypassing Keycloak email update for testing"* and returned, with the real write commented out. Both self-service flows — `PUT /users/email` (change) and `DELETE /users/email` (reset to dummy) — updated the app DB, Rocket.Chat, the appointment service and fired a "your email changed" notification, while **Keycloak (the login + password-reset/notification authority) kept the old address**. 2FA-by-email and registration use the 2-arg overloads and were unaffected.

**Fix:** restore the real write **and** the `verifyEmail` duplicate-check, so a collision maps to `409 EMAIL_NOT_AVAILABLE` exactly like `updateUserData`. Dropped the `info` log (it printed the raw email — PII).

## 2. Unguarded `.toLowerCase()` on possibly-null config → `409` became an opaque `500`
`handleCreateKeycloakUserError` lower-cased the configured duplicate-email/-username markers with no null guard, so an unset marker NPE'd the duplicate-account path into a 500 (and a *blank* marker matched every error). 

**Fix:** null/blank-guard both markers; keep the `status == CONFLICT && contains(...)` fallback so duplicates still yield `409`.

**Bonus (same method):** `keycloakError` is an `@Value`-injected singleton field that was mutated as a return channel — a concurrency clobber. It now returns a local message instead.

## 3. Matrix `/sync` long-poll was dead — no messages ever delivered
`MatrixUrlBuilder` appended query values literally, so `syncRoom`'s JSON `filter` (`{"room":{...}}`) was read as a URI template and `buildAndExpand` threw `IllegalArgumentException: Map has no value for '"room"'`. `syncRoom` swallowed it, so `GET /sessions/{id}/sync` returned an empty result every time. `getRoomMessages` passes brace-free values and was unaffected.

**Fix:** bind query values as `q__`-prefixed URI variables (expand-then-encode keeps `!`/`:` literal while percent-encoding the JSON braces/quotes). Verified output: `…/sync?timeout=30000&filter=%7B%22room%22…%22!room:example.org%22…`. Also narrowed `syncRoom`'s `catch(Exception)` into `HttpStatusCodeException` (graceful) + `RuntimeException` (logs full stack) so a future URL/parse bug is never hidden as "no messages forever" again.

## Tests
- Flipped the three pinned tests (`changeEmailAddress…`, `deleteEmailAddress…`, `updateDummyMail_id…`, `syncRoomShouldUseDedicatedLongPollRestTemplate`) to assert the fixed behavior.
- Added regression tests: the null-marker NPE path (generic 500 + `409`-via-status fallback) and `syncRoom` returning parsed messages + resuming from the cached `next_batch` token.
- **Full unit suite: 1540 run, 0 failures, 0 errors, 7 skipped** (JDK 17).

Closes #193