### PR TITLE
fix: avoid lazy registration profile failures

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProvider.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.UserAgencyService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -27,7 +28,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -44,6 +44,7 @@ public class AskerDataProvider {
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   private final @NonNull SessionService sessionService;
+  private final @NonNull UserAgencyService userAgencyService;
 
   private final @NonNull EmailNotificationMapper emailNotificationMapper;
 
@@ -54,6 +55,7 @@ public class AskerDataProvider {
    * @return the user data
    */
   public UserDataResponseDTO retrieveData(User user) {
+    var sessionsByUser = sessionsByUser(user);
     var userDataResponseDTOBuilder =
         UserDataResponseDTO.builder()
             .userId(user.getUserId())
@@ -67,20 +69,19 @@ public class AskerDataProvider {
             .isInTeamAgency(false)
             .userRoles(authenticatedUser.getRoles())
             .grantedAuthorities(authenticatedUser.getGrantedAuthorities())
-            .consultingTypes(getConsultingTypes(user))
+            .consultingTypes(getConsultingTypes(user, sessionsByUser))
             .hasAnonymousConversations(false)
             .hasArchive(false)
             .dataPrivacyConfirmation(user.getDataPrivacyConfirmation())
             .termsAndConditionsConfirmation(user.getTermsAndConditionsConfirmation())
             .emailNotifications(emailNotificationMapper.toEmailNotificationsDTO(user));
 
-    enrichWithUserSessions(user, userDataResponseDTOBuilder);
+    enrichWithUserSessions(sessionsByUser, userDataResponseDTOBuilder);
     return userDataResponseDTOBuilder.build();
   }
 
   private void enrichWithUserSessions(
-      User user, UserDataResponseDTOBuilder userDataResponseDTOBuilder) {
-    List<Session> sessionsByUser = sessionService.findSessionsByUser(user);
+      List<Session> sessionsByUser, UserDataResponseDTOBuilder userDataResponseDTOBuilder) {
     if (CollectionUtils.isNotEmpty(sessionsByUser)) {
       SessionMapper sessionMapper = new SessionMapper();
       userDataResponseDTOBuilder.sessions(
@@ -96,8 +97,9 @@ public class AskerDataProvider {
         : user.getEmail();
   }
 
-  private LinkedHashMap<String, Object> getConsultingTypes(User user) {
-    Set<Session> sessionList = SetUtils.emptyIfNull(user.getSessions());
+  private LinkedHashMap<String, Object> getConsultingTypes(
+      User user, List<Session> sessionsByUser) {
+    Set<Session> sessionList = Set.copyOf(sessionsByUser);
     List<AgencyDTO> agencyDTOs = agencyDTOsOf(user, sessionList);
     LinkedHashMap<String, Object> consultingTypes = new LinkedHashMap<>();
     for (int type : consultingTypeManager.getAllConsultingTypeIds()) {
@@ -171,11 +173,17 @@ public class AskerDataProvider {
   }
 
   private List<Long> collectAgencyIdsFromUser(User user) {
-    return CollectionUtils.isNotEmpty(user.getUserAgencies())
-        ? user.getUserAgencies().stream()
+    var userAgencies = userAgencyService.getUserAgenciesByUser(user);
+    return CollectionUtils.isNotEmpty(userAgencies)
+        ? userAgencies.stream()
             .map(UserAgency::getAgencyId)
             .filter(Objects::nonNull)
             .collect(Collectors.toList())
         : Collections.emptyList();
+  }
+
+  private List<Session> sessionsByUser(User user) {
+    var sessionsByUser = sessionService.findSessionsByUser(user);
+    return sessionsByUser == null ? Collections.emptyList() : sessionsByUser;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -105,6 +106,7 @@ public class ConsultantAgencyService {
     return isNull(consultantAgency.getConsultant().getDeleteDate());
   }
 
+  @Transactional(readOnly = true)
   public Set<String> getLanguageCodesOfAgency(long agencyId) {
     var consultantAgencies = findConsultantsByAgencyId(agencyId);
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/AskerDataProviderTest.java
@@ -12,6 +12,8 @@ import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.neovisionaries.i18n.LanguageCode;
@@ -25,6 +27,7 @@ import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManag
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.UserAgencyService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.util.Collections;
@@ -61,6 +64,8 @@ class AskerDataProviderTest {
   @Mock EmailNotificationMapper emailNotificationMapper;
 
   @Mock SessionService sessionService;
+
+  @Mock UserAgencyService userAgencyService;
 
   @Test
   void retrieveData_Should_ReturnUserDataWithAgency_When_ProvidedWithUserWithAgencyInSession() {
@@ -174,6 +179,8 @@ class AskerDataProviderTest {
     when(agencyService.getAgencies(any())).thenReturn(Collections.singletonList(AGENCY_DTO_SUCHT));
     LinkedHashMap<String, Object> sessionData = new LinkedHashMap<>();
     when(sessionDataProvider.getSessionDataMapFromSession(any())).thenReturn(sessionData);
+    when(sessionService.findSessionsByUser(USER_WITH_SESSIONS))
+        .thenReturn(sessionsWithLanguageCode(USER_WITH_SESSIONS));
 
     when(authenticatedUser.getGrantedAuthorities()).thenReturn(asSet(GRANTED_AUTHORIZATION_USER));
     when(authenticatedUser.getRoles()).thenReturn(asSet(UserRole.USER.toString()));
@@ -208,6 +215,24 @@ class AskerDataProviderTest {
   }
 
   @Test
+  void retrieveData_Should_LoadSessionsAndUserAgenciesViaServices_When_UserProxyIsDetached() {
+    givenAnEmailDummySuffixConfig();
+    var user = Mockito.spy(USER_WITH_SESSIONS);
+    var sessions = sessionsWithLanguageCode(USER_WITH_SESSIONS);
+    when(sessionService.findSessionsByUser(user)).thenReturn(sessions);
+    when(userAgencyService.getUserAgenciesByUser(user)).thenReturn(Collections.emptyList());
+    when(agencyService.getAgencies(any())).thenReturn(Collections.singletonList(AGENCY_DTO_SUCHT));
+    when(authenticatedUser.getRoles()).thenReturn(asSet(UserRole.USER.toString()));
+    when(consultingTypeManager.getAllConsultingTypeIds())
+        .thenReturn(IntStream.range(0, 22).boxed().collect(Collectors.toList()));
+
+    askerDataProvider.retrieveData(user);
+
+    verify(user, never()).getSessions();
+    verify(user, never()).getUserAgencies();
+  }
+
+  @Test
   void retrieveData_Should_ReturnUserDataWithoutAgency_When_userHasNotAgencyInSession() {
     givenAnEmailDummySuffixConfig();
 
@@ -230,5 +255,11 @@ class AskerDataProviderTest {
 
   private void givenAnEmailDummySuffixConfig() {
     when(identityClientConfig.getEmailDummySuffix()).thenReturn("@dummysuffix.de");
+  }
+
+  private List<Session> sessionsWithLanguageCode(User user) {
+    var sessions = List.copyOf(user.getSessions());
+    sessions.forEach(session -> session.setLanguageCode(LanguageCode.de));
+    return sessions;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
@@ -34,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(SpringExtension.class)
 public class ConsultantAgencyServiceTest {
@@ -96,6 +97,15 @@ public class ConsultantAgencyServiceTest {
     assertThat(
         consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID),
         everyItem(instanceOf(ConsultantAgency.class)));
+  }
+
+  @Test
+  public void getLanguageCodesOfAgency_Should_BeReadOnlyTransactional() throws Exception {
+    var method = ConsultantAgencyService.class.getMethod("getLanguageCodesOfAgency", long.class);
+    var transactional = method.getAnnotation(Transactional.class);
+
+    assertNotNull(transactional);
+    assertTrue(transactional.readOnly());
   }
 
   /** Method: getConsultantsOfAgency */


### PR DESCRIPTION
## Summary
- load asker sessions and user-agency assignments through services while building user profile data
- keep agency language lookup inside a read-only transaction so consultant languages initialize for public registration requests
- add regression coverage for detached user proxies and transactional language lookup

## Tests
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -Dtest=AskerDataProviderTest,ConsultantAgencyServiceTest test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw test

🤖 Generated with [Claude Code](https://claude.com/claude-code)