### PR TITLE
add unit tests for TopicConsultantRoutingService; fix null guard on getRocketChatId

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.service.availability;
 
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -19,11 +20,20 @@ import org.springframework.stereotype.Component;
 public class ConsultantActivityRegistry {
 
   private final ConcurrentHashMap<String, Long> availableSince = new ConcurrentHashMap<>();
+  private final Clock clock;
+
+  public ConsultantActivityRegistry() {
+    this.clock = Clock.systemUTC();
+  }
+
+  ConsultantActivityRegistry(Clock clock) {
+    this.clock = clock;
+  }
 
   /** Marks the consultant available now (Live Chat enabled). Adds them if not present. */
   public void markAvailable(String consultantId) {
     if (consultantId != null && !consultantId.isBlank()) {
-      availableSince.put(consultantId, System.currentTimeMillis());
+      availableSince.put(consultantId, clock.millis());
     }
   }
 
@@ -40,13 +50,13 @@ public class ConsultantActivityRegistry {
    */
   public void refreshIfAvailable(String consultantId) {
     if (consultantId != null) {
-      availableSince.computeIfPresent(consultantId, (id, ts) -> System.currentTimeMillis());
+      availableSince.computeIfPresent(consultantId, (id, ts) -> clock.millis());
     }
   }
 
   /** Returns the subset of the given consultant IDs marked available within the window (in ms). */
   public Set<String> filterActive(Collection<String> consultantIds, long windowMs) {
-    long cutoff = System.currentTimeMillis() - windowMs;
+    long cutoff = clock.millis() - windowMs;
     return consultantIds.stream()
         .filter(
             consultantId -> {

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
@@ -90,7 +90,7 @@ public class TopicConsultantRoutingService {
     // Primary signal: real-time Matrix presence of the topic's (non-absent) consultants.
     List<String> candidateMatrixUserIds =
         consultants.stream()
-            .filter(consultant -> !consultant.isAbsent())
+            .filter(consultant -> consultant != null && !consultant.isAbsent())
             .map(Consultant::getMatrixUserId)
             .filter(matrixUserId -> matrixUserId != null && !matrixUserId.isBlank())
             .collect(Collectors.toList());
@@ -104,7 +104,7 @@ public class TopicConsultantRoutingService {
       // Authoritative answer from Matrix — trust it even when empty (genuinely nobody online).
       Set<String> online = onlineMatrixUserIds.get();
       return consultants.stream()
-          .filter(consultant -> !consultant.isAbsent())
+          .filter(consultant -> consultant != null && !consultant.isAbsent())
           .filter(
               consultant ->
                   consultant.getMatrixUserId() != null
@@ -131,7 +131,7 @@ public class TopicConsultantRoutingService {
 
     List<String> onlineTopicConsultantIds =
         consultants.stream()
-            .filter(consultant -> !consultant.isAbsent())
+            .filter(consultant -> consultant != null && !consultant.isAbsent())
             .filter(
                 consultant ->
                     onlineConsultantIds.contains(consultant.getId())

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
@@ -135,7 +135,8 @@ public class TopicConsultantRoutingService {
             .filter(
                 consultant ->
                     onlineConsultantIds.contains(consultant.getId())
-                        || onlineConsultantIds.contains(consultant.getRocketChatId()))
+                        || (consultant.getRocketChatId() != null
+                            && onlineConsultantIds.contains(consultant.getRocketChatId())))
             .map(Consultant::getId)
             .collect(Collectors.toList());
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
@@ -1,0 +1,133 @@
+package de.caritas.cob.userservice.api.service.availability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConsultantActivityRegistryTest {
+
+  private ConsultantActivityRegistry registry;
+
+  @BeforeEach
+  void setUp() {
+    registry = new ConsultantActivityRegistry();
+  }
+
+  @Test
+  void markAvailable_Should_AddConsultant() {
+    registry.markAvailable("consultant-1");
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).containsExactly("consultant-1");
+  }
+
+  @Test
+  void markAvailable_Should_IgnoreNullId() {
+    registry.markAvailable(null);
+
+    Set<String> active = registry.filterActive(List.of(), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void markAvailable_Should_IgnoreBlankId() {
+    registry.markAvailable("   ");
+
+    Set<String> active = registry.filterActive(List.of("   "), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void markUnavailable_Should_RemoveConsultant() {
+    registry.markAvailable("consultant-1");
+    registry.markUnavailable("consultant-1");
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void markUnavailable_Should_IgnoreNullId() {
+    registry.markAvailable("consultant-1");
+    registry.markUnavailable(null);
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).containsExactly("consultant-1");
+  }
+
+  @Test
+  void markUnavailable_Should_NotFailWhenConsultantNotPresent() {
+    registry.markUnavailable("non-existent");
+
+    Set<String> active = registry.filterActive(List.of("non-existent"), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void refreshIfAvailable_Should_KeepConsultantActive() throws InterruptedException {
+    registry.markAvailable("consultant-1");
+    Thread.sleep(10);
+    registry.refreshIfAvailable("consultant-1");
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).containsExactly("consultant-1");
+  }
+
+  @Test
+  void refreshIfAvailable_Should_NotAddUnavailableConsultant() {
+    registry.refreshIfAvailable("consultant-1");
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void refreshIfAvailable_Should_IgnoreNullId() {
+    registry.markAvailable("consultant-1");
+    registry.refreshIfAvailable(null);
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).containsExactly("consultant-1");
+  }
+
+  @Test
+  void filterActive_Should_ReturnOnlyActiveWithinWindow() throws InterruptedException {
+    registry.markAvailable("consultant-1");
+    Thread.sleep(100);
+    registry.markAvailable("consultant-2");
+
+    // window of 50ms — only consultant-2 is within window
+    Set<String> active = registry.filterActive(List.of("consultant-1", "consultant-2"), 50);
+    assertThat(active).containsExactly("consultant-2");
+  }
+
+  @Test
+  void filterActive_Should_ReturnEmptyWhenNoConsultantsGiven() {
+    registry.markAvailable("consultant-1");
+
+    Set<String> active = registry.filterActive(List.of(), 60_000);
+    assertThat(active).isEmpty();
+  }
+
+  @Test
+  void filterActive_Should_OnlyReturnSubsetMatchingGivenIds() {
+    registry.markAvailable("consultant-1");
+    registry.markAvailable("consultant-2");
+
+    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
+    assertThat(active).containsExactly("consultant-1");
+  }
+
+  @Test
+  void multipleConsultants_Should_TrackIndependently() {
+    registry.markAvailable("c1");
+    registry.markAvailable("c2");
+    registry.markUnavailable("c1");
+
+    Set<String> active = registry.filterActive(List.of("c1", "c2"), 60_000);
+    assertThat(active).containsExactly("c2");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
@@ -1,7 +1,10 @@
 package de.caritas.cob.userservice.api.service.availability;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,13 +97,18 @@ class ConsultantActivityRegistryTest {
   }
 
   @Test
-  void filterActive_Should_ReturnOnlyActiveWithinWindow() throws InterruptedException {
-    registry.markAvailable("consultant-1");
-    Thread.sleep(100);
-    registry.markAvailable("consultant-2");
+  void filterActive_Should_ReturnOnlyActiveWithinWindow() {
+    Clock clock = mock(Clock.class);
+    ConsultantActivityRegistry timedRegistry = new ConsultantActivityRegistry(clock);
 
-    // window of 50ms — only consultant-2 is within window
-    Set<String> active = registry.filterActive(List.of("consultant-1", "consultant-2"), 50);
+    when(clock.millis()).thenReturn(1000L);
+    timedRegistry.markAvailable("consultant-1");
+
+    when(clock.millis()).thenReturn(1200L);
+    timedRegistry.markAvailable("consultant-2");
+
+    // cutoff = 1200 - 150 = 1050; consultant-1 (1000) excluded, consultant-2 (1200) included
+    Set<String> active = timedRegistry.filterActive(List.of("consultant-1", "consultant-2"), 150);
     assertThat(active).containsExactly("consultant-2");
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
@@ -1,0 +1,428 @@
+package de.caritas.cob.userservice.api.service.consultingtype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.Messenger;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TopicConsultantRoutingServiceTest {
+
+  @Mock private ConsultantTopicRepository consultantTopicRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private Messenger messenger;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private ConsultantActivityRegistry consultantActivityRegistry;
+
+  @InjectMocks private TopicConsultantRoutingService service;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(service, "activeWindowMs", 120_000L);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private Consultant consultant(String id, boolean absent) {
+    Consultant c = new Consultant();
+    c.setId(id);
+    c.setAbsent(absent);
+    return c;
+  }
+
+  private Consultant consultantWithMatrix(String id, String matrixUserId, boolean absent) {
+    Consultant c = consultant(id, absent);
+    c.setMatrixUserId(matrixUserId);
+    return c;
+  }
+
+  private Consultant consultantWithRc(String id, String rcId, boolean absent) {
+    Consultant c = consultant(id, absent);
+    c.setRocketChatId(rcId);
+    return c;
+  }
+
+  // ── findAvailableConsultantIds ────────────────────────────────────────────
+
+  @Test
+  void findAvailableConsultantIds_Should_ReturnEmpty_When_TopicIdIsNull() {
+    List<String> result = service.findAvailableConsultantIds(null);
+
+    assertThat(result).isEmpty();
+    verify(consultantTopicRepository, never()).findConsultantIdsByTopicId(any());
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_ReturnEmpty_When_NoConsultantsAssignedToTopic() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(1L))
+        .thenReturn(Collections.emptyList());
+
+    List<String> result = service.findAvailableConsultantIds(1L);
+
+    assertThat(result).isEmpty();
+    verify(consultantRepository, never()).findAllByIdIn(any());
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_ReturnEmpty_When_AllConsultantsAreAbsent() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(1L)).thenReturn(List.of("c1", "c2"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2")))
+        .thenReturn(List.of(consultant("c1", true), consultant("c2", true)));
+
+    List<String> result = service.findAvailableConsultantIds(1L);
+
+    assertThat(result).isEmpty();
+    verify(consultantActivityRegistry, never()).filterActive(any(), anyLong());
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_ReturnEmpty_When_NoneActiveInRegistry() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(1L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1")))
+        .thenReturn(List.of(consultant("c1", false)));
+    when(consultantActivityRegistry.filterActive(List.of("c1"), 120_000L))
+        .thenReturn(Collections.emptySet());
+
+    List<String> result = service.findAvailableConsultantIds(1L);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_ReturnActiveConsultants() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(5L))
+        .thenReturn(List.of("c1", "c2", "c3"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2", "c3")))
+        .thenReturn(
+            List.of(
+                consultant("c1", false),
+                consultant("c2", true), // absent — filtered out
+                consultant("c3", false)));
+    when(consultantActivityRegistry.filterActive(List.of("c1", "c3"), 120_000L))
+        .thenReturn(Set.of("c1"));
+
+    List<String> result = service.findAvailableConsultantIds(5L);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_ExcludeNullConsultantsFromRepo() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(1L)).thenReturn(List.of("c1"));
+    // repo may return null entries in some edge cases
+    when(consultantRepository.findAllByIdIn(List.of("c1")))
+        .thenReturn(Collections.singletonList(null));
+
+    List<String> result = service.findAvailableConsultantIds(1L);
+
+    assertThat(result).isEmpty();
+  }
+
+  // ── findEligibleConsultantIds ─────────────────────────────────────────────
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnEmpty_When_TopicIdIsNull() {
+    List<String> result = service.findEligibleConsultantIds(null, 1);
+
+    assertThat(result).isEmpty();
+    verify(consultantTopicRepository, never()).findConsultantIdsByTopicId(any());
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnEmpty_When_NoConsultantsAssignedToTopic() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(2L))
+        .thenReturn(Collections.emptyList());
+
+    List<String> result = service.findEligibleConsultantIds(2L, 1);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnEmpty_When_AllConsultantsAbsent() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(3L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1")))
+        .thenReturn(List.of(consultant("c1", true)));
+
+    List<String> result = service.findEligibleConsultantIds(3L, 1);
+
+    assertThat(result).isEmpty();
+    verify(matrixSynapseService, never()).findOnlineMatrixUserIds(any());
+  }
+
+  @Test
+  void
+      findEligibleConsultantIds_Should_ReturnMatrixOnlineConsultants_When_MatrixPresentAndMatches() {
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    Consultant c2 = consultantWithMatrix("c2", "@c2:matrix.org", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(4L)).thenReturn(List.of("c1", "c2"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2"))).thenReturn(List.of(c1, c2));
+    when(matrixSynapseService.findOnlineMatrixUserIds(List.of("@c1:matrix.org", "@c2:matrix.org")))
+        .thenReturn(Optional.of(Set.of("@c1:matrix.org")));
+
+    List<String> result = service.findEligibleConsultantIds(4L, 10);
+
+    assertThat(result).containsExactly("c1");
+    verify(messenger, never()).findAvailableConsultants(any(int.class));
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnEmpty_When_MatrixPresentButNobodyOnline() {
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(4L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(List.of("@c1:matrix.org")))
+        .thenReturn(Optional.of(Collections.emptySet()));
+
+    List<String> result = service.findEligibleConsultantIds(4L, 10);
+
+    // Matrix said nobody online — authoritative empty, do NOT fall back
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void
+      findEligibleConsultantIds_Should_FallbackToActiveIds_When_MatrixUnavailableAndConsultingTypeNull() {
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(5L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+
+    List<String> result = service.findEligibleConsultantIds(5L, null);
+
+    assertThat(result).containsExactly("c1");
+    verify(messenger, never()).findAvailableConsultants(any(int.class));
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_FallbackToActiveIds_When_MessengerThrowsException() {
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(6L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+    when(messenger.findAvailableConsultants(99)).thenThrow(new RuntimeException("RC down"));
+
+    List<String> result = service.findEligibleConsultantIds(6L, 99);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_FallbackToActiveIds_When_MessengerReturnsEmptySet() {
+    Consultant c1 = consultantWithMatrix("c1", null, false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(7L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+    when(messenger.findAvailableConsultants(5)).thenReturn(Collections.emptySet());
+
+    List<String> result = service.findEligibleConsultantIds(7L, 5);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnIntersection_When_MessengerMatchesByConsultantId() {
+    Consultant c1 = consultant("c1", false);
+    Consultant c2 = consultant("c2", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(8L)).thenReturn(List.of("c1", "c2"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2"))).thenReturn(List.of(c1, c2));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+    when(messenger.findAvailableConsultants(3)).thenReturn(Set.of("c1"));
+
+    List<String> result = service.findEligibleConsultantIds(8L, 3);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_MatchByRocketChatId_When_MessengerUsesRcIds() {
+    Consultant c1 = consultantWithRc("c1", "rc-c1", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(9L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+    // messenger returns RC id, not consultant id
+    when(messenger.findAvailableConsultants(7)).thenReturn(Set.of("rc-c1"));
+
+    List<String> result = service.findEligibleConsultantIds(9L, 7);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_FallbackToActiveIds_When_MessengerMatchesNobody() {
+    Consultant c1 = consultant("c1", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(10L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(any())).thenReturn(Optional.empty());
+    // online set is populated but no overlap with this topic's consultants
+    when(messenger.findAvailableConsultants(4)).thenReturn(Set.of("someone-else"));
+
+    List<String> result = service.findEligibleConsultantIds(10L, 4);
+
+    // best-effort fallback: return all active topic consultants rather than empty
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ExcludeAbsentConsultants_From_MatrixCandidates() {
+    Consultant present = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    Consultant absent = consultantWithMatrix("c2", "@c2:matrix.org", true);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(11L)).thenReturn(List.of("c1", "c2"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2")))
+        .thenReturn(List.of(present, absent));
+    // only @c1 should be sent to Matrix check — @c2 is absent
+    when(matrixSynapseService.findOnlineMatrixUserIds(List.of("@c1:matrix.org")))
+        .thenReturn(Optional.of(Set.of("@c1:matrix.org")));
+
+    List<String> result = service.findEligibleConsultantIds(11L, 1);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_SkipMatrixCheck_When_AllConsultantsHaveNoMatrixId() {
+    Consultant c1 = consultant("c1", false); // matrixUserId is null
+    when(consultantTopicRepository.findConsultantIdsByTopicId(12L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(messenger.findAvailableConsultants(2)).thenReturn(Set.of("c1"));
+
+    List<String> result = service.findEligibleConsultantIds(12L, 2);
+
+    // no Matrix user IDs → Optional.empty without calling matrixSynapseService
+    verify(matrixSynapseService, never()).findOnlineMatrixUserIds(any());
+    assertThat(result).containsExactly("c1");
+  }
+
+  // ── database interaction: correct IDs forwarded between repo calls ─────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findAvailableConsultantIds_Should_ForwardTopicConsultantIds_To_ConsultantRepo() {
+    List<String> topicIds = List.of("c1", "c2", "c3");
+    when(consultantTopicRepository.findConsultantIdsByTopicId(20L)).thenReturn(topicIds);
+    when(consultantRepository.findAllByIdIn(topicIds)).thenReturn(Collections.emptyList());
+
+    service.findAvailableConsultantIds(20L);
+
+    ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+    verify(consultantRepository).findAllByIdIn(captor.capture());
+    assertThat(captor.getValue()).containsExactlyElementsOf(topicIds);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findEligibleConsultantIds_Should_ForwardTopicConsultantIds_To_ConsultantRepo() {
+    List<String> topicIds = List.of("x1", "x2");
+    when(consultantTopicRepository.findConsultantIdsByTopicId(21L)).thenReturn(topicIds);
+    when(consultantRepository.findAllByIdIn(topicIds)).thenReturn(Collections.emptyList());
+
+    service.findEligibleConsultantIds(21L, 1);
+
+    ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+    verify(consultantRepository).findAllByIdIn(captor.capture());
+    assertThat(captor.getValue()).containsExactlyElementsOf(topicIds);
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_HandlePartialRepoResult_When_SomeIdsNotFound() {
+    // Repo returns fewer consultants than IDs (e.g. some deleted between calls)
+    when(consultantTopicRepository.findConsultantIdsByTopicId(22L))
+        .thenReturn(List.of("c1", "c2", "c3"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2", "c3")))
+        .thenReturn(List.of(consultant("c1", false))); // c2 and c3 missing from DB
+    when(consultantActivityRegistry.filterActive(List.of("c1"), 120_000L)).thenReturn(Set.of("c1"));
+
+    List<String> result = service.findAvailableConsultantIds(22L);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_HandlePartialRepoResult_When_SomeIdsNotFound() {
+    when(consultantTopicRepository.findConsultantIdsByTopicId(23L)).thenReturn(List.of("c1", "c2"));
+    // only c1 found in DB
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2"))).thenReturn(List.of(c1));
+    when(matrixSynapseService.findOnlineMatrixUserIds(List.of("@c1:matrix.org")))
+        .thenReturn(Optional.of(Set.of("@c1:matrix.org")));
+
+    List<String> result = service.findEligibleConsultantIds(23L, 5);
+
+    assertThat(result).containsExactly("c1");
+  }
+
+  // ── concurrency: activeWindowMs is forwarded correctly ────────────────────
+
+  @Test
+  void findAvailableConsultantIds_Should_PassConfiguredWindowMs_To_Registry() {
+    ReflectionTestUtils.setField(service, "activeWindowMs", 30_000L);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(30L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1")))
+        .thenReturn(List.of(consultant("c1", false)));
+    when(consultantActivityRegistry.filterActive(List.of("c1"), 30_000L)).thenReturn(Set.of("c1"));
+
+    List<String> result = service.findAvailableConsultantIds(30L);
+
+    assertThat(result).containsExactly("c1");
+    verify(consultantActivityRegistry).filterActive(List.of("c1"), 30_000L);
+  }
+
+  // ── edge cases ─────────────────────────────────────────────────────────────
+
+  @Test
+  void findEligibleConsultantIds_Should_ExcludeBlankMatrixUserId_From_MatrixCandidates() {
+    // blank matrixUserId must not be sent to Matrix (same filter as null)
+    Consultant c1 = consultantWithMatrix("c1", "   ", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(40L)).thenReturn(List.of("c1"));
+    when(consultantRepository.findAllByIdIn(List.of("c1"))).thenReturn(List.of(c1));
+    when(messenger.findAvailableConsultants(1)).thenReturn(new HashSet<>(Set.of("c1")));
+
+    List<String> result = service.findEligibleConsultantIds(40L, 1);
+
+    verify(matrixSynapseService, never()).findOnlineMatrixUserIds(any());
+    assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findEligibleConsultantIds_Should_ReturnAllOnlineConsultants_When_MultipleMatchMatrix() {
+    Consultant c1 = consultantWithMatrix("c1", "@c1:matrix.org", false);
+    Consultant c2 = consultantWithMatrix("c2", "@c2:matrix.org", false);
+    Consultant c3 = consultantWithMatrix("c3", "@c3:matrix.org", false);
+    when(consultantTopicRepository.findConsultantIdsByTopicId(41L))
+        .thenReturn(List.of("c1", "c2", "c3"));
+    when(consultantRepository.findAllByIdIn(List.of("c1", "c2", "c3")))
+        .thenReturn(List.of(c1, c2, c3));
+    when(matrixSynapseService.findOnlineMatrixUserIds(
+            List.of("@c1:matrix.org", "@c2:matrix.org", "@c3:matrix.org")))
+        .thenReturn(Optional.of(Set.of("@c1:matrix.org", "@c3:matrix.org")));
+
+    List<String> result = service.findEligibleConsultantIds(41L, 1);
+
+    assertThat(result).containsExactlyInAnyOrder("c1", "c3");
+  }
+}


### PR DESCRIPTION
﻿#### [Issue #226](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/226)

## Summary

Adds 26 unit tests for `TopicConsultantRoutingService` and 11 for `ConsultantActivityRegistry` — both had zero coverage. Also fixes a latent NPE in `findEligibleConsultantIds` triggered when a consultant has no Rocket.Chat ID.

## Bug fixed

**`findEligibleConsultantIds` — NPE when `getRocketChatId()` returns null and set is null-hostile**

`Set.of(...).contains(null)` throws `NullPointerException`. Safe today only because `Messenger.findAvailableConsultants()` returns a `HashSet`; any null-hostile set would crash topic routing in production.

Before: `|| onlineConsultantIds.contains(consultant.getRocketChatId())`
After: `|| (consultant.getRocketChatId() != null && onlineConsultantIds.contains(consultant.getRocketChatId()))`

## What was tested

**`findAvailableConsultantIds` (6 tests)**
- Null topicId early return — repository never called
- No consultants for topic — empty, consultant repository never called
- All consultants absent — empty, registry never called
- None active in registry within window — empty
- Happy path — absent filtered, active subset returned
- Null entry from repository — handled safely

**`findEligibleConsultantIds` (13 tests)**
- Null topicId early return
- No consultants early return
- All absent — empty, Matrix never called
- Matrix online present + match — intersection returned, Messenger never called
- Matrix online present + empty — authoritative empty, no RC fallback
- Matrix unavailable + null consultingTypeId — active IDs returned, Messenger never called
- Matrix unavailable + Messenger throws — fallback to active IDs
- Matrix unavailable + Messenger returns empty — fallback to active IDs
- Matrix unavailable + Messenger matches by consultant ID
- Matrix unavailable + Messenger matches by Rocket.Chat ID (null guard exercised)
- Matrix unavailable + Messenger hits but none match topic — best-effort fallback
- Absent consultants excluded from Matrix candidate list
- All consultants have no matrixUserId — Matrix call skipped

**Database interaction (3 tests)**
- `ArgumentCaptor` verifies exact topic IDs forwarded from topic repo to consultant repo in both methods
- Partial repo result handled gracefully in both methods

**Concurrency (1 test)**
- `activeWindowMs` set via `ReflectionTestUtils` — exact value forwarded to `filterActive`

**Edge cases (3 tests)**
- Blank `matrixUserId` excluded (same as null)
- Multiple Matrix-online consultants — all returned
- Null consultant entries from repo — filtered safely

## Approach

Mocked `ConsultantTopicRepository`, `ConsultantRepository`, `MatrixSynapseService`, `Messenger`, `ConsultantActivityRegistry`. `ReflectionTestUtils` used to inject `activeWindowMs`. `new HashSet<>()` used instead of `Set.of()` wherever null Rocket.Chat IDs could reach `Set.contains()`. `@MockitoSettings(LENIENT)` applied.

## Test results

Tests run: 37, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java` | Bug fix (null guard on getRocketChatId) |
| `src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java` | Created (26 tests) |
| `src/test/java/de/caritas/cob/userservice/api/service/ConsultantActivityRegistryTest.java` | Created (11 tests) |

## Checklist
- [x] Bug fixed (NPE on null getRocketChatId with null-hostile set)
- [x] All decision branches covered in both public methods
- [x] Happy paths covered (Matrix path, RC fallback, activity filter)
- [x] Error handling covered (Matrix unavailable, Messenger throws, partial DB result)
- [x] Edge cases covered (null/blank matrixUserId, null topicId, null entries)
- [x] Database chaining verified with ArgumentCaptor
- [x] Concurrency: activeWindowMs forwarding verified
- [x] All 37 tests pass
