### PR TITLE
[codex] Fix local AgencyService base URL docs

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -41,7 +41,7 @@ FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
 
 # The local service calls AgencyService internal endpoints through the public dev API gateway.
 # Base path for the generated AgencyService client. The client appends /agencies,
-# /agencies/{ids}, and /internal/agencies/{id}/matrix-service-account itself.
+# /agencies/{agencyIds}, and /internal/agencies/{id}/matrix-service-account itself.
 AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service
 CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
 # Use the remote dev API by default. If TenantService is running locally, use:

--- a/config.env.example
+++ b/config.env.example
@@ -40,8 +40,9 @@ MULTITENANCY_ENABLED=true
 FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
 
 # The local service calls AgencyService internal endpoints through the public dev API gateway.
-# The /service/agencies base is required for the matrix-service-account endpoint.
-AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
+# Base path for the generated AgencyService client. The client appends /agencies,
+# /agencies/{ids}, and /internal/agencies/{id}/matrix-service-account itself.
+AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service
 CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
 # Use the remote dev API by default. If TenantService is running locally, use:
 # TENANT_SERVICE_API_URL=http://localhost:8081/service

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -48,7 +48,7 @@ REGISTRATION_CORS_ALLOWED_PATHS=/**
 ```
 
 `AGENCY_SERVICE_API_URL` must point at the AgencyService base path. The generated client appends
-`/agencies`, `/agencies/{ids}`, and `/internal/agencies/{id}/matrix-service-account` itself.
+`/agencies`, `/agencies/{agencyIds}`, and `/internal/agencies/{id}/matrix-service-account` itself.
 
 If TenantService is running locally on `localhost:8081`, override TenantService calls with:
 

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -41,14 +41,14 @@ SERVER_SERVLET_CONTEXT_PATH=/service
 ROCKET_SYSTEMUSER_ID=rocket-chat-system-user
 ROCKET_SYSTEMUSER_USERNAME=rocket-chat-system-user
 ROCKET_SYSTEMUSER_PASSWORD=CHANGE_ME
-AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service/agencies
+AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service
 TENANT_SERVICE_API_URL=https://api.oriso-dev.site/service
 REGISTRATION_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
 REGISTRATION_CORS_ALLOWED_PATHS=/**
 ```
 
-`AGENCY_SERVICE_API_URL` must include `/service/agencies` for the agency Matrix service-account
-endpoint used while creating an initial enquiry chat room.
+`AGENCY_SERVICE_API_URL` must point at the AgencyService base path. The generated client appends
+`/agencies`, `/agencies/{ids}`, and `/internal/agencies/{id}/matrix-service-account` itself.
 
 If TenantService is running locally on `localhost:8081`, override TenantService calls with:
 

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -15,7 +15,7 @@ export SPRING_DATASOURCE_USERNAME=userservice
 export SPRING_DATASOURCE_PASSWORD='CHANGE_ME'
 
 export CONSULTING_TYPE_SERVICE_API_URL="https://api.oriso-dev.site/service"
-export AGENCY_SERVICE_API_URL="https://api.oriso-dev.site/service/agencies"
+export AGENCY_SERVICE_API_URL="https://api.oriso-dev.site/service"
 # Use "http://localhost:8081/service" when TenantService is running locally.
 export TENANT_SERVICE_API_URL="https://api.oriso-dev.site/service"
 export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso-dev.site"


### PR DESCRIPTION
## What changed

- Corrected local UserService examples so `AGENCY_SERVICE_API_URL` points to the AgencyService base path, `https://api.oriso-dev.site/service`.
- Updated local development docs to explain that the generated AgencyService client appends `/agencies`, `/agencies/{ids}`, and `/internal/agencies/{id}/matrix-service-account` itself.

## Why

Using `.../service/agencies` as the base path causes generated client calls such as agency-admin enrichment to resolve as `.../service/agencies/agencies/{ids}`. That broke local Admin agency-admin loading while testing Admin against local UserService.

## Validation

- Ran local Admin with local UserService on `localhost:8082`.
- Verified `http://localhost:9000/admin/users/agency-admins` renders `23 agency admins` after setting UserService `AGENCY_SERVICE_API_URL=http://localhost:8084/service` or `https://api.oriso-dev.site/service`.
- No unit tests run because this PR only changes docs/example env files.
