### PR TITLE
refactor: extract user session controller delegate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static de.caritas.cob.userservice.api.model.NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE;
-import static java.util.Collections.singletonList;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -53,8 +52,6 @@ import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
 import de.caritas.cob.userservice.api.admin.facade.AdminUserFacade;
 import de.caritas.cob.userservice.api.admin.service.consultant.update.ConsultantUpdateService;
 import de.caritas.cob.userservice.api.config.VideoChatConfig;
-import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
-import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
@@ -63,8 +60,6 @@ import de.caritas.cob.userservice.api.facade.CreateNewSessionFacade;
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
-import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
-import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
 import de.caritas.cob.userservice.api.facade.userdata.AskerDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
@@ -74,7 +69,6 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
-import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
@@ -88,12 +82,10 @@ import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.DecryptionService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.SessionDataService;
-import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
 import de.caritas.cob.userservice.api.service.helper.EmailUrlDecoder;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
-import de.caritas.cob.userservice.api.service.session.SessionFilter;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -142,17 +134,15 @@ public class UserController implements UsersApi {
   private final @NotNull ConsultantImportService consultantImportService;
   private final @NotNull EmailNotificationFacade emailNotificationFacade;
   private final @NotNull AskerImportService askerImportService;
-  private final @NotNull SessionListFacade sessionListFacade;
   private final @NotNull ConsultantAgencyService consultantAgencyService;
-  private final @NotNull AssignSessionFacade assignSessionFacade;
   private final @NotNull AssignEnquiryFacade assignEnquiryFacade;
   private final @NotNull DecryptionService decryptionService;
   private final @NotNull UserChatControllerDelegate userChatControllerDelegate;
+  private final @NotNull UserSessionControllerDelegate userSessionControllerDelegate;
   private final @NotNull CreateUserFacade createUserFacade;
   private final @NotNull CreateNewSessionFacade createNewSessionFacade;
   private final @NotNull ConsultantDataFacade consultantDataFacade;
   private final @NotNull SessionDataService sessionDataService;
-  private final @NotNull SessionArchiveService sessionArchiveService;
   private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
@@ -289,10 +279,10 @@ public class UserController implements UsersApi {
         RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
 
     /* Additional enquiries from the profile page go through the normal
-    enquiry pipeline — the consultant is NOT pre-assigned here. The asker
+    enquiry pipeline - the consultant is NOT pre-assigned here. The asker
     lands on the "write first message" screen, the enquiry sits in the
     agency queue, and a consultant picks it up. Direct-chat with a
-    specific consultant is a separate flow (QR code / ?cid=… link).
+    specific consultant is a separate flow (QR code / ?cid=... link).
     The empty constraint list keeps this endpoint permissive so existing
     askers can raise new enquiries even when they already had a past
     session for the same topic+agency. */
@@ -375,25 +365,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<UserSessionListResponseDTO> getSessionsForAuthenticatedUser(
       @RequestHeader(required = false) String rcToken) {
-
-    var user = this.userAccountProvider.retrieveValidatedUser();
-
-    // Use dummy RocketChat credentials if no token provided
-    String token = rcToken != null ? rcToken : "dummy-rc-token";
-    String rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
-
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatUserId(rcUserId).rocketChatToken(token).build();
-
-    var userSessionsDTO =
-        sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(
-            user.getUserId(), rocketChatCredentials);
-
-    consultantDataFacade.addConsultantDisplayNameToSessionList(userSessionsDTO);
-
-    return isNotEmpty(userSessionsDTO.getSessions())
-        ? new ResponseEntity<>(userSessionsDTO, HttpStatus.OK)
-        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    return userSessionControllerDelegate.getSessionsForAuthenticatedUser(rcToken);
   }
 
   /**
@@ -405,30 +377,9 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<GroupSessionListResponseDTO> getSessionsForGroupIds(
-      @RequestParam List<String> rcGroupIds, @RequestHeader(required = false) String rcToken) {
-    GroupSessionListResponseDTO groupSessionList;
-    if (authenticatedUser.isConsultant()) {
-      var consultant = userAccountProvider.retrieveValidatedConsultant();
-      groupSessionList =
-          sessionListFacade.retrieveSessionsForAuthenticatedConsultantByGroupIds(
-              consultant, rcGroupIds, authenticatedUser.getRoles());
-    } else {
-      var user = userAccountProvider.retrieveValidatedUser();
-      var rocketChatCredentials =
-          RocketChatCredentials.builder()
-              .rocketChatUserId(user.getRcUserId())
-              .rocketChatToken(rcToken != null ? rcToken : "")
-              .build();
-      groupSessionList =
-          sessionListFacade.retrieveSessionsForAuthenticatedUserByGroupIds(
-              user.getUserId(), rcGroupIds, rocketChatCredentials, authenticatedUser.getRoles());
-    }
-
-    consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
-
-    return isNotEmpty(groupSessionList.getSessions())
-        ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
-        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      @NotNull @RequestParam List<String> rcGroupIds,
+      @RequestHeader(required = false) String rcToken) {
+    return userSessionControllerDelegate.getSessionsForGroupIds(rcGroupIds, rcToken);
   }
 
   // MATRIX MIGRATION: Added manual mapping since generated interface hasn't updated yet
@@ -439,124 +390,13 @@ public class UserController implements UsersApi {
   public ResponseEntity<GroupSessionListResponseDTO> getSessionForId(
       @PathVariable Long sessionId,
       @RequestHeader(value = "RCToken", required = false) String rcToken) {
-    log.info(
-        "🔍 GET /users/sessions/room/{} - sessionId: {}, rcToken: {}",
-        sessionId,
-        sessionId,
-        rcToken != null ? "present" : "null");
-
-    try {
-      GroupSessionListResponseDTO groupSessionList;
-      if (authenticatedUser.isConsultant()) {
-        var consultant = userAccountProvider.retrieveValidatedConsultant();
-        log.info("🔍 User is CONSULTANT: {}, id: {}", consultant.getUsername(), consultant.getId());
-
-        // MATRIX MIGRATION: Try to find as session first, then as chat
-        log.info("🔍 Step 1: Trying to find as SESSION with ID: {}", sessionId);
-        groupSessionList =
-            sessionListFacade.retrieveSessionsForAuthenticatedConsultantBySessionIds(
-                consultant, singletonList(sessionId), authenticatedUser.getRoles());
-
-        log.info(
-            "🔍 Step 1 result: {} sessions found",
-            groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
-
-        // If no session found, try to find as a chat (group chat)
-        if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
-          log.info("🔍 Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
-          String token = rcToken != null ? rcToken : "dummy-rc-token";
-          var rocketChatCredentials =
-              RocketChatCredentials.builder()
-                  .rocketChatUserId(consultant.getRocketChatId())
-                  .rocketChatToken(token)
-                  .build();
-          groupSessionList =
-              sessionListFacade.retrieveChatsForConsultantByChatIds(
-                  consultant, singletonList(sessionId), rocketChatCredentials);
-
-          log.info(
-              "🔍 Step 2 result: {} chats found",
-              groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
-        }
-      } else {
-        var user = userAccountProvider.retrieveValidatedUser();
-        log.info("🔍 User is USER/ASKER: {}, id: {}", user.getUsername(), user.getUserId());
-
-        // MATRIX MIGRATION: Use dummy RocketChat credentials if no token provided
-        String token = rcToken != null ? rcToken : "dummy-rc-token";
-        String rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
-        var rocketChatCredentials =
-            RocketChatCredentials.builder()
-                .rocketChatUserId(rcUserId)
-                .rocketChatToken(token)
-                .build();
-
-        log.info("🔍 Step 1: Trying to find as SESSION with ID: {}", sessionId);
-        groupSessionList =
-            sessionListFacade.retrieveSessionsForAuthenticatedUserBySessionIds(
-                user.getUserId(),
-                singletonList(sessionId),
-                rocketChatCredentials,
-                authenticatedUser.getRoles());
-
-        log.info(
-            "🔍 Step 1 result: {} sessions found",
-            groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
-
-        // If no session found, try to find as a chat (group chat)
-        if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
-          log.info("🔍 Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
-          groupSessionList =
-              sessionListFacade.retrieveChatsForUserByChatIds(
-                  singletonList(sessionId), rocketChatCredentials);
-
-          log.info(
-              "🔍 Step 2 result: {} chats found",
-              groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
-        }
-      }
-
-      consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
-
-      return isNotEmpty(groupSessionList.getSessions())
-          ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
-          : new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    } catch (Exception e) {
-      log.error("Failed to load session room {}: {}", sessionId, e.getMessage(), e);
-      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    }
+    return userSessionControllerDelegate.getSessionForId(sessionId, rcToken);
   }
 
   @Override
-  public ResponseEntity<GroupSessionListResponseDTO> getChatById(String rcToken, Long chatId) {
-    GroupSessionListResponseDTO groupSessionList;
-    if (authenticatedUser.isConsultant()) {
-      var consultant = userAccountProvider.retrieveValidatedConsultant();
-      var rocketChatCredentials =
-          RocketChatCredentials.builder()
-              .rocketChatUserId(consultant.getRocketChatId())
-              .rocketChatToken(rcToken)
-              .build();
-      groupSessionList =
-          sessionListFacade.retrieveChatsForConsultantByChatIds(
-              consultant, singletonList(chatId), rocketChatCredentials);
-    } else {
-      var user = userAccountProvider.retrieveValidatedUser();
-      var rocketChatCredentials =
-          RocketChatCredentials.builder()
-              .rocketChatUserId(user.getRcUserId())
-              .rocketChatToken(rcToken)
-              .build();
-      groupSessionList =
-          sessionListFacade.retrieveChatsForUserByChatIds(
-              singletonList(chatId), rocketChatCredentials);
-    }
-
-    consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
-
-    return isNotEmpty(groupSessionList.getSessions())
-        ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
-        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  public ResponseEntity<GroupSessionListResponseDTO> getChatById(
+      @NotNull String rcToken, @NotNull Long chatId) {
+    return userSessionControllerDelegate.getChatById(rcToken, chatId);
   }
 
   /**
@@ -787,30 +627,8 @@ public class UserController implements UsersApi {
       Integer count,
       @RequestParam String filter,
       @RequestParam Integer status) {
-
-    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
-
-    ConsultantSessionListResponseDTO consultantSessionListResponseDTO = null;
-    var optionalSessionFilter = SessionFilter.getByValue(filter);
-    if (optionalSessionFilter.isPresent()) {
-
-      var sessionListQueryParameter =
-          SessionListQueryParameter.builder()
-              .sessionStatus(status)
-              .count(count)
-              .offset(offset)
-              .sessionFilter(optionalSessionFilter.get())
-              .build();
-
-      consultantSessionListResponseDTO =
-          sessionListFacade.retrieveSessionsDtoForAuthenticatedConsultant(
-              consultant, sessionListQueryParameter);
-    }
-
-    return nonNull(consultantSessionListResponseDTO)
-            && isNotEmpty(consultantSessionListResponseDTO.getSessions())
-        ? new ResponseEntity<>(consultantSessionListResponseDTO, HttpStatus.OK)
-        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    return userSessionControllerDelegate.getSessionsForAuthenticatedConsultant(
+        rcToken, offset, count, filter, status);
   }
 
   /**
@@ -824,29 +642,12 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionListResponseDTO> getTeamSessionsForAuthenticatedConsultant(
-      String rcToken, Integer offset, Integer count, String filter) {
-
-    var consultant = this.userAccountProvider.retrieveValidatedTeamConsultant();
-
-    ConsultantSessionListResponseDTO teamSessionListDTO = null;
-    var optionalSessionFilter = SessionFilter.getByValue(filter);
-    if (optionalSessionFilter.isPresent()) {
-
-      var sessionListQueryParameter =
-          SessionListQueryParameter.builder()
-              .count(count)
-              .offset(offset)
-              .sessionFilter(optionalSessionFilter.get())
-              .build();
-
-      teamSessionListDTO =
-          sessionListFacade.retrieveTeamSessionsDtoForAuthenticatedConsultant(
-              consultant, rcToken, sessionListQueryParameter);
-    }
-
-    return nonNull(teamSessionListDTO) && isNotEmpty(teamSessionListDTO.getSessions())
-        ? new ResponseEntity<>(teamSessionListDTO, HttpStatus.OK)
-        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      @NotNull @RequestHeader String rcToken,
+      @NotNull @Min(value = 0) Integer offset,
+      @NotNull @Min(value = 1) Integer count,
+      @NotNull @RequestParam String filter) {
+    return userSessionControllerDelegate.getTeamSessionsForAuthenticatedConsultant(
+        rcToken, offset, count, filter);
   }
 
   /**
@@ -1016,59 +817,14 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> assignSession(
-      @PathVariable Long sessionId, @PathVariable String consultantId) {
-
-    var session = sessionService.getSession(sessionId);
-    if (session.isEmpty()) {
-      log.error("Internal Server Error: Session with id {} not found.", sessionId);
-
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    var userId = authenticatedUser.getUserId();
-    // Check if the calling consultant has the correct right to assign the enquiry to a consultant
-    if (session.get().getStatus().equals(SessionStatus.NEW)
-        && !authenticatedUser
-            .getGrantedAuthorities()
-            .contains(AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY)) {
-      LogService.logForbidden(
-          String.format(
-              "The calling consultant with id %s does not have the authority to assign the enquiry to a consultant.",
-              userId));
-
-      return new ResponseEntity<>(HttpStatus.FORBIDDEN);
-    }
-
-    var consultantToAssign = userAccountProvider.retrieveValidatedConsultantById(consultantId);
-    var consultantToKeep = consultantService.getConsultant(userId).orElse(null);
-    assignSessionFacade.assignSession(session.get(), consultantToAssign, consultantToKeep);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+      @NotNull @PathVariable Long sessionId, @NotNull @PathVariable String consultantId) {
+    return userSessionControllerDelegate.assignSession(sessionId, consultantId);
   }
 
   @Override
-  public ResponseEntity<Void> removeFromSession(Long sessionId, UUID consultantId) {
-    var consultantMap =
-        accountManager
-            .findConsultant(consultantId.toString())
-            .orElseThrow(
-                () -> new NotFoundException("Consultant (%s) not found", consultantId.toString()));
-
-    var sessionMap =
-        messenger
-            .findSession(sessionId)
-            .orElseThrow(() -> new NotFoundException("Session (%s) not found", sessionId));
-
-    var chatId = consultantDtoMapper.chatIdOf(sessionMap);
-    var chatUserId = userDtoMapper.chatUserIdOf(consultantMap);
-    if (!messenger.removeUserFromSession(chatUserId, chatId)) {
-      var message =
-          String.format(
-              "Could not remove consultant (%s) from session (%s)", consultantId, sessionId);
-      throw new InternalServerErrorException(message);
-    }
-
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<Void> removeFromSession(
+      @NotNull Long sessionId, @NotNull UUID consultantId) {
+    return userSessionControllerDelegate.removeFromSession(sessionId, consultantId);
   }
 
   /**
@@ -1283,11 +1039,8 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionDTO> fetchSessionForConsultant(
-      @PathVariable Long sessionId) {
-
-    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
-    var consultantSessionDTO = sessionService.fetchSessionForConsultant(sessionId, consultant);
-    return new ResponseEntity<>(consultantSessionDTO, HttpStatus.OK);
+      @NotNull @PathVariable Long sessionId) {
+    return userSessionControllerDelegate.fetchSessionForConsultant(sessionId);
   }
 
   /**
@@ -1383,9 +1136,8 @@ public class UserController implements UsersApi {
    * @return {@link ResponseEntity}
    */
   @Override
-  public ResponseEntity<Void> archiveSession(@PathVariable Long sessionId) {
-    this.sessionArchiveService.archiveSession(sessionId);
-    return new ResponseEntity<>(HttpStatus.OK);
+  public ResponseEntity<Void> archiveSession(@NotNull @PathVariable Long sessionId) {
+    return userSessionControllerDelegate.archiveSession(sessionId);
   }
 
   /**
@@ -1395,9 +1147,8 @@ public class UserController implements UsersApi {
    * @return {@link ResponseEntity}
    */
   @Override
-  public ResponseEntity<Void> dearchiveSession(@PathVariable Long sessionId) {
-    this.sessionArchiveService.dearchiveSession(sessionId);
-    return new ResponseEntity<>(HttpStatus.OK);
+  public ResponseEntity<Void> dearchiveSession(@NotNull @PathVariable Long sessionId) {
+    return userSessionControllerDelegate.dearchiveSession(sessionId);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -92,6 +92,7 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UsersApi;
 import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.InternalServerErrorException;
 import java.net.URLDecoder;
@@ -364,7 +365,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<UserSessionListResponseDTO> getSessionsForAuthenticatedUser(
-      @RequestHeader(required = false) String rcToken) {
+      @RequestHeader String rcToken) {
     return userSessionControllerDelegate.getSessionsForAuthenticatedUser(rcToken);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -1,0 +1,346 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
+import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
+import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
+import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.LogService;
+import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
+import de.caritas.cob.userservice.api.service.session.SessionFilter;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.util.List;
+import java.util.UUID;
+import javax.ws.rs.InternalServerErrorException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class UserSessionControllerDelegate {
+
+  private final @NonNull UserAccountService userAccountProvider;
+  private final @NonNull SessionService sessionService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull SessionListFacade sessionListFacade;
+  private final @NonNull AssignSessionFacade assignSessionFacade;
+  private final @NonNull ConsultantDataFacade consultantDataFacade;
+  private final @NonNull SessionArchiveService sessionArchiveService;
+  private final @NonNull AccountManaging accountManager;
+  private final @NonNull Messaging messenger;
+  private final @NonNull ConsultantDtoMapper consultantDtoMapper;
+  private final @NonNull UserDtoMapper userDtoMapper;
+  private final @NonNull ConsultantService consultantService;
+
+  ResponseEntity<UserSessionListResponseDTO> getSessionsForAuthenticatedUser(String rcToken) {
+    var user = this.userAccountProvider.retrieveValidatedUser();
+
+    var token = rcToken != null ? rcToken : "dummy-rc-token";
+    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
+
+    var rocketChatCredentials =
+        RocketChatCredentials.builder().rocketChatUserId(rcUserId).rocketChatToken(token).build();
+
+    var userSessionsDTO =
+        sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(
+            user.getUserId(), rocketChatCredentials);
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(userSessionsDTO);
+
+    return isNotEmpty(userSessionsDTO.getSessions())
+        ? new ResponseEntity<>(userSessionsDTO, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  ResponseEntity<GroupSessionListResponseDTO> getSessionsForGroupIds(
+      List<String> rcGroupIds, String rcToken) {
+    GroupSessionListResponseDTO groupSessionList;
+    if (authenticatedUser.isConsultant()) {
+      var consultant = userAccountProvider.retrieveValidatedConsultant();
+      groupSessionList =
+          sessionListFacade.retrieveSessionsForAuthenticatedConsultantByGroupIds(
+              consultant, rcGroupIds, authenticatedUser.getRoles());
+    } else {
+      var user = userAccountProvider.retrieveValidatedUser();
+      var rocketChatCredentials =
+          RocketChatCredentials.builder()
+              .rocketChatUserId(user.getRcUserId())
+              .rocketChatToken(rcToken != null ? rcToken : "")
+              .build();
+      groupSessionList =
+          sessionListFacade.retrieveSessionsForAuthenticatedUserByGroupIds(
+              user.getUserId(), rcGroupIds, rocketChatCredentials, authenticatedUser.getRoles());
+    }
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
+
+    return isNotEmpty(groupSessionList.getSessions())
+        ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  ResponseEntity<GroupSessionListResponseDTO> getSessionForId(Long sessionId, String rcToken) {
+    log.info(
+        "GET /users/sessions/room/{} - sessionId: {}, rcToken: {}",
+        sessionId,
+        sessionId,
+        rcToken != null ? "present" : "null");
+
+    try {
+      GroupSessionListResponseDTO groupSessionList;
+      if (authenticatedUser.isConsultant()) {
+        groupSessionList = getSessionOrChatForConsultant(sessionId, rcToken);
+      } else {
+        groupSessionList = getSessionOrChatForUser(sessionId, rcToken);
+      }
+
+      consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
+
+      return isNotEmpty(groupSessionList.getSessions())
+          ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
+          : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    } catch (Exception e) {
+      log.error("Failed to load session room {}: {}", sessionId, e.getMessage(), e);
+      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+  }
+
+  ResponseEntity<GroupSessionListResponseDTO> getChatById(String rcToken, Long chatId) {
+    GroupSessionListResponseDTO groupSessionList;
+    if (authenticatedUser.isConsultant()) {
+      var consultant = userAccountProvider.retrieveValidatedConsultant();
+      var rocketChatCredentials =
+          RocketChatCredentials.builder()
+              .rocketChatUserId(consultant.getRocketChatId())
+              .rocketChatToken(rcToken)
+              .build();
+      groupSessionList =
+          sessionListFacade.retrieveChatsForConsultantByChatIds(
+              consultant, singletonList(chatId), rocketChatCredentials);
+    } else {
+      var user = userAccountProvider.retrieveValidatedUser();
+      var rocketChatCredentials =
+          RocketChatCredentials.builder()
+              .rocketChatUserId(user.getRcUserId())
+              .rocketChatToken(rcToken)
+              .build();
+      groupSessionList =
+          sessionListFacade.retrieveChatsForUserByChatIds(
+              singletonList(chatId), rocketChatCredentials);
+    }
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
+
+    return isNotEmpty(groupSessionList.getSessions())
+        ? new ResponseEntity<>(groupSessionList, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  ResponseEntity<ConsultantSessionListResponseDTO> getSessionsForAuthenticatedConsultant(
+      String rcToken, Integer offset, Integer count, String filter, Integer status) {
+    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
+
+    ConsultantSessionListResponseDTO consultantSessionListResponseDTO = null;
+    var optionalSessionFilter = SessionFilter.getByValue(filter);
+    if (optionalSessionFilter.isPresent()) {
+      var sessionListQueryParameter =
+          SessionListQueryParameter.builder()
+              .sessionStatus(status)
+              .count(count)
+              .offset(offset)
+              .sessionFilter(optionalSessionFilter.get())
+              .build();
+
+      consultantSessionListResponseDTO =
+          sessionListFacade.retrieveSessionsDtoForAuthenticatedConsultant(
+              consultant, sessionListQueryParameter);
+    }
+
+    return nonNull(consultantSessionListResponseDTO)
+            && isNotEmpty(consultantSessionListResponseDTO.getSessions())
+        ? new ResponseEntity<>(consultantSessionListResponseDTO, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  ResponseEntity<ConsultantSessionListResponseDTO> getTeamSessionsForAuthenticatedConsultant(
+      String rcToken, Integer offset, Integer count, String filter) {
+    var consultant = this.userAccountProvider.retrieveValidatedTeamConsultant();
+
+    ConsultantSessionListResponseDTO teamSessionListDTO = null;
+    var optionalSessionFilter = SessionFilter.getByValue(filter);
+    if (optionalSessionFilter.isPresent()) {
+      var sessionListQueryParameter =
+          SessionListQueryParameter.builder()
+              .count(count)
+              .offset(offset)
+              .sessionFilter(optionalSessionFilter.get())
+              .build();
+
+      teamSessionListDTO =
+          sessionListFacade.retrieveTeamSessionsDtoForAuthenticatedConsultant(
+              consultant, rcToken, sessionListQueryParameter);
+    }
+
+    return nonNull(teamSessionListDTO) && isNotEmpty(teamSessionListDTO.getSessions())
+        ? new ResponseEntity<>(teamSessionListDTO, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  ResponseEntity<Void> assignSession(Long sessionId, String consultantId) {
+    var session = sessionService.getSession(sessionId);
+    if (session.isEmpty()) {
+      log.error("Internal Server Error: Session with id {} not found.", sessionId);
+
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    var userId = authenticatedUser.getUserId();
+    if (session.get().getStatus().equals(SessionStatus.NEW)
+        && !authenticatedUser
+            .getGrantedAuthorities()
+            .contains(AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY)) {
+      LogService.logForbidden(
+          String.format(
+              "The calling consultant with id %s does not have the authority to assign the enquiry to a consultant.",
+              userId));
+
+      return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+    }
+
+    var consultantToAssign = userAccountProvider.retrieveValidatedConsultantById(consultantId);
+    var consultantToKeep = consultantService.getConsultant(userId).orElse(null);
+    assignSessionFacade.assignSession(session.get(), consultantToAssign, consultantToKeep);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> removeFromSession(Long sessionId, UUID consultantId) {
+    var consultantMap =
+        accountManager
+            .findConsultant(consultantId.toString())
+            .orElseThrow(
+                () -> new NotFoundException("Consultant (%s) not found", consultantId.toString()));
+
+    var sessionMap =
+        messenger
+            .findSession(sessionId)
+            .orElseThrow(() -> new NotFoundException("Session (%s) not found", sessionId));
+
+    var chatId = consultantDtoMapper.chatIdOf(sessionMap);
+    var chatUserId = userDtoMapper.chatUserIdOf(consultantMap);
+    if (!messenger.removeUserFromSession(chatUserId, chatId)) {
+      var message =
+          String.format(
+              "Could not remove consultant (%s) from session (%s)", consultantId, sessionId);
+      throw new InternalServerErrorException(message);
+    }
+
+    return ResponseEntity.noContent().build();
+  }
+
+  ResponseEntity<ConsultantSessionDTO> fetchSessionForConsultant(Long sessionId) {
+    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
+    var consultantSessionDTO = sessionService.fetchSessionForConsultant(sessionId, consultant);
+    return new ResponseEntity<>(consultantSessionDTO, HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> archiveSession(Long sessionId) {
+    this.sessionArchiveService.archiveSession(sessionId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> dearchiveSession(Long sessionId) {
+    this.sessionArchiveService.dearchiveSession(sessionId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  private GroupSessionListResponseDTO getSessionOrChatForConsultant(
+      Long sessionId, String rcToken) {
+    var consultant = userAccountProvider.retrieveValidatedConsultant();
+    log.info("User is CONSULTANT: {}, id: {}", consultant.getUsername(), consultant.getId());
+
+    log.info("Step 1: Trying to find as SESSION with ID: {}", sessionId);
+    var groupSessionList =
+        sessionListFacade.retrieveSessionsForAuthenticatedConsultantBySessionIds(
+            consultant, singletonList(sessionId), authenticatedUser.getRoles());
+
+    log.info(
+        "Step 1 result: {} sessions found",
+        groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
+
+    if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
+      log.info("Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
+      var token = rcToken != null ? rcToken : "dummy-rc-token";
+      var rocketChatCredentials =
+          RocketChatCredentials.builder()
+              .rocketChatUserId(consultant.getRocketChatId())
+              .rocketChatToken(token)
+              .build();
+      groupSessionList =
+          sessionListFacade.retrieveChatsForConsultantByChatIds(
+              consultant, singletonList(sessionId), rocketChatCredentials);
+
+      log.info(
+          "Step 2 result: {} chats found",
+          groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
+    }
+    return groupSessionList;
+  }
+
+  private GroupSessionListResponseDTO getSessionOrChatForUser(Long sessionId, String rcToken) {
+    var user = userAccountProvider.retrieveValidatedUser();
+    log.info("User is USER/ASKER: {}, id: {}", user.getUsername(), user.getUserId());
+
+    var token = rcToken != null ? rcToken : "dummy-rc-token";
+    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
+    var rocketChatCredentials =
+        RocketChatCredentials.builder().rocketChatUserId(rcUserId).rocketChatToken(token).build();
+
+    log.info("Step 1: Trying to find as SESSION with ID: {}", sessionId);
+    var groupSessionList =
+        sessionListFacade.retrieveSessionsForAuthenticatedUserBySessionIds(
+            user.getUserId(),
+            singletonList(sessionId),
+            rocketChatCredentials,
+            authenticatedUser.getRoles());
+
+    log.info(
+        "Step 1 result: {} sessions found",
+        groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
+
+    if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
+      log.info("Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
+      groupSessionList =
+          sessionListFacade.retrieveChatsForUserByChatIds(
+              singletonList(sessionId), rocketChatCredentials);
+
+      log.info(
+          "Step 2 result: {} chats found",
+          groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
+    }
+    return groupSessionList;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -42,6 +43,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class UserSessionControllerDelegate {
 
+  private static final String DUMMY_ROCKET_CHAT_TOKEN = "dummy-rc-token";
+  private static final String DUMMY_ROCKET_CHAT_USER_ID = "dummy-rc-user";
+
   private final @NonNull UserAccountService userAccountProvider;
   private final @NonNull SessionService sessionService;
   private final @NonNull AuthenticatedUser authenticatedUser;
@@ -57,12 +61,7 @@ class UserSessionControllerDelegate {
 
   ResponseEntity<UserSessionListResponseDTO> getSessionsForAuthenticatedUser(String rcToken) {
     var user = this.userAccountProvider.retrieveValidatedUser();
-
-    var token = rcToken != null ? rcToken : "dummy-rc-token";
-    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
-
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatUserId(rcUserId).rocketChatToken(token).build();
+    var rocketChatCredentials = buildUserRocketChatCredentials(user, rcToken);
 
     var userSessionsDTO =
         sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(
@@ -85,11 +84,7 @@ class UserSessionControllerDelegate {
               consultant, rcGroupIds, authenticatedUser.getRoles());
     } else {
       var user = userAccountProvider.retrieveValidatedUser();
-      var rocketChatCredentials =
-          RocketChatCredentials.builder()
-              .rocketChatUserId(user.getRcUserId())
-              .rocketChatToken(rcToken != null ? rcToken : "")
-              .build();
+      var rocketChatCredentials = buildUserRocketChatCredentials(user, rcToken);
       groupSessionList =
           sessionListFacade.retrieveSessionsForAuthenticatedUserByGroupIds(
               user.getUserId(), rcGroupIds, rocketChatCredentials, authenticatedUser.getRoles());
@@ -142,11 +137,7 @@ class UserSessionControllerDelegate {
               consultant, singletonList(chatId), rocketChatCredentials);
     } else {
       var user = userAccountProvider.retrieveValidatedUser();
-      var rocketChatCredentials =
-          RocketChatCredentials.builder()
-              .rocketChatUserId(user.getRcUserId())
-              .rocketChatToken(rcToken)
-              .build();
+      var rocketChatCredentials = buildUserRocketChatCredentials(user, rcToken);
       groupSessionList =
           sessionListFacade.retrieveChatsForUserByChatIds(
               singletonList(chatId), rocketChatCredentials);
@@ -314,10 +305,7 @@ class UserSessionControllerDelegate {
     var user = userAccountProvider.retrieveValidatedUser();
     log.info("User is USER/ASKER: {}, id: {}", user.getUsername(), user.getUserId());
 
-    var token = rcToken != null ? rcToken : "dummy-rc-token";
-    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : "dummy-rc-user";
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatUserId(rcUserId).rocketChatToken(token).build();
+    var rocketChatCredentials = buildUserRocketChatCredentials(user, rcToken);
 
     log.info("Step 1: Trying to find as SESSION with ID: {}", sessionId);
     var groupSessionList =
@@ -342,5 +330,14 @@ class UserSessionControllerDelegate {
           groupSessionList.getSessions() != null ? groupSessionList.getSessions().size() : 0);
     }
     return groupSessionList;
+  }
+
+  private RocketChatCredentials buildUserRocketChatCredentials(User user, String rcToken) {
+    var token = rcToken != null ? rcToken : DUMMY_ROCKET_CHAT_TOKEN;
+    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : DUMMY_ROCKET_CHAT_USER_ID;
+    return RocketChatCredentials.builder()
+        .rocketChatUserId(rcUserId)
+        .rocketChatToken(token)
+        .build();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -64,7 +64,6 @@ import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.servlet.http.Cookie;
 import java.util.*;
-import lombok.val;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.service.spi.ServiceException;
@@ -367,10 +366,6 @@ class UserControllerIT {
   @SuppressWarnings("unused")
   private EventNotificationService eventNotificationService;
 
-  @MockitoBean
-  @SuppressWarnings("unused")
-  private UsernameTranscoder usernameTranscoder;
-
   @BeforeEach
   void setUp() {
     when(usernameTranscoder.encodeUsername(anyString())).thenAnswer(inv -> inv.getArgument(0));
@@ -380,7 +375,7 @@ class UserControllerIT {
   @Test
   void userExists_Should_Return404_When_UserDoesNotExist() throws Exception {
     /* given */
-    val username = "john@doe.com";
+    var username = "john@doe.com";
     when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
     /* when */
     mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
@@ -391,7 +386,7 @@ class UserControllerIT {
   @Test
   void userExists_Should_Return200_When_UserDoesExist() throws Exception {
     /* given */
-    val username = "john@doe.com";
+    var username = "john@doe.com";
     when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
 
     /* when */
@@ -403,7 +398,7 @@ class UserControllerIT {
   @Test
   void usernameAvailability_Should_ReturnNoContent_When_UserDoesNotExist() throws Exception {
     /* given */
-    val username = "john@doe.com";
+    var username = "john@doe.com";
     when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
 
     /* when */
@@ -415,7 +410,7 @@ class UserControllerIT {
   @Test
   void usernameAvailability_Should_ReturnConflict_When_UserDoesExist() throws Exception {
     /* given */
-    val username = "john@doe.com";
+    var username = "john@doe.com";
     when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
 
     /* when */

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -92,6 +92,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 @Import({
   UserChatControllerDelegate.class,
+  UserSessionControllerDelegate.class,
   ApiResponseEntityExceptionHandler.class,
   EncodeUsernameJsonDeserializer.class,
   UrlDecodePasswordJsonDeserializer.class,
@@ -273,6 +274,7 @@ class UserControllerIT {
   @MockitoBean private DecryptionService encryptionService;
   @MockitoBean private ConsultingTypeManager consultingTypeManager;
   @MockitoBean private UserHelper userHelper;
+  @MockitoBean private UsernameTranscoder usernameTranscoder;
   @MockitoBean private ChatService chatService;
   @MockitoBean private StartChatFacade startChatFacade;
   @MockitoBean private GetChatFacade getChatFacade;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
@@ -1,0 +1,443 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
+import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
+import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
+import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.in.AccountManaging;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.ws.rs.InternalServerErrorException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class UserSessionControllerDelegateTest {
+
+  @Mock private UserAccountService userAccountProvider;
+  @Mock private SessionService sessionService;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private SessionListFacade sessionListFacade;
+  @Mock private AssignSessionFacade assignSessionFacade;
+  @Mock private ConsultantDataFacade consultantDataFacade;
+  @Mock private SessionArchiveService sessionArchiveService;
+  @Mock private AccountManaging accountManager;
+  @Mock private Messaging messenger;
+  @Mock private ConsultantDtoMapper consultantDtoMapper;
+  @Mock private UserDtoMapper userDtoMapper;
+  @Mock private ConsultantService consultantService;
+
+  @InjectMocks private UserSessionControllerDelegate delegate;
+
+  @Test
+  void getSessionsForAuthenticatedUserShouldReturnOkAndUseFallbackRocketChatCredentials() {
+    var responseDto =
+        new UserSessionListResponseDTO().sessions(List.of(new UserSessionResponseDTO()));
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
+    when(sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(eq("user-id"), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForAuthenticatedUser(null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+
+    var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
+    verify(sessionListFacade)
+        .retrieveSortedSessionsForAuthenticatedUser(eq("user-id"), credentialsCaptor.capture());
+    assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("dummy-rc-user");
+    assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("dummy-rc-token");
+  }
+
+  @Test
+  void getSessionsForAuthenticatedUserShouldReturnNoContentWhenNoSessionsExist() {
+    var responseDto = new UserSessionListResponseDTO().sessions(List.of());
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
+    when(sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(eq("user-id"), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForAuthenticatedUser("rc-token");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getSessionsForGroupIdsShouldUseConsultantPathAndReturnNoContentWhenNoSessionsExist() {
+    var responseDto = new GroupSessionListResponseDTO().sessions(List.of());
+    var consultant = consultant();
+    var roles = Set.of(UserRole.CONSULTANT.getValue());
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(sessionListFacade.retrieveSessionsForAuthenticatedConsultantByGroupIds(
+            consultant, List.of("group-id"), roles))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForGroupIds(List.of("group-id"), "rc-token");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getSessionsForGroupIdsShouldUseUserPathAndPassRocketChatCredentials() {
+    var responseDto =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    var roles = Set.of(UserRole.USER.getValue());
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithRocketChatId());
+    when(sessionListFacade.retrieveSessionsForAuthenticatedUserByGroupIds(
+            eq("user-id"), eq(List.of("group-id")), any(), eq(roles)))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForGroupIds(List.of("group-id"), "rc-token");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+
+    var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
+    verify(sessionListFacade)
+        .retrieveSessionsForAuthenticatedUserByGroupIds(
+            eq("user-id"), eq(List.of("group-id")), credentialsCaptor.capture(), eq(roles));
+    assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("rc-user-id");
+    assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("rc-token");
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getSessionsForAuthenticatedConsultantShouldPassSessionQueryParameters() {
+    var responseDto =
+        new ConsultantSessionListResponseDTO()
+            .sessions(List.of(new ConsultantSessionResponseDTO()))
+            .offset(5)
+            .count(10)
+            .total(1);
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant());
+    when(sessionListFacade.retrieveSessionsDtoForAuthenticatedConsultant(any(), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForAuthenticatedConsultant("rc-token", 5, 10, "all", 2);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+
+    var queryCaptor = ArgumentCaptor.forClass(SessionListQueryParameter.class);
+    verify(sessionListFacade)
+        .retrieveSessionsDtoForAuthenticatedConsultant(eq(consultant()), queryCaptor.capture());
+    assertThat(queryCaptor.getValue().getOffset()).isEqualTo(5);
+    assertThat(queryCaptor.getValue().getCount()).isEqualTo(10);
+    assertThat(queryCaptor.getValue().getSessionStatus()).isEqualTo(2);
+  }
+
+  @Test
+  void getTeamSessionsForAuthenticatedConsultantShouldPassSessionQueryParameters() {
+    var consultant = consultant();
+    var responseDto =
+        new ConsultantSessionListResponseDTO()
+            .sessions(List.of(new ConsultantSessionResponseDTO()))
+            .offset(3)
+            .count(7)
+            .total(1);
+    when(userAccountProvider.retrieveValidatedTeamConsultant()).thenReturn(consultant);
+    when(sessionListFacade.retrieveTeamSessionsDtoForAuthenticatedConsultant(any(), any(), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getTeamSessionsForAuthenticatedConsultant("rc-token", 3, 7, "all");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+
+    var queryCaptor = ArgumentCaptor.forClass(SessionListQueryParameter.class);
+    verify(sessionListFacade)
+        .retrieveTeamSessionsDtoForAuthenticatedConsultant(
+            eq(consultant), eq("rc-token"), queryCaptor.capture());
+    assertThat(queryCaptor.getValue().getOffset()).isEqualTo(3);
+    assertThat(queryCaptor.getValue().getCount()).isEqualTo(7);
+  }
+
+  @Test
+  void getSessionForIdShouldFallbackToChatLookupForAdviceSeekerWhenNoSessionExists() {
+    var emptySessionList = new GroupSessionListResponseDTO().sessions(List.of());
+    var chatSessionList =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.USER.getValue()));
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
+    when(sessionListFacade.retrieveSessionsForAuthenticatedUserBySessionIds(
+            eq("user-id"), eq(List.of(1L)), any(), eq(Set.of(UserRole.USER.getValue()))))
+        .thenReturn(emptySessionList);
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+        .thenReturn(chatSessionList);
+
+    var response = delegate.getSessionForId(1L, null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(chatSessionList);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(chatSessionList);
+  }
+
+  @Test
+  void getSessionForIdShouldReturnConsultantSessionWithoutChatFallbackWhenSessionExists() {
+    var responseDto =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    var roles = Set.of(UserRole.CONSULTANT.getValue());
+    var consultant = consultant();
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(sessionListFacade.retrieveSessionsForAuthenticatedConsultantBySessionIds(
+            consultant, List.of(1L), roles))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionForId(1L, "rc-token");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+    verify(sessionListFacade)
+        .retrieveSessionsForAuthenticatedConsultantBySessionIds(consultant, List.of(1L), roles);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getSessionForIdShouldReturnNoContentWhenLookupFails() {
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(userAccountProvider.retrieveValidatedUser()).thenThrow(new RuntimeException("boom"));
+
+    var response = delegate.getSessionForId(1L, null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verifyNoInteractions(consultantDataFacade);
+  }
+
+  @Test
+  void getChatByIdShouldUseConsultantLookupAndReturnOk() {
+    var responseDto =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    var consultant = consultant();
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(sessionListFacade.retrieveChatsForConsultantByChatIds(any(), eq(List.of(1L)), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getChatById("rc-token", 1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(responseDto);
+
+    var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
+    verify(sessionListFacade)
+        .retrieveChatsForConsultantByChatIds(
+            eq(consultant), eq(List.of(1L)), credentialsCaptor.capture());
+    assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("rocket-chat-id");
+    assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("rc-token");
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getChatByIdShouldUseUserLookupAndReturnNoContentWhenNoChatExists() {
+    var responseDto = new GroupSessionListResponseDTO().sessions(List.of());
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithRocketChatId());
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getChatById("rc-token", 1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void assignSessionShouldReturnForbiddenForNewSessionWithoutEnquiryAuthority() {
+    when(sessionService.getSession(1L)).thenReturn(Optional.of(newSession()));
+    when(authenticatedUser.getUserId()).thenReturn("consultant-id");
+    when(authenticatedUser.getGrantedAuthorities())
+        .thenReturn(Set.of(AuthorityValue.ASSIGN_CONSULTANT_TO_SESSION));
+
+    var response = delegate.assignSession(1L, "assigned-consultant-id");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    verifyNoInteractions(assignSessionFacade);
+  }
+
+  @Test
+  void assignSessionShouldReturnInternalServerErrorWhenSessionDoesNotExist() {
+    when(sessionService.getSession(1L)).thenReturn(Optional.empty());
+
+    var response = delegate.assignSession(1L, "assigned-consultant-id");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    verifyNoInteractions(assignSessionFacade, userAccountProvider, consultantService);
+  }
+
+  @Test
+  void assignSessionShouldAssignExistingSessionAndReturnOk() {
+    var session = inProgressSession();
+    var consultantToAssign = consultant("assigned-consultant-id");
+    var consultantToKeep = consultant("consultant-id");
+    when(sessionService.getSession(1L)).thenReturn(Optional.of(session));
+    when(authenticatedUser.getUserId()).thenReturn("consultant-id");
+    when(userAccountProvider.retrieveValidatedConsultantById("assigned-consultant-id"))
+        .thenReturn(consultantToAssign);
+    when(consultantService.getConsultant("consultant-id"))
+        .thenReturn(Optional.of(consultantToKeep));
+
+    var response = delegate.assignSession(1L, "assigned-consultant-id");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(assignSessionFacade).assignSession(session, consultantToAssign, consultantToKeep);
+  }
+
+  @Test
+  void removeFromSessionShouldRemoveConsultantAndReturnNoContent() {
+    var consultantId = UUID.randomUUID();
+    var consultantMap = Map.<String, Object>of("id", consultantId.toString());
+    var sessionMap = Map.<String, Object>of("chatId", "chat-id");
+    when(accountManager.findConsultant(consultantId.toString()))
+        .thenReturn(Optional.of(consultantMap));
+    when(messenger.findSession(1L)).thenReturn(Optional.of(sessionMap));
+    when(consultantDtoMapper.chatIdOf(sessionMap)).thenReturn("chat-id");
+    when(userDtoMapper.chatUserIdOf(consultantMap)).thenReturn("chat-user-id");
+    when(messenger.removeUserFromSession("chat-user-id", "chat-id")).thenReturn(true);
+
+    var response = delegate.removeFromSession(1L, consultantId);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(messenger).removeUserFromSession("chat-user-id", "chat-id");
+  }
+
+  @Test
+  void removeFromSessionShouldThrowNotFoundWhenConsultantDoesNotExist() {
+    var consultantId = UUID.randomUUID();
+    when(accountManager.findConsultant(consultantId.toString())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> delegate.removeFromSession(1L, consultantId))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void removeFromSessionShouldThrowInternalServerErrorWhenRemovalFails() {
+    var consultantId = UUID.randomUUID();
+    var consultantMap = Map.<String, Object>of("id", consultantId.toString());
+    var sessionMap = Map.<String, Object>of("chatId", "chat-id");
+    when(accountManager.findConsultant(consultantId.toString()))
+        .thenReturn(Optional.of(consultantMap));
+    when(messenger.findSession(1L)).thenReturn(Optional.of(sessionMap));
+    when(consultantDtoMapper.chatIdOf(sessionMap)).thenReturn("chat-id");
+    when(userDtoMapper.chatUserIdOf(consultantMap)).thenReturn("chat-user-id");
+    when(messenger.removeUserFromSession("chat-user-id", "chat-id")).thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.removeFromSession(1L, consultantId))
+        .isInstanceOf(InternalServerErrorException.class);
+  }
+
+  @Test
+  void fetchSessionForConsultantShouldReturnSessionDtoFromService() {
+    var consultant = consultant();
+    var sessionDto = new ConsultantSessionDTO().id(1L);
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(sessionService.fetchSessionForConsultant(1L, consultant)).thenReturn(sessionDto);
+
+    var response = delegate.fetchSessionForConsultant(1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(sessionDto);
+  }
+
+  @Test
+  void archiveAndDearchiveSessionShouldDelegateAndReturnOk() {
+    var archiveResponse = delegate.archiveSession(1L);
+    var dearchiveResponse = delegate.dearchiveSession(2L);
+
+    assertThat(archiveResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(dearchiveResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(sessionArchiveService).archiveSession(1L);
+    verify(sessionArchiveService).dearchiveSession(2L);
+  }
+
+  private User userWithoutRocketChatId() {
+    return User.builder().userId("user-id").username("user").email("user@example.com").build();
+  }
+
+  private User userWithRocketChatId() {
+    return User.builder()
+        .userId("user-id")
+        .username("user")
+        .email("user@example.com")
+        .rcUserId("rc-user-id")
+        .build();
+  }
+
+  private Consultant consultant() {
+    return consultant("consultant-id");
+  }
+
+  private Consultant consultant(String id) {
+    return Consultant.builder()
+        .id(id)
+        .rocketChatId("rocket-chat-id")
+        .username("consultant")
+        .firstName("Con")
+        .lastName("Sultant")
+        .email("consultant@example.com")
+        .build();
+  }
+
+  private Session newSession() {
+    return session(Session.SessionStatus.NEW);
+  }
+
+  private Session inProgressSession() {
+    return session(Session.SessionStatus.IN_PROGRESS);
+  }
+
+  private Session session(Session.SessionStatus status) {
+    return Session.builder()
+        .id(1L)
+        .registrationType(Session.RegistrationType.REGISTERED)
+        .postcode("10115")
+        .status(status)
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
@@ -146,6 +146,29 @@ class UserSessionControllerDelegateTest {
   }
 
   @Test
+  void getSessionsForGroupIdsShouldFallbackUserRocketChatCredentialsWhenMissing() {
+    var responseDto =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    var roles = Set.of(UserRole.USER.getValue());
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
+    when(sessionListFacade.retrieveSessionsForAuthenticatedUserByGroupIds(
+            eq("user-id"), eq(List.of("group-id")), any(), eq(roles)))
+        .thenReturn(responseDto);
+
+    var response = delegate.getSessionsForGroupIds(List.of("group-id"), null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
+    verify(sessionListFacade)
+        .retrieveSessionsForAuthenticatedUserByGroupIds(
+            eq("user-id"), eq(List.of("group-id")), credentialsCaptor.capture(), eq(roles));
+    assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("dummy-rc-user");
+    assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("dummy-rc-token");
+  }
+
+  @Test
   void getSessionsForAuthenticatedConsultantShouldPassSessionQueryParameters() {
     var responseDto =
         new ConsultantSessionListResponseDTO()
@@ -286,6 +309,25 @@ class UserSessionControllerDelegateTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     verify(consultantDataFacade).addConsultantDisplayNameToSessionList(responseDto);
+  }
+
+  @Test
+  void getChatByIdShouldFallbackUserRocketChatCredentialsWhenMissing() {
+    var responseDto =
+        new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+        .thenReturn(responseDto);
+
+    var response = delegate.getChatById(null, 1L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
+    verify(sessionListFacade)
+        .retrieveChatsForUserByChatIds(eq(List.of(1L)), credentialsCaptor.capture());
+    assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("dummy-rc-user");
+    assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("dummy-rc-token");
   }
 
   @Test


### PR DESCRIPTION
Summary
- Extracted session-related UserController flows into UserSessionControllerDelegate.
- Kept UserController as API delegator without behavior changes.
- Added focused delegate unit tests for session listing, lookup fallback, assign/remove, fetch, archive/dearchive flows.

Verification
- mvn -DskipTests -Dspotless.check.skip=true compile
- mvn -Dtest=UserSessionControllerDelegateTest -Dspotless.check.skip=true test
- mvn -DskipTests spotless:check
- git diff --check

Notes
- Follow-up candidates only: existing getSessionForId exception -> 204 behavior and broader coverage for less common branches.