### PR TITLE
docs(userservice): document local dev truststore

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -10,8 +10,9 @@ KEYCLOAK_CONFIG_ADMIN_CLIENT_SECRET=CHANGE_ME
 KEYCLOAK_DISABLE_TRUST_MANAGER=true
 KEYCLOAK_ALLOW_ANY_HOSTNAME=true
 
-# Optional if the remote Matrix/Keycloak certificates are not trusted by your local JVM.
-# JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=/Users/Hassan/.oriso/dev-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
+# Optional if the remote dev API, Matrix, or Keycloak certificates are not trusted by your local JVM.
+# Uncomment after creating a local truststore that contains the required dev CA certificate.
+# JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=$HOME/.oriso/dev-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
 
 SPRING_DATASOURCE_USERNAME=userservice
 SPRING_DATASOURCE_PASSWORD=CHANGE_ME

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -49,6 +49,14 @@ REGISTRATION_CORS_ALLOWED_PATHS=/**
 `AGENCY_SERVICE_API_URL` must include `/service/agencies` for the agency Matrix service-account
 endpoint used while creating an initial enquiry chat room.
 
+If login or tenant lookup fails with a Java `PKIX path building failed` /
+`unable to find valid certification path to requested target` error, create/import the dev CA into
+a local truststore and uncomment the `JAVA_TOOL_OPTIONS` line in `config.env`:
+
+```env
+JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=$HOME/.oriso/dev-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
+```
+
 ## 4. Run
 
 ```bash


### PR DESCRIPTION
## Summary\n- make the optional local JVM truststore setting generic in config.env.example\n- document the PKIX login/tenant lookup failure and the JAVA_TOOL_OPTIONS fix in local-development.md\n\n## Verification\n- git diff --check\n- verified local UserService login worked after enabling the truststore in config.env