### PR TITLE
extend chatservice unit tests to increase coverage

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -341,4 +341,69 @@ class ChatServiceTest {
 
     verify(chatRepository).delete(chat);
   }
+
+  @Test
+  void saveUserChatRelation_Should_ThrowConflictException_WhenUserAlreadyAssigned() {
+    UserChat userChat = new UserChat();
+    when(chatUserRepository.findByChatAndUser(Mockito.any(), Mockito.any()))
+        .thenReturn(Optional.of(userChat));
+
+    assertThrows(ConflictException.class, () -> chatService.saveUserChatRelation(userChat));
+  }
+
+  @Test
+  void saveChat_Should_saveChatInRepository() {
+    Chat chat = new Chat();
+    when(chatRepository.save(chat)).thenReturn(chat);
+
+    Chat result = chatService.saveChat(chat);
+
+    verify(chatRepository).save(chat);
+    assertEquals(chat, result);
+  }
+
+  @Test
+  void getChatSessionsByIds_Should_returnUserSessionsForGivenIds() {
+    when(chatRepository.findAllById(Set.of(CHAT_ID))).thenReturn(List.of(activeChatWithAgency()));
+
+    List<UserSessionResponseDTO> result = chatService.getChatSessionsByIds(Set.of(CHAT_ID));
+
+    assertThat(result, hasSize(1));
+    assertNotNull(result.get(0).getChat());
+  }
+
+  @Test
+  void getChatSessionsForConsultantByIds_Should_returnConsultantSessionsForGivenIds() {
+    when(chatRepository.findAllById(Set.of(CHAT_ID))).thenReturn(List.of(activeChatWithAgency()));
+
+    List<ConsultantSessionResponseDTO> result =
+        chatService.getChatSessionsForConsultantByIds(Set.of(CHAT_ID));
+
+    assertThat(result, hasSize(1));
+    assertNotNull(result.get(0).getChat());
+  }
+
+  @Test
+  void getChatSessionsByGroupIds_Should_returnUserSessionsForGivenGroupIds() {
+    when(chatRepository.findByGroupIds(Set.of(RC_GROUP_ID)))
+        .thenReturn(List.of(activeChatWithAgency()));
+
+    List<UserSessionResponseDTO> result =
+        chatService.getChatSessionsByGroupIds(Set.of(RC_GROUP_ID));
+
+    assertThat(result, hasSize(1));
+    assertNotNull(result.get(0).getChat());
+  }
+
+  @Test
+  void getChatSessionsForConsultantByGroupIds_Should_returnConsultantSessionsForGivenGroupIds() {
+    when(chatRepository.findByGroupIds(Set.of(RC_GROUP_ID)))
+        .thenReturn(List.of(activeChatWithAgency()));
+
+    List<ConsultantSessionResponseDTO> result =
+        chatService.getChatSessionsForConsultantByGroupIds(Set.of(RC_GROUP_ID));
+
+    assertThat(result, hasSize(1));
+    assertNotNull(result.get(0).getChat());
+  }
 }


### PR DESCRIPTION
## What
- Extended ChatServiceTest from 15 to 21 tests (+6)
- saveUserChatRelation: throws ConflictException when user is already assigned to chat
- saveChat: delegates to repository and returns saved entity
- getChatSessionsByIds: returns UserSessionResponseDTO list for given chat id set
- getChatSessionsForConsultantByIds: returns ConsultantSessionResponseDTO list for given chat id set
- getChatSessionsByGroupIds: returns UserSessionResponseDTO list for given group id set
- getChatSessionsForConsultantByGroupIds: returns ConsultantSessionResponseDTO list for given group id set

## Why
Closes #258 - ChatService had 72% instruction coverage; the duplicate-user conflict guard, saveChat return path, and all four getChatSessions*ByIds/ByGroupIds methods were entirely untested

## Test
- [ ] Run ./mvnw test -Dtest=ChatServiceTest -- all 21 tests should pass