### PR TITLE
refactor: extract user registration controller delegate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -1,12 +1,10 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
-import static de.caritas.cob.userservice.api.model.NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
-import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.web.dto.AbsenceDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyAdminResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
@@ -46,27 +44,17 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionListResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
 import de.caritas.cob.userservice.api.admin.facade.AdminUserFacade;
-import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
-import de.caritas.cob.userservice.api.facade.CreateEnquiryMessageFacade;
-import de.caritas.cob.userservice.api.facade.CreateNewSessionFacade;
-import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
-import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.helper.UserHelper;
-import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.AskerImportService;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.SessionDataService;
-import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
-import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
 import de.caritas.cob.userservice.api.service.helper.EmailUrlDecoder;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -85,9 +73,7 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.apache.commons.validator.routines.EmailValidator;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -110,72 +96,45 @@ public class UserController implements UsersApi {
   private final @NotNull UserAccountService userAccountProvider;
   private final @NotNull SessionService sessionService;
   private final @NotNull AuthenticatedUser authenticatedUser;
-  private final @NotNull CreateEnquiryMessageFacade createEnquiryMessageFacade;
   private final @NotNull ConsultantImportService consultantImportService;
   private final @NotNull EmailNotificationFacade emailNotificationFacade;
   private final @NotNull AskerImportService askerImportService;
   private final @NotNull ConsultantAgencyService consultantAgencyService;
-  private final @NotNull AssignEnquiryFacade assignEnquiryFacade;
   private final @NotNull UserChatControllerDelegate userChatControllerDelegate;
   private final @NotNull UserSessionControllerDelegate userSessionControllerDelegate;
   private final @NotNull UserAccountControllerDelegate userAccountControllerDelegate;
   private final @NotNull UserTwoFactorAuthControllerDelegate userTwoFactorAuthControllerDelegate;
-  private final @NotNull CreateUserFacade createUserFacade;
-  private final @NotNull CreateNewSessionFacade createNewSessionFacade;
+  private final @NotNull UserRegistrationControllerDelegate userRegistrationControllerDelegate;
   private final @NotNull ConsultantDataFacade consultantDataFacade;
   private final @NotNull SessionDataService sessionDataService;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull Messaging messenger;
   private final @NonNull ConsultantDtoMapper consultantDtoMapper;
   private final @NonNull ConsultantService consultantService;
-  private final @NonNull UserHelper userHelper;
-  private final @NotNull IdentityClient identityClient;
-  private final @NonNull MagicLinkLoginService magicLinkLoginService;
 
   private final @NotNull AdminUserFacade adminUserFacade;
 
-  @Value("${feature.topics.enabled}")
-  private boolean featureTopicsEnabled;
-
-  private final @NonNull SessionDeleteService sessionDeleteService;
   private final @NonNull EventNotificationService eventNotificationService;
 
   @Override
   public ResponseEntity<Void> userExists(String username) {
-    val usernameAvailable = identityClient.isUsernameAvailable(username);
-    val userExists = !usernameAvailable;
-    if (userExists) {
-      return ResponseEntity.ok().build();
-    }
-    return ResponseEntity.notFound().build();
+    return userRegistrationControllerDelegate.userExists(username);
   }
 
   @GetMapping("/users/availability/{username}")
   public ResponseEntity<Void> usernameAvailability(@PathVariable String username) {
-    val usernameAvailable = identityClient.isUsernameAvailable(username);
-    return usernameAvailable
-        ? ResponseEntity.noContent().build()
-        : ResponseEntity.status(HttpStatus.CONFLICT).build();
+    return userRegistrationControllerDelegate.usernameAvailability(username);
   }
 
   @org.springframework.web.bind.annotation.PostMapping("/users/magic-link/request")
   public ResponseEntity<Void> requestMagicLink(@Valid @RequestBody MagicLinkRequestDTO requestDTO) {
-    var result = magicLinkLoginService.requestMagicLink(requestDTO.getUsername());
-    if (result
-        == de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService.MagicLinkRequestResult
-            .NOT_ENABLED) {
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-    }
-    return ResponseEntity.noContent().build();
+    return userRegistrationControllerDelegate.requestMagicLink(requestDTO);
   }
 
   @org.springframework.web.bind.annotation.PostMapping("/users/magic-link/consume")
   public ResponseEntity<KeycloakLoginResponseDTO> consumeMagicLink(
       @Valid @RequestBody MagicLinkConsumeDTO consumeDTO) {
-    return magicLinkLoginService
-        .consumeMagicLink(consumeDTO.getToken())
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.badRequest().build());
+    return userRegistrationControllerDelegate.consumeMagicLink(consumeDTO);
   }
 
   /**
@@ -186,34 +145,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> registerUser(@RequestBody UserDTO user) {
-    validateUserHasChosenTopicIfTopicsFeatureIsEnabled(user);
-    if (!userHelper.isUsernameValid(user.getUsername())) {
-      throw new BadRequestException("Username is invalid");
-    }
-    decodePassword(user);
-    user.setNewUserAccount(true);
-    var sessionId = createUserFacade.createUserAccountWithInitializedConsultingType(user);
-
-    HttpStatus status;
-    if (user.isConsultantSet() && !messenger.markAsDirectConsultant(sessionId)) {
-      status = HttpStatus.INTERNAL_SERVER_ERROR;
-    } else {
-      status = HttpStatus.CREATED;
-    }
-
-    return ResponseEntity.status(status).build();
-  }
-
-  private void decodePassword(UserDTO user) {
-    if (user.getPassword() != null) {
-      user.setPassword(URLDecoder.decode(user.getPassword(), StandardCharsets.UTF_8));
-    }
-  }
-
-  private void validateUserHasChosenTopicIfTopicsFeatureIsEnabled(UserDTO user) {
-    if (featureTopicsEnabled && user.getMainTopicId() == null) {
-      throw new BadRequestException("Main topic id is required");
-    }
+    return userRegistrationControllerDelegate.registerUser(user);
   }
 
   /**
@@ -229,19 +161,8 @@ public class UserController implements UsersApi {
       @RequestBody NewRegistrationDto newRegistrationDto,
       @RequestHeader(value = "RCToken", required = false) String rcToken,
       @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
-
-    var user = this.userAccountProvider.retrieveValidatedUser();
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
-
-    var registrationResponse =
-        createNewSessionFacade.initializeNewSession(
-            newRegistrationDto,
-            user,
-            rocketChatCredentials,
-            Lists.newArrayList(ONE_SESSION_PER_CONSULTING_TYPE));
-
-    return new ResponseEntity<>(registrationResponse, registrationResponse.getStatus());
+    return userRegistrationControllerDelegate.registerNewConsultingType(
+        newRegistrationDto, rcToken, rcUserId);
   }
 
   /**
@@ -254,26 +175,11 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<NewRegistrationResponseDto> registerNewSession(
-      de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto newRegistrationDto,
+      NewRegistrationDto newRegistrationDto,
       @RequestHeader(value = "RCToken", required = false) String rcToken,
       @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
-    var user = this.userAccountProvider.retrieveValidatedUser();
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
-
-    /* Additional enquiries from the profile page go through the normal
-    enquiry pipeline - the consultant is NOT pre-assigned here. The asker
-    lands on the "write first message" screen, the enquiry sits in the
-    agency queue, and a consultant picks it up. Direct-chat with a
-    specific consultant is a separate flow (QR code / ?cid=... link).
-    The empty constraint list keeps this endpoint permissive so existing
-    askers can raise new enquiries even when they already had a past
-    session for the same topic+agency. */
-    var response =
-        createNewSessionFacade.initializeNewSession(
-            newRegistrationDto, user, rocketChatCredentials, Lists.newArrayList());
-
-    return new ResponseEntity<>(response, response.getStatus());
+    return userRegistrationControllerDelegate.registerNewSession(
+        newRegistrationDto, rcToken, rcUserId);
   }
 
   /**
@@ -286,18 +192,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<Void> acceptEnquiry(
       @PathVariable Long sessionId, @RequestHeader(required = false) String rcUserId) {
-    var session = sessionService.getSession(sessionId);
-
-    // MATRIX MIGRATION: Removed groupId check - Matrix sessions don't have RocketChat groupId
-    if (session.isEmpty()) {
-      log.error("Internal Server Error: Session id {} is invalid, session not found.", sessionId);
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
-    this.assignEnquiryFacade.assignRegisteredEnquiry(session.get(), consultant);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userRegistrationControllerDelegate.acceptEnquiry(sessionId);
   }
 
   /**
@@ -313,30 +208,13 @@ public class UserController implements UsersApi {
       @RequestBody EnquiryMessageDTO enquiryMessage,
       @RequestHeader(value = "RCToken", required = false) String rcToken,
       @RequestHeader(value = "RCUserId", required = false) String rcUserId) {
-
-    var user = this.userAccountProvider.retrieveValidatedUser();
-    var rocketChatCredentials =
-        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
-    var language = consultantDtoMapper.languageOf(enquiryMessage.getLanguage());
-    var enquiryData =
-        new EnquiryData(
-            user,
-            sessionId,
-            enquiryMessage.getMessage(),
-            language,
-            rocketChatCredentials,
-            enquiryMessage.getT(),
-            null);
-
-    var response = createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
-
-    return new ResponseEntity<>(response, HttpStatus.CREATED);
+    return userRegistrationControllerDelegate.createEnquiryMessage(
+        sessionId, enquiryMessage, rcToken, rcUserId);
   }
 
   @Override
   public ResponseEntity<Void> deleteSessionAndInactiveUser(@PathVariable Long sessionId) {
-    sessionDeleteService.deleteSession(sessionId);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userRegistrationControllerDelegate.deleteSessionAndInactiveUser(sessionId);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -1,0 +1,200 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static de.caritas.cob.userservice.api.model.NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE;
+
+import com.google.common.collect.Lists;
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateEnquiryMessageResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.EnquiryMessageDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.facade.CreateEnquiryMessageFacade;
+import de.caritas.cob.userservice.api.facade.CreateNewSessionFacade;
+import de.caritas.cob.userservice.api.facade.CreateUserFacade;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
+import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class UserRegistrationControllerDelegate {
+
+  private final @NonNull UserAccountService userAccountProvider;
+  private final @NonNull SessionService sessionService;
+  private final @NonNull CreateEnquiryMessageFacade createEnquiryMessageFacade;
+  private final @NonNull AssignEnquiryFacade assignEnquiryFacade;
+  private final @NonNull CreateUserFacade createUserFacade;
+  private final @NonNull CreateNewSessionFacade createNewSessionFacade;
+  private final @NonNull Messaging messenger;
+  private final @NonNull ConsultantDtoMapper consultantDtoMapper;
+  private final @NonNull UserHelper userHelper;
+  private final @NonNull IdentityClient identityClient;
+  private final @NonNull MagicLinkLoginService magicLinkLoginService;
+  private final @NonNull SessionDeleteService sessionDeleteService;
+
+  @Value("${feature.topics.enabled}")
+  private boolean featureTopicsEnabled;
+
+  ResponseEntity<Void> userExists(String username) {
+    val usernameAvailable = identityClient.isUsernameAvailable(username);
+    val userExists = !usernameAvailable;
+    if (userExists) {
+      return ResponseEntity.ok().build();
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  ResponseEntity<Void> usernameAvailability(String username) {
+    val usernameAvailable = identityClient.isUsernameAvailable(username);
+    return usernameAvailable
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.status(HttpStatus.CONFLICT).build();
+  }
+
+  ResponseEntity<Void> requestMagicLink(MagicLinkRequestDTO requestDTO) {
+    var result = magicLinkLoginService.requestMagicLink(requestDTO.getUsername());
+    if (result == MagicLinkLoginService.MagicLinkRequestResult.NOT_ENABLED) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+    return ResponseEntity.noContent().build();
+  }
+
+  ResponseEntity<KeycloakLoginResponseDTO> consumeMagicLink(MagicLinkConsumeDTO consumeDTO) {
+    return magicLinkLoginService
+        .consumeMagicLink(consumeDTO.getToken())
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.badRequest().build());
+  }
+
+  ResponseEntity<Void> registerUser(UserDTO user) {
+    validateUserHasChosenTopicIfTopicsFeatureIsEnabled(user);
+    if (!userHelper.isUsernameValid(user.getUsername())) {
+      throw new BadRequestException("Username is invalid");
+    }
+    decodePassword(user);
+    user.setNewUserAccount(true);
+    var sessionId = createUserFacade.createUserAccountWithInitializedConsultingType(user);
+
+    HttpStatus status;
+    if (user.isConsultantSet() && !messenger.markAsDirectConsultant(sessionId)) {
+      status = HttpStatus.INTERNAL_SERVER_ERROR;
+    } else {
+      status = HttpStatus.CREATED;
+    }
+
+    return ResponseEntity.status(status).build();
+  }
+
+  private void decodePassword(UserDTO user) {
+    if (user.getPassword() != null) {
+      user.setPassword(URLDecoder.decode(user.getPassword(), StandardCharsets.UTF_8));
+    }
+  }
+
+  private void validateUserHasChosenTopicIfTopicsFeatureIsEnabled(UserDTO user) {
+    if (featureTopicsEnabled && user.getMainTopicId() == null) {
+      throw new BadRequestException("Main topic id is required");
+    }
+  }
+
+  ResponseEntity<NewRegistrationResponseDto> registerNewConsultingType(
+      NewRegistrationDto newRegistrationDto, String rcToken, String rcUserId) {
+    var user = this.userAccountProvider.retrieveValidatedUser();
+    var rocketChatCredentials =
+        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
+
+    var registrationResponse =
+        createNewSessionFacade.initializeNewSession(
+            newRegistrationDto,
+            user,
+            rocketChatCredentials,
+            Lists.newArrayList(ONE_SESSION_PER_CONSULTING_TYPE));
+
+    return new ResponseEntity<>(registrationResponse, registrationResponse.getStatus());
+  }
+
+  ResponseEntity<NewRegistrationResponseDto> registerNewSession(
+      NewRegistrationDto newRegistrationDto, String rcToken, String rcUserId) {
+    var user = this.userAccountProvider.retrieveValidatedUser();
+    var rocketChatCredentials =
+        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
+
+    /* Additional enquiries from the profile page go through the normal
+    enquiry pipeline - the consultant is NOT pre-assigned here. The asker
+    lands on the "write first message" screen, the enquiry sits in the
+    agency queue, and a consultant picks it up. Direct-chat with a
+    specific consultant is a separate flow (QR code / ?cid=... link).
+    The empty constraint list keeps this endpoint permissive so existing
+    askers can raise new enquiries even when they already had a past
+    session for the same topic+agency. */
+    var response =
+        createNewSessionFacade.initializeNewSession(
+            newRegistrationDto, user, rocketChatCredentials, Lists.newArrayList());
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  ResponseEntity<Void> acceptEnquiry(Long sessionId) {
+    var session = sessionService.getSession(sessionId);
+
+    // MATRIX MIGRATION: Removed groupId check - Matrix sessions don't have RocketChat groupId
+    if (session.isEmpty()) {
+      log.error("Internal Server Error: Session id {} is invalid, session not found.", sessionId);
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
+    this.assignEnquiryFacade.assignRegisteredEnquiry(session.get(), consultant);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<CreateEnquiryMessageResponseDTO> createEnquiryMessage(
+      Long sessionId, EnquiryMessageDTO enquiryMessage, String rcToken, String rcUserId) {
+    var user = this.userAccountProvider.retrieveValidatedUser();
+    var rocketChatCredentials =
+        RocketChatCredentials.builder().rocketChatToken(rcToken).rocketChatUserId(rcUserId).build();
+    var language = consultantDtoMapper.languageOf(enquiryMessage.getLanguage());
+    var enquiryData =
+        new EnquiryData(
+            user,
+            sessionId,
+            enquiryMessage.getMessage(),
+            language,
+            rocketChatCredentials,
+            enquiryMessage.getT(),
+            null);
+
+    var response = createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
+
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
+  }
+
+  ResponseEntity<Void> deleteSessionAndInactiveUser(Long sessionId) {
+    sessionDeleteService.deleteSession(sessionId);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -94,6 +94,7 @@ import org.springframework.test.web.servlet.MockMvc;
   UserSessionControllerDelegate.class,
   UserAccountControllerDelegate.class,
   UserTwoFactorAuthControllerDelegate.class,
+  UserRegistrationControllerDelegate.class,
   ApiResponseEntityExceptionHandler.class,
   EncodeUsernameJsonDeserializer.class,
   UrlDecodePasswordJsonDeserializer.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -1,0 +1,277 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static de.caritas.cob.userservice.api.model.NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateEnquiryMessageResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.EnquiryMessageDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.facade.CreateEnquiryMessageFacade;
+import de.caritas.cob.userservice.api.facade.CreateNewSessionFacade;
+import de.caritas.cob.userservice.api.facade.CreateUserFacade;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.model.NewSessionValidationConstraint;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
+import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserRegistrationControllerDelegateTest {
+
+  private static final String USER_ID = "user-id";
+  private static final String USERNAME = "username";
+  private static final String RC_TOKEN = "rc-token";
+  private static final String RC_USER_ID = "rc-user-id";
+  private static final Long SESSION_ID = 1L;
+
+  @Mock private UserAccountService userAccountProvider;
+  @Mock private SessionService sessionService;
+  @Mock private CreateEnquiryMessageFacade createEnquiryMessageFacade;
+  @Mock private AssignEnquiryFacade assignEnquiryFacade;
+  @Mock private CreateUserFacade createUserFacade;
+  @Mock private CreateNewSessionFacade createNewSessionFacade;
+  @Mock private Messaging messenger;
+  @Mock private ConsultantDtoMapper consultantDtoMapper;
+  @Mock private UserHelper userHelper;
+  @Mock private IdentityClient identityClient;
+  @Mock private MagicLinkLoginService magicLinkLoginService;
+  @Mock private SessionDeleteService sessionDeleteService;
+
+  @InjectMocks private UserRegistrationControllerDelegate delegate;
+
+  @Test
+  void userExistsShouldReturnOkWhenUsernameExists() {
+    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(false);
+
+    var response = delegate.userExists(USERNAME);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void usernameAvailabilityShouldReturnConflictWhenUsernameIsTaken() {
+    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(false);
+
+    var response = delegate.usernameAvailability(USERNAME);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void requestMagicLinkShouldReturnForbiddenWhenMagicLinkIsNotEnabled() {
+    var request = new MagicLinkRequestDTO();
+    request.setUsername(USERNAME);
+    when(magicLinkLoginService.requestMagicLink(USERNAME))
+        .thenReturn(MagicLinkLoginService.MagicLinkRequestResult.NOT_ENABLED);
+
+    var response = delegate.requestMagicLink(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  void consumeMagicLinkShouldReturnOkWhenTokenIsValid() {
+    var consume = new MagicLinkConsumeDTO();
+    consume.setToken("token");
+    var loginResponse = new KeycloakLoginResponseDTO();
+    when(magicLinkLoginService.consumeMagicLink("token")).thenReturn(Optional.of(loginResponse));
+
+    var response = delegate.consumeMagicLink(consume);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(loginResponse);
+  }
+
+  @Test
+  void registerUserShouldDecodePasswordSetNewUserAndReturnCreated() {
+    var user = newUserDto();
+    user.setPassword("pa%20ss");
+    when(userHelper.isUsernameValid(USERNAME)).thenReturn(true);
+    when(createUserFacade.createUserAccountWithInitializedConsultingType(user))
+        .thenReturn(SESSION_ID);
+
+    var response = delegate.registerUser(user);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(user.getPassword()).isEqualTo("pa ss");
+    assertThat(user.isNewUserAccount()).isTrue();
+  }
+
+  @Test
+  void registerUserShouldRejectMissingTopicWhenTopicsFeatureIsEnabled() {
+    ReflectionTestUtils.setField(delegate, "featureTopicsEnabled", true);
+    var user = newUserDto();
+
+    assertThatThrownBy(() -> delegate.registerUser(user)).isInstanceOf(BadRequestException.class);
+
+    verifyNoInteractions(userHelper, createUserFacade);
+  }
+
+  @Test
+  void registerUserShouldReturnInternalServerErrorWhenDirectConsultantMarkFails() {
+    var user = newUserDto();
+    user.setConsultantId("consultant-id");
+    when(userHelper.isUsernameValid(USERNAME)).thenReturn(true);
+    when(createUserFacade.createUserAccountWithInitializedConsultingType(user))
+        .thenReturn(SESSION_ID);
+    when(messenger.markAsDirectConsultant(SESSION_ID)).thenReturn(false);
+
+    var response = delegate.registerUser(user);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void registerNewConsultingTypeShouldUseOneSessionPerConsultingTypeConstraint() {
+    var registration = new NewRegistrationDto();
+    var user = newUser();
+    var registrationResponse = new NewRegistrationResponseDto().status(HttpStatus.CREATED);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
+    when(createNewSessionFacade.initializeNewSession(any(), any(), any(), anyList()))
+        .thenReturn(registrationResponse);
+
+    var response = delegate.registerNewConsultingType(registration, RC_TOKEN, RC_USER_ID);
+
+    var constraintsCaptor = constraintsCaptor();
+    verify(createNewSessionFacade)
+        .initializeNewSession(
+            eq(registration),
+            eq(user),
+            any(RocketChatCredentials.class),
+            constraintsCaptor.capture());
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isSameAs(registrationResponse);
+    assertThat(constraintsCaptor.getValue()).containsExactly(ONE_SESSION_PER_CONSULTING_TYPE);
+  }
+
+  @Test
+  void registerNewSessionShouldUseEmptyConstraintList() {
+    var registration = new NewRegistrationDto();
+    var user = newUser();
+    var registrationResponse = new NewRegistrationResponseDto().status(HttpStatus.ACCEPTED);
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
+    when(createNewSessionFacade.initializeNewSession(any(), any(), any(), anyList()))
+        .thenReturn(registrationResponse);
+
+    var response = delegate.registerNewSession(registration, RC_TOKEN, RC_USER_ID);
+
+    var constraintsCaptor = constraintsCaptor();
+    verify(createNewSessionFacade)
+        .initializeNewSession(
+            eq(registration),
+            eq(user),
+            any(RocketChatCredentials.class),
+            constraintsCaptor.capture());
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+    assertThat(response.getBody()).isSameAs(registrationResponse);
+    assertThat(constraintsCaptor.getValue()).isEmpty();
+  }
+
+  @Test
+  void acceptEnquiryShouldReturnInternalServerErrorWhenSessionIsMissing() {
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.empty());
+
+    var response = delegate.acceptEnquiry(SESSION_ID);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    verify(assignEnquiryFacade, never()).assignRegisteredEnquiry(any(), any());
+  }
+
+  @Test
+  void acceptEnquiryShouldAssignRegisteredEnquiry() {
+    var session = new Session();
+    var consultant = new Consultant();
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+
+    var response = delegate.acceptEnquiry(SESSION_ID);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(assignEnquiryFacade).assignRegisteredEnquiry(session, consultant);
+  }
+
+  @Test
+  void createEnquiryMessageShouldBuildEnquiryDataAndReturnCreated() {
+    var user = newUser();
+    var enquiryMessage = org.mockito.Mockito.mock(EnquiryMessageDTO.class);
+    var messageResponse =
+        new CreateEnquiryMessageResponseDTO().sessionId(SESSION_ID).rcGroupId("rc-group-id");
+    when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
+    when(enquiryMessage.getMessage()).thenReturn("message");
+    when(enquiryMessage.getLanguage()).thenReturn(LanguageCode.EN);
+    when(enquiryMessage.getT()).thenReturn("text");
+    when(consultantDtoMapper.languageOf(LanguageCode.EN)).thenReturn("en");
+    when(createEnquiryMessageFacade.createEnquiryMessage(any())).thenReturn(messageResponse);
+
+    var response = delegate.createEnquiryMessage(SESSION_ID, enquiryMessage, RC_TOKEN, RC_USER_ID);
+
+    var enquiryDataCaptor = ArgumentCaptor.forClass(EnquiryData.class);
+    verify(createEnquiryMessageFacade).createEnquiryMessage(enquiryDataCaptor.capture());
+    var enquiryData = enquiryDataCaptor.getValue();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getBody()).isSameAs(messageResponse);
+    assertThat(enquiryData.getUser()).isSameAs(user);
+    assertThat(enquiryData.getSessionId()).isEqualTo(SESSION_ID);
+    assertThat(enquiryData.getMessage()).isEqualTo("message");
+    assertThat(enquiryData.getLanguage()).isEqualTo("en");
+    assertThat(enquiryData.getType()).isEqualTo("text");
+    assertThat(enquiryData.getRocketChatCredentials().getRocketChatToken()).isEqualTo(RC_TOKEN);
+    assertThat(enquiryData.getRocketChatCredentials().getRocketChatUserId()).isEqualTo(RC_USER_ID);
+  }
+
+  @Test
+  void deleteSessionAndInactiveUserShouldDelegateSessionDeletion() {
+    var response = delegate.deleteSessionAndInactiveUser(SESSION_ID);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(sessionDeleteService).deleteSession(SESSION_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ArgumentCaptor<List<NewSessionValidationConstraint>> constraintsCaptor() {
+    return ArgumentCaptor.forClass(List.class);
+  }
+
+  private UserDTO newUserDto() {
+    return new UserDTO(USERNAME, "12345", 1L, "password", "user@example.org", "true", "0");
+  }
+
+  private User newUser() {
+    return new User(USER_ID, null, USERNAME, "user@example.org", false);
+  }
+}


### PR DESCRIPTION
## Summary

- Extract registration, magic-link, new-session/new-consulting-type, enquiry accept/message, and inactive-session deletion flows into `UserRegistrationControllerDelegate`.
- Keep `UserController` as the `UsersApi` entry point and delegate these flows without intended behavior changes.
- Add focused unit coverage for the new delegate and wire it into `UserControllerIT`.

## Verification

- `mvnw.cmd spotless:apply`
- `mvnw.cmd -Dspotless.check.skip=true -Dtest=UserRegistrationControllerDelegateTest,UserControllerIT test`
- `git diff --check`

## Notes

Part of the ongoing `UserController` refactor track (#91/#92), following the same delegate pattern as the already merged chat/session/account slices.