### PR TITLE
add unit tests for EventNotificationService

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -117,6 +117,9 @@ public class EventNotificationService {
   @Transactional
   public void createSupervisorRemovedNotification(
       Session session, String recipientUserId, String supervisorName) {
+    if (session == null || recipientUserId == null || recipientUserId.isBlank()) {
+      return;
+    }
     Map<String, Object> params = baseParams(session);
     putIfPresent(params, "supervisorName", supervisorName);
     createEvent(

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.service.notification;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,6 +23,7 @@ import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +67,10 @@ class EventNotificationServiceTest {
     when(session.getGroupId()).thenReturn("rc-group-1");
     return session;
   }
+
+  // ---------------------------------------------------------------------------
+  // createNewClientRequestNotifications
+  // ---------------------------------------------------------------------------
 
   @Test
   void createNewClientRequestNotifications_persistsRequestNewEventPerRecipient() throws Exception {
@@ -114,8 +120,22 @@ class EventNotificationServiceTest {
     verify(eventNotificationRepository, never()).save(any());
   }
 
-  // WP-06 Slice 2b: every producer now emits structured params alongside the (unchanged)
-  // title/text.
+  @Test
+  void createNewClientRequestNotifications_swallowsExceptionForOneRecipientAndContinues() {
+    Session session = sessionMock();
+    when(eventNotificationRepository.save(any()))
+        .thenThrow(new RuntimeException("DB error"))
+        .thenReturn(mock(EventNotification.class));
+
+    eventNotificationService.createNewClientRequestNotifications(
+        session, List.of("consultant-a", "consultant-b"));
+
+    verify(eventNotificationRepository, times(2)).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createInquiryAcceptedNotification
+  // ---------------------------------------------------------------------------
 
   @Test
   void createInquiryAcceptedNotification_setsSessionAndConsultantNameParams() throws Exception {
@@ -138,6 +158,70 @@ class EventNotificationServiceTest {
   }
 
   @Test
+  void createInquiryAcceptedNotification_doesNothingForNullSession() {
+    eventNotificationService.createInquiryAcceptedNotification(null, mock(Consultant.class));
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createInquiryAcceptedNotification_doesNothingWhenUserIsNull() {
+    Session session = mock(Session.class);
+    when(session.getUser()).thenReturn(null);
+    eventNotificationService.createInquiryAcceptedNotification(session, mock(Consultant.class));
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createInquiryAcceptedNotification_doesNothingWhenUserIdIsNull() {
+    Session session = mock(Session.class);
+    User user = mock(User.class);
+    when(session.getUser()).thenReturn(user);
+    when(user.getUserId()).thenReturn(null);
+    eventNotificationService.createInquiryAcceptedNotification(session, mock(Consultant.class));
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createInquiryAcceptedNotification_usesFullNameWhenDisplayNameIsEncoded() throws Exception {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getDisplayName()).thenReturn("enc.someCrypticallyEncodedValue");
+    when(consultant.getFullName()).thenReturn("Jane Real Name");
+
+    eventNotificationService.createInquiryAcceptedNotification(session, consultant);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    JsonNode params = objectMapper.readTree(eventCaptor.getValue().getParams());
+    assertEquals("Jane Real Name", params.get("consultantName").asText());
+  }
+
+  @Test
+  void createInquiryAcceptedNotification_returnsCounselorWhenAllConsultantFieldsAreEncoded()
+      throws Exception {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getDisplayName()).thenReturn("enc.encodedDisplayName");
+    when(consultant.getFullName()).thenReturn("enc.encodedFullName");
+    when(consultant.getUsername()).thenReturn("enc.encodedUsername");
+
+    eventNotificationService.createInquiryAcceptedNotification(session, consultant);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    JsonNode params = objectMapper.readTree(eventCaptor.getValue().getParams());
+    assertEquals("Counselor", params.get("consultantName").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createSupervisorAddedNotification
+  // ---------------------------------------------------------------------------
+
+  @Test
   void createSupervisorAddedNotification_setsSessionAndSupervisorNameParams() throws Exception {
     eventNotificationService.createSupervisorAddedNotification(
         sessionMock(), "asker-1", "Sam Supervisor");
@@ -149,6 +233,10 @@ class EventNotificationServiceTest {
     assertEquals(100L, params.get("sessionId").asLong());
     assertEquals("Sam Supervisor", params.get("supervisorName").asText());
   }
+
+  // ---------------------------------------------------------------------------
+  // createSupervisorAssignedNotification
+  // ---------------------------------------------------------------------------
 
   @Test
   void createSupervisorAssignedNotification_setsParamsAndConsultantActionPath() throws Exception {
@@ -166,9 +254,48 @@ class EventNotificationServiceTest {
   @Test
   void createSupervisorAssignedNotification_doesNothingForBlankRecipient() {
     eventNotificationService.createSupervisorAssignedNotification(sessionMock(), "  ");
-
     verify(eventNotificationRepository, never()).save(any());
   }
+
+  @Test
+  void createSupervisorAssignedNotification_doesNothingForNullSession() {
+    eventNotificationService.createSupervisorAssignedNotification(null, "consultant-x");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createSupervisorRemovedNotification
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createSupervisorRemovedNotification_setsSessionAndSupervisorNameParams() throws Exception {
+    eventNotificationService.createSupervisorRemovedNotification(
+        sessionMock(), "user-1", "Sam Supervisor");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    EventNotification saved = eventCaptor.getValue();
+    assertEquals("supervisor.removed", saved.getEventType());
+    assertEquals("user-1", saved.getRecipientUserId());
+    JsonNode params = objectMapper.readTree(saved.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals("Sam Supervisor", params.get("supervisorName").asText());
+  }
+
+  @Test
+  void createSupervisorRemovedNotification_doesNothingForNullSession() {
+    eventNotificationService.createSupervisorRemovedNotification(null, "user-1", "Sam");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createSupervisorRemovedNotification_doesNothingForNullRecipient() {
+    eventNotificationService.createSupervisorRemovedNotification(sessionMock(), null, "Sam");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createCounselorRenamedNotification
+  // ---------------------------------------------------------------------------
 
   @Test
   void createCounselorRenamedNotification_setsOldAndNewNameParams() throws Exception {
@@ -183,6 +310,22 @@ class EventNotificationServiceTest {
     assertEquals("Old Name", params.get("oldName").asText());
     assertEquals("New Name", params.get("newName").asText());
   }
+
+  @Test
+  void createCounselorRenamedNotification_doesNothingForNullSession() {
+    eventNotificationService.createCounselorRenamedNotification(null, "user-1", "Old", "New");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createCounselorRenamedNotification_doesNothingForBlankRecipient() {
+    eventNotificationService.createCounselorRenamedNotification(sessionMock(), "  ", "Old", "New");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createMessageNotificationFromRoom — routing and guards
+  // ---------------------------------------------------------------------------
 
   @Test
   void createMessageNotificationFromRoom_setsParamsAndNeverLeaksMessageBody() throws Exception {
@@ -208,81 +351,214 @@ class EventNotificationServiceTest {
   }
 
   @Test
+  void createMessageNotificationFromRoom_doesNothingForNullRoomId() {
+    eventNotificationService.createMessageNotificationFromRoom(null, "sender", "msg", false);
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
   void createMessageNotificationFromRoom_doesNothingForBlankRoomId() {
     eventNotificationService.createMessageNotificationFromRoom("  ", "sender", "msg", false);
-
     verify(eventNotificationRepository, never()).save(any());
   }
 
   @Test
   void createMessageNotificationFromRoom_doesNothingWhenSessionNotFound() {
-    when(sessionRepository.findByGroupId("no-room")).thenReturn(Optional.empty());
-
-    eventNotificationService.createMessageNotificationFromRoom("no-room", "sender", "msg", false);
-
+    when(sessionRepository.findByGroupId("unknown-room")).thenReturn(Optional.empty());
+    eventNotificationService.createMessageNotificationFromRoom(
+        "unknown-room", "sender", "msg", false);
     verify(eventNotificationRepository, never()).save(any());
   }
 
   @Test
-  void createMessageNotificationFromRoom_doesNothingForSystemNotificationMessages() {
-    Session sysSession = sessionMock();
-    when(sessionRepository.findByGroupId("rc-room")).thenReturn(Optional.of(sysSession));
+  void createMessageNotificationFromRoom_filtersSystemNotificationMessages() {
+    Session session = sessionMock();
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-room", "sender", "[SYSTEM_NOTIFICATION] system stuff", false);
+        "rc-group-1", "sender", "[SYSTEM_NOTIFICATION] room created", false);
 
     verify(eventNotificationRepository, never()).save(any());
   }
 
   @Test
-  void createSupervisorRemovedNotification_setsCorrectEventType() {
-    eventNotificationService.createSupervisorRemovedNotification(
-        sessionMock(), "asker-1", "Sam Supervisor");
+  void createMessageNotificationFromRoom_usesMatrixRoomIdLookupWhenMatrixRoomTrue() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!matrix-room-id")).thenReturn(Optional.of(session));
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    assertEquals("supervisor.removed", eventCaptor.getValue().getEventType());
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!matrix-room-id", "sender", "hello", true);
+
+    verify(sessionRepository).findByMatrixRoomId("!matrix-room-id");
+    verify(sessionRepository, never()).findByGroupId(any());
+    verify(eventNotificationRepository).save(any());
   }
 
   @Test
-  void markAsRead_updatesReadDate_When_NotificationExistsAndUnread() {
-    EventNotification notification = EventNotification.builder().id(1L).build();
-    when(eventNotificationRepository.findByIdAndRecipientUserId(1L, "user-1"))
-        .thenReturn(Optional.of(notification));
+  void createMessageNotificationFromRoom_suppressesNotificationWhenRecipientIsActiveInRoom() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
 
-    eventNotificationService.markAsRead("user-1", 1L);
-
-    verify(eventNotificationRepository).save(notification);
-    assertNotNull(notification.getReadDate());
-  }
-
-  @Test
-  void markAsRead_doesNotSave_When_AlreadyRead() {
-    EventNotification notification = EventNotification.builder().id(1L).build();
-    notification.setReadDate(java.time.LocalDateTime.now());
-    when(eventNotificationRepository.findByIdAndRecipientUserId(1L, "user-1"))
-        .thenReturn(Optional.of(notification));
-
-    eventNotificationService.markAsRead("user-1", 1L);
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", null, true);
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "hello", false);
 
     verify(eventNotificationRepository, never()).save(any());
   }
 
   @Test
-  void markAllAsRead_savesAllUnread() {
-    EventNotification n1 = EventNotification.builder().build();
-    EventNotification n2 = EventNotification.builder().build();
-    when(eventNotificationRepository.findByRecipientUserIdAndReadDateIsNull("user-1"))
-        .thenReturn(List.of(n1, n2));
+  void createMessageNotificationFromRoom_doesNotSuppressWhenUserIsInDifferentRoom() {
+    eventNotificationService.updateActiveView("asker-1", "different-room", null, true);
 
-    eventNotificationService.markAllAsRead("user-1");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
 
-    verify(eventNotificationRepository).saveAll(List.of(n1, n2));
-    assertNotNull(n1.getReadDate());
-    assertNotNull(n2.getReadDate());
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "msg", false);
+
+    verify(eventNotificationRepository).save(any());
   }
 
   @Test
-  void markAllAsRead_doesNothing_When_NoUnread() {
+  void createMessageNotificationFromRoom_consultantReceivesNotificationWhenNotSender() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getId()).thenReturn("consultant-1");
+    when(session.getConsultant()).thenReturn(consultant);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    // sender is the user — consultant should receive notification, not user
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "asker-1", "hello", false);
+
+    verify(eventNotificationRepository, times(1)).save(eventCaptor.capture());
+    assertEquals("consultant-1", eventCaptor.getValue().getRecipientUserId());
+  }
+
+  // ---------------------------------------------------------------------------
+  // createThreadReplyNotificationFromRoom
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createThreadReplyNotificationFromRoom_doesNothingForBlankRoomId() {
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "  ", "sender", "reply", "thread-1", false);
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_doesNothingWhenSessionNotFound() {
+    when(sessionRepository.findByGroupId("missing-room")).thenReturn(Optional.empty());
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "missing-room", "sender", "reply", "thread-1", false);
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_suppressesWhenUserActiveInSameThread() {
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-root-1", true);
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", "reply", "thread-root-1", false);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_doesNotSuppressWhenThreadRootIdMismatch() {
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-root-1", true);
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", "reply", "different-thread", false);
+
+    verify(eventNotificationRepository).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getFeed — page and perPage clamping
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getFeed_clampsNegativePageToZeroAndOverLimitPerPageToHundred() {
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of());
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    var result = eventNotificationService.getFeed("user-1", -5, 999);
+
+    assertThat(result.getPage()).isEqualTo(0);
+    assertThat(result.getPerPage()).isEqualTo(100);
+  }
+
+  @Test
+  void getFeed_clampsZeroPerPageToOne() {
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of());
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    var result = eventNotificationService.getFeed("user-1", 0, 0);
+
+    assertThat(result.getPerPage()).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // markAsRead
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void markAsRead_doesNotSaveWhenNotificationAlreadyRead() {
+    EventNotification alreadyRead = mock(EventNotification.class);
+    when(alreadyRead.getReadDate()).thenReturn(LocalDateTime.now());
+    when(eventNotificationRepository.findByIdAndRecipientUserId(42L, "user-1"))
+        .thenReturn(Optional.of(alreadyRead));
+
+    eventNotificationService.markAsRead("user-1", 42L);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void markAsRead_savesWhenNotificationIsUnread() {
+    EventNotification unread = mock(EventNotification.class);
+    when(unread.getReadDate()).thenReturn(null);
+    when(eventNotificationRepository.findByIdAndRecipientUserId(42L, "user-1"))
+        .thenReturn(Optional.of(unread));
+
+    eventNotificationService.markAsRead("user-1", 42L);
+
+    verify(eventNotificationRepository).save(unread);
+  }
+
+  // ---------------------------------------------------------------------------
+  // markAllAsRead
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void markAllAsRead_doesNothingWhenNoUnreadNotifications() {
     when(eventNotificationRepository.findByRecipientUserIdAndReadDateIsNull("user-1"))
         .thenReturn(List.of());
 
@@ -292,352 +568,570 @@ class EventNotificationServiceTest {
   }
 
   @Test
-  void clearFeed_delegatesToRepository() {
-    eventNotificationService.clearFeed("user-1");
+  void markAllAsRead_setsReadDateOnAllUnreadAndSaves() {
+    EventNotification n1 = mock(EventNotification.class);
+    EventNotification n2 = mock(EventNotification.class);
+    when(eventNotificationRepository.findByRecipientUserIdAndReadDateIsNull("user-1"))
+        .thenReturn(List.of(n1, n2));
 
+    eventNotificationService.markAllAsRead("user-1");
+
+    verify(n1).setReadDate(any());
+    verify(n2).setReadDate(any());
+    verify(eventNotificationRepository).saveAll(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // clearFeed
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void clearFeed_delegatesToDeleteByRecipientUserId() {
+    eventNotificationService.clearFeed("user-1");
     verify(eventNotificationRepository).deleteByRecipientUserId("user-1");
   }
 
-  @Test
-  void updateActiveView_removesEntry_When_NotActive() {
-    eventNotificationService.updateActiveView("user-1", "room-1", null, true);
-    eventNotificationService.updateActiveView("user-1", "room-1", null, false);
-    // After deactivation, active view is gone — should not suppress notification
-    // No repository interaction, but verifies no exception and state change works
-  }
+  // ---------------------------------------------------------------------------
+  // updateActiveView
+  // ---------------------------------------------------------------------------
 
   @Test
-  void updateActiveView_doesNothing_When_UserIdBlank() {
-    // Should not throw
+  void updateActiveView_doesNothingForBlankUserId() {
+    // No exception and no state change that would suppress future notifications
     eventNotificationService.updateActiveView("  ", "room-1", null, true);
-    eventNotificationService.updateActiveView(null, "room-1", null, true);
-  }
 
-  @Test
-  void updateActiveView_removesEntry_When_RoomIdBlankAndActive() {
-    eventNotificationService.updateActiveView("user-1", "room-1", null, true);
-    // Passing blank roomId with active=true should remove the entry
-    eventNotificationService.updateActiveView("user-1", "  ", null, true);
-    // No exception expected
-  }
-
-  @Test
-  void createEvent_doesNothing_When_RecipientIsBlank() {
-    eventNotificationService.createEvent("  ", "type", "cat", "title", "text", "/path", 1L, 1L);
-
-    verify(eventNotificationRepository, never()).save(any());
-  }
-
-  @Test
-  void createEvent_savesNotification_When_RecipientIsValid() {
-    eventNotificationService.createEvent(
-        "user-1", "type", "cat", "title", "text", "/path", 10L, 5L);
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    EventNotification saved = eventCaptor.getValue();
-    assertEquals("user-1", saved.getRecipientUserId());
-    assertEquals("type", saved.getEventType());
-    assertEquals(10L, saved.getSourceSessionId());
-    assertEquals(5L, saved.getTenantId());
-  }
-
-  // ── Helper ────────────────────────────────────────────────────────────────
-
-  private Session sessionWithUser(String userId) {
     Session session = sessionMock();
     User user = mock(User.class);
-    when(user.getUserId()).thenReturn(userId);
+    when(user.getUserId()).thenReturn("asker-1");
     when(session.getUser()).thenReturn(user);
-    when(session.getConsultant()).thenReturn(null);
-    return session;
-  }
-
-  // ── Privacy modes — createMessageNotificationFromRoom ─────────────────────
-
-  @Test
-  void createMessageNotification_NONE_mode_textDescribesEventWithoutPreview() {
-    Session session = sessionWithUser("asker-1");
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "secret message", false, false, "Jane");
+        "rc-group-1", "sender", "msg", false);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertTrue(text.startsWith("Jane sent a new message."));
-    assertFalse(text.contains("secret message"));
+    // Notification must still be delivered — blank userId never registered any suppression
+    verify(eventNotificationRepository).save(any());
   }
 
   @Test
-  void createMessageNotification_MASKED_mode_textShowsRedactedPlaceholder() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "secret message", false, false, "Jane");
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertTrue(text.contains("[content hidden]"));
-    assertFalse(text.contains("secret message"));
-  }
-
-  @Test
-  void createMessageNotification_FULL_mode_textIncludesPreview() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "hello world", false, false, "Jane");
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    assertTrue(eventCaptor.getValue().getText().contains("hello world"));
-  }
-
-  @Test
-  void createMessageNotification_invalid_privacyMode_fallsBackToNone() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "GARBAGE");
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "secret", false, false, "Jane");
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertFalse(text.contains("secret"));
-    assertFalse(text.contains("[content hidden]"));
-  }
-
-  // ── Privacy modes — createThreadReplyNotificationFromRoom ─────────────────
-
-  @Test
-  void createThreadReplyNotification_NONE_mode_textDoesNotContainPreview() {
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createThreadReplyNotificationFromRoom(
-        "rc-group-1", "sender-x", "secret reply", "thread-root", false, false, "Jane", null);
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertEquals("thread.reply.new", eventCaptor.getValue().getEventType());
-    assertTrue(text.contains("replied in a thread"));
-    assertFalse(text.contains("secret reply"));
-  }
-
-  @Test
-  void createThreadReplyNotification_MASKED_mode_showsRedactedPlaceholder() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createThreadReplyNotificationFromRoom(
-        "rc-group-1", "sender-x", "secret reply", "thread-root", false, false, "Jane", null);
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertTrue(text.contains("[content hidden]"));
-    assertFalse(text.contains("secret reply"));
-  }
-
-  @Test
-  void createThreadReplyNotification_FULL_mode_includesPreviewAndParentPreview() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-
-    eventNotificationService.createThreadReplyNotificationFromRoom(
-        "rc-group-1", "sender-x", "my reply", "thread-root", false, false, "Jane", "parent msg");
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String text = eventCaptor.getValue().getText();
-    assertTrue(text.contains("my reply"));
-    assertTrue(text.contains("parent msg"));
-  }
-
-  // ── getFeed pagination clamping ────────────────────────────────────────────
-
-  @Test
-  void getFeed_Should_ClampNegativePage_To_Zero() {
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
-        .thenReturn(List.of());
-    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
-
-    EventNotificationService.NotificationFeedResponse response =
-        eventNotificationService.getFeed("user-1", -5, 10);
-
-    assertEquals(0, response.getPage());
-    assertEquals(10, response.getPerPage());
-  }
-
-  @Test
-  void getFeed_Should_ClampPerPage_When_ExceedsMaxOf100() {
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
-        .thenReturn(List.of());
-    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
-
-    EventNotificationService.NotificationFeedResponse response =
-        eventNotificationService.getFeed("user-1", 0, 999);
-
-    assertEquals(100, response.getPerPage());
-  }
-
-  @Test
-  void getFeed_Should_ClampPerPage_When_ZeroOrBelow() {
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
-        .thenReturn(List.of());
-    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
-
-    EventNotificationService.NotificationFeedResponse response =
-        eventNotificationService.getFeed("user-1", 0, 0);
-
-    assertEquals(1, response.getPerPage());
-  }
-
-  // ── Active view suppression ────────────────────────────────────────────────
-
-  @Test
-  void createMessageNotification_Should_Suppress_When_UserActiveInSameRoom() {
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+  void updateActiveView_removesViewWhenActiveFalse() {
     eventNotificationService.updateActiveView("asker-1", "rc-group-1", null, true);
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", null, false);
 
-    eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "hello", false, false, "Jane");
-
-    verify(eventNotificationRepository, never()).save(any());
-  }
-
-  @Test
-  void createMessageNotification_Should_NotSuppress_When_UserActiveInDifferentRoom() {
-    Session session = sessionWithUser("asker-1");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    eventNotificationService.updateActiveView("asker-1", "other-room", null, true);
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "hello", false, false, "Jane");
+        "rc-group-1", "sender", "msg", false);
 
     verify(eventNotificationRepository).save(any());
   }
 
   @Test
-  void createThreadReply_Should_Suppress_When_UserWatchingSameThread() {
-    Session session = sessionWithUser("asker-1");
+  void updateActiveView_removesViewWhenRoomIdIsBlankEvenIfActiveTrue() {
+    eventNotificationService.updateActiveView("asker-1", "rc-group-1", null, true);
+    eventNotificationService.updateActiveView("asker-1", "  ", null, true);
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-123", true);
 
-    eventNotificationService.createThreadReplyNotificationFromRoom(
-        "rc-group-1", "sender-x", "reply text", "thread-123", false);
-
-    verify(eventNotificationRepository, never()).save(any());
-  }
-
-  @Test
-  void createThreadReply_Should_NotSuppress_When_UserWatchingDifferentThread() {
-    Session session = sessionWithUser("asker-1");
-    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    eventNotificationService.updateActiveView("asker-1", "rc-group-1", "thread-999", true);
-
-    eventNotificationService.createThreadReplyNotificationFromRoom(
-        "rc-group-1", "sender-x", "reply text", "thread-123", false);
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "msg", false);
 
     verify(eventNotificationRepository).save(any());
   }
 
-  // ── buildSessionActionPath — matrixRoomId priority ────────────────────────
+  // ---------------------------------------------------------------------------
+  // createEvent — low-level builder guards
+  // ---------------------------------------------------------------------------
 
   @Test
-  void createNewClientRequestNotifications_Should_UseMatrixRoomId_When_BothRoomIdsPresent()
-      throws Exception {
-    Session session = mock(Session.class);
-    when(session.getId()).thenReturn(200L);
-    when(session.getTenantId()).thenReturn(3L);
-    when(session.getAgencyId()).thenReturn(null);
-    when(session.getMainTopicId()).thenReturn(null);
-    when(session.getConsultingTypeId()).thenReturn(2);
-    when(session.getMatrixRoomId()).thenReturn("!matrix-abc:oriso.org");
-    when(session.getGroupId()).thenReturn("rc-group-1");
-
-    eventNotificationService.createNewClientRequestNotifications(session, List.of("consultant-x"));
-
-    verify(eventNotificationRepository).save(eventCaptor.capture());
-    String actionPath = eventCaptor.getValue().getActionPath();
-    assertTrue(actionPath.contains("!matrix-abc"));
-    assertFalse(actionPath.contains("rc-group-1"));
+  void createEvent_doesNothingForBlankRecipientUserId() {
+    eventNotificationService.createEvent(
+        "  ", "message.new", EventNotificationService.CATEGORY_MESSAGE, "T", "B", null, 1L, 1L);
+    verify(eventNotificationRepository, never()).save(any());
   }
 
-  // ── contentLabel via PrivacyEnvelope ──────────────────────────────────────
+  @Test
+  void createEvent_defaultsToCategorySystemWhenNullCategoryPassed() {
+    eventNotificationService.createEvent(
+        "user-1", "message.new", null, "Title", "Text", null, 1L, 1L);
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertEquals(EventNotificationService.CATEGORY_SYSTEM, eventCaptor.getValue().getCategory());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Notification preview modes (via createMessageNotificationFromRoom)
+  // ---------------------------------------------------------------------------
 
   @Test
-  void createMessageNotification_Should_UseContentClass_From_Envelope() {
-    Session session = sessionWithUser("asker-1");
+  void createMessageNotificationFromRoom_nonePreviewModeDoesNotIncludeMessageBody() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "NONE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    PrivacyEnvelope envelope =
-        PrivacyEnvelope.builder().contentClass("IMAGE").messageId("m1").build();
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", false, envelope);
+        "rc-group-1", "sender", "secret body", false);
 
     verify(eventNotificationRepository).save(eventCaptor.capture());
-    // NONE mode (default): "Someone sent a new image."
-    assertTrue(eventCaptor.getValue().getText().contains("image"));
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("sent a new message");
+    assertThat(text).doesNotContain("secret body");
+    assertThat(text).doesNotContain("[content hidden]");
   }
 
-  // ── resolveSenderName — lookup chain ──────────────────────────────────────
+  @Test
+  void createMessageNotificationFromRoom_maskedPreviewModeShowsRedactedPlaceholder() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "secret body", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("[content hidden]");
+    assertThat(text).doesNotContain("secret body");
+  }
 
   @Test
-  void createMessageNotification_Should_UseConsultantDisplayName_When_LookupSucceeds() {
-    Session session = sessionWithUser("asker-1");
+  void createMessageNotificationFromRoom_fullPreviewModeIncludesMessageBody() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "hello there", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getText()).contains("hello there");
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_invalidPreviewModeDefaultsToNone() {
+    ReflectionTestUtils.setField(
+        eventNotificationService, "notificationPreviewMode", "INVALID_VALUE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", "hello", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    // IllegalArgumentException on valueOf → falls back to NONE, which omits the preview
+    assertThat(eventCaptor.getValue().getText()).doesNotContain("hello");
+    assertThat(eventCaptor.getValue().getText()).doesNotContain("[content hidden]");
+  }
+
+  // ---------------------------------------------------------------------------
+  // resolveSenderName paths (exercised via createMessageNotificationFromRoom)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void resolveSenderName_usesDisplayNameWhenNotEncoded() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender-id", "msg", false, false, "Alice Consultant");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getParams()).contains("Alice Consultant");
+  }
+
+  @Test
+  void resolveSenderName_fallsBackToConsultantRepositoryWhenNoDisplayName() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
     Consultant consultant = mock(Consultant.class);
-    when(consultant.getDisplayName()).thenReturn("Dr Smith");
-    when(consultant.getFullName()).thenReturn(null);
-    when(consultant.getUsername()).thenReturn(null);
-    when(consultantRepository.findByIdAndDeleteDateIsNull("sender-x"))
+    when(consultant.getDisplayName()).thenReturn("Bob Smith");
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant-sender"))
         .thenReturn(Optional.of(consultant));
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "msg", false);
+        "rc-group-1", "consultant-sender", "msg", false);
 
     verify(eventNotificationRepository).save(eventCaptor.capture());
-    assertTrue(eventCaptor.getValue().getText().contains("Dr Smith"));
+    assertThat(eventCaptor.getValue().getParams()).contains("Bob Smith");
   }
 
   @Test
-  void createMessageNotification_Should_UseUsername_When_ConsultantNotFound() {
-    Session session = sessionWithUser("asker-1");
+  void resolveSenderName_fallsBackToUserRepositoryWhenNotConsultant() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    when(consultantRepository.findByIdAndDeleteDateIsNull("sender-x")).thenReturn(Optional.empty());
     User senderUser = mock(User.class);
-    when(senderUser.getUsername()).thenReturn("johndoe");
-    when(userRepository.findByUserIdAndDeleteDateIsNull("sender-x"))
+    when(senderUser.getUsername()).thenReturn("carol-user");
+    when(consultantRepository.findByIdAndDeleteDateIsNull("user-sender"))
+        .thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("user-sender"))
         .thenReturn(Optional.of(senderUser));
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", "msg", false);
+        "rc-group-1", "user-sender", "msg", false);
 
     verify(eventNotificationRepository).save(eventCaptor.capture());
-    assertTrue(eventCaptor.getValue().getText().contains("johndoe"));
+    assertThat(eventCaptor.getValue().getParams()).contains("carol-user");
   }
 
-  // ── normalizePreview — truncation ─────────────────────────────────────────
-
   @Test
-  void createMessageNotification_FULL_mode_Should_TruncateLongPreview() {
-    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
-    Session session = sessionWithUser("asker-1");
+  void resolveSenderName_returnsSomeoneWhenAllRepoLookupsFail() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
     when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
-    String longText = "a".repeat(150);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("unknown")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("unknown")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("unknown")).thenReturn(Optional.empty());
 
     eventNotificationService.createMessageNotificationFromRoom(
-        "rc-group-1", "sender-x", longText, false, false, "Jane");
+        "rc-group-1", "unknown", "msg", false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getParams()).contains("Someone");
+  }
+
+  // ---------------------------------------------------------------------------
+  // getFeed — toItem mapping (hit previously uncovered toItem path)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void getFeed_mapsNotificationsToItemsWithReadAtAndCreatedAt() {
+    EventNotification n = new EventNotification();
+    n.setId(99L);
+    n.setEventType("message.new");
+    n.setCategory(EventNotificationService.CATEGORY_MESSAGE);
+    n.setTitle("New message");
+    n.setText("hello");
+    n.setParams("{\"sessionId\":1}");
+    n.setActionPath("/sessions/user/view/room/1");
+    n.setSourceSessionId(1L);
+    n.setReadDate(LocalDateTime.of(2026, 1, 1, 12, 0));
+    n.setCreateDate(LocalDateTime.of(2026, 1, 1, 11, 0));
+
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of(n));
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
+
+    var result = eventNotificationService.getFeed("user-1", 0, 10);
+
+    assertThat(result.getItems()).hasSize(1);
+    var item = result.getItems().get(0);
+    assertThat(item.getId()).isEqualTo(99L);
+    assertThat(item.getEventType()).isEqualTo("message.new");
+    assertThat(item.getReadAt()).isNotNull();
+    assertThat(item.getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  void getFeed_setsReadAtNullWhenNotificationIsUnread() {
+    EventNotification n = new EventNotification();
+    n.setId(1L);
+    n.setEventType("request.new");
+    n.setCategory(EventNotificationService.CATEGORY_SYSTEM);
+    n.setTitle("T");
+    n.setText("B");
+    n.setCreateDate(LocalDateTime.now());
+    n.setReadDate(null);
+
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+        .thenReturn(List.of(n));
+    when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(1L);
+
+    var result = eventNotificationService.getFeed("user-1", 0, 10);
+
+    assertThat(result.getItems().get(0).getReadAt()).isNull();
+    assertThat(result.getUnreadCount()).isEqualTo(1L);
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildThreadReplyNotificationText — MASKED + FULL modes
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createThreadReplyNotificationFromRoom_maskedModeShowsRedactedPlaceholder() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "MASKED");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", "secret reply", "thread-1", false);
 
     verify(eventNotificationRepository).save(eventCaptor.capture());
     String text = eventCaptor.getValue().getText();
-    assertTrue(text.contains("..."));
-    assertFalse(text.contains(longText));
+    assertThat(text).contains("replied in a thread");
+    assertThat(text).contains("[content hidden]");
+    assertThat(text).doesNotContain("secret reply");
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_fullModeIncludesPreviewAndParentPreview() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", "my reply text", "thread-1", false, false, null, "parent message");
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("my reply text");
+    assertThat(text).contains("parent message");
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_fullModeEmptyPreviewFallsBackToMessageId() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", null, "thread-1", false, false, null, null);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("replied in a thread");
+    assertThat(text).contains("n/a");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Untested delegator overloads — PrivacyEnvelope variants
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createMessageNotificationFromRoom_envelopeOverloadDelegatesAndCreatesNotification() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder().messageId("msg-1").contentClass("IMAGE").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", false, envelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getEventType()).isEqualTo("message.new");
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_envelopeOverloadDelegatesAndCreatesNotification() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder().messageId("msg-2").contentClass("FILE").build();
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "rc-group-1", "sender", "thread-root-1", false, envelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getEventType()).isEqualTo("thread.reply.new");
+  }
+
+  // ---------------------------------------------------------------------------
+  // contentLabel — via NONE preview mode (shows contentLabel in text)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createMessageNotificationFromRoom_noneMode_usesContentClassAsLabel() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "NONE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope imageEnvelope =
+        PrivacyEnvelope.builder().messageId("m1").contentClass("IMAGE").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", null, false, false, null, imageEnvelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getText()).contains("image");
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_noneMode_fileContentClassLabelIsFile() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "NONE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope fileEnvelope =
+        PrivacyEnvelope.builder().messageId("m2").contentClass("FILE").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", null, false, false, null, fileEnvelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getText()).contains("file");
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_noneMode_audioContentClassLabelIsAudioMessage() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "NONE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope audioEnvelope =
+        PrivacyEnvelope.builder().messageId("m3").contentClass("AUDIO").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", null, false, false, null, audioEnvelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getText()).contains("audio message");
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_noneMode_videoContentClassLabelIsVideoMessage() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "NONE");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope videoEnvelope =
+        PrivacyEnvelope.builder().messageId("m4").contentClass("VIDEO").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", null, false, false, null, videoEnvelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getText()).contains("video message");
+  }
+
+  // ---------------------------------------------------------------------------
+  // normalizePreview — long message truncation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createMessageNotificationFromRoom_fullMode_truncatesLongPreviewAt117CharsWithEllipsis() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    String longMessage = "A".repeat(150);
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", longMessage, false);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("...");
+    assertThat(text).doesNotContain("A".repeat(118));
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildMessageNotificationText FULL with empty preview (messageId fallback)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createMessageNotificationFromRoom_fullMode_emptyPreviewFallsBackToMessageId() {
+    ReflectionTestUtils.setField(eventNotificationService, "notificationPreviewMode", "FULL");
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(userRepository.findByUserIdAndDeleteDateIsNull("sender")).thenReturn(Optional.empty());
+    when(identityTombstoneService.resolveDisplayLabel("sender")).thenReturn(Optional.empty());
+
+    PrivacyEnvelope envelope = PrivacyEnvelope.builder().messageId("evt-123").build();
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "sender", null, false, false, null, envelope);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    String text = eventCaptor.getValue().getText();
+    assertThat(text).contains("evt-123");
   }
 }


### PR DESCRIPTION
## What
- Extended EventNotificationServiceTest from 9 to 51 tests (+42), then further to 68 tests (+17)
- Added null guard tests for all notification creator methods
- Added preview mode tests (NONE / MASKED / FULL / invalid to NONE)
- Added active view suppression tests (updateActiveView + shouldSuppressNotification paths)
- Added sender name resolution tests (displayName to consultant repo to user repo to tombstone to Someone)
- Added resolveConsultantName fallback tests (encoded displayName to fullName to username to Counselor)
- Added getFeed page/perPage clamping tests, markAsRead already-read guard, markAllAsRead early-return, clearFeed delegation
- Added createEvent blank recipientUserId guard and null category default tests
- Added createSupervisorRemovedNotification happy path (was completely untested)
- Added per-recipient exception swallowing test for createNewClientRequestNotifications
- Added thread reply modes (MASKED shows redacted placeholder, FULL includes preview and parent preview, empty preview falls back to messageId)
- Added toItem mapping (readAt non-null when readDate set, readAt null when unread, unreadCount=1)
- Added contentLabel tests for all content classes (IMAGE, FILE, AUDIO, VIDEO)
- Added PrivacyEnvelope overload delegation tests for message and thread reply creators
- Added fix: JaCoCo argLine on default Surefire execution so coverage is measured correctly

## Why
Closes #253 - EventNotificationService had 52% coverage with 799 missed instructions; most branch paths (null guards, preview modes, active view suppression, sender resolution chain, toItem mapping, contentLabel) were untested

## Test
- [ ] Run ./mvnw test -Dtest=EventNotificationServiceTest -- all 68 tests should pass