### PR TITLE
fix: make RCToken optional on getSessionsForAuthenticatedUser.

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -267,7 +267,7 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
       responses:

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -996,14 +996,22 @@ class UserControllerIT {
   }
 
   @Test
-  void getSessionsForAuthenticatedUser_Should_ReturnBadRequest_WhenHeaderParamIsMissing()
+  void getSessionsForAuthenticatedUser_Should_ReturnNoContent_WhenRcTokenHeaderIsMissing()
       throws Exception {
+    List<UserSessionResponseDTO> session = new ArrayList<>();
+    UserSessionListResponseDTO response = new UserSessionListResponseDTO().sessions(session);
+
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userAccountService.retrieveValidatedUser()).thenReturn(USER);
+
+    when(sessionListFacade.retrieveSortedSessionsForAuthenticatedUser(anyString(), Mockito.any()))
+        .thenReturn(response);
 
     mvc.perform(
             get(PATH_GET_SESSIONS_FOR_AUTHENTICATED_USER)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isNoContent());
   }
 
   @Test


### PR DESCRIPTION
Chat clients call /users/sessions/askers without RCToken; treat the header as optional and return 204 when sessions are empty.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

