### PR TITLE
fix(useradmin): scope agency-admin list to caller's own agencies

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -10,6 +10,8 @@ import de.caritas.cob.userservice.api.admin.service.admin.delete.DeleteAdminServ
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.admin.service.admin.update.UpdateAdminService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
@@ -43,6 +45,7 @@ public class AgencyAdminUserService {
   private final @NonNull AgencyService agencyService;
   private final @NonNull TenantService tenantService;
   private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
 
   public AdminResponseDTO createNewAgencyAdmin(final CreateAdminDTO createAgencyAdminDTO) {
     final Admin newAdmin = createAdminService.createNewAgencyAdmin(createAgencyAdminDTO);
@@ -50,18 +53,43 @@ public class AgencyAdminUserService {
   }
 
   public AdminResponseDTO findAgencyAdmin(final String adminId) {
+    assertCallerMayAccessAgencyAdmin(adminId);
     final Admin admin = retrieveAdminService.findAdmin(adminId, Admin.AdminType.AGENCY);
     return AdminResponseDTOBuilder.getInstance(admin).buildAgencyAdminResponseDTO();
   }
 
   public AdminResponseDTO updateAgencyAdmin(
       final String adminId, final UpdateAgencyAdminDTO updateAgencyAdminDTO) {
+    assertCallerMayAccessAgencyAdmin(adminId);
     final Admin updatedAdmin = updateAdminService.updateAgencyAdmin(adminId, updateAgencyAdminDTO);
     return AdminResponseDTOBuilder.getInstance(updatedAdmin).buildAgencyAdminResponseDTO();
   }
 
   public void deleteAgencyAdmin(final String adminId) {
+    assertCallerMayAccessAgencyAdmin(adminId);
     this.deleteAdminService.deleteAgencyAdmin(adminId);
+  }
+
+  /**
+   * A restricted agency admin (an agency-level admin without the broader agency-super-admin role)
+   * may only act on agency admins that share at least one of their own agencies. This prevents a
+   * single Beratungsstellen-Admin from reading, editing or deleting admins of other Träger by
+   * targeting their id directly, mirroring the agency scoping already applied to consultants.
+   */
+  private void assertCallerMayAccessAgencyAdmin(final String targetAdminId) {
+    if (!authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      return;
+    }
+    var callerAgencyIds = retrieveAdminService.findAgencyIdsOfAdmin(authenticatedUser.getUserId());
+    var targetAgencyIds = retrieveAdminService.findAgencyIdsOfAdmin(targetAdminId);
+    if (Collections.disjoint(callerAgencyIds, targetAgencyIds)) {
+      log.warn(
+          "Restricted agency admin {} attempted to access agency admin {} outside their agencies",
+          authenticatedUser.getUserId(),
+          targetAdminId);
+      throw new ForbiddenException(
+          "Agency admin is not allowed to access an admin outside their own agencies");
+    }
   }
 
   public List<Long> findAgenciesOfAdmin(final String adminId) {
@@ -69,8 +97,7 @@ public class AgencyAdminUserService {
   }
 
   public Map<String, Object> findAgencyAdminsByInfix(String infix, PageRequest pageRequest) {
-    Page<AdminBase> adminsPage =
-        retrieveAdminService.findAllByInfix(infix, Admin.AdminType.AGENCY, pageRequest);
+    Page<AdminBase> adminsPage = findScopedAgencyAdminsByInfix(infix, pageRequest);
     var adminIds = adminsPage.stream().map(AdminBase::getId).collect(Collectors.toSet());
     var fullAdmins = retrieveAdminService.findAllById(adminIds);
 
@@ -97,6 +124,22 @@ public class AgencyAdminUserService {
         agenciesOfAdmin,
         tenantIdsToNameMap,
         idsWithConsultantIdentity);
+  }
+
+  /**
+   * Returns the infix-matched agency admins visible to the current caller. A restricted agency
+   * admin only sees admins of their own agencies; platform/tenant admins keep the full list. This
+   * closes the cross-Träger leak where any holder of the user-admin authority (which every agency
+   * admin also carries, to manage consultants) could list every agency admin of every Träger.
+   */
+  private Page<AdminBase> findScopedAgencyAdminsByInfix(String infix, PageRequest pageRequest) {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      var callerAgencyIds =
+          retrieveAdminService.findAgencyIdsOfAdmin(authenticatedUser.getUserId());
+      return retrieveAdminService.findAllByInfixScopedToAgencies(
+          infix, Admin.AdminType.AGENCY, callerAgencyIds, pageRequest);
+    }
+    return retrieveAdminService.findAllByInfix(infix, Admin.AdminType.AGENCY, pageRequest);
   }
 
   public AdminResponseDTO patchAgencyAdmin(String adminId, PatchAdminDTO patchAdminDTO) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.model.AdminAgency;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -48,6 +49,22 @@ public class RetrieveAdminService {
   public Page<AdminBase> findAllByInfix(
       String infix, Admin.AdminType adminType, PageRequest pageRequest) {
     return adminRepository.findAllByInfix(infix, adminType, pageRequest);
+  }
+
+  /**
+   * Infix search scoped to the given agencies. Returns an empty page when the caller manages no
+   * agencies, so a restricted agency admin without agency assignments sees nothing instead of
+   * falling back to the unscoped list.
+   */
+  public Page<AdminBase> findAllByInfixScopedToAgencies(
+      String infix,
+      Admin.AdminType adminType,
+      Collection<Long> agencyIds,
+      PageRequest pageRequest) {
+    if (agencyIds == null || agencyIds.isEmpty()) {
+      return Page.empty(pageRequest);
+    }
+    return adminRepository.findAllByInfixAndAgencyIds(infix, adminType, agencyIds, pageRequest);
   }
 
   public List<Admin> findAllById(Set<String> adminIds) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -33,6 +33,32 @@ public interface AdminRepository extends CrudRepository<Admin, String> {
               + " )")
   Page<AdminBase> findAllByInfix(String infix, Admin.AdminType type, Pageable pageable);
 
+  /**
+   * Same infix search as {@link #findAllByInfix}, but restricted to admins that are assigned to at
+   * least one of the given agencies. Used to scope the agency-admin list for restricted agency
+   * admins so they only ever see admins of their own agencies (and never other Träger's admins).
+   */
+  @Query(
+      value =
+          "SELECT a.id as id, a.firstName as firstName, a.lastName as lastName, a.email as email, a.tenantId as tenantId "
+              + ", a.type as type, a.updateDate as updateDate "
+              + "FROM Admin a "
+              + "WHERE"
+              + "  type = ?2 "
+              + "AND a.id IN (SELECT aa.admin.id FROM AdminAgency aa WHERE aa.agencyId IN ?3) "
+              + "AND ("
+              + "  ?1 = '*' "
+              + "  OR ("
+              + "    UPPER(a.id) = UPPER(?1)"
+              + "    OR UPPER(a.firstName) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR UPPER(a.lastName) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR UPPER(a.email) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR CONVERT(a.tenantId,char) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "  )"
+              + " )")
+  Page<AdminBase> findAllByInfixAndAgencyIds(
+      String infix, Admin.AdminType type, Collection<Long> agencyIds, Pageable pageable);
+
   @Query(value = "SELECT a FROM Admin a WHERE id = ?1 AND type = ?2")
   Optional<Admin> findByIdAndType(String adminId, Admin.AdminType type);
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -8,6 +8,8 @@ import de.caritas.cob.userservice.api.admin.service.admin.delete.DeleteAdminServ
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.admin.service.admin.update.UpdateAdminService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -51,6 +53,89 @@ class AgencyAdminUserServiceTest {
   @Mock private TenantService tenantService;
 
   @Mock private de.caritas.cob.userservice.api.port.out.ConsultantRepository consultantRepository;
+
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @Test
+  void findAgencyAdminsByInfix_Should_ScopeToCallerAgencies_WhenRestrictedAgencyAdmin() {
+    // given
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    List<Long> callerAgencyIds = Arrays.asList(5L, 6L);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("caller-admin");
+    when(retrieveAdminService.findAgencyIdsOfAdmin("caller-admin")).thenReturn(callerAgencyIds);
+    when(retrieveAdminService.findAllByInfixScopedToAgencies(
+            "*", Admin.AdminType.AGENCY, callerAgencyIds, pageRequest))
+        .thenReturn(new PageImpl<>(Collections.emptyList(), pageRequest, 0));
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(Collections.emptyList());
+    when(retrieveAdminService.agenciesOfAdmin(Mockito.anySet()))
+        .thenReturn(Collections.emptyList());
+    when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    // when
+    agencyAdminUserService.findAgencyAdminsByInfix("*", pageRequest);
+
+    // then: scoped query is used, the unscoped one is never called
+    Mockito.verify(retrieveAdminService)
+        .findAllByInfixScopedToAgencies("*", Admin.AdminType.AGENCY, callerAgencyIds, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfix(Mockito.any(), Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  void deleteAgencyAdmin_Should_ThrowForbidden_WhenRestrictedAgencyAdminTargetsForeignAgency() {
+    // given
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("caller-admin");
+    when(retrieveAdminService.findAgencyIdsOfAdmin("caller-admin"))
+        .thenReturn(Collections.singletonList(5L));
+    when(retrieveAdminService.findAgencyIdsOfAdmin("foreign-admin"))
+        .thenReturn(Collections.singletonList(9L));
+
+    // when / then
+    Assertions.assertThrows(
+        ForbiddenException.class, () -> agencyAdminUserService.deleteAgencyAdmin("foreign-admin"));
+    Mockito.verify(deleteAdminService, Mockito.never()).deleteAgencyAdmin(Mockito.any());
+  }
+
+  @Test
+  void deleteAgencyAdmin_Should_Delete_WhenRestrictedAgencyAdminSharesAgency() {
+    // given
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("caller-admin");
+    when(retrieveAdminService.findAgencyIdsOfAdmin("caller-admin"))
+        .thenReturn(Arrays.asList(5L, 7L));
+    when(retrieveAdminService.findAgencyIdsOfAdmin("peer-admin"))
+        .thenReturn(Collections.singletonList(7L));
+
+    // when
+    agencyAdminUserService.deleteAgencyAdmin("peer-admin");
+
+    // then
+    Mockito.verify(deleteAdminService).deleteAgencyAdmin("peer-admin");
+  }
+
+  @Test
+  void deleteAgencyAdmin_Should_NotScope_WhenCallerIsPlatformAdmin() {
+    // given a platform/user admin without restricted-agency privileges
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+
+    // when
+    agencyAdminUserService.deleteAgencyAdmin("any-admin");
+
+    // then no agency lookup happens and deletion proceeds
+    Mockito.verify(retrieveAdminService, Mockito.never()).findAgencyIdsOfAdmin(Mockito.any());
+    Mockito.verify(deleteAdminService).deleteAgencyAdmin("any-admin");
+  }
 
   @Test
   void findAgencyAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {


### PR DESCRIPTION
## Why
A restricted agency admin (Beratungsstellen-Admin) could see and act on the agency admins of **every** Träger. Reproduced live: logged in as an agency admin whose only agency is *Beratungsstelle West [88885]*, the agency-admin list returned all **28** admins across foreign Träger (Kiel, Berlin, …), each with edit/delete actions — a cross-tenant authorization / IDOR leak.

Root cause: new agency admins are granted the broad `USER_ADMIN` authority (so they can manage their own consultants), which opens `/useradmin/agencyadmins/search`; the underlying query (`AdminRepository.findAllByInfix`) filters only by `type=AGENCY` + search text, with **no** tenant/agency scoping.

## What
Surgical, backend-only fix mirroring the existing consultant scoping:
- `AdminRepository.findAllByInfixAndAgencyIds` — infix search restricted to a set of agencies.
- `RetrieveAdminService.findAllByInfixScopedToAgencies` — empty page when the caller manages no agencies.
- `AgencyAdminUserService.findAgencyAdminsByInfix` — when the caller `hasRestrictedAgencyPriviliges()`, scope to the caller's own agencies (`findAgencyIdsOfAdmin`). Platform/tenant admins keep the full list.
- by-id IDOR guard `assertCallerMayAccessAgencyAdmin` on get/update/delete — `Forbidden` if the target shares no agency with a restricted agency admin.

No role/Keycloak change, no schema change, no frontend change (the tab stays; the list simply returns the scoped rows).

## Acceptance
- Restricted agency admin → agency-admin list contains only admins sharing one of their agencies.
- Platform / tenant admin → unchanged (full list).
- Direct get/update/delete of a foreign agency admin by id → 403.
- Verified live on the dev cluster: same real agency-admin token, unpatched **28 → fixed 1** (only the caller's own-agency admin).
- 5/5 unit tests green (`AgencyAdminUserServiceTest`).

Affected repos: ORISO-UserService

🤖 Generated with [Claude Code](https://claude.com/claude-code)