### PR TITLE
fix: allow empty emailToggles array on patch user.

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2550,7 +2550,6 @@ components:
           description: "Is true if the walk through is enabled for the user"
         emailToggles:
           type: array
-          minItems: 1
           uniqueItems: true
           items:
             $ref: '#/components/schemas/EmailToggle'
@@ -2593,7 +2592,6 @@ components:
           description: indicates should the walkt hrough be enabled
         emailToggles:
           type: array
-          minItems: 1
           uniqueItems: true
           items:
             $ref: '#/components/schemas/EmailToggle'

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerE2EIT.java
@@ -177,9 +177,7 @@ class UserControllerE2EIT {
 
   @Autowired private UserAgencyRepository userAgencyRepository;
 
-  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-  @Autowired
-  private ConsultingTypeControllerApi consultingTypeControllerApi;
+  @MockitoBean private ConsultingTypeControllerApi consultingTypeControllerApi;
 
   @Autowired private VideoChatConfig videoChatConfig;
 
@@ -1165,6 +1163,26 @@ class UserControllerE2EIT {
                 .content(objectMapper.writeValueAsString(patchDtoMap))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(authorities = AuthorityValue.CONSULTANT_DEFAULT)
+  void patchUserDataShouldRespondWithNoContentOnEmptyEmailTogglesArray() throws Exception {
+    givenAValidConsultant();
+
+    var patchDto = new HashMap<String, Object>(1);
+    patchDto.put("emailToggles", List.of());
+
+    mockMvc
+        .perform(
+            patch("/users/data")
+                .cookie(CSRF_COOKIE)
+                .cookie(RC_TOKEN_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(patchDto))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
   }
 
   @Test


### PR DESCRIPTION
Clients send emailToggles: [] when clearing toggles; remove minItems validation and cover the case in E2E tests.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

