### PR TITLE
fix: provision missing Matrix accounts when accepting enquiries.

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -496,8 +496,7 @@ public class AssignEnquiryFacade {
     if (!isBlank(matrixUserId)) {
       user.setMatrixUserId(matrixUserId);
       userRepository.save(user);
-      log.info(
-          "Ensured Matrix account for user {} with ID: {}", user.getUserId(), matrixUserId);
+      log.info("Ensured Matrix account for user {} with ID: {}", user.getUserId(), matrixUserId);
     }
   }
 
@@ -537,7 +536,9 @@ public class AssignEnquiryFacade {
     var candidateUserId = "@" + matrixLocalpart + ":" + matrixConfig.getServerName();
     if (!isBlank(matrixSynapseService.loginAsUserAccessToken(candidateUserId))) {
       log.info(
-          "Resolved existing Matrix account for localpart {}: {}", matrixLocalpart, candidateUserId);
+          "Resolved existing Matrix account for localpart {}: {}",
+          matrixLocalpart,
+          candidateUserId);
       return candidateUserId;
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -7,17 +7,22 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupMemberDTO;
 import de.caritas.cob.userservice.api.admin.service.rocketchat.RocketChatRemoveFromGroupOperationService;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
 import de.caritas.cob.userservice.api.facade.RocketChatFacade;
 import de.caritas.cob.userservice.api.helper.MatrixIds;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
@@ -59,7 +64,11 @@ public class AssignEnquiryFacade {
   private final @NonNull TenantContextProvider tenantContextProvider;
   private final @NonNull HttpServletRequest httpServletRequest;
   private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull MatrixConfig matrixConfig;
   private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull UserRepository userRepository;
+  private final @NonNull UserHelper userHelper;
+  private final @NonNull UsernameTranscoder usernameTranscoder;
   private final @NonNull AgencyMatrixCredentialClient agencyMatrixCredentialClient;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final @NonNull EventNotificationService eventNotificationService;
@@ -144,38 +153,17 @@ public class AssignEnquiryFacade {
 
     // Create Matrix room and invite user
     try {
-      // First, ensure consultant has a Matrix account
-      if (consultant.getMatrixUserId() == null) {
-        try {
-          var consultantPassword = java.util.UUID.randomUUID() + "-" + java.util.UUID.randomUUID();
-          var matrixUserResponse =
-              matrixSynapseService.createUser(
-                  consultant.getUsername(),
-                  consultantPassword,
-                  consultant.getFirstName() + " " + consultant.getLastName());
-
-          if (matrixUserResponse.getBody() != null
-              && matrixUserResponse.getBody().getUserId() != null) {
-            consultant.setMatrixUserId(matrixUserResponse.getBody().getUserId());
-            consultantRepository.save(consultant);
-            log.info(
-                "Created Matrix account for consultant: {} with ID: {}",
-                consultant.getUsername(),
-                matrixUserResponse.getBody().getUserId());
-          }
-        } catch (Exception e) {
-          log.error(
-              "Failed to create Matrix account for consultant: {}", consultant.getUsername(), e);
-        }
-      }
+      var user = session.getUser();
+      ensureUserMatrixAccount(user);
+      ensureConsultantMatrixAccount(consultant);
 
       log.info(
           "Matrix account status for session {}: user_matrix_id={}, consultant_matrix_id={}",
           session.getId(),
-          session.getUser().getMatrixUserId(),
+          user.getMatrixUserId(),
           consultant.getMatrixUserId());
 
-      if (session.getUser().getMatrixUserId() != null && consultant.getMatrixUserId() != null) {
+      if (!isBlank(user.getMatrixUserId()) && !isBlank(consultant.getMatrixUserId())) {
         String existingRoomId = session.getMatrixRoomId();
 
         if (existingRoomId != null && !existingRoomId.isBlank()) {
@@ -333,8 +321,8 @@ public class AssignEnquiryFacade {
       } else {
         throw new InternalServerErrorException(
             String.format(
-                "Matrix room creation failed for session %s: missing Matrix user id",
-                session.getId()));
+                "Matrix room creation failed for session %s: missing Matrix user id (user=%s, consultant=%s)",
+                session.getId(), user.getMatrixUserId(), consultant.getMatrixUserId()));
       }
     } catch (Exception e) {
       rollbackSessionUpdate(session);
@@ -496,6 +484,64 @@ public class AssignEnquiryFacade {
           e);
       return false;
     }
+  }
+
+  private void ensureUserMatrixAccount(User user) {
+    if (user == null || !isBlank(user.getMatrixUserId())) {
+      return;
+    }
+
+    var matrixLocalpart = usernameTranscoder.decodeUsername(user.getUsername());
+    var matrixUserId = createOrResolveMatrixUserId(matrixLocalpart, matrixLocalpart);
+    if (!isBlank(matrixUserId)) {
+      user.setMatrixUserId(matrixUserId);
+      userRepository.save(user);
+      log.info(
+          "Ensured Matrix account for user {} with ID: {}", user.getUserId(), matrixUserId);
+    }
+  }
+
+  private void ensureConsultantMatrixAccount(Consultant consultant) {
+    if (consultant == null || !isBlank(consultant.getMatrixUserId())) {
+      return;
+    }
+
+    var matrixLocalpart = usernameTranscoder.decodeUsername(consultant.getUsername());
+    var displayName = consultant.getFirstName() + " " + consultant.getLastName();
+    var matrixUserId = createOrResolveMatrixUserId(matrixLocalpart, displayName);
+    if (!isBlank(matrixUserId)) {
+      consultant.setMatrixUserId(matrixUserId);
+      consultantRepository.save(consultant);
+      log.info(
+          "Ensured Matrix account for consultant {} with ID: {}",
+          consultant.getUsername(),
+          matrixUserId);
+    }
+  }
+
+  private String createOrResolveMatrixUserId(String matrixLocalpart, String displayName) {
+    try {
+      var matrixResponse =
+          matrixSynapseService.createUser(
+              matrixLocalpart, userHelper.getRandomPassword(), displayName);
+      if (matrixResponse.getBody() != null && matrixResponse.getBody().getUserId() != null) {
+        return matrixResponse.getBody().getUserId();
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Failed to create Matrix user {}, attempting to resolve existing account: {}",
+          matrixLocalpart,
+          e.getMessage());
+    }
+
+    var candidateUserId = "@" + matrixLocalpart + ":" + matrixConfig.getServerName();
+    if (!isBlank(matrixSynapseService.loginAsUserAccessToken(candidateUserId))) {
+      log.info(
+          "Resolved existing Matrix account for localpart {}: {}", matrixLocalpart, candidateUserId);
+      return candidateUserId;
+    }
+
+    return null;
   }
 
   private String buildUniqueSessionRoomAlias(Long sessionId, String consultantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -50,7 +50,6 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.RegistrationType;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
-import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -128,7 +127,9 @@ class AssignEnquiryFacadeTest {
     // Anonymous enquiry constant has no user wired; assignEnquiry now dereferences it.
     ANONYMOUS_ENQUIRY_WITHOUT_CONSULTANT.setUser(USER_WITH_RC_ID);
 
-    lenient().when(usernameTranscoder.decodeUsername(anyString())).thenAnswer(i -> i.getArgument(0));
+    lenient()
+        .when(usernameTranscoder.decodeUsername(anyString()))
+        .thenAnswer(i -> i.getArgument(0));
     lenient().when(userHelper.getRandomPassword()).thenReturn("random-password");
     lenient().when(matrixConfig.getServerName()).thenReturn("matrix.example.com");
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -11,6 +11,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.ROCKETCHAT
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.ROCKET_CHAT_SYSTEM_USER_ID;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.SESSION_WITHOUT_CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.U25_SESSION_WITHOUT_CONSULTANT;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.USERNAME;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER_WITH_RC_ID;
 import static java.util.Arrays.asList;
 import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -31,19 +33,26 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Level;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupMemberDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
 import de.caritas.cob.userservice.api.facade.RocketChatFacade;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.RegistrationType;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
@@ -91,6 +100,10 @@ class AssignEnquiryFacadeTest {
   @Mock EmailNotificationFacade emailNotificationFacade;
   @Mock MatrixSynapseService matrixSynapseService;
   @Mock ConsultantRepository consultantRepository;
+  @Mock UserRepository userRepository;
+  @Mock UserHelper userHelper;
+  @Mock UsernameTranscoder usernameTranscoder;
+  @Mock MatrixConfig matrixConfig;
   @Mock AgencyMatrixCredentialClient agencyMatrixCredentialClient;
   @Mock LiveEventNotificationService liveEventNotificationService;
   @Mock EventNotificationService eventNotificationService;
@@ -115,6 +128,10 @@ class AssignEnquiryFacadeTest {
     // Anonymous enquiry constant has no user wired; assignEnquiry now dereferences it.
     ANONYMOUS_ENQUIRY_WITHOUT_CONSULTANT.setUser(USER_WITH_RC_ID);
 
+    lenient().when(usernameTranscoder.decodeUsername(anyString())).thenAnswer(i -> i.getArgument(0));
+    lenient().when(userHelper.getRandomPassword()).thenReturn("random-password");
+    lenient().when(matrixConfig.getServerName()).thenReturn("matrix.example.com");
+
     givenMatrixRoomCreationSucceeds();
   }
 
@@ -138,6 +155,7 @@ class AssignEnquiryFacadeTest {
   public void tearDown() {
     // Undo mutations of the shared TestConstants so other test classes are not affected.
     USER_WITH_RC_ID.setMatrixUserId(null);
+    USER_WITH_RC_ID.setUsername(USERNAME);
     CONSULTANT_WITH_AGENCY.setMatrixUserId(null);
     ANONYMOUS_ENQUIRY_WITHOUT_CONSULTANT.setUser(null);
 
@@ -159,6 +177,43 @@ class AssignEnquiryFacadeTest {
                     consultantSessionDTO.getConsultant().equals(consultant)
                         && consultantSessionDTO.getSession().equals(session)),
             Mockito.eq(false));
+  }
+
+  @Test
+  void assignEnquiry_Should_ProvisionMissingUserMatrixAccountBeforeRoomCreation()
+      throws MatrixCreateUserException {
+    TenantContext.setCurrentTenant(CURRENT_TENANT_ID);
+    USER_WITH_RC_ID.setMatrixUserId(null);
+    when(rocketChatFacade.retrieveRocketChatMembers(anyString())).thenReturn(LIST_GROUP_MEMBER_DTO);
+
+    var matrixUserResponse = new MatrixCreateUserResponseDTO();
+    matrixUserResponse.setUserId(USER_MATRIX_ID);
+    when(matrixSynapseService.createUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.status(HttpStatus.OK).body(matrixUserResponse));
+
+    assignEnquiryFacade.assignRegisteredEnquiry(SESSION_WITHOUT_CONSULTANT, CONSULTANT_WITH_AGENCY);
+
+    verify(userRepository).save(USER_WITH_RC_ID);
+    assertEquals(USER_MATRIX_ID, USER_WITH_RC_ID.getMatrixUserId());
+  }
+
+  @Test
+  void assignEnquiry_Should_ResolveExistingUserMatrixAccount_WhenCreateFails()
+      throws MatrixCreateUserException {
+    TenantContext.setCurrentTenant(CURRENT_TENANT_ID);
+    USER_WITH_RC_ID.setMatrixUserId(null);
+    USER_WITH_RC_ID.setUsername("asker");
+    when(rocketChatFacade.retrieveRocketChatMembers(anyString())).thenReturn(LIST_GROUP_MEMBER_DTO);
+    when(matrixSynapseService.createUser(eq("asker"), anyString(), eq("asker")))
+        .thenThrow(new MatrixCreateUserException("User ID already taken"));
+    when(matrixSynapseService.loginAsUserAccessToken("@asker:matrix.example.com"))
+        .thenReturn(MATRIX_TOKEN);
+
+    assignEnquiryFacade.assignRegisteredEnquiry(SESSION_WITHOUT_CONSULTANT, CONSULTANT_WITH_AGENCY);
+
+    verify(userRepository).save(USER_WITH_RC_ID);
+    assertEquals("@asker:matrix.example.com", USER_WITH_RC_ID.getMatrixUserId());
+    verify(matrixSynapseService, times(1)).createUser(eq("asker"), anyString(), eq("asker"));
   }
 
   @Test


### PR DESCRIPTION
Legacy users may lack matrix_user_id; create or resolve accounts for both parties before room setup and persist the IDs.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

