### PR TITLE
fix: fetch asker session data for profile

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -98,6 +98,9 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
 
   List<Session> findByUser(User user);
 
+  @Query("select distinct s from Session s left join fetch s.sessionData where s.user = :user")
+  List<Session> findByUserWithSessionData(@Param("user") User user);
+
   List<Session> findByUserAndConsultingTypeId(User user, int consultingTypeId);
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -910,7 +910,7 @@ public class SessionService {
 
   public List<Session> findSessionsByUser(User user) {
     if (nonNull(user)) {
-      return sessionRepository.findByUser(user);
+      return sessionRepository.findByUserWithSessionData(user);
     }
     return emptyList();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -326,6 +326,30 @@ class SessionServiceTest {
   }
 
   @Test
+  void findSessionsByUser_Should_ReturnSessionsWithSessionData_When_ProvidedWithUser() {
+
+    List<Session> sessions = new ArrayList<>();
+    sessions.add(SESSION);
+    sessions.add(SESSION_2);
+
+    when(sessionRepository.findByUserWithSessionData(USER)).thenReturn(sessions);
+
+    List<Session> result = sessionService.findSessionsByUser(USER);
+
+    assertEquals(sessions, result);
+    verify(sessionRepository, never()).findByUser(USER);
+  }
+
+  @Test
+  void findSessionsByUser_Should_ReturnEmptyList_When_UserIsNull() {
+
+    List<Session> result = sessionService.findSessionsByUser(null);
+
+    assertEquals(List.of(), result);
+    verifyNoInteractions(sessionRepository);
+  }
+
+  @Test
   void getSessionsForUserByConsultingType_Should_ReturnListOfSessionsForUser() {
 
     List<Session> sessions = new ArrayList<>();


### PR DESCRIPTION
## Summary
- fetch sessionData with asker sessions when building user profile data
- keep null-user handling unchanged for session lookups
- cover the repository call with SessionService tests

## Tests
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -Dtest=SessionServiceTest,AskerDataProviderTest test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw test (1545 tests, 0 failures, 0 errors, 7 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)