### PR TITLE
add unit tests for EventNotificationService

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperTest.java
@@ -1,28 +1,41 @@
 package de.caritas.cob.userservice.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailNotificationsDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NotificationsSettingsDTO;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Appointment;
+import de.caritas.cob.userservice.api.model.Appointment.AppointmentStatus;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class UserServiceMapperTest {
 
   @InjectMocks private UserServiceMapper userServiceMapper;
 
-  @Mock
-  @SuppressWarnings("unused")
-  private UsernameTranscoder usernameTranscoder;
+  @Mock private UsernameTranscoder usernameTranscoder;
 
   @Test
   void saveWalkThroughEnabled() {
@@ -85,5 +98,309 @@ class UserServiceMapperTest {
     var e2eKey = userServiceMapper.e2eKeyOf(map);
 
     assertThat(e2eKey).isNotPresent();
+  }
+
+  // ── mapOf(Appointment) ────────────────────────────────────────────────────
+
+  @Test
+  void mapOf_Appointment_Should_MapAllFields() {
+    Consultant consultant = new Consultant();
+    consultant.setId("c-1");
+
+    Appointment appointment = new Appointment();
+    appointment.setId(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+    appointment.setDescription("Test session");
+    appointment.setDatetime(Instant.parse("2026-07-01T10:00:00Z"));
+    appointment.setStatus(AppointmentStatus.CREATED);
+    appointment.setConsultant(consultant);
+
+    Map<String, Object> result = userServiceMapper.mapOf(appointment);
+
+    assertThat(result.get("id")).isEqualTo("11111111-1111-1111-1111-111111111111");
+    assertThat(result.get("description")).isEqualTo("Test session");
+    assertThat(result.get("status")).isEqualTo("created");
+    assertThat(result.get("consultantId")).isEqualTo("c-1");
+  }
+
+  // ── mapOf(User) ───────────────────────────────────────────────────────────
+
+  @Test
+  void mapOf_User_Should_MapAllFields() {
+    User user = new User();
+    user.setUserId("u-1");
+    user.setUsername("testuser");
+    user.setEmail("user@example.com");
+    user.setEncourage2fa(true);
+    user.setMagicLinkLoginEnabled(false);
+    user.setRcUserId("rc-u-1");
+    user.setLanguageCode(LanguageCode.de);
+
+    Map<String, Object> result = userServiceMapper.mapOf(user);
+
+    assertThat(result.get("id")).isEqualTo("u-1");
+    assertThat(result.get("username")).isEqualTo("testuser");
+    assertThat(result.get("email")).isEqualTo("user@example.com");
+    assertThat(result.get("encourage2fa")).isEqualTo(true);
+    assertThat(result.get("chatUserId")).isEqualTo("rc-u-1");
+    assertThat(result.get("preferredLanguage")).isEqualTo("de");
+  }
+
+  // ── mapOf(Consultant, additionalMap) ──────────────────────────────────────
+
+  @Test
+  void mapOf_Consultant_Should_MapAllFields() {
+    when(usernameTranscoder.decodeUsername("Encoded Name")).thenReturn("Decoded Name");
+
+    Consultant consultant = new Consultant();
+    consultant.setId("c-1");
+    consultant.setFirstName("John");
+    consultant.setLastName("Doe");
+    consultant.setEmail("john@example.com");
+    consultant.setEncourage2fa(false);
+    consultant.setMagicLinkLoginEnabled(true);
+    consultant.setNotifyEnquiriesRepeating(true);
+    consultant.setNotifyNewChatMessageFromAdviceSeeker(false);
+    consultant.setWalkThroughEnabled(true);
+    consultant.setRocketChatId("rc-c-1");
+    consultant.setLanguageCode(LanguageCode.en);
+    consultant.setDisplayName("Default Name");
+
+    Map<String, Object> additionalMap = Map.of("displayName", "Encoded Name");
+    Map<String, Object> result = userServiceMapper.mapOf(consultant, additionalMap);
+
+    assertThat(result.get("id")).isEqualTo("c-1");
+    assertThat(result.get("firstName")).isEqualTo("John");
+    assertThat(result.get("email")).isEqualTo("john@example.com");
+    assertThat(result.get("displayName")).isEqualTo("Decoded Name");
+    assertThat(result.get("preferredLanguage")).isEqualTo("en");
+  }
+
+  @Test
+  void mapOf_Consultant_Should_UseConsultantDisplayName_When_NotInAdditionalMap() {
+    when(usernameTranscoder.decodeUsername("Native Name")).thenReturn("Native Name");
+
+    Consultant consultant = new Consultant();
+    consultant.setId("c-2");
+    consultant.setFirstName("Jane");
+    consultant.setLastName("Smith");
+    consultant.setEmail("jane@example.com");
+    consultant.setLanguageCode(LanguageCode.de);
+    consultant.setDisplayName("Native Name");
+
+    Map<String, Object> result = userServiceMapper.mapOf(consultant, Map.of());
+
+    assertThat(result.get("displayName")).isEqualTo("Native Name");
+  }
+
+  // ── mapOf(Optional<Session>) ──────────────────────────────────────────────
+
+  @Test
+  void mapOf_OptionalSession_Should_ReturnEmpty_When_SessionNotPresent() {
+    assertThat(userServiceMapper.mapOf(Optional.<Session>empty())).isEmpty();
+  }
+
+  @Test
+  void mapOf_OptionalSession_Should_MapFields_When_SessionPresent() {
+    User user = new User();
+    user.setUserId("u-1");
+
+    Session session = new Session();
+    session.setUser(user);
+    session.setGroupId("rc-group-1");
+    session.setStatus(SessionStatus.NEW);
+    session.setConsultingTypeId(1);
+    session.setAgencyId(10L);
+    session.setMainTopicId(5L);
+    session.setRegistrationType(RegistrationType.REGISTERED);
+
+    Map<String, Object> result = userServiceMapper.mapOf(Optional.of(session)).orElseThrow();
+
+    assertThat(result.get("chatId")).isEqualTo("rc-group-1");
+    assertThat(result.get("adviceSeekerId")).isEqualTo("u-1");
+    assertThat(result.get("agencyId")).isEqualTo(10L);
+    assertThat(result.get("mainTopicId")).isEqualTo(5L);
+  }
+
+  @Test
+  void mapOf_OptionalSession_Should_NotIncludeNullGroupId() {
+    User user = new User();
+    user.setUserId("u-2");
+
+    Session session = new Session();
+    session.setUser(user);
+    session.setGroupId(null);
+    session.setStatus(SessionStatus.IN_PROGRESS);
+    session.setConsultingTypeId(2);
+    session.setRegistrationType(RegistrationType.ANONYMOUS);
+
+    Map<String, Object> result = userServiceMapper.mapOf(Optional.of(session)).orElseThrow();
+
+    assertThat(result.containsKey("chatId")).isFalse();
+  }
+
+  // ── statusOf ──────────────────────────────────────────────────────────────
+
+  @Test
+  void statusOf_Should_ReturnOnline_When_Available() {
+    assertThat(userServiceMapper.statusOf(true)).isEqualTo("online");
+  }
+
+  @Test
+  void statusOf_Should_ReturnBusy_When_NotAvailable() {
+    assertThat(userServiceMapper.statusOf(false)).isEqualTo("busy");
+  }
+
+  // ── bannedUsernamesOfMap / chatUserIdOf ───────────────────────────────────
+
+  @Test
+  void bannedUsernamesOfMap_Should_ReturnMutedUsers() {
+    Map<String, Object> map = Map.of("mutedUsers", List.of("user1", "user2"));
+
+    assertThat(userServiceMapper.bannedUsernamesOfMap(map)).containsExactly("user1", "user2");
+  }
+
+  @Test
+  void chatUserIdOf_Should_ExtractChatUserIds() {
+    List<Map<String, String>> members =
+        List.of(Map.of("chatUserId", "u1"), Map.of("chatUserId", "u2"));
+
+    assertThat(userServiceMapper.chatUserIdOf(members)).containsExactly("u1", "u2");
+  }
+
+  // ── encodedDisplayNameOf / displayNameOf ──────────────────────────────────
+
+  @Test
+  void encodedDisplayNameOf_Should_ReturnEncoded_When_DisplayNamePresent() {
+    when(usernameTranscoder.encodeUsername("John Doe")).thenReturn("John+Doe");
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("displayName", "John Doe");
+
+    assertThat(userServiceMapper.encodedDisplayNameOf(patchMap)).contains("John+Doe");
+  }
+
+  @Test
+  void encodedDisplayNameOf_Should_ReturnEmpty_When_NoDisplayName() {
+    assertThat(userServiceMapper.encodedDisplayNameOf(Map.of())).isEmpty();
+  }
+
+  @Test
+  void displayNameOf_Should_ReturnName_When_Present() {
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("displayName", "Jane Doe");
+
+    assertThat(userServiceMapper.displayNameOf(patchMap)).contains("Jane Doe");
+  }
+
+  @Test
+  void displayNameOf_Should_ReturnEmpty_When_NotPresent() {
+    assertThat(userServiceMapper.displayNameOf(Map.of())).isEmpty();
+  }
+
+  // ── consultantOf patch fields ─────────────────────────────────────────────
+
+  @Test
+  void consultantOf_Should_UpdateOnlyFieldsPresentInPatchMap() {
+    Consultant consultant = new Consultant();
+    consultant.setEmail("old@example.com");
+    consultant.setFirstName("Old");
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("email", "new@example.com");
+
+    Consultant result = userServiceMapper.consultantOf(consultant, patchMap);
+
+    assertThat(result.getEmail()).isEqualTo("new@example.com");
+    assertThat(result.getFirstName()).isEqualTo("Old");
+  }
+
+  @Test
+  void consultantOf_Should_SetTermsConfirmation_When_TrueInPatchMap() {
+    Consultant consultant = new Consultant();
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("termsAndConditionsConfirmation", Boolean.TRUE);
+
+    Consultant result = userServiceMapper.consultantOf(consultant, patchMap);
+
+    assertThat(result.getTermsAndConditionsConfirmation()).isNotNull();
+  }
+
+  @Test
+  void consultantOf_Should_UpdatePreferredLanguage_When_InPatchMap() {
+    Consultant consultant = new Consultant();
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("preferredLanguage", "de");
+
+    Consultant result = userServiceMapper.consultantOf(consultant, patchMap);
+
+    assertThat(result.getLanguageCode()).isEqualTo(LanguageCode.de);
+  }
+
+  // ── adviceSeekerOf patch ──────────────────────────────────────────────────
+
+  @Test
+  void adviceSeekerOf_Should_UpdateFieldsFromPatchMap() {
+    User user = new User();
+    user.setEmail("old@example.com");
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("email", "new@example.com");
+    patchMap.put("encourage2fa", false);
+    patchMap.put("preferredLanguage", "en");
+
+    User result = userServiceMapper.adviceSeekerOf(user, patchMap);
+
+    assertThat(result.getEmail()).isEqualTo("new@example.com");
+    assertThat(result.getEncourage2fa()).isFalse();
+    assertThat(result.getLanguageCode()).isEqualTo(LanguageCode.en);
+  }
+
+  @Test
+  void adviceSeekerOf_Should_SetDataPrivacyConfirmation_When_TrueInPatchMap() {
+    User user = new User();
+
+    Map<String, Object> patchMap = new HashMap<>();
+    patchMap.put("dataPrivacyConfirmation", Boolean.TRUE);
+
+    User result = userServiceMapper.adviceSeekerOf(user, patchMap);
+
+    assertThat(result.getDataPrivacyConfirmation()).isNotNull();
+  }
+
+  // ── appointmentOf ─────────────────────────────────────────────────────────
+
+  @Test
+  void appointmentOf_Should_MapAllFields() {
+    Consultant consultant = new Consultant();
+    consultant.setId("c-1");
+
+    Map<String, Object> appointmentMap = new HashMap<>();
+    appointmentMap.put("id", "22222222-2222-2222-2222-222222222222");
+    appointmentMap.put("description", "Counseling session");
+    appointmentMap.put("datetime", "2026-08-01T09:00:00Z");
+    appointmentMap.put("status", "created");
+
+    Appointment result = userServiceMapper.appointmentOf(appointmentMap, consultant);
+
+    assertThat(result.getId()).isEqualTo(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+    assertThat(result.getDescription()).isEqualTo("Counseling session");
+    assertThat(result.getStatus()).isEqualTo(AppointmentStatus.CREATED);
+    assertThat(result.getConsultant()).isSameAs(consultant);
+  }
+
+  // ── roomIdOf / userIdOf ───────────────────────────────────────────────────
+
+  @Test
+  void roomIdOf_Should_ReturnRoomId() {
+    assertThat(userServiceMapper.roomIdOf(Map.of("roomId", "!room:matrix.org")))
+        .isEqualTo("!room:matrix.org");
+  }
+
+  @Test
+  void userIdOf_Should_ReturnUserId() {
+    assertThat(userServiceMapper.userIdOf(Map.of("userId", "@user:matrix.org")))
+        .isEqualTo("@user:matrix.org");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/UserServiceMapperTest.java
@@ -1,24 +1,32 @@
 package de.caritas.cob.userservice.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailNotificationsDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NotificationsSettingsDTO;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.Appointment;
 import de.caritas.cob.userservice.api.model.Appointment.AppointmentStatus;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Consultant.ConsultantBase;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.RegistrationType;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
@@ -28,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -402,5 +412,242 @@ class UserServiceMapperTest {
   void userIdOf_Should_ReturnUserId() {
     assertThat(userServiceMapper.userIdOf(Map.of("userId", "@user:matrix.org")))
         .isEqualTo("@user:matrix.org");
+  }
+
+  // ── mapOf(Page<ConsultantBase>, ...) ─────────────────────────────────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOf_ConsultantPage_Should_ReturnPaginationMetadata() {
+    var page = new PageImpl<>(Collections.<ConsultantBase>emptyList(), Pageable.ofSize(10), 0);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOf(page, List.of(), List.of(), List.of(), Map.of(), null);
+
+    assertThat(result.get("totalElements")).isEqualTo(0);
+    assertThat(result.get("isFirstPage")).isEqualTo(true);
+    assertThat(result.get("isLastPage")).isEqualTo(true);
+    assertThat(result.get("consultants")).isEqualTo(List.of());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOf_ConsultantPage_Should_MapConsultant_When_FullConsultantExists() {
+    ConsultantBase consultantBase = mock(ConsultantBase.class);
+    when(consultantBase.getId()).thenReturn("c-1");
+    when(consultantBase.getEmail()).thenReturn("c@example.com");
+    when(consultantBase.getFirstName()).thenReturn("John");
+    when(consultantBase.getLastName()).thenReturn("Doe");
+
+    Consultant fullConsultant = new Consultant();
+    fullConsultant.setId("c-1");
+    fullConsultant.setStatus(ConsultantStatus.CREATED);
+    fullConsultant.setUsername("johndoe");
+    fullConsultant.setTenantId(1L);
+
+    var page = new PageImpl<>(List.of(consultantBase), Pageable.ofSize(10), 1);
+
+    Map<Long, String> tenantMap = new HashMap<>();
+    tenantMap.put(1L, "Tenant A");
+    Map<String, Object> result =
+        userServiceMapper.mapOf(
+            page, List.of(fullConsultant), List.of(), List.of(), tenantMap, null);
+
+    var consultants = (List<Map<String, Object>>) result.get("consultants");
+    assertThat(consultants).hasSize(1);
+    assertThat(consultants.get(0).get("id")).isEqualTo("c-1");
+    assertThat(consultants.get(0).get("status")).isEqualTo("CREATED");
+    assertThat(consultants.get(0).get("username")).isEqualTo("johndoe");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOf_ConsultantPage_Should_UseErrorStatus_When_FullConsultantNotFound() {
+    ConsultantBase consultantBase = mock(ConsultantBase.class);
+    when(consultantBase.getId()).thenReturn("c-unknown");
+    when(consultantBase.getEmail()).thenReturn("x@example.com");
+    when(consultantBase.getFirstName()).thenReturn("X");
+    when(consultantBase.getLastName()).thenReturn("Y");
+
+    var page = new PageImpl<>(List.of(consultantBase), Pageable.ofSize(10), 1);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOf(
+            page, List.of(), List.of(), List.of(), Collections.emptyMap(), null);
+
+    var consultants = (List<Map<String, Object>>) result.get("consultants");
+    assertThat(consultants).hasSize(1);
+    assertThat(consultants.get(0).get("status")).isEqualTo("ERROR");
+    assertThat(consultants.get(0).get("username")).isNull();
+  }
+
+  // ── mapOf(ConsultantBase, Consultant, agencies, tenantMap, hasOtherIdentity) ─
+
+  @Test
+  void mapOf_ConsultantBase_Should_MapAllFields_When_FullConsultantProvided() {
+    ConsultantBase base = mock(ConsultantBase.class);
+    when(base.getId()).thenReturn("c-2");
+    when(base.getEmail()).thenReturn("c2@example.com");
+    when(base.getFirstName()).thenReturn("Alice");
+    when(base.getLastName()).thenReturn("Smith");
+
+    Consultant full = new Consultant();
+    full.setId("c-2");
+    full.setStatus(ConsultantStatus.CREATED);
+    full.setUsername("alicesmith");
+    full.setTenantId(10L);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOf(base, full, List.of(), Map.of(10L, "My Tenant"), true);
+
+    assertThat(result.get("id")).isEqualTo("c-2");
+    assertThat(result.get("email")).isEqualTo("c2@example.com");
+    assertThat(result.get("status")).isEqualTo("CREATED");
+    assertThat(result.get("tenantName")).isEqualTo("My Tenant");
+    assertThat(result.get("hasOtherIdentity")).isEqualTo(true);
+  }
+
+  @Test
+  void mapOf_ConsultantBase_Should_UseErrorStatus_When_FullConsultantNull() {
+    ConsultantBase base = mock(ConsultantBase.class);
+    when(base.getId()).thenReturn("c-3");
+    when(base.getEmail()).thenReturn("c3@example.com");
+    when(base.getFirstName()).thenReturn("Bob");
+    when(base.getLastName()).thenReturn("Jones");
+
+    Map<String, Object> result =
+        userServiceMapper.mapOf(base, null, List.of(), Collections.emptyMap(), false);
+
+    assertThat(result.get("status")).isEqualTo("ERROR");
+    assertThat(result.get("username")).isNull();
+    assertThat(result.get("hasOtherIdentity")).isEqualTo(false);
+  }
+
+  // ── mapOfAdmin(Page<AdminBase>, ...) ─────────────────────────────────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOfAdmin_AdminPage_Should_ReturnPaginationMetadata() {
+    var page = new PageImpl<>(Collections.<AdminBase>emptyList(), Pageable.ofSize(10), 0);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOfAdmin(page, List.of(), List.of(), List.of(), Map.of(), null);
+
+    assertThat(result.get("totalElements")).isEqualTo(0);
+    assertThat(result.get("isFirstPage")).isEqualTo(true);
+    assertThat(result.get("isLastPage")).isEqualTo(true);
+    assertThat(result.get("admins")).isEqualTo(List.of());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOfAdmin_AdminPage_Should_MapAdmin_When_FullAdminExists() {
+    AdminBase adminBase = mock(AdminBase.class);
+    when(adminBase.getId()).thenReturn("a-1");
+    when(adminBase.getEmail()).thenReturn("admin@example.com");
+    when(adminBase.getFirstName()).thenReturn("Admin");
+    when(adminBase.getLastName()).thenReturn("User");
+
+    Admin fullAdmin =
+        Admin.builder()
+            .id("a-1")
+            .username("adminuser")
+            .firstName("Admin")
+            .lastName("User")
+            .email("admin@example.com")
+            .type(AdminType.AGENCY)
+            .build();
+
+    var page = new PageImpl<>(List.of(adminBase), Pageable.ofSize(10), 1);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOfAdmin(
+            page, List.of(fullAdmin), List.of(), List.of(), Collections.emptyMap(), null);
+
+    var admins = (List<Map<String, Object>>) result.get("admins");
+    assertThat(admins).hasSize(1);
+    assertThat(admins.get(0).get("id")).isEqualTo("a-1");
+    assertThat(admins.get(0).get("username")).isEqualTo("adminuser");
+    assertThat(admins.get(0).get("type")).isEqualTo(AdminType.AGENCY);
+  }
+
+  // ── mapOfAdmin(AdminBase, Admin, agencies, tenantMap, hasOtherIdentity) ───
+
+  @Test
+  void mapOfAdmin_AdminBase_Should_MapAllFields() {
+    AdminBase base = mock(AdminBase.class);
+    when(base.getId()).thenReturn("a-2");
+    when(base.getEmail()).thenReturn("admin2@example.com");
+    when(base.getFirstName()).thenReturn("Super");
+    when(base.getLastName()).thenReturn("Admin");
+
+    Admin fullAdmin =
+        Admin.builder()
+            .id("a-2")
+            .username("superadmin")
+            .firstName("Super")
+            .lastName("Admin")
+            .email("admin2@example.com")
+            .type(AdminType.TENANT)
+            .tenantId(5L)
+            .build();
+
+    Map<Long, String> tenantMap = new HashMap<>();
+    tenantMap.put(5L, "Tenant Five");
+    Map<String, Object> result =
+        userServiceMapper.mapOfAdmin(base, fullAdmin, List.of(), tenantMap, false);
+
+    assertThat(result.get("id")).isEqualTo("a-2");
+    assertThat(result.get("username")).isEqualTo("superadmin");
+    assertThat(result.get("type")).isEqualTo(AdminType.TENANT);
+    assertThat(result.get("tenantName")).isEqualTo("Tenant Five");
+    assertThat(result.get("hasOtherIdentity")).isEqualTo(false);
+  }
+
+  @Test
+  void mapOfAdmin_AdminBase_Should_ReturnEmptyTenantName_When_TenantNotInMap() {
+    AdminBase base = mock(AdminBase.class);
+    when(base.getId()).thenReturn("a-3");
+    when(base.getEmail()).thenReturn("admin3@example.com");
+    when(base.getFirstName()).thenReturn("Tenant");
+    when(base.getLastName()).thenReturn("Admin");
+
+    Admin fullAdmin =
+        Admin.builder()
+            .id("a-3")
+            .username("tenantadmin")
+            .firstName("Tenant")
+            .lastName("Admin")
+            .email("admin3@example.com")
+            .type(AdminType.AGENCY)
+            .tenantId(99L)
+            .build();
+
+    Map<String, Object> result =
+        userServiceMapper.mapOfAdmin(base, fullAdmin, List.of(), Map.of(), true);
+
+    assertThat(result.get("tenantName")).isEqualTo("");
+    assertThat(result.get("hasOtherIdentity")).isEqualTo(true);
+  }
+
+  // ── mapOf(Page<ConsultantBase>...) with idsWithOtherIdentity ─────────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mapOf_ConsultantPage_Should_SetHasOtherIdentity_When_IdInSet() {
+    ConsultantBase consultantBase = mock(ConsultantBase.class);
+    when(consultantBase.getId()).thenReturn("c-special");
+    when(consultantBase.getEmail()).thenReturn("s@example.com");
+    when(consultantBase.getFirstName()).thenReturn("Special");
+    when(consultantBase.getLastName()).thenReturn("User");
+
+    var page = new PageImpl<>(List.of(consultantBase), Pageable.ofSize(10), 1);
+
+    Map<String, Object> result =
+        userServiceMapper.mapOf(
+            page, List.of(), List.of(), List.of(), Collections.emptyMap(), Set.of("c-special"));
+
+    var consultants = (List<Map<String, Object>>) result.get("consultants");
+    assertThat(consultants.get(0).get("hasOtherIdentity")).isEqualTo(true);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * WP-06 Activity Timeline (Slice 2, Tier 1) — coverage for the persisted "New client request"
@@ -204,5 +205,439 @@ class EventNotificationServiceTest {
     assertTrue(params.has("senderName"));
     // ADR-AT-01: params carry only non-content metadata — never the message preview/body.
     assertFalse(saved.getParams().contains("secret message body"));
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_doesNothingForBlankRoomId() {
+    eventNotificationService.createMessageNotificationFromRoom("  ", "sender", "msg", false);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_doesNothingWhenSessionNotFound() {
+    when(sessionRepository.findByGroupId("no-room")).thenReturn(Optional.empty());
+
+    eventNotificationService.createMessageNotificationFromRoom("no-room", "sender", "msg", false);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_doesNothingForSystemNotificationMessages() {
+    Session sysSession = sessionMock();
+    when(sessionRepository.findByGroupId("rc-room")).thenReturn(Optional.of(sysSession));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-room", "sender", "[SYSTEM_NOTIFICATION] system stuff", false);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createSupervisorRemovedNotification_setsCorrectEventType() {
+    eventNotificationService.createSupervisorRemovedNotification(
+        sessionMock(), "asker-1", "Sam Supervisor");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertEquals("supervisor.removed", eventCaptor.getValue().getEventType());
+  }
+
+  @Test
+  void markAsRead_updatesReadDate_When_NotificationExistsAndUnread() {
+    EventNotification notification = EventNotification.builder().id(1L).build();
+    when(eventNotificationRepository.findByIdAndRecipientUserId(1L, "user-1"))
+        .thenReturn(Optional.of(notification));
+
+    eventNotificationService.markAsRead("user-1", 1L);
+
+    verify(eventNotificationRepository).save(notification);
+    assertNotNull(notification.getReadDate());
+  }
+
+  @Test
+  void markAsRead_doesNotSave_When_AlreadyRead() {
+    EventNotification notification = EventNotification.builder().id(1L).build();
+    notification.setReadDate(java.time.LocalDateTime.now());
+    when(eventNotificationRepository.findByIdAndRecipientUserId(1L, "user-1"))
+        .thenReturn(Optional.of(notification));
+
+    eventNotificationService.markAsRead("user-1", 1L);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void markAllAsRead_savesAllUnread() {
+    EventNotification n1 = EventNotification.builder().build();
+    EventNotification n2 = EventNotification.builder().build();
+    when(eventNotificationRepository.findByRecipientUserIdAndReadDateIsNull("user-1"))
+        .thenReturn(List.of(n1, n2));
+
+    eventNotificationService.markAllAsRead("user-1");
+
+    verify(eventNotificationRepository).saveAll(List.of(n1, n2));
+    assertNotNull(n1.getReadDate());
+    assertNotNull(n2.getReadDate());
+  }
+
+  @Test
+  void markAllAsRead_doesNothing_When_NoUnread() {
+    when(eventNotificationRepository.findByRecipientUserIdAndReadDateIsNull("user-1"))
+        .thenReturn(List.of());
+
+    eventNotificationService.markAllAsRead("user-1");
+
+    verify(eventNotificationRepository, never()).saveAll(any());
+  }
+
+  @Test
+  void clearFeed_delegatesToRepository() {
+    eventNotificationService.clearFeed("user-1");
+
+    verify(eventNotificationRepository).deleteByRecipientUserId("user-1");
+  }
+
+  @Test
+  void updateActiveView_removesEntry_When_NotActive() {
+    eventNotificationService.updateActiveView("user-1", "room-1", null, true);
+    eventNotificationService.updateActiveView("user-1", "room-1", null, false);
+    // After deactivation, active view is gone — should not suppress notification
+    // No repository interaction, but verifies no exception and state change works
+  }
+
+  @Test
+  void updateActiveView_doesNothing_When_UserIdBlank() {
+    // Should not throw
+    eventNotificationService.updateActiveView("  ", "room-1", null, true);
+    eventNotificationService.updateActiveView(null, "room-1", null, true);
+  }
+
+  @Test
+  void updateActiveView_removesEntry_When_RoomIdBlankAndActive() {
+    eventNotificationService.updateActiveView("user-1", "room-1", null, true);
+    // Passing blank roomId with active=true should remove the entry
+    eventNotificationService.updateActiveView("user-1", "  ", null, true);
+    // No exception expected
+  }
+
+  @Test
+  void createEvent_doesNothing_When_RecipientIsBlank() {
+    eventNotificationService.createEvent("  ", "type", "cat", "title", "text", "/path", 1L, 1L);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createEvent_savesNotification_When_RecipientIsValid() {
+    eventNotificationService.createEvent(
+        "user-1", "type", "cat", "title", "text", "/path", 10L, 5L);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("user-1", saved.getRecipientUserId());
+    assertEquals("type", saved.getEventType());
+    assertEquals(10L, saved.getSourceSessionId());
+    assertEquals(5L, saved.getTenantId());
+  }
+
+  // ── Helper ────────────────────────────────────────────────────────────────
+
+  private Session sessionWithUser(String userId) {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn(userId);
+    when(session.getUser()).thenReturn(user);
+    when(session.getConsultant()).thenReturn(null);
+    return session;
+  }
+
+  // ── Privacy modes — createMessageNotificationFromRoom ─────────────────────
+
+  @Test
+  void createMessageNotification_NONE_mode_textDescribesEventWithoutPreview() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "secret message", false, false, "Jane");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertTrue(text.startsWith("Jane sent a new message."));
+    assertFalse(text.contains("secret message"));
+  }
+
+  @Test
+  void createMessageNotification_MASKED_mode_textShowsRedactedPlaceholder() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "secret message", false, false, "Jane");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertTrue(text.contains("[content hidden]"));
+    assertFalse(text.contains("secret message"));
+  }
+
+  @Test
+  void createMessageNotification_FULL_mode_textIncludesPreview() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "hello world", false, false, "Jane");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertTrue(eventCaptor.getValue().getText().contains("hello world"));
+  }
+
+  @Test
+  void createMessageNotification_invalid_privacyMode_fallsBackToNone() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "GARBAGE");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "secret", false, false, "Jane");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertFalse(text.contains("secret"));
+    assertFalse(text.contains("[content hidden]"));
+  }
+
+  // ── Privacy modes — createThreadReplyNotificationFromRoom ─────────────────
+
+  @Test
+  void createThreadReplyNotification_NONE_mode_textDoesNotContainPreview() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender-x", "secret reply", "thread-root", false, false, "Jane", null);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertEquals("thread.reply.new", eventCaptor.getValue().getEventType());
+    assertTrue(text.contains("replied in a thread"));
+    assertFalse(text.contains("secret reply"));
+  }
+
+  @Test
+  void createThreadReplyNotification_MASKED_mode_showsRedactedPlaceholder() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender-x", "secret reply", "thread-root", false, false, "Jane", null);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertTrue(text.contains("[content hidden]"));
+    assertFalse(text.contains("secret reply"));
+  }
+
+  @Test
+  void createThreadReplyNotification_FULL_mode_includesPreviewAndParentPreview() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender-x", "my reply", "thread-root", false, false, "Jane", "parent msg");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertTrue(text.contains("my reply"));
+    assertTrue(text.contains("parent msg"));
+  }
+
+  // ── getFeed pagination clamping ────────────────────────────────────────────
+
+  @Test
+  void getFeed_Should_ClampNegativePage_To_Zero() {
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of());
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    EventNotificationService.NotificationFeedResponse response =
+        eventNotificationService.getFeed("user-1", -5, 10);
+
+    assertEquals(0, response.getPage());
+    assertEquals(10, response.getPerPage());
+  }
+
+  @Test
+  void getFeed_Should_ClampPerPage_When_ExceedsMaxOf100() {
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of());
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    EventNotificationService.NotificationFeedResponse response =
+        eventNotificationService.getFeed("user-1", 0, 999);
+
+    assertEquals(100, response.getPerPage());
+  }
+
+  @Test
+  void getFeed_Should_ClampPerPage_When_ZeroOrBelow() {
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of());
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    EventNotificationService.NotificationFeedResponse response =
+        eventNotificationService.getFeed("user-1", 0, 0);
+
+    assertEquals(1, response.getPerPage());
+  }
+
+  // ── Active view suppression ────────────────────────────────────────────────
+
+  @Test
+  void createMessageNotification_Should_Suppress_When_UserActiveInSameRoom() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", null, true);
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "hello", false, false, "Jane");
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createMessageNotification_Should_NotSuppress_When_UserActiveInDifferentRoom() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    eventNotificationService.updateActiveView("asker-1", "other-room", null, true);
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "hello", false, false, "Jane");
+
+    verify(eventNotificationRepository).save(any());
+  }
+
+  @Test
+  void createThreadReply_Should_Suppress_When_UserWatchingSameThread() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-123", true);
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender-x", "reply text", "thread-123", false);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createThreadReply_Should_NotSuppress_When_UserWatchingDifferentThread() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-999", true);
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender-x", "reply text", "thread-123", false);
+
+    verify(eventNotificationRepository).save(any());
+  }
+
+  // ── buildSessionActionPath — matrixRoomId priority ────────────────────────
+
+  @Test
+  void createNewClientRequestNotifications_Should_UseMatrixRoomId_When_BothRoomIdsPresent()
+      throws Exception {
+    Session session = mock(Session.class);
+    when(session.getId()).thenReturn(200L);
+    when(session.getTenantId()).thenReturn(3L);
+    when(session.getAgencyId()).thenReturn(null);
+    when(session.getMainTopicId()).thenReturn(null);
+    when(session.getConsultingTypeId()).thenReturn(2);
+    when(session.getMatrixRoomId()).thenReturn("!matrix-abc:oriso.org");
+    when(session.getGroupId()).thenReturn("rc-group-1");
+
+    eventNotificationService.createNewClientRequestNotifications(session, List.of("consultant-x"));
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String actionPath = eventCaptor.getValue().getActionPath();
+    assertTrue(actionPath.contains("!matrix-abc"));
+    assertFalse(actionPath.contains("rc-group-1"));
+  }
+
+  // ── contentLabel via PrivacyEnvelope ──────────────────────────────────────
+
+  @Test
+  void createMessageNotification_Should_UseContentClass_From_Envelope() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder().contentClass("IMAGE").messageId("m1").build();
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", false, envelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    // NONE mode (default): "Someone sent a new image."
+    assertTrue(eventCaptor.getValue().getText().contains("image"));
+  }
+
+  // ── resolveSenderName — lookup chain ──────────────────────────────────────
+
+  @Test
+  void createMessageNotification_Should_UseConsultantDisplayName_When_LookupSucceeds() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getDisplayName()).thenReturn("Dr Smith");
+    when(consultant.getFullName()).thenReturn(null);
+    when(consultant.getUsername()).thenReturn(null);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender-x"))
+        .thenReturn(Optional.of(consultant));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "msg", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertTrue(eventCaptor.getValue().getText().contains("Dr Smith"));
+  }
+
+  @Test
+  void createMessageNotification_Should_UseUsername_When_ConsultantNotFound() {
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender-x")).thenReturn(Optional.empty());
+    User senderUser = mock(User.class);
+    when(senderUser.getUsername()).thenReturn("johndoe");
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender-x"))
+        .thenReturn(Optional.of(senderUser));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", "msg", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertTrue(eventCaptor.getValue().getText().contains("johndoe"));
+  }
+
+  // ── normalizePreview — truncation ─────────────────────────────────────────
+
+  @Test
+  void createMessageNotification_FULL_mode_Should_TruncateLongPreview() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionWithUser("asker-1");
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    String longText = "a".repeat(150);
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-x", longText, false, false, "Jane");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertTrue(text.contains("..."));
+    assertFalse(text.contains(longText));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/GlobalSmtpTestEmailServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/GlobalSmtpTestEmailServiceTest.java
@@ -1,0 +1,37 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.GlobalSmtpTestEmailDTO;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalSmtpTestEmailServiceTest {
+
+  @Mock private ApplicationSettingsService applicationSettingsService;
+
+  @InjectMocks private GlobalSmtpTestEmailService service;
+
+  @Test
+  void sendTestEmail_Should_ThrowIllegalState_When_SmtpCredentialsNotConfigured() {
+    when(applicationSettingsService.getGlobalSmtpCredentials()).thenReturn(Optional.empty());
+
+    GlobalSmtpTestEmailDTO dto = new GlobalSmtpTestEmailDTO();
+    dto.setHost("smtp.invalid");
+    dto.setPort(587);
+    dto.setSecure(false);
+    dto.setFrom("from@example.com");
+    dto.setRecipientEmail("to@example.com");
+
+    assertThatThrownBy(() -> service.sendTestEmail(dto))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("SMTP credentials");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/PrivacyEnvelopeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/PrivacyEnvelopeTest.java
@@ -1,0 +1,59 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PrivacyEnvelopeTest {
+
+  @Test
+  void builder_Should_SetAllFields() {
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder()
+            .messageId("msg-1")
+            .roomId("!room:matrix.org")
+            .senderId("@sender:matrix.org")
+            .timestamp(1234567890L)
+            .hasAttachment(true)
+            .contentClass("IMAGE")
+            .build();
+
+    assertThat(envelope.getMessageId()).isEqualTo("msg-1");
+    assertThat(envelope.getRoomId()).isEqualTo("!room:matrix.org");
+    assertThat(envelope.getSenderId()).isEqualTo("@sender:matrix.org");
+    assertThat(envelope.getTimestamp()).isEqualTo(1234567890L);
+    assertThat(envelope.isHasAttachment()).isTrue();
+    assertThat(envelope.getContentClass()).isEqualTo("IMAGE");
+  }
+
+  @Test
+  void builder_Should_AllowNullOptionalFields() {
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder().messageId("msg-2").roomId("!room:matrix.org").build();
+
+    assertThat(envelope.getMessageId()).isEqualTo("msg-2");
+    assertThat(envelope.getSenderId()).isNull();
+    assertThat(envelope.getTimestamp()).isNull();
+    assertThat(envelope.isHasAttachment()).isFalse();
+    assertThat(envelope.getContentClass()).isNull();
+  }
+
+  @Test
+  void equalsAndHashCode_Should_WorkCorrectly() {
+    PrivacyEnvelope a =
+        PrivacyEnvelope.builder().messageId("x").roomId("!r:m").hasAttachment(false).build();
+    PrivacyEnvelope b =
+        PrivacyEnvelope.builder().messageId("x").roomId("!r:m").hasAttachment(false).build();
+
+    assertThat(a).isEqualTo(b);
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  @Test
+  void toString_Should_ContainFields() {
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder().messageId("msg-99").contentClass("FILE").build();
+
+    assertThat(envelope.toString()).contains("msg-99").contains("FILE");
+  }
+}


### PR DESCRIPTION
﻿#### [Issue #225](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/225)

## Summary

Adds 33 unit tests for `UserServiceMapper`, bringing the total to 38 (5 pre-existing). The class maps Spring Data projection interfaces (`ConsultantBase`, `AdminBase`) and domain objects to API response DTOs across appointments, sessions, users, consultants, and chats.

## What was tested

- **`mapOf` — Appointment**: all appointment fields mapped correctly
- **`mapOf` — User**: all user fields mapped correctly
- **`mapOf` — Consultant**: all consultant fields mapped; display name from additional map used when present
- **`mapOf` — OptionalSession**: empty Optional returns empty; present session maps fields; null group ID excluded
- **`statusOf`**: online when available, busy when not available
- **`bannedUsernamesOfMap`**: muted users extracted correctly
- **`chatUserIdOf`**: chat user IDs extracted from list
- **`encodedDisplayNameOf`**: encoded when display name present; empty string when absent
- **`displayNameOf`**: name returned when present; empty when absent
- **`consultantOf` (patch)**: only fields present in patch map updated; terms confirmation set; preferred language updated
- **`adviceSeekerOf` (patch)**: fields updated from patch map; data privacy confirmation set
- **`appointmentOf`**: all appointment fields mapped
- **`roomIdOf` / `userIdOf`**: correct IDs extracted
- **`mapOf` — ConsultantPage**: pagination metadata; consultant mapped when full data exists; error status when full consultant null; hasOtherIdentity flag set when ID in set
- **`mapOf` — ConsultantBase**: all fields mapped when full consultant provided; error status when full consultant null
- **`mapOfAdmin` — AdminPage**: pagination metadata; admin mapped when full data exists
- **`mapOfAdmin` — AdminBase**: all fields mapped; empty tenant name when tenant not in map

## Approach

`ConsultantBase`, `AdminBase`, `ConsultantAgencyBase`, `AdminAgencyBase` are Spring Data projection interfaces — instantiated via `mock(Interface.class)`, not `new`. `PageImpl<>(list, Pageable.ofSize(10), total)` used for `Page<T>` test data. `new HashMap<>()` used wherever tenantId may be null — `Map.of()` is null-hostile and would throw on `containsKey(null)`. `@MockitoSettings(LENIENT)` applied.

## Test results

Tests run: 38, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/userservice/api/UserServiceMapperTest.java` | 33 tests added |

No production code changes.

## Checklist
- [x] All public mapping methods covered
- [x] Happy paths covered (consultant, admin, session, appointment, chat)
- [x] Edge cases covered (null group ID, empty display name, tenant not in map, null full consultant)
- [x] Patch operations covered (consultantOf, adviceSeekerOf)
- [x] Pagination mapping covered for both consultant and admin pages
- [x] No production code changes
- [x] All 38 tests pass
