### PR TITLE
fix(userservice): allow configured CORS preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ consultants-import.txt*
 *localdev*
 *.jar
 run-local-remote-db.sh
+config.env
+dev-local-ca.pem
+dev-truststore.jks
 .env.local
 application-local.properties
 src/main/resources/application-local.properties

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
@@ -77,6 +78,9 @@ public class HttpTenantFilter extends OncePerRequestFilter {
   class DefaultRequiresTenantFilterMatcher implements RequestMatcher {
     @Override
     public boolean matches(HttpServletRequest request) {
+      if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+        return false;
+      }
 
       List<String> tenantWhitelist = new ArrayList<>(Arrays.asList(TENANCY_FILTER_WHITELIST));
       return !belongsToWhitelist(request, tenantWhitelist);

--- a/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
@@ -4,7 +4,13 @@ import java.util.List;
 import lombok.NonNull;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -58,5 +64,22 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
         .allowedOrigins(allowedOrigins)
         .allowedHeaders("*")
         .exposedHeaders("X-Reason");
+  }
+
+  @Bean
+  public FilterRegistrationBean<CorsFilter> corsFilterRegistrationBean() {
+    var configuration = new CorsConfiguration();
+    configuration.setAllowCredentials(true);
+    configuration.setAllowedOrigins(List.of(allowedOrigins));
+    configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setExposedHeaders(List.of("X-Reason"));
+
+    var source = new UrlBasedCorsConfigurationSource();
+    allowedPaths.forEach(path -> source.registerCorsConfiguration(path, configuration));
+
+    var registrationBean = new FilterRegistrationBean<>(new CorsFilter(source));
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registrationBean;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -49,21 +48,6 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
     registry
         .addResourceHandler(docuPath + "/**")
         .addResourceLocations("classpath:/META-INF/resources/");
-  }
-
-  @Override
-  public void addCorsMappings(@NonNull CorsRegistry registry) {
-    allowedPaths.forEach(path -> addCorsMapping(registry, path));
-  }
-
-  private void addCorsMapping(CorsRegistry registry, String path) {
-    registry
-        .addMapping(path)
-        .allowCredentials(true)
-        .allowedMethods("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
-        .allowedOrigins(allowedOrigins)
-        .allowedHeaders("*")
-        .exposedHeaders("X-Reason");
   }
 
   @Bean


### PR DESCRIPTION
## Summary
- add an early CORS filter using the existing `registration.cors.allowed.*` configuration
- skip tenant resolution for `OPTIONS` preflight requests
- ignore local-only config/truststore files used for local development

## Production safety
This does not broaden production CORS by itself. It reuses the existing configured allowed origins and paths, so production remains restricted by deployed environment values. Local development can opt in by setting local `REGISTRATION_CORS_ALLOWED_ORIGINS` and `REGISTRATION_CORS_ALLOWED_PATHS` in an ignored config file.

## Validation
- `./mvnw -DskipTests -Dspotless.check.skip=true compile`
- `./mvnw spotless:check -DskipTests`