### PR TITLE
[codex] Document local TenantService pairing

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -43,6 +43,8 @@ FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
 # The /service/agencies base is required for the matrix-service-account endpoint.
 AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
 CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
+# Use the remote dev API by default. If TenantService is running locally, use:
+# TENANT_SERVICE_API_URL=http://localhost:8081/service
 TENANT_SERVICE_API_URL=https://api.oriso-dev.site/service
 
 # Local infrastructure expected by this setup.

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -42,12 +42,22 @@ ROCKET_SYSTEMUSER_ID=rocket-chat-system-user
 ROCKET_SYSTEMUSER_USERNAME=rocket-chat-system-user
 ROCKET_SYSTEMUSER_PASSWORD=CHANGE_ME
 AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
+TENANT_SERVICE_API_URL=https://api.oriso-dev.site/service
 REGISTRATION_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
 REGISTRATION_CORS_ALLOWED_PATHS=/**
 ```
 
 `AGENCY_SERVICE_API_URL` must include `/service/agencies` for the agency Matrix service-account
 endpoint used while creating an initial enquiry chat room.
+
+If TenantService is running locally on `localhost:8081`, override TenantService calls with:
+
+```env
+TENANT_SERVICE_API_URL=http://localhost:8081/service
+```
+
+The `/service` suffix is required because the local TenantService uses
+`SERVER_SERVLET_CONTEXT_PATH=/service`.
 
 If login or tenant lookup fails with a Java `PKIX path building failed` /
 `unable to find valid certification path to requested target` error, create/import the dev CA into
@@ -85,6 +95,8 @@ Use the frontend local setup with:
 
 ```env
 REACT_APP_USER_SERVICE_ORIGIN=http://localhost:8082
+REACT_APP_TENANT_SERVICE_ORIGIN=http://localhost:8081
+REACT_APP_LOCAL_TENANT_ID=1
 ```
 
 If that frontend variable is removed or commented, the frontend falls back to the broad remote API

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -16,6 +16,7 @@ export SPRING_DATASOURCE_PASSWORD='CHANGE_ME'
 
 export CONSULTING_TYPE_SERVICE_API_URL="https://api.oriso-dev.site/service"
 export AGENCY_SERVICE_API_URL="https://api.oriso-dev.site/service/agencies"
+# Use "http://localhost:8081/service" when TenantService is running locally.
 export TENANT_SERVICE_API_URL="https://api.oriso-dev.site/service"
 export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso-dev.site"
 export IDENTITY_TECHNICAL_USER_USERNAME="technical"


### PR DESCRIPTION
## Summary
- Document how UserService should call local TenantService with the `/service` context path.
- Add local TenantService notes to `config.env.example`, `run-local-remote-db.sh.example`, and local development docs.
- Keep all sensitive values as `CHANGE_ME` placeholders.

## Why
When TenantService runs locally with `SERVER_SERVLET_CONTEXT_PATH=/service`, UserService must use `TENANT_SERVICE_API_URL=http://localhost:8081/service`; otherwise generated TenantService client calls miss the context path.

## Safety
- Documentation and sample config only.
- Default sample continues to use the remote dev API unless the local TenantService override is explicitly selected.

## Validation
- Diff reviewed; docs/example-only change.
