### PR TITLE
fix flaky ArchiveOrDeleteSessionStatisticsEventTest — replace LocalDateTime.now() with fixed timestamp

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/service/statistics/event/ArchiveOrDeleteSessionStatisticsEventTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/statistics/event/ArchiveOrDeleteSessionStatisticsEventTest.java
@@ -22,7 +22,7 @@ class ArchiveOrDeleteSessionStatisticsEventTest {
   private ArchiveOrDeleteSessionStatisticsEvent archiveOrDeleteSessionStatisticsEvent;
   private static final Long TENANT_ID = 2L;
   private static final String USER_ID = "userId";
-  private static final LocalDateTime END_DATE = LocalDateTime.now();
+  private static final LocalDateTime END_DATE = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
 
   @BeforeEach
   public void setup() throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
﻿#### [Issue #251](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/251)

## Summary

Fixes a flaky test in `ArchiveOrDeleteSessionStatisticsEventTest` that caused non-deterministic CI failures on any branch inheriting this test from `dev`. One-line change — no production code touched.

## Bug fixed

**`getPayload_Should_ReturnValidJsonPayload` — fails when `LocalDateTime.now()` lands on `:00` seconds**

`LocalDateTime.toString()` silently drops trailing zero seconds. When `now()` is e.g. `10:54:00`, `.truncatedTo(ChronoUnit.SECONDS).toString()` produces `"2026-06-30T10:54"` instead of `"2026-06-30T10:54:00"`. The serializer in `getPayload()` always emits the full `":00Z"` suffix, so the strings don't match at that exact second — test fails.

Before: `private static final LocalDateTime END_DATE = LocalDateTime.now();`
After: `private static final LocalDateTime END_DATE = LocalDateTime.of(2024, 1, 15, 10, 30, 45);`

A fixed timestamp with non-zero seconds eliminates the race condition entirely.

## What was tested

- **`getEventType_Should_ReturnEventTypeArchiveMessage`**: still passes — no change to event type logic
- **`getPayload_Should_ReturnValidJsonPayload`**: now deterministic — fixed timestamp always serializes to `"2024-01-15T10:30:45Z"`, assertion always matches

## Approach

No mocks needed. Single static field replacement. `LocalDateTime.of(2024, 1, 15, 10, 30, 45)` was chosen as a clearly artificial fixed date with non-zero seconds that can never produce the `:00` edge case. `spotless:apply` run before commit — no formatting changes needed.

## Impact

Once merged to `dev`, the Feature Branch CI on PR #237 and PR #241 will stop failing on this test. Both PRs are currently blocked from approval due to this flaky failure.

## Test results

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/userservice/api/service/statistics/event/ArchiveOrDeleteSessionStatisticsEventTest.java` | 1 line changed |

No production code changes.

## Checklist
- [x] Bug fixed (flaky LocalDateTime.now() replaced with fixed timestamp)
- [x] Both existing tests pass
- [x] No production code changes
- [x] Unblocks PR #237 and PR #241 once merged to dev
