### PR TITLE
Deactivate Rocket.Chat behind rocket-chat.enabled=false (Matrix-only backend)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
@@ -29,10 +29,10 @@ import org.springframework.web.client.RestTemplate;
 /**
  * Inert Rocket.Chat adapter bound when {@code rocket-chat.enabled=false} (the default, ADR-004).
  *
- * <p>Every operation is a no-op: read paths return empty results and never throw, write paths log
- * a warning once per operation (data that would have gone to Rocket.Chat is intentionally
- * dropped — Matrix is the only chat backend). Login-style operations that cannot fake a usable
- * result throw the declared {@link RocketChatLoginException}, which all callers already handle.
+ * <p>Every operation is a no-op: read paths return empty results and never throw, write paths log a
+ * warning once per operation (data that would have gone to Rocket.Chat is intentionally dropped —
+ * Matrix is the only chat backend). Login-style operations that cannot fake a usable result throw
+ * the declared {@link RocketChatLoginException}, which all callers already handle.
  *
  * <p>No Rocket.Chat REST call, MongoDB connection or credential cron ever happens: the overridden
  * {@link #updateCredentials()} carries neither {@code @PostConstruct} nor {@code @Scheduled}
@@ -61,7 +61,8 @@ public class DisabledRocketChatService extends RocketChatService {
 
   private void warnOnce(String operation) {
     if (warnedOperations.add(operation)) {
-      log.warn("{} - {} is a no-op; nothing is written to Rocket.Chat", DISABLED_MESSAGE, operation);
+      log.warn(
+          "{} - {} is a no-op; nothing is written to Rocket.Chat", DISABLED_MESSAGE, operation);
     } else {
       skip(operation);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
@@ -1,0 +1,331 @@
+package de.caritas.cob.userservice.api.adapters.rocketchat;
+
+import static java.util.Collections.emptyList;
+
+import de.caritas.cob.userservice.api.adapters.rocketchat.config.RocketChatConfig;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.StandardResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupMemberDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.LoginResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.room.RoomsUpdateDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.subscriptions.SubscriptionsUpdateDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.RocketChatUserDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.UserInfoResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.UserUpdateRequestDTO;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Inert Rocket.Chat adapter bound when {@code rocket-chat.enabled=false} (the default, ADR-004).
+ *
+ * <p>Every operation is a no-op: read paths return empty results and never throw, write paths log
+ * a warning once per operation (data that would have gone to Rocket.Chat is intentionally
+ * dropped — Matrix is the only chat backend). Login-style operations that cannot fake a usable
+ * result throw the declared {@link RocketChatLoginException}, which all callers already handle.
+ *
+ * <p>No Rocket.Chat REST call, MongoDB connection or credential cron ever happens: the overridden
+ * {@link #updateCredentials()} carries neither {@code @PostConstruct} nor {@code @Scheduled}
+ * semantics at runtime because scheduling only considers the most specific method declaration.
+ */
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "rocket-chat.enabled", havingValue = "false", matchIfMissing = true)
+public class DisabledRocketChatService extends RocketChatService {
+
+  private static final String DISABLED_MESSAGE =
+      "Rocket.Chat is disabled (rocket-chat.enabled=false)";
+
+  private final Set<String> warnedOperations = ConcurrentHashMap.newKeySet();
+
+  public DisabledRocketChatService(
+      RocketChatCredentialsProvider rcCredentialHelper,
+      RocketChatConfig rocketChatConfig,
+      RocketChatMapper mapper) {
+    super(new RestTemplate(), rcCredentialHelper, null, null, rocketChatConfig, mapper, null);
+  }
+
+  private void skip(String operation) {
+    log.debug("{} - skipping {}", DISABLED_MESSAGE, operation);
+  }
+
+  private void warnOnce(String operation) {
+    if (warnedOperations.add(operation)) {
+      log.warn("{} - {} is a no-op; nothing is written to Rocket.Chat", DISABLED_MESSAGE, operation);
+    } else {
+      skip(operation);
+    }
+  }
+
+  @Override
+  public void updateCredentials() {
+    skip("credential rotation");
+  }
+
+  @Override
+  public boolean muteUserInChat(String username, String roomId) {
+    skip("muteUserInChat");
+    return true;
+  }
+
+  @Override
+  public boolean unmuteUserInChat(String username, String roomId) {
+    skip("unmuteUserInChat");
+    return true;
+  }
+
+  @Override
+  public UserInfoResponseDTO updateUser(UserUpdateRequestDTO requestDTO) {
+    warnOnce("updateUser");
+    return emptyUserInfo(requestDTO != null ? requestDTO.getUserId() : null);
+  }
+
+  @Override
+  public boolean updateUser(String chatUserId, String displayName) {
+    warnOnce("updateUser(displayName)");
+    return true;
+  }
+
+  @Override
+  public Set<String> findAllAvailableUserIds() {
+    return Set.of();
+  }
+
+  @Override
+  public Optional<Boolean> isLoggedIn(String chatUserId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Boolean> isAvailable(String chatUserId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean setUserPresence(String username, String status) {
+    skip("setUserPresence");
+    return true;
+  }
+
+  @Override
+  public Optional<Map<String, Object>> findUser(String chatUserId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Map<String, Object>> findUserAndAddToCache(String chatUserId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Map<String, Object>> getChatInfo(String roomId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<GroupResponseDTO> createPrivateGroup(
+      String name, RocketChatCredentials rocketChatCredentials) {
+    warnOnce("createPrivateGroup");
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<GroupResponseDTO> createPrivateGroupWithSystemUser(String groupName) {
+    warnOnce("createPrivateGroupWithSystemUser");
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean deleteGroupAsSystemUser(String groupId) {
+    skip("deleteGroupAsSystemUser");
+    return true;
+  }
+
+  @Override
+  public void deleteGroupAsTechnicalUser(String groupId) {
+    skip("deleteGroupAsTechnicalUser");
+  }
+
+  @Override
+  public boolean rollbackGroup(String groupId, RocketChatCredentials rocketChatCredentials) {
+    skip("rollbackGroup");
+    return true;
+  }
+
+  @Override
+  public String getUserID(String username, String password, boolean firstLogin)
+      throws RocketChatLoginException {
+    warnOnce("getUserID");
+    throw new RocketChatLoginException(DISABLED_MESSAGE);
+  }
+
+  @Override
+  public ResponseEntity<LoginResponseDTO> loginWithPassword(String username, String password)
+      throws RocketChatLoginException {
+    warnOnce("loginWithPassword");
+    throw new RocketChatLoginException(DISABLED_MESSAGE);
+  }
+
+  @Override
+  public ResponseEntity<LoginResponseDTO> loginUserFirstTime(String username, String password)
+      throws RocketChatLoginException {
+    warnOnce("loginUserFirstTime");
+    throw new RocketChatLoginException(DISABLED_MESSAGE);
+  }
+
+  @Override
+  public boolean logoutUser(RocketChatCredentials rocketChatCredentials) {
+    skip("logoutUser");
+    return true;
+  }
+
+  @Override
+  public void addUserToGroup(String rcUserId, String rcGroupId) {
+    skip("addUserToGroup");
+  }
+
+  @Override
+  public void addTechnicalUserToGroup(String rcGroupId) {
+    skip("addTechnicalUserToGroup");
+  }
+
+  @Override
+  public void leaveFromGroupAsTechnicalUser(String rcGroupId) {
+    skip("leaveFromGroupAsTechnicalUser");
+  }
+
+  @Override
+  public void removeUserFromGroup(String rcUserId, String rcGroupId) {
+    skip("removeUserFromGroup");
+  }
+
+  @Override
+  public boolean removeUserFromSession(String chatUserId, String chatId) {
+    skip("removeUserFromSession");
+    return true;
+  }
+
+  @Override
+  public List<GroupMemberDTO> getStandardMembersOfGroup(String rcGroupId) {
+    return emptyList();
+  }
+
+  @Override
+  public void removeAllStandardUsersFromGroup(String rcGroupId) {
+    skip("removeAllStandardUsersFromGroup");
+  }
+
+  @Override
+  public Optional<List<Map<String, String>>> findMembers(String chatId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public List<GroupMemberDTO> getChatUsers(String chatId) {
+    return emptyList();
+  }
+
+  @Override
+  public List<GroupMemberDTO> getMembersOfGroup(String rcGroupId) {
+    return emptyList();
+  }
+
+  @Override
+  public void removeSystemMessages(String rcGroupId, LocalDateTime oldest, LocalDateTime latest) {
+    skip("removeSystemMessages");
+  }
+
+  @Override
+  public void removeAllMessages(String rcGroupId) {
+    skip("removeAllMessages");
+  }
+
+  @Override
+  public List<SubscriptionsUpdateDTO> getSubscriptionsOfUser(
+      RocketChatCredentials rocketChatCredentials) {
+    return emptyList();
+  }
+
+  @Override
+  public Optional<List<Map<String, String>>> findAllChats(String chatUserId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean updateChatE2eKey(String chatUserId, String roomId, String key) {
+    warnOnce("updateChatE2eKey");
+    return true;
+  }
+
+  @Override
+  public List<RoomsUpdateDTO> getRoomsOfUser(RocketChatCredentials rocketChatCredentials) {
+    return emptyList();
+  }
+
+  @Override
+  public UserInfoResponseDTO getUserInfo(String rcUserId) {
+    return emptyUserInfo(rcUserId);
+  }
+
+  @Override
+  public void deleteUser(String rcUserId) {
+    skip("deleteUser");
+  }
+
+  @Override
+  public void setRoomReadOnly(String rcRoomId) {
+    skip("setRoomReadOnly");
+  }
+
+  @Override
+  public void setRoomWriteable(String rcRoomId) {
+    skip("setRoomWriteable");
+  }
+
+  @Override
+  public List<GroupDTO> fetchAllInactivePrivateGroupsSinceGivenDate(
+      LocalDateTime dateTimeSinceInactive) {
+    return emptyList();
+  }
+
+  @Override
+  public String getRocketChatUserIdByUsername(String username) {
+    skip("getRocketChatUserIdByUsername");
+    return null;
+  }
+
+  @Override
+  public boolean saveRoomSettings(String chatId, boolean encrypted) {
+    skip("saveRoomSettings");
+    return true;
+  }
+
+  @Override
+  public void removeUserFromGroupIgnoreGroupNotFound(String rcUserId, String rcGroupId) {
+    skip("removeUserFromGroupIgnoreGroupNotFound");
+  }
+
+  @Override
+  public ResponseEntity<StandardResponseDTO> createUser(
+      String username, String password, String email) throws RocketChatLoginException {
+    warnOnce("createUser");
+    throw new RocketChatLoginException(DISABLED_MESSAGE);
+  }
+
+  private static UserInfoResponseDTO emptyUserInfo(String rcUserId) {
+    var user = new RocketChatUserDTO();
+    user.setId(rcUserId);
+    user.setRooms(emptyList());
+    return new UserInfoResponseDTO(user, true, null, null);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatService.java
@@ -71,6 +71,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
@@ -87,10 +88,15 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-/** Service for Rocket.Chat functionalities. */
+/**
+ * Service for Rocket.Chat functionalities. Only registered when {@code rocket-chat.enabled=true}
+ * (ADR-004); with the default {@code false} the inert {@link DisabledRocketChatService} is bound
+ * instead and the service runs Matrix-only.
+ */
 @Slf4j
 @Getter
 @Service
+@ConditionalOnProperty(name = "rocket-chat.enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class RocketChatService implements MessageClient {
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import lombok.Data;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.hibernate.validator.constraints.URL;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -42,11 +43,18 @@ public class RocketChatConfig {
 
   private final HttpServletRequest httpServletRequest;
 
+  /**
+   * Master switch for the Rocket.Chat integration (ADR-004). Defaults to {@code false}: the
+   * service runs Matrix-only and no Rocket.Chat REST call, MongoDB connection or credential cron
+   * is ever made. Only when {@code rocket-chat.enabled=true} are the Rocket.Chat beans created.
+   */
+  private boolean enabled;
+
   @URL private String baseUrl;
 
   @NotBlank private String credentialCron;
 
-  @NotBlank private String mongoUrl;
+  private String mongoUrl;
 
   @Bean("rocketChatRestTemplate")
   public RestTemplate rocketChatRestTemplate(RestTemplateBuilder restTemplateBuilder) {
@@ -69,6 +77,7 @@ public class RocketChatConfig {
   }
 
   @Bean
+  @ConditionalOnProperty(name = "rocket-chat.enabled", havingValue = "true")
   public MongoClient mongoClient() {
     var connectionString = new ConnectionString(mongoUrl);
     var settings = MongoClientSettings.builder().applyConnectionString(connectionString).build();
@@ -95,6 +104,18 @@ public class RocketChatConfig {
   @SuppressWarnings("unused")
   private boolean isCronExpression() {
     return CronExpression.isValidExpression(credentialCron);
+  }
+
+  @AssertTrue(message = "rocket-chat.base-url must be set when rocket-chat.enabled=true")
+  @SuppressWarnings("unused")
+  private boolean isBaseUrlPresentWhenEnabled() {
+    return !enabled || StringUtils.hasText(baseUrl);
+  }
+
+  @AssertTrue(message = "rocket-chat.mongo-url must be set when rocket-chat.enabled=true")
+  @SuppressWarnings("unused")
+  private boolean isMongoUrlPresentWhenEnabled() {
+    return !enabled || StringUtils.hasText(mongoUrl);
   }
 
   public String getApiUrl(String path) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatConfig.java
@@ -44,9 +44,9 @@ public class RocketChatConfig {
   private final HttpServletRequest httpServletRequest;
 
   /**
-   * Master switch for the Rocket.Chat integration (ADR-004). Defaults to {@code false}: the
-   * service runs Matrix-only and no Rocket.Chat REST call, MongoDB connection or credential cron
-   * is ever made. Only when {@code rocket-chat.enabled=true} are the Rocket.Chat beans created.
+   * Master switch for the Rocket.Chat integration (ADR-004). Defaults to {@code false}: the service
+   * runs Matrix-only and no Rocket.Chat REST call, MongoDB connection or credential cron is ever
+   * made. Only when {@code rocket-chat.enabled=true} are the Rocket.Chat beans created.
    */
   private boolean enabled;
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Creator class to generate new {@link ConsultantAgency} instances. */
@@ -38,6 +39,9 @@ public class ConsultantAgencyRelationCreatorService {
   private final @NonNull IdentityClient identityClient;
   private final @NonNull ConsultingTypeManager consultingTypeManager;
   private final @NonNull RocketChatAsyncHelper rocketChatAsyncHelper;
+
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
 
   /**
    * Creates a new {@link ConsultantAgency} based on the {@link ImportRecord} and agency ids.
@@ -98,8 +102,14 @@ public class ConsultantAgencyRelationCreatorService {
       consultantRepository.save(consultant);
     }
 
-    rocketChatAsyncHelper.addConsultantToSessions(
-        consultant, agency, logMethod, TenantContext.getCurrentTenant());
+    if (rocketChatEnabled) {
+      rocketChatAsyncHelper.addConsultantToSessions(
+          consultant, agency, logMethod, TenantContext.getCurrentTenant());
+    } else {
+      // Matrix-only: no Rocket.Chat group assignments exist, so finalize synchronously in this
+      // transaction — the async variant cannot see the uncommitted consultant_agency row.
+      rocketChatAsyncHelper.finalizeConsultantAgencyRelation(consultant, agency);
+    }
 
     if (isTeamAgencyButNotTeamConsultant(agency, consultant)) {
       consultant.setTeamConsultant(true);

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelper.java
@@ -79,12 +79,33 @@ public class RocketChatAsyncHelper {
     TenantContext.clear();
   }
 
+  /**
+   * Synchronous finalization for the Matrix-only path (rocket-chat.enabled=false): there is no
+   * Rocket.Chat work to do, so the relation status must be completed in the caller's transaction.
+   * The async variant races the caller's not-yet-committed consultant_agency row and cannot see it
+   * from its own fresh transaction.
+   */
+  @Transactional
+  public void finalizeConsultantAgencyRelation(Consultant consultant, AgencyDTO agency) {
+    updateConsultantStatus(consultant, agency);
+  }
+
   private void updateConsultantStatus(Consultant consultant, AgencyDTO agencyDTO) {
     ConsultantAgency consultantAgency =
         consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
             consultant.getId(), agencyDTO.getId(), ConsultantAgencyStatus.IN_PROGRESS);
 
+    if (consultantAgency == null) {
+      log.warn(
+          "No IN_PROGRESS consultant_agency relation visible for consultant {} and agency {};"
+              + " skipping status finalization",
+          consultant.getId(),
+          agencyDTO.getId());
+      return;
+    }
+
     consultantAgency.setStatus(ConsultantAgencyStatus.CREATED);
+    consultantAgencyRepository.save(consultantAgency);
     List<ConsultantAgency> consultantAgencies =
         consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(
             consultant.getId(), ConsultantAgencyStatus.IN_PROGRESS);

--- a/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
@@ -37,6 +37,10 @@ public class ConfigurationValidator {
   @Value("${identity.technical-user.password:}")
   private String identityTechnicalPassword;
 
+  /** ADR-004: Rocket.Chat settings are only required when the integration is enabled. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
+
   @Value("${rocket-chat.base-url:}")
   private String rocketChatBaseUrl;
 
@@ -89,17 +93,21 @@ public class ConfigurationValidator {
     if (isEmpty(identityTechnicalPassword)) {
       missingConfigs.add("identity.technical-user.password (IDENTITY_TECHNICAL_USER_PASSWORD)");
     }
-    if (isEmpty(rocketChatBaseUrl)) {
-      missingConfigs.add("rocket-chat.base-url (ROCKET_CHAT_BASE_URL)");
-    }
-    if (isEmpty(rocketChatMongoUrl)) {
-      missingConfigs.add("rocket-chat.mongo-url (ROCKET_CHAT_MONGO_URL)");
-    }
-    if (isEmpty(rocketTechnicalUsername)) {
-      missingConfigs.add("rocket.technical.username (ROCKET_TECHNICAL_USERNAME)");
-    }
-    if (isEmpty(rocketTechnicalPassword)) {
-      missingConfigs.add("rocket.technical.password (ROCKET_TECHNICAL_PASSWORD)");
+    // ADR-004: with rocket-chat.enabled=false (the default) the service is Matrix-only and no
+    // Rocket.Chat configuration is required.
+    if (rocketChatEnabled) {
+      if (isEmpty(rocketChatBaseUrl)) {
+        missingConfigs.add("rocket-chat.base-url (ROCKET_CHAT_BASE_URL)");
+      }
+      if (isEmpty(rocketChatMongoUrl)) {
+        missingConfigs.add("rocket-chat.mongo-url (ROCKET_CHAT_MONGO_URL)");
+      }
+      if (isEmpty(rocketTechnicalUsername)) {
+        missingConfigs.add("rocket.technical.username (ROCKET_TECHNICAL_USERNAME)");
+      }
+      if (isEmpty(rocketTechnicalPassword)) {
+        missingConfigs.add("rocket.technical.password (ROCKET_TECHNICAL_PASSWORD)");
+      }
     }
     if (isEmpty(consultingTypeServiceApiUrl)) {
       missingConfigs.add("consulting.type.service.api.url (CONSULTING_TYPE_SERVICE_API_URL)");

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -31,10 +31,12 @@ import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.function.BiFunction;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Facade to encapsulate the steps for creating a chat. */
@@ -53,6 +55,10 @@ public class CreateChatFacade {
   private final @NonNull GroupChatParticipantRepository groupChatParticipantRepository;
   private final @NonNull de.caritas.cob.userservice.api.port.out.UserRepository userRepository;
 
+  /** ADR-004: with Rocket.Chat disabled every chat is created as a Matrix group chat. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
+
   /**
    * Creates a chat in MariaDB, it's relation to the agency and Rocket.Chat-room (or Matrix room for
    * group chats with consultantIds).
@@ -64,6 +70,10 @@ public class CreateChatFacade {
   public CreateChatResponseDTO createChatV1(ChatDTO chatDTO, Consultant consultant) {
     // Check if this is a simplified group chat creation (with consultantIds)
     if (chatDTO.getConsultantIds() != null && !chatDTO.getConsultantIds().isEmpty()) {
+      return createSimplifiedGroupChat(chatDTO, consultant);
+    }
+    // ADR-004: without Rocket.Chat there is no legacy flow - always create a Matrix group chat
+    if (!rocketChatEnabled) {
       return createSimplifiedGroupChat(chatDTO, consultant);
     }
     // Otherwise, use the old Rocket.Chat flow
@@ -80,6 +90,10 @@ public class CreateChatFacade {
   public CreateChatResponseDTO createChatV2(ChatDTO chatDTO, Consultant consultant) {
     // Check if this is a simplified group chat creation (with consultantIds)
     if (chatDTO.getConsultantIds() != null && !chatDTO.getConsultantIds().isEmpty()) {
+      return createSimplifiedGroupChat(chatDTO, consultant);
+    }
+    // ADR-004: without Rocket.Chat there is no legacy flow - always create a Matrix group chat
+    if (!rocketChatEnabled) {
       return createSimplifiedGroupChat(chatDTO, consultant);
     }
     // Otherwise, use the old flow
@@ -209,6 +223,11 @@ public class CreateChatFacade {
   private CreateChatResponseDTO createSimplifiedGroupChat(ChatDTO chatDTO, Consultant consultant) {
     log.info("Creating group chat with Session + Chat: {}", chatDTO.getTopic());
 
+    // Callers routed here from the legacy V1 flow may not carry an agency id or participant list
+    List<String> participantIds =
+        chatDTO.getConsultantIds() == null ? List.of() : chatDTO.getConsultantIds();
+    Long agencyId = resolveAgencyId(chatDTO, consultant);
+
     // Create a session for the group (needed for backend logic)
     Session session = new Session();
     session.setConsultant(consultant);
@@ -218,11 +237,11 @@ public class CreateChatFacade {
     session.setUser(systemUser);
 
     // Get consulting type from agency
-    AgencyDTO agency = agencyService.getAgency(chatDTO.getAgencyId());
+    AgencyDTO agency = agencyService.getAgency(agencyId);
     session.setConsultingTypeId(agency.getConsultingType());
 
     session.setPostcode("00000"); // Dummy postcode for group chats
-    session.setAgencyId(chatDTO.getAgencyId());
+    session.setAgencyId(agencyId);
     session.setStatus(SessionStatus.IN_PROGRESS);
     session.setRegistrationType(RegistrationType.REGISTERED);
     session.setTeamSession(true); // Mark as group chat
@@ -247,7 +266,7 @@ public class CreateChatFacade {
     log.info("Created chat {} for group chat", chatId);
 
     // Create chat-agency relation
-    createChatAgencyRelation(chat, chatDTO.getAgencyId());
+    createChatAgencyRelation(chat, agencyId);
 
     String matrixRoomId = null;
 
@@ -291,7 +310,7 @@ public class CreateChatFacade {
       log.info("Added creator consultant {} to group_chat_participant", consultant.getId());
 
       // Invite and auto-join all selected consultants
-      for (String participantId : chatDTO.getConsultantIds()) {
+      for (String participantId : participantIds) {
         try {
           Consultant participant = consultantRepository.findById(participantId).orElse(null);
           if (participant == null) {
@@ -330,7 +349,7 @@ public class CreateChatFacade {
           sessionId,
           chatId,
           matrixRoomId,
-          chatDTO.getConsultantIds().size() + 1); // +1 for creator
+          participantIds.size() + 1); // +1 for creator
 
       return new CreateChatResponseDTO()
           .groupId(matrixRoomId)
@@ -355,6 +374,21 @@ public class CreateChatFacade {
       }
       throw new InternalServerErrorException("Failed to create group chat: " + e.getMessage());
     }
+  }
+
+  /**
+   * Resolves the agency for a group chat: prefer the explicitly requested agency (V2 semantics),
+   * fall back to the consultant's first agency (legacy V1 semantics).
+   */
+  private Long resolveAgencyId(ChatDTO chatDTO, Consultant consultant) {
+    if (chatDTO.getAgencyId() != null) {
+      return chatDTO.getAgencyId();
+    }
+    if (isEmpty(consultant.getConsultantAgencies())) {
+      throw new InternalServerErrorException(
+          String.format("Consultant with id %s is not assigned to any agency", consultant.getId()));
+    }
+    return consultant.getConsultantAgencies().iterator().next().getAgencyId();
   }
 
   private User resolveOrCreateGroupChatSystemUser(Consultant consultant) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -80,6 +80,10 @@ public class CreateEnquiryMessageFacade {
   @Value("${rocket.systemuser.id}")
   private String rocketChatSystemUserId;
 
+  /** ADR-004: with Rocket.Chat disabled every enquiry always takes the Matrix path. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
+
   /**
    * Creates the private Rocket.Chat group, initializes the session and saves the enquiry message in
    * Rocket.Chat.
@@ -88,7 +92,8 @@ public class CreateEnquiryMessageFacade {
    */
   public CreateEnquiryMessageResponseDTO createEnquiryMessage(EnquiryData enquiryData) {
     try {
-      var hasRocketChatCredentials = hasUsableRocketChatCredentials(enquiryData);
+      var hasRocketChatCredentials =
+          rocketChatEnabled && hasUsableRocketChatCredentials(enquiryData);
       if (hasRocketChatCredentials) {
         checkIfKeycloakAndRocketChatUsernamesMatch(
             enquiryData.getRocketChatCredentials().getRocketChatUserId(), enquiryData.getUser());

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacade.java
@@ -24,6 +24,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,10 @@ public class CreateUserChatRelationFacade {
   private final @NonNull RollbackFacade rollbackFacade;
   private final AuditingHandler auditingHandler;
 
+  /** ADR-004: with Rocket.Chat disabled no Rocket.Chat account is created or logged in. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
+
   /**
    * Creates an user-chat/agency relation for the provided {@link User}. Either provide username and
    * password in {@link UserDTO} (new user account registrations) or valid {@link
@@ -52,6 +57,17 @@ public class CreateUserChatRelationFacade {
    */
   public void initializeUserChatAgencyRelation(
       UserDTO userDTO, User user, RocketChatCredentials rocketChatCredentials) {
+
+    if (!rocketChatEnabled) {
+      // ADR-004: Matrix-only - persist the user/agency relation without any Rocket.Chat
+      // account creation, login or rc_user_id update.
+      log.debug(
+          "Rocket.Chat is disabled - creating user-chat/agency relation for user {} without "
+              + "Rocket.Chat credentials",
+          user.getUserId());
+      createUserChatAgencyRelation(userDTO, user);
+      return;
+    }
 
     DataDTO rcUserCredentials = obtainValidUserCredentials(userDTO, user, rocketChatCredentials);
     updateRocketChatUserIdInDatabase(

--- a/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProvider.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -28,6 +29,10 @@ public class RocketChatRoomInformationProvider {
   private final RocketChatService rocketChatService;
   private final MatrixSynapseService matrixSynapseService;
   private final ConsultantRepository consultantRepository;
+
+  /** ADR-004: with Rocket.Chat disabled room information is always Matrix-derived. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
 
   public RocketChatRoomInformationProvider(
       RocketChatService rocketChatService,
@@ -64,11 +69,14 @@ public class RocketChatRoomInformationProvider {
     List<RoomsUpdateDTO> roomsForUpdate = emptyList();
     List<String> userRooms = emptyList();
 
-    if (isMatrixMigrationCredential(rocketChatCredentials)) {
+    if (!rocketChatEnabled || isMatrixMigrationCredential(rocketChatCredentials)) {
       userRooms =
           consultant != null
               ? getMatrixRoomsForConsultant(consultant)
-              : getMatrixRoomsForUser(rocketChatCredentials.getRocketChatUserId());
+              : getMatrixRoomsForUser(
+                  rocketChatCredentials == null
+                      ? null
+                      : rocketChatCredentials.getRocketChatUserId());
       return buildRoomInformation(readMessages, roomsForUpdate, userRooms);
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -56,6 +56,7 @@ rocket.technical.password=${ROCKET_TECHNICAL_PASSWORD:}
 rocket.systemuser.id=${ROCKET_SYSTEMUSER_ID:}
 rocket.systemuser.username=${ROCKET_SYSTEMUSER_USERNAME:}
 rocket.systemuser.password=${ROCKET_SYSTEMUSER_PASSWORD:}
+rocket-chat.enabled=${ROCKET_CHAT_ENABLED:false}
 rocket-chat.credential-cron=0 */10 * * * ?
 rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -57,6 +57,7 @@ rocket.technical.password=${ROCKET_TECHNICAL_PASSWORD:}
 rocket.systemuser.id=${ROCKET_SYSTEMUSER_ID:}
 rocket.systemuser.username=${ROCKET_SYSTEMUSER_USERNAME:}
 rocket.systemuser.password=${ROCKET_SYSTEMUSER_PASSWORD:}
+rocket-chat.enabled=${ROCKET_CHAT_ENABLED:false}
 rocket-chat.credential-cron=0 */10 * * * ?
 rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:}

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -44,6 +44,7 @@ rocket.technical.password=${ROCKET_TECHNICAL_PASSWORD:}
 rocket.systemuser.id=${ROCKET_SYSTEMUSER_ID:}
 rocket.systemuser.username=${ROCKET_SYSTEMUSER_USERNAME:}
 rocket.systemuser.password=${ROCKET_SYSTEMUSER_PASSWORD:}
+rocket-chat.enabled=${ROCKET_CHAT_ENABLED:false}
 rocket-chat.credential-cron=0 */10 * * * ?
 rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -52,6 +52,7 @@ rocket.technical.password=${ROCKET_TECHNICAL_PASSWORD:secret}
 rocket.systemuser.id=${ROCKET_SYSTEMUSER_ID:}
 rocket.systemuser.username=${ROCKET_SYSTEMUSER_USERNAME:}
 rocket.systemuser.password=${ROCKET_SYSTEMUSER_PASSWORD:}
+rocket-chat.enabled=false
 rocket-chat.credential-cron=0 */10 * * * ?
 rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:https://testing.com/api/v1}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:mongodb://localhost:27017/testing}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -110,8 +110,12 @@ springfox.docuLicenseUrl=http://www.apache.org/licenses/LICENSE-2.0.html
 springfox.docuPath=/users/docs
 
 # ---------------- Rocket.Chat ----------------
+# Rocket.Chat is DISABLED by default (ADR-004, Matrix-only backend). When disabled, no
+# Rocket.Chat REST call, MongoDB connection or credential cron is made and base-url/mongo-url
+# may stay empty. Set rocket-chat.enabled=true (plus base-url/mongo-url) to re-enable.
 # Use Kubernetes DNS names, e.g., http://rocketchat.caritas.svc.cluster.local:3000/api/v1
 # MongoDB URL: mongodb://mongodb.caritas.svc.cluster.local:27017/rocketchat?retryWrites=false
+rocket-chat.enabled=${ROCKET_CHAT_ENABLED:false}
 rocket-chat.credential-cron=0 0 * * * ?
 rocket-chat.base-url=${ROCKET_CHAT_BASE_URL:}
 rocket-chat.mongo-url=${ROCKET_CHAT_MONGO_URL:}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatServiceTest.java
@@ -1,0 +1,111 @@
+package de.caritas.cob.userservice.api.adapters.rocketchat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import de.caritas.cob.userservice.api.adapters.rocketchat.config.RocketChatConfig;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-004: the inert adapter must never talk to Rocket.Chat - read paths return empty results
+ * without throwing, write paths are silent no-ops and login-style calls fail with the declared
+ * exception.
+ */
+class DisabledRocketChatServiceTest {
+
+  private RocketChatCredentialsProvider credentialsProvider;
+  private RocketChatConfig rocketChatConfig;
+  private RocketChatMapper mapper;
+  private DisabledRocketChatService service;
+
+  @BeforeEach
+  void setUp() {
+    credentialsProvider = mock(RocketChatCredentialsProvider.class);
+    rocketChatConfig = mock(RocketChatConfig.class);
+    mapper = mock(RocketChatMapper.class);
+    service = new DisabledRocketChatService(credentialsProvider, rocketChatConfig, mapper);
+  }
+
+  @Test
+  void readPathsShouldReturnEmptyResultsWithoutThrowing() throws Exception {
+    assertThat(service.findUser("chat-user")).isEmpty();
+    assertThat(service.findUserAndAddToCache("chat-user")).isEmpty();
+    assertThat(service.getChatInfo("room")).isEmpty();
+    assertThat(service.findMembers("chat")).isEmpty();
+    assertThat(service.findAllChats("chat-user")).isEmpty();
+    assertThat(service.findAllAvailableUserIds()).isEmpty();
+    assertThat(service.isLoggedIn("chat-user")).isEmpty();
+    assertThat(service.isAvailable("chat-user")).isEmpty();
+    assertThat(service.getStandardMembersOfGroup("group")).isEmpty();
+    assertThat(service.getChatUsers("chat")).isEmpty();
+    assertThat(service.getMembersOfGroup("group")).isEmpty();
+    assertThat(service.getSubscriptionsOfUser(null)).isEmpty();
+    assertThat(service.getRoomsOfUser(null)).isEmpty();
+    assertThat(service.fetchAllInactivePrivateGroupsSinceGivenDate(LocalDateTime.now())).isEmpty();
+    assertThat(service.getRocketChatUserIdByUsername("username")).isNull();
+    assertThat(service.getUserInfo("rc-user").getUser().getRooms()).isEmpty();
+    assertThat(service.createPrivateGroup("group", null)).isEmpty();
+    assertThat(service.createPrivateGroupWithSystemUser("group")).isEmpty();
+  }
+
+  @Test
+  void writePathsShouldBeInertNoOps() {
+    assertThatCode(
+            () -> {
+              service.updateCredentials();
+              service.addUserToGroup("user", "group");
+              service.addTechnicalUserToGroup("group");
+              service.leaveFromGroupAsTechnicalUser("group");
+              service.removeUserFromGroup("user", "group");
+              service.removeUserFromGroupIgnoreGroupNotFound("user", "group");
+              service.removeAllStandardUsersFromGroup("group");
+              service.removeSystemMessages("group", LocalDateTime.now(), LocalDateTime.now());
+              service.removeAllMessages("group");
+              service.deleteUser("rc-user");
+              service.deleteGroupAsTechnicalUser("group");
+              service.setRoomReadOnly("room");
+              service.setRoomWriteable("room");
+              service.updateUser(null);
+            })
+        .doesNotThrowAnyException();
+
+    assertThat(service.muteUserInChat("user", "room")).isTrue();
+    assertThat(service.unmuteUserInChat("user", "room")).isTrue();
+    assertThat(service.updateUser("user", "display")).isTrue();
+    assertThat(service.setUserPresence("user", "online")).isTrue();
+    assertThat(service.logoutUser(null)).isTrue();
+    assertThat(service.removeUserFromSession("user", "chat")).isTrue();
+    assertThat(service.deleteGroupAsSystemUser("group")).isTrue();
+    assertThat(service.rollbackGroup("group", null)).isTrue();
+    assertThat(service.saveRoomSettings("chat", true)).isTrue();
+    assertThat(service.updateChatE2eKey("user", "room", "key")).isTrue();
+  }
+
+  @Test
+  void loginStylePathsShouldThrowDeclaredLoginException() {
+    assertThatThrownBy(() -> service.getUserID("username", "password", true))
+        .isInstanceOf(RocketChatLoginException.class);
+    assertThatThrownBy(() -> service.loginWithPassword("username", "password"))
+        .isInstanceOf(RocketChatLoginException.class);
+    assertThatThrownBy(() -> service.loginUserFirstTime("username", "password"))
+        .isInstanceOf(RocketChatLoginException.class);
+    assertThatThrownBy(() -> service.createUser("username", "password", "mail@example.com"))
+        .isInstanceOf(RocketChatLoginException.class);
+  }
+
+  @Test
+  void nothingShouldEverReachRocketChatCollaborators() throws Exception {
+    service.updateCredentials();
+    service.getUserInfo("rc-user");
+    service.addUserToGroup("user", "group");
+    service.getRoomsOfUser(null);
+
+    verifyNoInteractions(credentialsProvider, rocketChatConfig, mapper);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatConditionalRegistrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/RocketChatConditionalRegistrationTest.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.adapters.rocketchat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * ADR-004 wiring guard: exactly one Rocket.Chat adapter is registered per flag state - the real
+ * {@link RocketChatService} only when {@code rocket-chat.enabled=true}, the inert {@link
+ * DisabledRocketChatService} otherwise (including when the property is missing entirely).
+ */
+class RocketChatConditionalRegistrationTest {
+
+  @Test
+  void realServiceShouldOnlyRegisterWhenRocketChatIsEnabled() {
+    try (var context = contextWithProperty("rocket-chat.enabled", "true")) {
+      assertThat(context.containsBeanDefinition("rocketChatService")).isTrue();
+      assertThat(context.containsBeanDefinition("disabledRocketChatService")).isFalse();
+    }
+  }
+
+  @Test
+  void inertServiceShouldRegisterWhenRocketChatIsDisabled() {
+    try (var context = contextWithProperty("rocket-chat.enabled", "false")) {
+      assertThat(context.containsBeanDefinition("rocketChatService")).isFalse();
+      assertThat(context.containsBeanDefinition("disabledRocketChatService")).isTrue();
+    }
+  }
+
+  @Test
+  void inertServiceShouldRegisterWhenPropertyIsMissing() {
+    try (var context = new AnnotationConfigApplicationContext()) {
+      context.register(RocketChatService.class, DisabledRocketChatService.class);
+      assertThat(context.containsBeanDefinition("rocketChatService")).isFalse();
+      assertThat(context.containsBeanDefinition("disabledRocketChatService")).isTrue();
+    }
+  }
+
+  private AnnotationConfigApplicationContext contextWithProperty(String key, String value) {
+    var context = new AnnotationConfigApplicationContext();
+    context
+        .getEnvironment()
+        .getPropertySources()
+        .addFirst(new MapPropertySource("test", Map.of(key, value)));
+    // conditions are evaluated at registration time - no refresh needed, definitions suffice
+    context.register(RocketChatService.class, DisabledRocketChatService.class);
+    return context;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.adapters.rocketchat.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.client.MongoClient;
+import de.caritas.cob.userservice.api.adapters.rocketchat.DisabledRocketChatService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * ADR-004 proof: the service boots Matrix-only with {@code rocket-chat.enabled=false} (the
+ * default) and WITHOUT any Rocket.Chat URL configured. The full application context must start,
+ * the inert {@link DisabledRocketChatService} must be bound, and neither a Rocket.Chat MongoDB
+ * client nor the credential cron may exist.
+ */
+@SpringBootTest(
+    properties = {"rocket-chat.enabled=false", "rocket-chat.base-url=", "rocket-chat.mongo-url="})
+@ActiveProfiles("testing")
+class RocketChatDisabledBootTest {
+
+  @Autowired private ApplicationContext context;
+
+  @Test
+  void contextShouldBootWithInertRocketChatAdapterAndNoMongoClient() {
+    assertThat(context.getBean(RocketChatService.class))
+        .isInstanceOf(DisabledRocketChatService.class);
+    assertThat(context.getBeanNamesForType(MongoClient.class)).isEmpty();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
@@ -12,10 +12,10 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * ADR-004 proof: the service boots Matrix-only with {@code rocket-chat.enabled=false} (the
- * default) and WITHOUT any Rocket.Chat URL configured. The full application context must start,
- * the inert {@link DisabledRocketChatService} must be bound, and neither a Rocket.Chat MongoDB
- * client nor the credential cron may exist.
+ * ADR-004 proof: the service boots Matrix-only with {@code rocket-chat.enabled=false} (the default)
+ * and WITHOUT any Rocket.Chat URL configured. The full application context must start, the inert
+ * {@link DisabledRocketChatService} must be bound, and neither a Rocket.Chat MongoDB client nor the
+ * credential cron may exist.
  */
 @SpringBootTest(
     properties = {"rocket-chat.enabled=false", "rocket-chat.base-url=", "rocket-chat.mongo-url="})

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
@@ -116,7 +116,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootTest
+@SpringBootTest(properties = "rocket-chat.enabled=true")
 @ExtendWith(OutputCaptureExtension.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("testing")

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerSessionE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerSessionE2EIT.java
@@ -139,7 +139,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExc
 import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
 import org.springframework.web.util.UriTemplateHandler;
 
-@SpringBootTest
+@SpringBootTest(properties = "rocket-chat.enabled=true")
 @ExtendWith(OutputCaptureExtension.class)
 @ActiveProfiles("testing")
 @AutoConfigureTestDatabase

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV1FacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV1FacadeTest.java
@@ -90,6 +90,9 @@ public class CreateChatV1FacadeTest {
 
   @BeforeEach
   public void setup() {
+    // These tests cover the legacy Rocket.Chat flow (ADR-004: disabled by default)
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        createChatFacade, "rocketChatEnabled", true);
     when(chat.getId()).thenReturn(CHAT_ID);
     when(chat.getConsultingTypeId()).thenReturn(15);
     when(chat.getCreateDate()).thenReturn(LocalDateTime.now());

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV2FacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV2FacadeTest.java
@@ -96,6 +96,9 @@ public class CreateChatV2FacadeTest {
 
   @BeforeEach
   public void setup() {
+    // These tests cover the legacy Rocket.Chat flow (ADR-004: disabled by default)
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        createChatFacade, "rocketChatEnabled", true);
     when(chat.getId()).thenReturn(CHAT_ID);
     when(chat.getCreateDate()).thenReturn(LocalDateTime.now());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -291,8 +291,7 @@ class CreateEnquiryMessageFacadeTest {
   }
 
   @Test
-  void createEnquiryMessage_Should_PostMatrixEnquiry_When_RocketChatIsDisabled()
-      throws Exception {
+  void createEnquiryMessage_Should_PostMatrixEnquiry_When_RocketChatIsDisabled() throws Exception {
     // ADR-004: even with usable Rocket.Chat credentials the Matrix path must be taken
     setField(createEnquiryMessageFacade, "rocketChatEnabled", false);
     var matrixRoomId = "!session-room:oriso.org";

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -206,6 +206,8 @@ class CreateEnquiryMessageFacadeTest {
 
   @BeforeEach
   void setUp() throws SecurityException {
+    // Most cases cover the Rocket.Chat enquiry flow (ADR-004: disabled by default)
+    setField(createEnquiryMessageFacade, "rocketChatEnabled", true);
     setField(
         createEnquiryMessageFacade,
         FIELD_NAME_ROCKET_CHAT_SYSTEM_USER_ID,
@@ -285,6 +287,48 @@ class CreateEnquiryMessageFacadeTest {
     assertEquals(matrixRoomId, session.getMatrixRoomId());
     assertEquals(SessionStatus.NEW, session.getStatus());
     assertNotNull(session.getEnquiryMessageDate());
+    resetRequestAttributes();
+  }
+
+  @Test
+  void createEnquiryMessage_Should_PostMatrixEnquiry_When_RocketChatIsDisabled()
+      throws Exception {
+    // ADR-004: even with usable Rocket.Chat credentials the Matrix path must be taken
+    setField(createEnquiryMessageFacade, "rocketChatEnabled", false);
+    var matrixRoomId = "!session-room:oriso.org";
+    var matrixUserId = "@asker:oriso.org";
+    var matrixToken = "matrix-token";
+    var matrixEventId = "$event";
+    user.setMatrixUserId(matrixUserId);
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setIsConsultantDirectlySet(false);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(matrixRoomId);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId()))
+        .thenReturn(extendedConsultingTypeResponseDTO);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+    when(matrixSynapseService.loginAsUserAccessToken(matrixUserId)).thenReturn(matrixToken);
+    when(matrixSynapseService.sendMessage(matrixRoomId, MESSAGE, matrixToken))
+        .thenReturn(Map.of("event_id", matrixEventId));
+
+    final var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(user, SESSION_ID, MESSAGE, null, RC_CREDENTIALS));
+
+    verify(rocketChatService, never()).getUserInfo(anyString());
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+    verify(messageServiceProvider, never())
+        .postEnquiryMessage(
+            any(RocketChatData.class), any(CreateEnquiryExceptionInformation.class));
+    assertEquals(matrixRoomId, response.getRcGroupId());
+    assertEquals(matrixEventId, response.getT());
+    assertEquals(matrixRoomId, session.getGroupId());
     resetRequestAttributes();
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserChatRelationFacadeTest.java
@@ -50,6 +50,13 @@ public class CreateUserChatRelationFacadeTest {
   @SuppressWarnings("unused")
   private AuditingHandler auditingHandler;
 
+  @org.junit.jupiter.api.BeforeEach
+  void enableRocketChat() {
+    // These tests cover the legacy Rocket.Chat flow (ADR-004: disabled by default)
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        createUserChatRelationFacade, "rocketChatEnabled", true);
+  }
+
   @Test
   public void
       initializeUserChatAgencyRelation_Should_CreateUserChatAgencyRelation_ForNewUserAccountCreation()

--- a/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProviderTest.java
@@ -39,6 +39,13 @@ class RocketChatRoomInformationProviderTest {
 
   @Mock private ConsultantRepository consultantRepository;
 
+  @org.junit.jupiter.api.BeforeEach
+  void enableRocketChat() {
+    // These tests cover the Rocket.Chat-backed room info flow (ADR-004: disabled by default)
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        rocketChatRoomInformationProvider, "rocketChatEnabled", true);
+  }
+
   @Test
   void retrieveRocketChatInformation_Should_Return_CorrectMessagesReadMap() {
 

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/RocketChatTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/RocketChatTestConfig.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.MeDTO;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,13 @@ public class RocketChatTestConfig {
 
   @MockitoBean MongoClient mongoClient;
 
+  /**
+   * ADR-004: this fake replaces the real Rocket.Chat adapter only when the integration is enabled.
+   * With {@code rocket-chat.enabled=false} (the testing default) contexts get the inert {@code
+   * DisabledRocketChatService} instead; RC-specific tests must set rocket-chat.enabled=true.
+   */
   @Bean
+  @ConditionalOnProperty(name = "rocket-chat.enabled", havingValue = "true")
   public RocketChatService rocketChatService(
       RestTemplate restTemplate,
       RocketChatCredentialsProvider rocketChatCredentialsProvider,

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
@@ -30,8 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(
-    properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
+@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({KeycloakTestConfig.class, RocketChatTestConfig.class, ApiControllerTestConfig.class})
 class DeactivateAnonymousUserSchedulerIT {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
@@ -30,7 +30,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(properties = "spring.profiles.active=testing")
+@TestPropertySource(
+    properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({KeycloakTestConfig.class, RocketChatTestConfig.class, ApiControllerTestConfig.class})
 class DeactivateAnonymousUserSchedulerIT {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
@@ -32,8 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(
-    properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
+@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({
   KeycloakTestConfig.class,

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
@@ -32,7 +32,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(properties = "spring.profiles.active=testing")
+@TestPropertySource(
+    properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({
   KeycloakTestConfig.class,


### PR DESCRIPTION
## Summary

Deactivates **all** Rocket.Chat in UserService so the service runs **Matrix only**, behind a `rocket-chat.enabled` property (**default `false`**) — the `@ConditionalOnProperty` flag-off planned in ADR-004. With the flag off (the default), the service boots and serves every flow with **zero** Rocket.Chat traffic: no RC REST calls, no RC MongoDB connection, no RC credential cron. No DB schema changes (Liquibase stays off on the clusters; the `rc_user_id` / `rc_group_id` columns are left untouched).

Verified live on Pre-Dev (hot-deployed image) by the ORISO E2E Quality Gate — consultants, askers and group chats are all provisioned as Matrix users into real Matrix rooms; UserService logs show `DisabledRocketChatService … no-op` on the user/enquiry paths.

Base branch: `dev`.

## Design

- New property `rocket-chat.enabled` (`${ROCKET_CHAT_ENABLED:false}`), hard-`false` in the `testing` profile.
- `@ConditionalOnProperty(name="rocket-chat.enabled", havingValue="true")` on `RocketChatConfig` and the RC-only Mongo client bean.
- A type-compatible **`DisabledRocketChatService extends RocketChatService`** is bound when the flag is off and overrides all 46 public methods: read paths return empty and never throw; write paths are inert (`log.warn` once, then debug); login-style calls throw the already-declared `RocketChatLoginException` that every caller already catches. Overriding `updateCredentials()` also kills the `@PostConstruct` boot login and the `@Scheduled` credential cron.
- Matrix paths are forced when the flag is off: `CreateEnquiryMessageFacade` always takes the Matrix branch; `CreateChatFacade` always uses the Matrix/`createSimplifiedGroupChat` flow; deletion workflows skip RC actions; `RocketChatRoomInformationProvider` returns Matrix-derived room info so session lists keep working.
- `ConfigurationValidator` / `RocketChatConfig` no longer hard-require RC base-url/mongo-url/technical-user at boot when the flag is off.

To re-enable Rocket.Chat anywhere: `ROCKET_CHAT_ENABLED=true` plus the existing URL/credential env vars — behaviour is then byte-identical to before this change.

## Bug found live by the E2E gate and fixed here

- **Consultant-agency status stuck `IN_PROGRESS` with RC off** — the async `RocketChatAsyncHelper` path raced the caller's not-yet-committed `consultant_agency` row (invisible to the fresh async transaction → NPE), so consultant + relation stayed `IN_PROGRESS` forever. With RC off there is no Rocket.Chat work to do, so the status is now finalized synchronously in the caller's transaction, and the async path is null-guarded.

## Validation

- `./mvnw compile` — clean
- `./mvnw test` — **2090 tests, 0 failures, 0 errors, 7 skipped**
- New `RocketChatDisabledBootTest` boots the full context (`testing`/H2) with `rocket-chat.enabled=false` and **empty** RC URLs, asserting the inert adapter is bound and no `MongoClient` bean exists.
- Live on Pre-Dev: user/consultant/asker creation, enquiry, group-chat creation and supervision all Matrix-only; `addSupervisor` returns 201 + `matrixRoomId` and the supervisor joins the Matrix room.

> Note: blocked by the CodeRabbit review gate on `dev` until addressed. Pairs with ORISO-Frontend `feat/matrix-only-rc-teardown` — merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
