### PR TITLE
Revert PR #273: chat agencies lazy-load change

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ChatAgencyRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ChatAgencyRepository.java
@@ -1,17 +1,6 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.ChatAgency;
-import java.util.List;
-import java.util.Set;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 
-public interface ChatAgencyRepository extends CrudRepository<ChatAgency, Long> {
-
-  @Query("SELECT ca FROM ChatAgency ca JOIN FETCH ca.chat WHERE ca.chat.id = :chatId")
-  List<ChatAgency> findByChat_Id(@Param("chatId") Long chatId);
-
-  @Query("SELECT ca FROM ChatAgency ca JOIN FETCH ca.chat WHERE ca.chat.id IN :chatIds")
-  List<ChatAgency> findByChat_IdIn(@Param("chatIds") Set<Long> chatIds);
-}
+public interface ChatAgencyRepository extends CrudRepository<ChatAgency, Long> {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -25,9 +25,7 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -78,30 +76,20 @@ public class ChatService {
                 chat.getChatOwner() != null ? chat.getChatOwner().getId() : null,
                 chat.isActive()));
 
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
-
     return chats.stream()
-        .map(
-            chat ->
-                convertChatToConsultantSessionResponseDTO(
-                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+        .map(this::convertChatToConsultantSessionResponseDTO)
         .collect(Collectors.toList());
   }
 
-  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(
-      Chat chat, Set<ChatAgency> chatAgencies) {
+  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(Chat chat) {
     return new ConsultantSessionResponseDTO()
-        .chat(createUserChat(chat, chatAgencies))
+        .chat(createUserChat(chat))
         .consultant(
             new SessionConsultantForConsultantDTO()
                 .id(chat.getChatOwner().getId())
                 .firstName(chat.getChatOwner().getFirstName())
                 .lastName(chat.getChatOwner().getLastName())
                 .username(chat.getChatOwner().getUsername()));
-  }
-
-  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(Chat chat) {
-    return convertChatToConsultantSessionResponseDTO(chat, loadChatAgencies(chat.getId()));
   }
 
   private String[] getChatModerators(Set<ChatAgency> chatAgencies) {
@@ -156,51 +144,29 @@ public class ChatService {
   public List<UserSessionResponseDTO> getChatsForUserId(String userId) {
     List<Chat> chats = chatRepository.findByUserId(userId);
     List<Chat> assignedChats = chatRepository.findAssignedByUserId(userId);
-    var allChats =
-        Stream.concat(chats.stream(), assignedChats.stream()).collect(Collectors.toList());
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(allChats);
-    return allChats.stream()
-        .map(
-            chat ->
-                convertChatToUserSessionResponseDTO(
-                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+    return Stream.concat(chats.stream(), assignedChats.stream())
+        .map(this::convertChatToUserSessionResponseDTO)
         .collect(Collectors.toList());
   }
 
   public List<UserSessionResponseDTO> getChatSessionsByIds(Set<Long> chatIds) {
-    var chats =
-        StreamSupport.stream(chatRepository.findAllById(chatIds).spliterator(), false)
-            .collect(Collectors.toList());
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
-    return chats.stream()
-        .map(
-            chat ->
-                convertChatToUserSessionResponseDTO(
-                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+    return StreamSupport.stream(chatRepository.findAllById(chatIds).spliterator(), false)
+        .map(this::convertChatToUserSessionResponseDTO)
         .collect(Collectors.toList());
   }
 
-  private UserSessionResponseDTO convertChatToUserSessionResponseDTO(
-      Chat chat, Set<ChatAgency> chatAgencies) {
-    return new UserSessionResponseDTO().chat(createUserChat(chat, chatAgencies));
-  }
-
   private UserSessionResponseDTO convertChatToUserSessionResponseDTO(Chat chat) {
-    return convertChatToUserSessionResponseDTO(chat, loadChatAgencies(chat.getId()));
+    return new UserSessionResponseDTO().chat(createUserChat(chat));
   }
 
   private UserChatDTO createUserChat(Chat chat) {
-    return createUserChat(chat, loadChatAgencies(chat.getId()));
-  }
-
-  private UserChatDTO createUserChat(Chat chat, Set<ChatAgency> chatAgencies) {
-    if (chatAgencies.size() > 1) {
+    if (chat.getChatAgencies().size() > 1) {
       log.warn(
           "Chat with id {} has more than one agency assigned. " + "This should not be the case.",
           chat.getId());
     }
-    var agencies =
-        chatAgencies.stream()
+    var chatAgencies =
+        chat.getChatAgencies().stream()
             .map(chatAgency -> agencyService.getAgency(chatAgency.getAgencyId()))
             .collect(Collectors.toList());
 
@@ -225,28 +191,12 @@ public class ChatService {
         chat.getGroupId(),
         null,
         false,
-        getChatModerators(chatAgencies),
+        getChatModerators(chat.getChatAgencies()),
         chat.getStartDate(),
         null,
         chat.getCreateDate() != null ? chat.getCreateDate().toString() : null,
-        agencies,
+        chatAgencies,
         chat.getHintMessage());
-  }
-
-  private Set<ChatAgency> loadChatAgencies(Long chatId) {
-    return new HashSet<>(chatAgencyRepository.findByChat_Id(chatId));
-  }
-
-  private Map<Long, Set<ChatAgency>> loadChatAgenciesByChatId(List<Chat> chats) {
-    var chatIds = chats.stream().map(Chat::getId).collect(Collectors.toSet());
-    if (chatIds.isEmpty()) {
-      return Map.of();
-    }
-
-    return chatAgencyRepository.findByChat_IdIn(chatIds).stream()
-        .collect(
-            Collectors.groupingBy(
-                chatAgency -> chatAgency.getChat().getId(), Collectors.toCollection(HashSet::new)));
   }
 
   /**
@@ -295,14 +245,9 @@ public class ChatService {
                 chat.getChatOwner() != null ? chat.getChatOwner().getId() : null,
                 chat.isActive()));
 
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
-
     var result =
         chats.stream()
-            .map(
-                chat ->
-                    convertChatToConsultantSessionResponseDTO(
-                        chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+            .map(this::convertChatToConsultantSessionResponseDTO)
             .collect(Collectors.toList());
 
     log.info("🔍 ChatService: Converted to {} ConsultantSessionResponseDTO", result.size());
@@ -317,25 +262,15 @@ public class ChatService {
    * @return {@link List<UserSessionResponseDTO>}
    */
   public List<UserSessionResponseDTO> getChatSessionsByGroupIds(Set<String> groupIds) {
-    var chats = chatRepository.findByGroupIds(groupIds);
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
-    return chats.stream()
-        .map(
-            chat ->
-                convertChatToUserSessionResponseDTO(
-                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+    return chatRepository.findByGroupIds(groupIds).stream()
+        .map(this::convertChatToUserSessionResponseDTO)
         .collect(Collectors.toList());
   }
 
   public List<ConsultantSessionResponseDTO> getChatSessionsForConsultantByGroupIds(
       Set<String> groupIds) {
-    var chats = chatRepository.findByGroupIds(groupIds);
-    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
-    return chats.stream()
-        .map(
-            chat ->
-                convertChatToConsultantSessionResponseDTO(
-                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
+    return chatRepository.findByGroupIds(groupIds).stream()
+        .map(this::convertChatToConsultantSessionResponseDTO)
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -185,7 +185,9 @@ class AssignEnquiryFacadeTest {
       throws MatrixCreateUserException {
     TenantContext.setCurrentTenant(CURRENT_TENANT_ID);
     USER_WITH_RC_ID.setMatrixUserId(null);
-    when(rocketChatFacade.retrieveRocketChatMembers(anyString())).thenReturn(LIST_GROUP_MEMBER_DTO);
+    lenient()
+        .when(rocketChatFacade.retrieveRocketChatMembers(anyString()))
+        .thenReturn(LIST_GROUP_MEMBER_DTO);
 
     var matrixUserResponse = new MatrixCreateUserResponseDTO();
     matrixUserResponse.setUserId(USER_MATRIX_ID);
@@ -204,7 +206,9 @@ class AssignEnquiryFacadeTest {
     TenantContext.setCurrentTenant(CURRENT_TENANT_ID);
     USER_WITH_RC_ID.setMatrixUserId(null);
     USER_WITH_RC_ID.setUsername("asker");
-    when(rocketChatFacade.retrieveRocketChatMembers(anyString())).thenReturn(LIST_GROUP_MEMBER_DTO);
+    lenient()
+        .when(rocketChatFacade.retrieveRocketChatMembers(anyString()))
+        .thenReturn(LIST_GROUP_MEMBER_DTO);
     when(matrixSynapseService.createUser(eq("asker"), anyString(), eq("asker")))
         .thenThrow(new MatrixCreateUserException("User ID already taken"));
     when(matrixSynapseService.loginAsUserAccessToken("@asker:matrix.example.com"))

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -7,7 +7,6 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.AUTHENTICA
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_DTO;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_HINT_MESSAGE;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID;
-import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID_3;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_V2;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.INACTIVE_CHAT;
@@ -19,7 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,11 +38,9 @@ import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -69,44 +65,6 @@ class ChatServiceTest {
   @Mock private AgencyService agencyService;
 
   private static final long LOCAL_CHAT_AGENCY_ID = 1L;
-
-  @BeforeEach
-  void stubChatAgencyRepository() {
-    lenient()
-        .when(chatAgencyRepository.findByChat_IdIn(Mockito.anySet()))
-        .thenAnswer(
-            invocation -> {
-              @SuppressWarnings("unchecked")
-              Set<Long> chatIds = invocation.getArgument(0);
-              List<ChatAgency> agencies = new ArrayList<>();
-              if (chatIds.contains(ACTIVE_CHAT.getId())) {
-                agencies.add(chatAgencyFor(ACTIVE_CHAT.getId(), LOCAL_CHAT_AGENCY_ID));
-              }
-              if (chatIds.contains(CHAT_ID_3)) {
-                agencies.add(chatAgencyFor(CHAT_ID_3, LOCAL_CHAT_AGENCY_ID));
-              }
-              return agencies;
-            });
-    lenient()
-        .when(chatAgencyRepository.findByChat_Id(Mockito.anyLong()))
-        .thenAnswer(
-            invocation -> {
-              Long chatId = invocation.getArgument(0);
-              if (ACTIVE_CHAT.getId().equals(chatId)) {
-                return List.of(chatAgencyFor(chatId, LOCAL_CHAT_AGENCY_ID));
-              }
-              if (CHAT_ID_3.equals(chatId)) {
-                return List.of(chatAgencyFor(chatId, LOCAL_CHAT_AGENCY_ID));
-              }
-              return List.of();
-            });
-  }
-
-  private ChatAgency chatAgencyFor(Long chatId, Long agencyId) {
-    Chat chat = Mockito.mock(Chat.class);
-    Mockito.when(chat.getId()).thenReturn(chatId);
-    return new ChatAgency(chat, agencyId);
-  }
 
   /**
    * Returns a fresh {@link Chat} that mirrors the shared {@code ACTIVE_CHAT} fixture but, unlike


### PR DESCRIPTION
## Summary
Reverts only the most recent merge **#273** (`fix: load chat agencies explicitly to avoid LazyInitializationException`).

Keeps earlier merges on `dev` intact:
- #267 HV000151 validation fix
- #269 optional RCToken
- #270 empty emailToggles
- #272 Matrix account provisioning on enquiry accept

## Test plan
- [ ] CI passes
- [ ] Consultant session list works as before PR #273