### PR TITLE
chore(ci): clarify UserService validation workflows

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,15 +1,12 @@
-name: Reusable Docker Build and Publish steps
+name: Reusable Docker build and publish steps
 
 inputs:
   push_to_ghcr:
     required: true
-    type: boolean
   image_name:
     required: true
-    type: string
   github_token:
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -18,6 +15,7 @@ runs:
     uses: docker/setup-buildx-action@v4
 
   - name: Login to GitHub Container Registry
+    if: ${{ inputs.push_to_ghcr == 'true' }}
     uses: docker/login-action@v4
     with:
       registry: ${{ env.REGISTRY }}
@@ -34,7 +32,7 @@ runs:
         type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
         type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
-  - name: Build and Push Docker image
+  - name: Build Docker image and publish when enabled
     id: build
     uses: docker/build-push-action@v7
     with:

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -1,9 +1,8 @@
-name: Reusable Maven Build steps
+name: Reusable Maven validation and build steps
 
 inputs:
   java_version:
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -15,6 +14,30 @@ runs:
       distribution: 'temurin'
       cache: maven
 
-  - name: Build with Maven Wrapper
+  - name: Run Maven tests
     shell: bash
-    run: ./mvnw -B package
+    run: |
+      ./mvnw -B test
+      python3 - <<'PY'
+      from pathlib import Path
+      import sys
+      import xml.etree.ElementTree as ET
+
+      failing_reports = []
+      for report in Path("target/surefire-reports").glob("TEST-*.xml"):
+          root = ET.parse(report).getroot()
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          if failures or errors:
+              failing_reports.append((report, failures, errors))
+
+      if failing_reports:
+          print("Maven reported test failures/errors:")
+          for report, failures, errors in failing_reports:
+              print(f"- {report}: failures={failures}, errors={errors}")
+          sys.exit(1)
+      PY
+
+  - name: Package Java application
+    shell: bash
+    run: ./mvnw -B package -DskipTests

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -1,4 +1,4 @@
-name: CI - Feature Branch
+name: UserService Branch Validation
 
 on:
   push:
@@ -7,14 +7,15 @@ on:
     - dev
 
 jobs:
-  build:
+  validate:
+    name: test and build UserService
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '17'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: CI - Main
+name: UserService Build and Publish
 
 on:
   push:
@@ -11,7 +11,8 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  publish:
+    name: test, build and publish image
     runs-on: ubuntu-latest
 
     permissions:
@@ -22,12 +23,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '17'
 
-    - name: Create and Publish Docker image
+    - name: Publish UserService Docker image
       uses: ./.github/actions/docker-build-push
       with:
         push_to_ghcr: true

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI - Pull Request
+name: UserService PR Validation
 
 on:
   pull_request:
@@ -8,19 +8,20 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  validate:
+    name: test, build and Docker validation
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '17'
 
-    - name: Create Docker image
+    - name: Docker build validation without publishing
       uses: ./.github/actions/docker-build-push
       with:
         push_to_ghcr: false


### PR DESCRIPTION
## What changed

- Renamed UserService CI workflows and jobs so the check names describe what they do: branch validation, PR validation, and build/publish.
- Updated the reusable Maven action to run tests before packaging, then package with tests skipped to avoid running the same test phase twice.
- Added a Surefire report guard so CI fails when Maven test reports contain failures/errors. This is needed because the current POM can still print `BUILD SUCCESS` even when tests fail.
- Updated the reusable Docker action so PR validation builds the image without logging in to GHCR or publishing, while main/dev still publish images.
- Removed unsupported `type:` metadata from composite action inputs.

## Why

This follows the same CI clarity improvement we applied in the frontend repository: PRs should validate changes only, while publishing should happen only after merge to `dev` or `main`.

## Important merge note

This PR is expected to expose existing failing UserService tests once CI runs. Locally, `./mvnw -B test` completed with Maven `BUILD SUCCESS`, but Surefire reports showed failures/errors. With this PR, CI will correctly fail on those reports.

So this PR should be reviewed first, but merged only after the team decides whether to fix the existing tests first or phase in strict test enforcement separately.

## Validation

- YAML parsing passed for the changed workflow/action files.
- `git diff --check` passed.
- Local Maven test run exposed existing test failures in Surefire reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer CI workflow names for branch validation, pull requests, and main builds.
  * Main pipeline now includes testing, building, and conditional image publishing.

* **Bug Fixes**
  * Maven builds now run tests first and fail the workflow if any test errors or failures are found.
  * Docker publishing now only runs when image publishing is enabled.

* **Chores**
  * Simplified workflow input declarations and updated step labels for clearer build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->