### PR TITLE
docs(userservice): add local run guide and sample config

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,53 @@
+# Copy to config.env and fill the CHANGE_ME values.
+# config.env is ignored by git and must not be committed.
+
+KEYCLOAK_REALM=online-beratung
+KEYCLOAK_CONFIG_ADMIN_USERNAME=technical
+KEYCLOAK_CONFIG_ADMIN_PASSWORD=CHANGE_ME
+KEYCLOAK_CONFIG_ADMIN_CLIENT_ID=admin-cli
+KEYCLOAK_CONFIG_APP_CLIENT_ID=app
+KEYCLOAK_CONFIG_ADMIN_CLIENT_SECRET=CHANGE_ME
+KEYCLOAK_DISABLE_TRUST_MANAGER=true
+KEYCLOAK_ALLOW_ANY_HOSTNAME=true
+
+# Optional if the remote Matrix/Keycloak certificates are not trusted by your local JVM.
+# JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/Users/Hassan/.oriso/dev-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
+
+SPRING_DATASOURCE_USERNAME=userservice
+SPRING_DATASOURCE_PASSWORD=CHANGE_ME
+SPRING_LIQUIBASE_ENABLED=false
+SERVER_SERVLET_CONTEXT_PATH=/service
+
+IDENTITY_TECHNICAL_USER_USERNAME=technical
+IDENTITY_TECHNICAL_USER_PASSWORD=CHANGE_ME
+IDENTITY_OPENID_CONNECT_URL=https://auth.oriso-dev.site/realms/online-beratung/protocol/openid-connect
+
+MATRIX_API_URL=https://matrix.oriso-dev.site
+MATRIX_SERVER_NAME=91.99.183.160
+MATRIX_REGISTRATION_SHARED_SECRET=CHANGE_ME
+MATRIX_ADMIN_USERNAME=matrixadm
+MATRIX_ADMIN_PASSWORD=CHANGE_ME
+MATRIX_MIGRATION_ENABLED=true
+MATRIX_PRESENCE_ENABLED=false
+
+MULTITENANCY_ENABLED=true
+FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
+
+# The local service calls AgencyService internal endpoints through the public dev API gateway.
+# The /service/agencies base is required for the matrix-service-account endpoint.
+AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
+CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
+TENANT_SERVICE_API_URL=https://api.oriso-dev.site/service
+
+# Local infrastructure expected by this setup.
+SPRING_REDIS_HOST=localhost
+SPRING_REDIS_PORT=6379
+SPRING_REDIS_PASSWORD=CHANGE_ME
+
+SPRING_RABBITMQ_HOST=localhost
+SPRING_RABBITMQ_PORT=5672
+SPRING_RABBITMQ_USERNAME=admin
+SPRING_RABBITMQ_PASSWORD=CHANGE_ME
+
+REGISTRATION_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
+REGISTRATION_CORS_ALLOWED_PATHS=/**

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -1,0 +1,80 @@
+# Local Development
+
+This setup runs UserService locally on `localhost:8082`, uses the remote ORISO dev database/API
+services where needed, and allows the frontend on `localhost:9001` to call it directly.
+
+## 1. Java
+
+Use Java 17:
+
+```bash
+/usr/libexec/java_home -V
+```
+
+The local run script example auto-detects Java 17 on macOS when `JAVA_HOME` is not already set.
+
+## 2. Create `run-local-remote-db.sh`
+
+Copy the example script:
+
+```bash
+cp run-local-remote-db.sh.example run-local-remote-db.sh
+chmod +x run-local-remote-db.sh
+```
+
+`run-local-remote-db.sh` is ignored by git because it may contain local secrets.
+
+## 3. Create `config.env`
+
+Copy the sample config:
+
+```bash
+cp config.env.example config.env
+```
+
+Fill all `CHANGE_ME` values.
+
+Important values for the mixed local setup:
+
+```env
+SERVER_SERVLET_CONTEXT_PATH=/service
+AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
+REGISTRATION_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
+REGISTRATION_CORS_ALLOWED_PATHS=/**
+```
+
+`AGENCY_SERVICE_API_URL` must include `/service/agencies` for the agency Matrix service-account
+endpoint used while creating an initial enquiry chat room.
+
+## 4. Run
+
+```bash
+./run-local-remote-db.sh
+```
+
+Expected local base URL:
+
+```text
+http://localhost:8082/service
+```
+
+## 5. Useful Checks
+
+Check whether UserService is listening:
+
+```bash
+lsof -nP -iTCP:8082 -sTCP:LISTEN
+```
+
+Stop the service with `Ctrl+C` in the terminal running the app.
+
+## Frontend Pairing
+
+Use the frontend local setup with:
+
+```env
+REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
+```
+
+If that frontend variable is removed or commented, the frontend falls back to the broad remote API
+instead of calling this local UserService.

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -5,17 +5,19 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-export JAVA_HOME="${JAVA_HOME:-/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home}"
+if [ -z "${JAVA_HOME:-}" ]; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+fi
 export PATH="$JAVA_HOME/bin:$PATH"
 
-export SPRING_DATASOURCE_URL="jdbc:mariadb://46.224.170.69:32491/userservice"
-export SPRING_DATASOURCE_USERNAME=root
+export SPRING_DATASOURCE_URL="jdbc:mariadb://46.224.170.69:32492/userservice"
+export SPRING_DATASOURCE_USERNAME=userservice
 export SPRING_DATASOURCE_PASSWORD='CHANGE_ME'
 
-export CONSULTING_TYPE_SERVICE_API_URL="https://api.oriso.org/service"
-export AGENCY_SERVICE_API_URL="https://api.oriso.org/service"
-export TENANT_SERVICE_API_URL="https://api.oriso.org/service"
-export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso.org"
+export CONSULTING_TYPE_SERVICE_API_URL="https://api.oriso-dev.site/service"
+export AGENCY_SERVICE_API_URL="https://api.oriso-dev.site/service/agencies"
+export TENANT_SERVICE_API_URL="https://api.oriso-dev.site/service"
+export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso-dev.site"
 export IDENTITY_TECHNICAL_USER_USERNAME="technical"
 export IDENTITY_TECHNICAL_USER_PASSWORD='CHANGE_ME'
 
@@ -26,5 +28,12 @@ export ROCKET_TECHNICAL_PASSWORD="technical"
 
 export SPRING_DATA_MONGODB_URI="mongodb://localhost:27017/userservice"
 
+if [ -f config.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./config.env
+  set +a
+fi
+
 echo "Datasource: ${SPRING_DATASOURCE_URL}"
-mvn spring-boot:run -Dspring-boot.run.profiles=local -Dspotless.check.skip=true
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local -Dspotless.check.skip=true


### PR DESCRIPTION
## Summary
- add `config.env.example` with placeholders only
- document the local UserService run flow for `localhost:8082`
- update `run-local-remote-db.sh.example` to source `config.env`, use Java 17, and use the dev AgencyService gateway base required by Matrix room creation

## Validation
- documentation/sample-config-only change; no runtime source code changed