### PR TITLE
fix: route matrix enquiry credentials through matrix

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -167,7 +167,13 @@ public class CreateEnquiryMessageFacade {
       return false;
     }
     var rcUserId = credentials.getRocketChatUserId();
-    return !isBlank(rcUserId) && !MATRIX_MIGRATION_DUMMY_RC_USER_ID.equals(rcUserId);
+    return !isBlank(rcUserId)
+        && !MATRIX_MIGRATION_DUMMY_RC_USER_ID.equals(rcUserId)
+        && !isMatrixUserId(rcUserId);
+  }
+
+  private boolean isMatrixUserId(String userId) {
+    return userId != null && userId.startsWith("@") && userId.contains(":");
   }
 
   private CreateEnquiryMessageResponseDTO createMatrixEnquiryMessage(

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -289,6 +289,53 @@ class CreateEnquiryMessageFacadeTest {
   }
 
   @Test
+  void createEnquiryMessage_Should_PostMatrixEnquiry_When_RocketChatUserIdIsMatrixUserId()
+      throws Exception {
+    var matrixRoomId = "!session-room:oriso.org";
+    var matrixUserId = "@asker:oriso.org";
+    var matrixToken = "matrix-token";
+    var matrixEventId = "$event";
+    user.setMatrixUserId(matrixUserId);
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setIsConsultantDirectlySet(false);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(matrixRoomId);
+    rocketChatCredentials.setRocketChatUserId(matrixUserId);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId()))
+        .thenReturn(extendedConsultingTypeResponseDTO);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+    when(matrixSynapseService.loginAsUserAccessToken(matrixUserId)).thenReturn(matrixToken);
+    when(matrixSynapseService.sendMessage(matrixRoomId, MESSAGE, matrixToken))
+        .thenReturn(Map.of("event_id", matrixEventId));
+
+    final var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(rocketChatService, never()).getUserInfo(anyString());
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+    verify(messageServiceProvider, never())
+        .postEnquiryMessage(
+            any(RocketChatData.class), any(CreateEnquiryExceptionInformation.class));
+    verify(agencyPreAssignmentRoomService, never()).ensureHoldingRoom(any(), any());
+    verify(sessionService).saveSession(session);
+    assertEquals(SESSION_ID, response.getSessionId());
+    assertEquals(matrixRoomId, response.getRcGroupId());
+    assertEquals(matrixEventId, response.getT());
+    assertEquals(matrixRoomId, session.getGroupId());
+    assertEquals(matrixRoomId, session.getMatrixRoomId());
+    assertEquals(SessionStatus.NEW, session.getStatus());
+    assertNotNull(session.getEnquiryMessageDate());
+    resetRequestAttributes();
+  }
+
+  @Test
   void createEnquiryMessage_Should_CreateMatrixEnquiryWithoutMessage_When_AppointmentEnquiry()
       throws Exception {
     var matrixRoomId = "!appointment-room:oriso.org";


### PR DESCRIPTION
## Summary
- Treat Matrix-style user IDs in the legacy Rocket.Chat credential slot as Matrix-only enquiry credentials.
- Keep redirected Matrix enquiries from calling Rocket.Chat user info or room creation.
- Add a regression test for the Pre-Dev failure shape where `rocketChatUserId` contains `@user:server`.

## Tests
- `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD":/workspace -v "$HOME/.m2":/var/maven/.m2 -e HOME=/var/maven -e MAVEN_CONFIG=/var/maven/.m2 -w /workspace maven:3.9.9-eclipse-temurin-17 ./mvnw -Dtest=CreateEnquiryMessageFacadeTest test`

Tracked in OpenResilienceInitiative/ORISO-Frontend#280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
