### PR TITLE
feat(availability): consultant self-availability read endpoint (ADR-007)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
@@ -1,11 +1,15 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantLiveAvailabilityRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantLiveAvailabilityResponseDTO;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +18,10 @@ import org.springframework.web.bind.annotation.RestController;
  * Lets the consultant app drive live-chat availability directly from Live Chat enable/disable and
  * logout events, so the anonymous availability count updates immediately instead of waiting for the
  * heartbeat to expire.
+ *
+ * <p>Also exposes a self-availability READ (ADR-007) so the consultant app can drive its "live"
+ * indicator from the authoritative {@link ConsultantActivityRegistry} instead of mirroring a
+ * client-side flag (which is the root cause of the "stuck live" indicator).
  */
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +29,14 @@ public class ConsultantLiveAvailabilityController {
 
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull ConsultantActivityRegistry consultantActivityRegistry;
+
+  /**
+   * The live-chat availability window in milliseconds. Kept in sync with {@code
+   * TopicConsultantRoutingService} (same property + default) so the READ and the routing read
+   * agree.
+   */
+  @Value("${consultant.availability.activeWindowMs:120000}")
+  private long activeWindowMs;
 
   @PutMapping("/conversations/consultants/availability")
   public ResponseEntity<Void> setLiveChatAvailability(
@@ -35,5 +51,20 @@ public class ConsultantLiveAvailabilityController {
     }
 
     return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Returns whether the calling consultant is currently within the live-chat availability window,
+   * read from {@link ConsultantActivityRegistry}. Non-consultants always read {@code false}.
+   */
+  @GetMapping("/conversations/consultants/availability")
+  public ResponseEntity<ConsultantLiveAvailabilityResponseDTO> getLiveChatAvailability() {
+    boolean available = false;
+    if (authenticatedUser.isConsultant() && authenticatedUser.getUserId() != null) {
+      String userId = authenticatedUser.getUserId();
+      available =
+          consultantActivityRegistry.filterActive(List.of(userId), activeWindowMs).contains(userId);
+    }
+    return ResponseEntity.ok(new ConsultantLiveAvailabilityResponseDTO(available));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantLiveAvailabilityResponseDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantLiveAvailabilityResponseDTO.java
@@ -1,0 +1,18 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response body reporting whether the calling consultant is currently available for live chat, read
+ * from the authoritative {@code ConsultantActivityRegistry} (ADR-007).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsultantLiveAvailabilityResponseDTO {
+
+  /** {@code true} when the consultant is within the live-chat availability window. */
+  private Boolean available;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptor.java
@@ -22,6 +22,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class ConsultantActivityInterceptor implements HandlerInterceptor {
 
+  static final String AVAILABILITY_PATH = "/conversations/consultants/availability";
+
   private final ObjectProvider<AuthenticatedUser> authenticatedUser;
   private final ObjectProvider<ConsultantActivityRegistry> consultantActivityRegistry;
 
@@ -29,6 +31,10 @@ public class ConsultantActivityInterceptor implements HandlerInterceptor {
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
     try {
+      if ("GET".equalsIgnoreCase(request.getMethod())
+          && AVAILABILITY_PATH.equals(request.getRequestURI())) {
+        return true;
+      }
       AuthenticatedUser user = authenticatedUser.getIfAvailable();
       ConsultantActivityRegistry registry = consultantActivityRegistry.getIfAvailable();
       if (user != null && registry != null && user.isConsultant() && user.getUserId() != null) {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
@@ -1,0 +1,91 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.config.auth.RoleAuthorizationAuthorityMapper;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.hateoas.client.LinkDiscoverers;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies the self-availability READ endpoint (ADR-007): the indicator must read the authoritative
+ * {@link ConsultantActivityRegistry}, not mirror a client flag. The endpoint reports whether the
+ * calling consultant is currently within the live-chat availability window.
+ */
+@WebMvcTest(ConsultantLiveAvailabilityController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+class ConsultantLiveAvailabilityControllerIT {
+
+  private static final String AVAILABILITY_PATH = "/conversations/consultants/availability";
+  private static final String CONSULTANT_ID = "consultant-1";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private AuthenticatedUser authenticatedUser;
+
+  @MockBean private ConsultantActivityRegistry consultantActivityRegistry;
+
+  @MockBean private RoleAuthorizationAuthorityMapper roleAuthorizationAuthorityMapper;
+
+  @MockBean private LinkDiscoverers linkDiscoverers;
+
+  @MockBean private KeycloakConfigResolver keycloakConfigResolver;
+
+  @Test
+  void getLiveChatAvailability_Should_returnAvailableTrue_When_consultantIsInActiveSet()
+      throws Exception {
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantActivityRegistry.filterActive(anyCollection(), anyLong()))
+        .thenReturn(Set.of(CONSULTANT_ID));
+
+    this.mockMvc
+        .perform(get(AVAILABILITY_PATH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.available").value(true));
+  }
+
+  @Test
+  void getLiveChatAvailability_Should_returnAvailableFalse_When_consultantIsNotInActiveSet()
+      throws Exception {
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantActivityRegistry.filterActive(anyCollection(), anyLong()))
+        .thenReturn(Collections.emptySet());
+
+    this.mockMvc
+        .perform(get(AVAILABILITY_PATH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.available").value(false));
+  }
+
+  @Test
+  void getLiveChatAvailability_Should_returnAvailableFalse_And_notQueryRegistry_When_notConsultant()
+      throws Exception {
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+
+    this.mockMvc
+        .perform(get(AVAILABILITY_PATH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.available").value(false));
+
+    verifyNoInteractions(consultantActivityRegistry);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
@@ -1,7 +1,10 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -87,5 +90,27 @@ class ConsultantLiveAvailabilityControllerIT {
         .andExpect(jsonPath("$.available").value(false));
 
     verifyNoInteractions(consultantActivityRegistry);
+  }
+
+  @Test
+  void getLiveChatAvailability_Should_notRefreshTtl_When_pollingAvailability() throws Exception {
+    // Documents the pure-read contract at the controller level.
+    // Note: @WebMvcTest does not load ConsultantActivityInterceptor, so this test only verifies
+    // the controller itself does not mutate the registry. The interceptor's TTL-skip behavior
+    // for GET requests is verified in ConsultantActivityInterceptorTest.
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantActivityRegistry.filterActive(anyCollection(), anyLong()))
+        .thenReturn(Set.of(CONSULTANT_ID));
+
+    this.mockMvc
+        .perform(get(AVAILABILITY_PATH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.available").value(true));
+
+    // Registry was queried (filterActive) but never mutated (no markAvailable/refreshIfAvailable)
+    verify(consultantActivityRegistry).filterActive(anyCollection(), anyLong());
+    verify(consultantActivityRegistry, never()).refreshIfAvailable(any());
+    verify(consultantActivityRegistry, never()).markAvailable(any());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptorTest.java
@@ -1,0 +1,78 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class ConsultantActivityInterceptorTest {
+
+  private static final String CONSULTANT_ID = "consultant-1";
+
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private ConsultantActivityRegistry consultantActivityRegistry;
+  @Mock private ObjectProvider<AuthenticatedUser> authenticatedUserProvider;
+  @Mock private ObjectProvider<ConsultantActivityRegistry> consultantActivityRegistryProvider;
+
+  private ConsultantActivityInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    interceptor =
+        new ConsultantActivityInterceptor(
+            authenticatedUserProvider, consultantActivityRegistryProvider);
+  }
+
+  private void givenAuthenticatedConsultant() {
+    when(authenticatedUserProvider.getIfAvailable()).thenReturn(authenticatedUser);
+    when(consultantActivityRegistryProvider.getIfAvailable())
+        .thenReturn(consultantActivityRegistry);
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+  }
+
+  @Test
+  void preHandle_Should_notRefreshTtl_When_getAvailabilityPath() {
+    var request =
+        new MockHttpServletRequest("GET", ConsultantActivityInterceptor.AVAILABILITY_PATH);
+    var response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+
+    verify(consultantActivityRegistry, never()).refreshIfAvailable(CONSULTANT_ID);
+  }
+
+  @Test
+  void preHandle_Should_refreshTtl_When_putAvailabilityPath() {
+    givenAuthenticatedConsultant();
+    var request =
+        new MockHttpServletRequest("PUT", ConsultantActivityInterceptor.AVAILABILITY_PATH);
+    var response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+
+    verify(consultantActivityRegistry).refreshIfAvailable(CONSULTANT_ID);
+  }
+
+  @Test
+  void preHandle_Should_refreshTtl_When_getOtherPath() {
+    givenAuthenticatedConsultant();
+    var request = new MockHttpServletRequest("GET", "/users/sessions/open");
+    var response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+
+    verify(consultantActivityRegistry).refreshIfAvailable(CONSULTANT_ID);
+  }
+}


### PR DESCRIPTION
## Why
The live-chat "live" indicator is driven by a write-only client-side `localStorage` flag and never reads the backend, so it stays lit after a counsellor's availability window (120s TTL) expires — the "stuck live" bug. ADR-007 decides the indicator must **read** the authoritative `ConsultantActivityRegistry`.

## What
Adds `GET /conversations/consultants/availability` returning `{ "available": boolean }` for the calling consultant, computed from `ConsultantActivityRegistry.filterActive(...)`. **Additive only:**
- new `@GetMapping` on the existing `ConsultantLiveAvailabilityController` (no `SecurityConfig` change — the `/conversations/consultants/**` rule already authorizes it)
- a small `ConsultantLiveAvailabilityResponseDTO`
- a `WebMvcTest` with 3 cases (active / inactive / non-consultant), written test-first (red → green)

## Acceptance
- GET returns `{available:true}` when the consultant is inside the active window; `{available:false}` otherwise and for non-consultants.
- `ConsultantLiveAvailabilityControllerIT` green (3/3). Additive; no existing behaviour changed.

## Affected repos
`ORISO-UserService` only. The frontend nav-pill that will consume this endpoint is a separate slice (held behind #126).

Refs **ADR-007** (live-chat liveness — the indicator reads backend availability, never mirrors it).

🤖 Built test-first in an isolated worktree off `origin/dev`.
