### PR TITLE
fix(sb4): remove dead Keycloak adapter resolver bean (incompatible with Spring Boot 4)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -16,8 +16,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Data;
 import org.hibernate.validator.constraints.URL;
-import org.keycloak.adapters.KeycloakConfigResolver;
-import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -106,15 +104,6 @@ public class KeycloakConfig {
         .password(config.getAdminPassword())
         .clientId(config.getAdminClientId())
         .build();
-  }
-
-  /**
-   * Use the KeycloakSpringBootConfigResolver to be able to save the Keycloak settings in the spring
-   * application properties.
-   */
-  @Bean
-  public KeycloakConfigResolver keyCloakConfigResolver() {
-    return new KeycloakSpringBootConfigResolver();
   }
 
   @URL private String authServerUrl;


### PR DESCRIPTION
> **Draft — first, self-contained step toward green integration tests on the SB4 upgrade branch (#231).** Assigning @shazia-k to review.

## What
Removes the leftover `keyCloakConfigResolver()` bean in `KeycloakConfig.java` that instantiates `KeycloakSpringBootConfigResolver` (a Spring-Boot-2.x / `javax` adapter class), plus its two `org.keycloak.adapters.*` imports. Authentication already runs through `oauth2-resource-server` in `SecurityConfig`, so this bean is dead — and instantiating an SB-2.x class at context startup is a concrete Spring-Boot-2.x-under-4.0 incompatibility.

## Why
See the linked issue for full evidence. The SB4 migration left adapter-era code wired in; this bean is the most direct incompatibility and a strong candidate for the `mvn verify` context-load failures (`mvn test` passes because unit tests don't boot the context).

## Scope & honest validation
- **Self-contained:** only `KeycloakConfig.java` (no pom/test changes), so it does **not** cascade into the `@MockitoBean KeycloakConfigResolver` test mocks.
- `mvn test-compile` green (JDK 25 → target 21).
- **Not IT-validated locally** — I don't have JDK 21, and JDK 25 hits an unrelated Mockito/ByteBuddy limit (`Could not modify all classes …`). Please run `mvn verify` on JDK 21.
- The **complete** cleanup (drop `keycloak-spring-boot-starter` + `keycloak-spring-security-adapter` from the pom; remove the 5 obsolete `@MockitoBean KeycloakConfigResolver` fields) is described in the linked issue — left to your judgement since it touches your active branch. `keycloak-admin-client` should stay.

Base: `upgrade/userservice-java21-springboot4`.

Refs #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the app’s Keycloak integration to use a different configuration approach for authentication services.
  * Kept existing Keycloak settings and related behavior unchanged for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->