### PR TITLE
fix: keep consultant session lists transactional

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** {@link ConversationListProvider} to provide anonymous enquiry conversations. */
 @Service
@@ -46,6 +47,7 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
 
   /** {@inheritDoc} */
   @Override
+  @Transactional(readOnly = true)
   public ConsultantSessionListResponseDTO buildConversations(
       PageableListRequest pageableListRequest) {
     var consultant = this.userAccountProvider.retrieveValidatedConsultant();

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -59,6 +59,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 
 /** Service for sessions */
@@ -286,6 +287,7 @@ public class SessionService {
    * @param consultant the consultant
    * @return A list of {@link ConsultantSessionResponseDTO}
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getTeamSessionsForConsultant(Consultant consultant) {
 
     List<Session> sessions = new ArrayList<>();
@@ -355,6 +357,7 @@ public class SessionService {
    * @param consultant the consultant
    * @return the related {@link ConsultantSessionResponseDTO}s
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getRegisteredEnquiriesForConsultant(
       Consultant consultant) {
     List<Session> mergedSessions = new ArrayList<>();
@@ -448,6 +451,7 @@ public class SessionService {
    * @param consultant the consultant
    * @return the related {@link ConsultantSessionResponseDTO}s
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getActiveAndDoneSessionsForConsultant(
       Consultant consultant) {
     return Stream.of(
@@ -589,6 +593,7 @@ public class SessionService {
    * @param roles the roles of the given consultant
    * @return {@link ConsultantSessionResponseDTO}
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getAllowedSessionsByConsultantAndGroupIds(
       Consultant consultant, Set<String> rcGroupIds, Set<String> roles) {
     checkForUserOrConsultantRole(roles);
@@ -610,6 +615,7 @@ public class SessionService {
    * @param roles the roles of the given consultant
    * @return {@link ConsultantSessionResponseDTO}
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getSessionsByIds(
       Consultant consultant, Set<Long> sessionIds, Set<String> roles) {
     checkForUserOrConsultantRole(roles);
@@ -843,6 +849,7 @@ public class SessionService {
    * @param consultant the consultant
    * @return the related {@link ConsultantSessionResponseDTO}s
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getArchivedSessionsForConsultant(
       Consultant consultant) {
     final List<Session> sessions = retrieveArchivedSessions(consultant);
@@ -861,6 +868,7 @@ public class SessionService {
    * @param consultant the consultant
    * @return the related {@link ConsultantSessionResponseDTO}s
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getArchivedTeamSessionsForConsultant(
       Consultant consultant) {
     final List<Session> sessions = retrieveArchivedTeamSessionsForConsultant(consultant);

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/RegisteredEnquiryConversationListProviderIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/RegisteredEnquiryConversationListProviderIT.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.util.Lists;
+import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.UserServiceApplication;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
@@ -21,13 +22,19 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.SessionData;
+import de.caritas.cob.userservice.api.model.SessionData.SessionDataType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import org.apache.commons.collections4.iterators.PeekingIterator;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +58,8 @@ public class RegisteredEnquiryConversationListProviderIT {
   @Autowired private SessionRepository sessionRepository;
 
   @Autowired private UserRepository userRepository;
+
+  @Autowired private EntityManager entityManager;
 
   @MockBean private UserAccountService userAccountProvider;
 
@@ -118,6 +127,21 @@ public class RegisteredEnquiryConversationListProviderIT {
   }
 
   @Test
+  public void
+      buildConversations_Should_includeSessionData_When_registeredEnquiryWasReloadedDetached() {
+    saveRegisteredSessionWithSessionData();
+    entityManager.clear();
+    PageableListRequest request = PageableListRequest.builder().count(1).offset(0).build();
+
+    ConsultantSessionListResponseDTO responseDTO =
+        this.registeredEnquiryConversationListProvider.buildConversations(request);
+
+    Map<String, Object> sessionData = responseDTO.getSessions().get(0).getUser().getSessionData();
+    assertThat(responseDTO.getCount(), is(1));
+    assertThat(sessionData.get("age"), is("42"));
+  }
+
+  @Test
   public void providedType_Should_return_registeredEnquiry() {
     ConversationListType conversationListType =
         this.registeredEnquiryConversationListProvider.providedType();
@@ -149,5 +173,22 @@ public class RegisteredEnquiryConversationListProviderIT {
     sessions.get(2).setStatus(SessionStatus.DONE);
     sessions.get(3).setStatus(SessionStatus.IN_ARCHIVE);
     this.sessionRepository.saveAll(sessions);
+  }
+
+  private void saveRegisteredSessionWithSessionData() {
+    User user = this.userRepository.findAll().iterator().next();
+    Session session = new Session(user, 1, "12345", 1L, SessionStatus.NEW, false);
+    session.setId(null);
+    session.setLanguageCode(LanguageCode.de);
+    session.setEnquiryMessageDate(LocalDateTime.now());
+    session.setCreateDate(LocalDateTime.now());
+    session.setUpdateDate(LocalDateTime.now());
+    session.setMainTopicId(9L);
+    session.setIsConsultantDirectlySet(false);
+    session.setSessionTopics(Lists.newArrayList());
+    SessionData age = new SessionData(session, SessionDataType.REGISTRATION, "age", "42");
+    session.setSessionData(Arrays.asList(age));
+
+    this.sessionRepository.save(session);
   }
 }


### PR DESCRIPTION
## Problem
Fresh Matrix enquiries can be created on Pre-Dev, but the consultant registered enquiry list still fails with HTTP 500 when session registration data is lazy-loaded after the repository query.

Fixes #207

## Solution
- Keep consultant session-list mapping paths in `SessionService` inside read-only transactions.
- Add the same transactional boundary for anonymous enquiry list mapping, which maps sessions directly.
- Add a regression IT for a reloaded registered enquiry with `SessionData`.

## Validation
- `docker run --rm -v /Users/frankgerhardt/ORISO/_worktrees/ORISO-UserService-consultant-enquiry-session-data:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:17 ./mvnw -DskipTests package`
  - Main test suite completed: 1546 tests run, 0 failures, 0 errors, 7 skipped.
- `git diff --check`
- Targeted provider ITs are currently blocked locally by the existing testing-profile schema validation issue: `Schema-validation: missing table [admin]`.
