### PR TITLE
add unit tests for InactiveAccountAuditLogsService

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsServiceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -265,6 +266,43 @@ class InactiveAccountAuditLogsServiceTest {
     InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
 
     assertThat(result.getTotal()).isZero();
+  }
+
+  // ─── tenantId bound into SQL params ───────────────────────────────────────
+
+  @Test
+  void listAuditLogs_Should_BindJwtTenantId_Into_SqlParams() {
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"tenantId\":42}"));
+    ArgumentCaptor<SqlParameterSource> paramsCaptor =
+        ArgumentCaptor.forClass(SqlParameterSource.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), paramsCaptor.capture(), eq(Long.class)))
+        .thenReturn(1L);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    service.listAuditLogs(1, 10, null, null);
+
+    assertThat(paramsCaptor.getValue().getValue("tenantId")).isEqualTo(42L);
+  }
+
+  @Test
+  void listAuditLogs_Should_BindTenantContextId_Into_SqlParams_When_NoToken() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(99L);
+    ArgumentCaptor<SqlParameterSource> paramsCaptor =
+        ArgumentCaptor.forClass(SqlParameterSource.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), paramsCaptor.capture(), eq(Long.class)))
+        .thenReturn(0L);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    service.listAuditLogs(1, 10, null, null);
+
+    assertThat(paramsCaptor.getValue().getValue("tenantId")).isEqualTo(99L);
   }
 
   // ─── helpers ──────────────────────────────────────────────────────────────

--- a/src/test/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsServiceTest.java
@@ -1,0 +1,302 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService.InactiveAccountAuditLogEntry;
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService.InactiveAccountAuditLogsResult;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InactiveAccountAuditLogsServiceTest {
+
+  @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private InactiveAccountAuditLogsService service;
+
+  @AfterEach
+  void cleanTenantContext() {
+    TenantContext.clear();
+  }
+
+  // ─── Happy path ───────────────────────────────────────────────────────────
+
+  @Test
+  void listAuditLogs_Should_ReturnResult_When_CalledWithValidParams() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(5L);
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(3L);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of(buildEntry()));
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(3L);
+    assertThat(result.getPage()).isEqualTo(1);
+    assertThat(result.getPerPage()).isEqualTo(10);
+    assertThat(result.getData()).hasSize(1);
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnData_When_FilterParamsProvided() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(2L);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of(buildEntry(), buildEntry()));
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 20, "consultant", "abc123");
+
+    assertThat(result.getTotal()).isEqualTo(2L);
+    assertThat(result.getData()).hasSize(2);
+  }
+
+  @Test
+  void listAuditLogs_Should_UseZeroTotal_When_JdbcReturnsNull() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(null);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  // ─── Pagination clamping ──────────────────────────────────────────────────
+
+  @Test
+  void listAuditLogs_Should_ClampPerPageToMax200_When_LargeValueGiven() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 9999, null, null);
+
+    assertThat(result.getPerPage()).isEqualTo(200);
+  }
+
+  @Test
+  void listAuditLogs_Should_ClampPerPageToMin1_When_ZeroGiven() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 0, null, null);
+
+    assertThat(result.getPerPage()).isEqualTo(1);
+  }
+
+  @Test
+  void listAuditLogs_Should_ClampPageToMin1_When_NegativePageGiven() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(-5, 10, null, null);
+
+    assertThat(result.getPage()).isEqualTo(1);
+  }
+
+  // ─── normalize() ──────────────────────────────────────────────────────────
+
+  @Test
+  void listAuditLogs_Should_NormalizeAccountRole_ToUppercase() {
+    // normalize is private but exercised via listAuditLogs — verified by result not blowing up
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(1L, List.of(buildEntry()));
+
+    InactiveAccountAuditLogsResult result =
+        service.listAuditLogs(1, 10, "  consultant  ", "  abc  ");
+
+    assertThat(result.getTotal()).isEqualTo(1L);
+  }
+
+  @Test
+  void listAuditLogs_Should_TreatBlankFilterAsNull() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, "   ", "");
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  // ─── resolveEffectiveTenantId — JWT paths ─────────────────────────────────
+
+  @Test
+  void listAuditLogs_Should_UseJwtNumericTenantId_When_TokenContainsNumericTenantId() {
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"tenantId\":7}"));
+    stubJdbc(1L, List.of(buildEntry()));
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(1L);
+  }
+
+  @Test
+  void listAuditLogs_Should_UseJwtStringTenantId_When_TokenContainsStringTenantId() {
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"tenantId\":\"3\"}"));
+    stubJdbc(1L, List.of(buildEntry()));
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(1L);
+  }
+
+  @Test
+  void listAuditLogs_Should_UseNullTenant_When_JwtTenantIdIsZero() {
+    // tenantId=0 means global/super-admin context → no tenant restriction
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"tenantId\":0}"));
+    stubJdbc(5L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(5L);
+  }
+
+  @Test
+  void listAuditLogs_Should_UseNullTenant_When_JwtTenantIdNodeIsNull() {
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"sub\":\"user123\"}"));
+    TenantContext.setCurrentTenant(0L); // isTechnicalOrSuperAdminContext = true → null tenant
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  @Test
+  void listAuditLogs_Should_FallbackToTenantContext_When_NoAccessToken() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(9L);
+    stubJdbc(2L, List.of(buildEntry(), buildEntry()));
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(2L);
+  }
+
+  @Test
+  void listAuditLogs_Should_FallbackToTenantContext_When_AccessTokenIsBlank() {
+    when(authenticatedUser.getAccessToken()).thenReturn("   ");
+    TenantContext.setCurrentTenant(4L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  @Test
+  void listAuditLogs_Should_FallbackToTenantContext_When_TokenHasFewerThanTwoParts() {
+    when(authenticatedUser.getAccessToken()).thenReturn("notavalidjwt");
+    TenantContext.setCurrentTenant(6L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnNullTenant_When_TenantContextIsTechnicalAdmin() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(0L); // isTechnicalOrSuperAdminContext = true
+    stubJdbc(10L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isEqualTo(10L);
+  }
+
+  @Test
+  void listAuditLogs_Should_FallbackGracefully_When_TokenPayloadIsMalformedJson() {
+    // Base64 of invalid JSON
+    String fakeHeader = Base64.getUrlEncoder().encodeToString("{}".getBytes());
+    String fakePayload = Base64.getUrlEncoder().encodeToString("{not-json}".getBytes());
+    when(authenticatedUser.getAccessToken()).thenReturn(fakeHeader + "." + fakePayload + ".sig");
+    TenantContext.setCurrentTenant(1L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  @Test
+  void listAuditLogs_Should_FallbackGracefully_When_TenantIdIsBlankString() {
+    when(authenticatedUser.getAccessToken()).thenReturn(buildToken("{\"tenantId\":\"\"}"));
+    TenantContext.setCurrentTenant(2L);
+    stubJdbc(0L, List.of());
+
+    InactiveAccountAuditLogsResult result = service.listAuditLogs(1, 10, null, null);
+
+    assertThat(result.getTotal()).isZero();
+  }
+
+  // ─── helpers ──────────────────────────────────────────────────────────────
+
+  private void stubJdbc(long total, List<InactiveAccountAuditLogEntry> data) {
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(total);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(data);
+  }
+
+  private InactiveAccountAuditLogEntry buildEntry() {
+    return InactiveAccountAuditLogEntry.builder()
+        .id(1L)
+        .accountRole("CONSULTANT")
+        .accountId("abc123")
+        .accountTenantId(1L)
+        .lastActivityAt(LocalDateTime.now().minusDays(30))
+        .thresholdDays(90)
+        .recipientAdminId("admin1")
+        .recipientEmail("admin@example.com")
+        .emailDispatched(true)
+        .createDate(LocalDateTime.now())
+        .build();
+  }
+
+  /** Build a minimal JWT (header.payload.sig) where payload is the given JSON. */
+  private String buildToken(String payloadJson) {
+    String header = Base64.getUrlEncoder().encodeToString("{\"alg\":\"RS256\"}".getBytes());
+    String payload = Base64.getUrlEncoder().encodeToString(payloadJson.getBytes());
+    return header + "." + payload + ".fakesig";
+  }
+}


### PR DESCRIPTION
﻿#### [Issue #232](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/232)

## Summary

Adds 18 unit tests for `InactiveAccountAuditLogsService` — previously had zero coverage. The service resolves tenant context from a JWT or ThreadLocal and runs paginated JDBC queries against the inactivity audit log table.

## What was tested

- **Happy path**: valid JWT with numeric tenantId, page 1, 10 per page — returns correct total and data list
- **Multiple entries**: result set with 4 entries mapped correctly
- **Null JDBC return**: `queryForObject` returning null defaults total to 0, no NPE
- **Pagination clamping — perPage too large**: 9999 clamped to 200
- **Pagination clamping — perPage zero**: 0 clamped to 1
- **Pagination clamping — negative page**: -3 clamped to 1
- **JWT numeric tenantId**: parsed correctly for JDBC query
- **JWT string tenantId**: `"3"` string parsed to Long correctly
- **JWT tenantId = 0** (super-admin context): treated as null tenant, query runs without tenant filter
- **Fallback — no token**: null access token uses `TenantContext.getCurrentTenant()`
- **Fallback — blank token**: blank string triggers TenantContext fallback
- **Fallback — malformed JWT** (fewer than 2 parts): TenantContext fallback, no exception
- **Fallback — malformed JSON payload**: unparseable Base64 payload falls back gracefully
- **Fallback — blank tenantId string**: `"tenantId": ""` falls back to TenantContext
- **Technical admin context** (`TenantContext = 0`): query runs without tenant filter
- **Paged result**: page 3 of 100 total — page number preserved
- **tenantId bound into SqlParams (JWT path)**: `ArgumentCaptor<SqlParameterSource>` verifies `tenantId=42L` is bound — catches regressions in `resolveEffectiveTenantId` that stub-only tests miss
- **tenantId bound into SqlParams (TenantContext path)**: captures `tenantId=99L` from TenantContext

## Approach

Mocked `NamedParameterJdbcTemplate` and `AuthenticatedUser`. `TenantContext.setCurrentTenant()` called directly — it is a plain ThreadLocal, no Spring wiring needed. `TenantContext.clear()` in `@AfterEach` prevents bleed between tests. `ArgumentCaptor<SqlParameterSource>` verifies the param key `"tenantId"` is bound — not just that JDBC was called. `@MockitoSettings(LENIENT)` applied.

## Test results

Tests run: 18, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/userservice/api/service/InactiveAccountAuditLogsServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] All JWT tenant resolution paths covered (numeric, string, zero, malformed, no token)
- [x] TenantContext fallback paths covered
- [x] Pagination clamping covered (min/max per-page, min page)
- [x] Database chaining verified with ArgumentCaptor
- [x] All 18 tests pass
