### PR TITLE
chore(ci): check UserService validation against dev

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,15 +1,12 @@
-name: Reusable Docker Build and Publish steps
+name: Reusable Docker build and publish steps
 
 inputs:
   push_to_ghcr:
     required: true
-    type: boolean
   image_name:
     required: true
-    type: string
   github_token:
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -18,6 +15,7 @@ runs:
     uses: docker/setup-buildx-action@v4
 
   - name: Login to GitHub Container Registry
+    if: ${{ inputs.push_to_ghcr == 'true' }}
     uses: docker/login-action@v4
     with:
       registry: ${{ env.REGISTRY }}
@@ -34,7 +32,7 @@ runs:
         type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
         type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
-  - name: Build and Push Docker image
+  - name: Build Docker image and publish when enabled
     id: build
     uses: docker/build-push-action@v7
     with:

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -1,9 +1,8 @@
-name: Reusable Maven Build steps
+name: Reusable Maven validation and build steps
 
 inputs:
   java_version:
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -15,6 +14,30 @@ runs:
       distribution: 'temurin'
       cache: maven
 
-  - name: Build with Maven Wrapper
+  - name: Run Maven tests
     shell: bash
-    run: ./mvnw -B package
+    run: |
+      ./mvnw -B test
+      python3 - <<'PY'
+      from pathlib import Path
+      import sys
+      import xml.etree.ElementTree as ET
+
+      failing_reports = []
+      for report in Path("target/surefire-reports").glob("TEST-*.xml"):
+          root = ET.parse(report).getroot()
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          if failures or errors:
+              failing_reports.append((report, failures, errors))
+
+      if failing_reports:
+          print("Maven reported test failures/errors:")
+          for report, failures, errors in failing_reports:
+              print(f"- {report}: failures={failures}, errors={errors}")
+          sys.exit(1)
+      PY
+
+  - name: Package Java application
+    shell: bash
+    run: ./mvnw -B package -DskipTests

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -1,4 +1,4 @@
-name: CI - Feature Branch
+name: UserService Branch Validation
 
 on:
   push:
@@ -7,14 +7,15 @@ on:
     - dev
 
 jobs:
-  build:
+  validate:
+    name: test and build UserService
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,4 +1,4 @@
-name: CI - Main
+name: UserService Build and Publish
 
 on:
   push:
@@ -11,7 +11,8 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  publish:
+    name: test, build and publish image
     runs-on: ubuntu-latest
 
     permissions:
@@ -22,12 +23,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'
 
-    - name: Create and Publish Docker image
+    - name: Publish UserService Docker image
       uses: ./.github/actions/docker-build-push
       with:
         push_to_ghcr: true

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,4 +1,4 @@
-name: CI - Pull Request
+name: UserService PR Validation
 
 on:
   pull_request:
@@ -8,19 +8,20 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  build:
+  validate:
+    name: test, build and Docker validation
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Compile and Package Java application
+    - name: Run UserService tests and build
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'
 
-    - name: Create Docker image
+    - name: Docker build validation without publishing
       uses: ./.github/actions/docker-build-push
       with:
         push_to_ghcr: false


### PR DESCRIPTION
## What changed

This applies the same UserService CI workflow updates against the `dev` branch so we can observe how the updated validation behaves on the current dev codebase.

- Clarifies workflow and job names.
- Runs Maven tests before packaging.
- Fails CI when Surefire reports contain test failures/errors.
- Keeps PR Docker validation as build-only, without publishing.
- Removes unsupported composite-action input `type:` metadata.

## Why

This PR is for checking the CI workflow behavior against `dev` before deciding whether/when to merge strict test enforcement.

## Merge note

This is expected to expose any existing test failures in `dev`. It should not be merged until the test results are reviewed and the team agrees on the rollout.
