### PR TITLE
extend agencyservice unit tests to increase coverage

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
@@ -67,4 +67,64 @@ class AgencyServiceTest {
     assertThat(headers.get("tenantId").get(0)).isEqualTo("1");
     TenantContext.clear();
   }
+
+  @Test
+  void getAgencyWithoutCaching_Should_returnAgency() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    var agencyDTOS =
+        Lists.newArrayList(
+            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
+    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(agencyDTOS);
+
+    AgencyDTO result = agencyService.getAgencyWithoutCaching(1L);
+
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  void getAgenciesNotCached_Should_returnEmptyList_When_emptyIdsProvided() {
+    List<AgencyDTO> result = agencyService.getAgenciesNotCached(List.of());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getAgenciesNotCached_Should_returnAgencies_When_idsProvided() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    var agencyDTOS =
+        Lists.newArrayList(
+            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
+    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(agencyDTOS);
+
+    List<AgencyDTO> result = agencyService.getAgenciesNotCached(Lists.newArrayList(1L));
+
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void getAgenciesWithoutCaching_Should_returnEmptyList_When_emptyIdsProvided() {
+    List<AgencyDTO> result = agencyService.getAgenciesWithoutCaching(List.of());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getAgenciesByConsultingType_Should_returnMappedAgencies() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    var agencyDTOS =
+        Lists.newArrayList(
+            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
+    when(agencyControllerApi.getAgenciesByConsultingType(1)).thenReturn(agencyDTOS);
+
+    List<AgencyDTO> result = agencyService.getAgenciesByConsultingType(1);
+
+    assertThat(result).hasSize(1);
+  }
 }


### PR DESCRIPTION
## What
- Extended AgencyServiceTest from 2 to 8 tests (+6)
- getAgencyWithoutCaching: delegates to API and returns mapped AgencyDTO
- getAgenciesNotCached: returns empty list for empty input; returns mapped list for valid ids
- getAgenciesWithoutCaching: returns empty list for empty input
- getAgenciesByConsultingType: calls consulting-type API endpoint and returns mapped list

## Why
Closes #257 - AgencyService had 62% instruction coverage; the non-cached variants and consulting-type lookup were entirely untested paths

## Test
- [ ] Run ./mvnw test -Dtest=AgencyServiceTest -- all 8 tests should pass