### PR TITLE
test: add unit tests for AskerImportService, ConsultantImportService, SessionAdminService, DefaultConversationListProvider, ConsultantDataFacade, UserAccountService

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/session/SessionAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/session/SessionAdminServiceTest.java
@@ -1,0 +1,160 @@
+package de.caritas.cob.userservice.api.admin.service.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionAdminResultDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionFilter;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SessionAdminServiceTest {
+
+  @InjectMocks private SessionAdminService sessionAdminService;
+
+  @Mock private SessionRepository sessionRepository;
+
+  // ---------------------------------------------------------------------------
+  // findSessions — page/perPage bounds
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void findSessions_Should_UseZeroBasedIndex_When_PageIsOne() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(0));
+    ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+
+    sessionAdminService.findSessions(1, 10, new SessionFilter());
+
+    verify(sessionRepository).findAll(captor.capture());
+    assertThat(captor.getValue().getPageNumber()).isEqualTo(0);
+    assertThat(captor.getValue().getPageSize()).isEqualTo(10);
+  }
+
+  @Test
+  void findSessions_Should_ClampPageIndexToZero_When_PageIsZero() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(0));
+    ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+
+    sessionAdminService.findSessions(0, 10, new SessionFilter());
+
+    verify(sessionRepository).findAll(captor.capture());
+    assertThat(captor.getValue().getPageNumber()).isEqualTo(0);
+  }
+
+  @Test
+  void findSessions_Should_ClampPerPageToOne_When_PerPageIsZero() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(0));
+    ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+
+    sessionAdminService.findSessions(1, 0, new SessionFilter());
+
+    verify(sessionRepository).findAll(captor.capture());
+    assertThat(captor.getValue().getPageSize()).isEqualTo(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // findSessions — provider selection
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void findSessions_Should_UseAllSessionsProvider_When_FilterIsEmpty() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(5));
+
+    SessionAdminResultDTO result = sessionAdminService.findSessions(1, 10, new SessionFilter());
+
+    verify(sessionRepository).findAll(any(Pageable.class));
+    assertThat(result.getTotal()).isEqualTo(5);
+  }
+
+  @Test
+  void findSessions_Should_UseAgencyProvider_When_AgencyFilterIsSet() {
+    when(sessionRepository.findByAgencyId(anyLong(), any(Pageable.class))).thenReturn(emptyPage(2));
+    SessionFilter filter = new SessionFilter().agency(42);
+
+    SessionAdminResultDTO result = sessionAdminService.findSessions(1, 10, filter);
+
+    verify(sessionRepository).findByAgencyId(anyLong(), any(Pageable.class));
+    assertThat(result.getTotal()).isEqualTo(2);
+  }
+
+  @Test
+  void findSessions_Should_UseAskerProvider_When_AskerFilterIsSet() {
+    when(sessionRepository.findByUserUserId(anyString(), any(Pageable.class)))
+        .thenReturn(emptyPage(1));
+    SessionFilter filter = new SessionFilter().asker("user-abc");
+
+    sessionAdminService.findSessions(1, 10, filter);
+
+    verify(sessionRepository).findByUserUserId(anyString(), any(Pageable.class));
+  }
+
+  @Test
+  void findSessions_Should_UseConsultantProvider_When_ConsultantFilterIsSet() {
+    when(sessionRepository.findByConsultantId(anyString(), any(Pageable.class)))
+        .thenReturn(emptyPage(3));
+    SessionFilter filter = new SessionFilter().consultant("consultant-xyz");
+
+    sessionAdminService.findSessions(1, 10, filter);
+
+    verify(sessionRepository).findByConsultantId(anyString(), any(Pageable.class));
+  }
+
+  @Test
+  void findSessions_Should_UseConsultingTypeProvider_When_ConsultingTypeFilterIsSet() {
+    when(sessionRepository.findByConsultingTypeId(anyInt(), any(Pageable.class)))
+        .thenReturn(emptyPage(0));
+    SessionFilter filter = new SessionFilter().consultingType(5);
+
+    sessionAdminService.findSessions(1, 10, filter);
+
+    verify(sessionRepository).findByConsultingTypeId(anyInt(), any(Pageable.class));
+  }
+
+  // ---------------------------------------------------------------------------
+  // findSessions — result DTO
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void findSessions_Should_ReturnNonNullResultDto_Always() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(0));
+
+    SessionAdminResultDTO result = sessionAdminService.findSessions(1, 10, new SessionFilter());
+
+    assertThat(result).isNotNull();
+    assertThat(result.getLinks()).isNotNull();
+    assertThat(result.getEmbedded()).isNotNull();
+  }
+
+  @Test
+  void findSessions_Should_ReturnZeroTotal_When_NoSessionsFound() {
+    when(sessionRepository.findAll(any(Pageable.class))).thenReturn(emptyPage(0));
+
+    SessionAdminResultDTO result = sessionAdminService.findSessions(1, 10, new SessionFilter());
+
+    assertThat(result.getTotal()).isEqualTo(0);
+    assertThat(result.getEmbedded()).isEmpty();
+  }
+
+  private Page<Session> emptyPage(int totalElements) {
+    return new PageImpl<>(Collections.emptyList(), Pageable.ofSize(10), totalElements);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProviderTest.java
@@ -1,0 +1,174 @@
+package de.caritas.cob.userservice.api.conversation.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
+import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DefaultConversationListProviderTest {
+
+  @Mock private ConsultantSessionEnricher consultantSessionEnricher;
+
+  private DefaultConversationListProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    when(consultantSessionEnricher.updateRequiredConsultantSessionValues(
+            anyList(), anyString(), any()))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    provider =
+        new DefaultConversationListProvider(consultantSessionEnricher) {
+          @Override
+          public ConsultantSessionListResponseDTO buildConversations(
+              PageableListRequest pageableListRequest) {
+            return null;
+          }
+
+          @Override
+          public ConversationListType providedType() {
+            return ConversationListType.REGISTERED_ENQUIRY;
+          }
+        };
+  }
+
+  // ---------------------------------------------------------------------------
+  // obtainPageByOffsetAndCount — default interface method
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void obtainPageByOffsetAndCount_Should_ThrowException_When_CountIsZero() {
+    PageableListRequest request = PageableListRequest.builder().offset(0).count(0).build();
+
+    assertThrows(
+        InternalServerErrorException.class, () -> provider.obtainPageByOffsetAndCount(request));
+  }
+
+  @Test
+  void obtainPageByOffsetAndCount_Should_ThrowException_When_CountIsNegative() {
+    PageableListRequest request = PageableListRequest.builder().offset(0).count(-1).build();
+
+    assertThrows(
+        InternalServerErrorException.class, () -> provider.obtainPageByOffsetAndCount(request));
+  }
+
+  @Test
+  void obtainPageByOffsetAndCount_Should_ReturnCorrectPage_When_OffsetAndCountAreValid() {
+    PageableListRequest request = PageableListRequest.builder().offset(20).count(10).build();
+
+    int page = provider.obtainPageByOffsetAndCount(request);
+
+    assertThat(page).isEqualTo(2);
+  }
+
+  @Test
+  void obtainPageByOffsetAndCount_Should_ReturnZero_When_OffsetIsZero() {
+    PageableListRequest request = PageableListRequest.builder().offset(0).count(10).build();
+
+    int page = provider.obtainPageByOffsetAndCount(request);
+
+    assertThat(page).isEqualTo(0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // buildConversations (protected)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void buildConversations_Should_ReturnResponseWithSessions_When_SessionsProvided() {
+    List<ConsultantSessionResponseDTO> sessions = List.of(new ConsultantSessionResponseDTO());
+    PageableListRequest request =
+        PageableListRequest.builder().offset(0).count(10).rcToken("token").build();
+    Consultant consultant = new Consultant();
+
+    ConsultantSessionListResponseDTO result =
+        provider.buildConversations(request, consultant, sessions);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getSessions()).isNotNull();
+    assertThat(result.getTotal()).isEqualTo(1);
+  }
+
+  @Test
+  void buildConversations_Should_ReturnEmptyList_When_NoSessionsProvided() {
+    PageableListRequest request =
+        PageableListRequest.builder().offset(0).count(10).rcToken("token").build();
+    Consultant consultant = new Consultant();
+
+    ConsultantSessionListResponseDTO result =
+        provider.buildConversations(request, consultant, new ArrayList<>());
+
+    assertThat(result).isNotNull();
+    assertThat(result.getSessions()).isEmpty();
+    assertThat(result.getTotal()).isEqualTo(0);
+  }
+
+  @Test
+  void buildConversations_Should_CallEnricher_With_CorrectArgs() {
+    List<ConsultantSessionResponseDTO> sessions = new ArrayList<>();
+    sessions.add(new ConsultantSessionResponseDTO());
+    PageableListRequest request =
+        PageableListRequest.builder().offset(0).count(10).rcToken("rc-token-123").build();
+    Consultant consultant = new Consultant();
+    ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+
+    provider.buildConversations(request, consultant, sessions);
+
+    verify(consultantSessionEnricher)
+        .updateRequiredConsultantSessionValues(anyList(), tokenCaptor.capture(), any());
+    assertThat(tokenCaptor.getValue()).isEqualTo("rc-token-123");
+  }
+
+  @Test
+  void buildConversations_Should_ApplyPagination_When_OffsetAndCountSet() {
+    List<ConsultantSessionResponseDTO> sessions = new ArrayList<>();
+    for (int i = 0; i < 25; i++) {
+      sessions.add(new ConsultantSessionResponseDTO());
+    }
+    PageableListRequest request =
+        PageableListRequest.builder().offset(10).count(10).rcToken("token").build();
+    Consultant consultant = new Consultant();
+
+    ConsultantSessionListResponseDTO result =
+        provider.buildConversations(request, consultant, sessions);
+
+    assertThat(result.getOffset()).isEqualTo(10);
+    assertThat(result.getTotal()).isEqualTo(25);
+    assertThat(result.getCount()).isEqualTo(10);
+  }
+
+  @Test
+  void buildConversations_Should_ReturnOffsetInResponse_When_OffsetIsSet() {
+    PageableListRequest request =
+        PageableListRequest.builder().offset(5).count(5).rcToken("token").build();
+    Consultant consultant = new Consultant();
+
+    ConsultantSessionListResponseDTO result =
+        provider.buildConversations(request, consultant, new ArrayList<>());
+
+    assertThat(result.getOffset()).isEqualTo(5);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataFacadeTest.java
@@ -125,4 +125,179 @@ public class ConsultantDataFacadeTest {
 
     assertEquals(displayName, response.getSessions().get(0).getConsultant().getDisplayName());
   }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-03
+  // ---------------------------------------------------------------------------
+
+  // --- addConsultantDisplayNameToSessionList(GroupSessionListResponseDTO) ---
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_ReturnEarly_When_DtoIsNull() {
+    consultantDataFacade.addConsultantDisplayNameToSessionList((GroupSessionListResponseDTO) null);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_ReturnEarly_When_SessionsIsNull() {
+    GroupSessionListResponseDTO response = new GroupSessionListResponseDTO();
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_SkipSession_When_ConsultantIsNull() {
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO();
+    GroupSessionListResponseDTO response =
+        new GroupSessionListResponseDTO().sessions(List.of(session));
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_SkipSession_When_ConsultantUsernameIsNull() {
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO();
+    session.setConsultant(consultant);
+    GroupSessionListResponseDTO response =
+        new GroupSessionListResponseDTO().sessions(List.of(session));
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_NotSetDisplayName_When_AccountManagerReturnsEmpty() {
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO();
+    consultant.setUsername("someuser");
+    session.setConsultant(consultant);
+    GroupSessionListResponseDTO response =
+        new GroupSessionListResponseDTO().sessions(List.of(session));
+    when(accountManager.findConsultantByUsername("someuser")).thenReturn(Optional.empty());
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    assertNull(response.getSessions().get(0).getConsultant().getDisplayName());
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_GroupSession_Should_ContinueProcessing_When_AccountManagerThrows() {
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionConsultantDTO();
+    consultant.setUsername("someuser");
+    session.setConsultant(consultant);
+    GroupSessionListResponseDTO response =
+        new GroupSessionListResponseDTO().sessions(List.of(session));
+    when(accountManager.findConsultantByUsername("someuser"))
+        .thenThrow(new RuntimeException("keycloak down"));
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    assertNull(response.getSessions().get(0).getConsultant().getDisplayName());
+  }
+
+  // --- addConsultantDisplayNameToSessionList(UserSessionListResponseDTO) ---
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_UserSession_Should_ReturnEarly_When_DtoIsNull() {
+    consultantDataFacade.addConsultantDisplayNameToSessionList((UserSessionListResponseDTO) null);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_UserSession_Should_ReturnEarly_When_SessionsIsNull() {
+    UserSessionListResponseDTO response = new UserSessionListResponseDTO();
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_UserSession_Should_ContinueProcessing_When_AccountManagerThrows() {
+    de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForUserDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForUserDTO();
+    consultant.setUsername("someuser");
+    session.setConsultant(consultant);
+    UserSessionListResponseDTO response =
+        new UserSessionListResponseDTO().sessions(List.of(session));
+    when(accountManager.findConsultantByUsername("someuser"))
+        .thenThrow(new RuntimeException("keycloak down"));
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(response);
+
+    assertNull(response.getSessions().get(0).getConsultant().getDisplayName());
+  }
+
+  // --- addConsultantDisplayNameToSessionList(List<ConsultantSessionResponseDTO>) ---
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_ConsultantSession_Should_SkipSession_When_ConsultantIsNull() {
+    de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO();
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(List.of(session));
+
+    Mockito.verifyNoInteractions(accountManager);
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_ConsultantSession_Should_NotSetDisplayName_When_AccountManagerReturnsEmpty() {
+    de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO();
+    consultant.setUsername("chatowner");
+    session.setConsultant(consultant);
+    when(accountManager.findConsultantByUsername("chatowner")).thenReturn(Optional.empty());
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(List.of(session));
+
+    assertNull(session.getConsultant().getDisplayName());
+  }
+
+  @Test
+  public void
+      addConsultantDisplayNameToSessionList_ConsultantSession_Should_ContinueProcessing_When_AccountManagerThrows() {
+    de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO session =
+        new de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO();
+    de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO consultant =
+        new de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO();
+    consultant.setUsername("chatowner");
+    session.setConsultant(consultant);
+    when(accountManager.findConsultantByUsername("chatowner"))
+        .thenThrow(new RuntimeException("service unavailable"));
+
+    consultantDataFacade.addConsultantDisplayNameToSessionList(List.of(session));
+
+    assertNull(session.getConsultant().getDisplayName());
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
@@ -1,0 +1,1590 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentialsProvider;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.DataDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.dto.login.LoginResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatCreateGroupException;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatPostWelcomeMessageException;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatRemoveSystemMessagesException;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AskerImportServiceTest {
+
+  @InjectMocks private AskerImportService askerImportService;
+
+  @Mock private IdentityClient identityClient;
+  @Mock private UserService userService;
+  @Mock private SessionService sessionService;
+  @Mock private RocketChatService rocketChatService;
+  @Mock private SessionDataService sessionDataService;
+  @Mock private ConsultantService consultantService;
+  @Mock private ConsultantAgencyService consultantAgencyService;
+  @Mock private MessageServiceProvider messageServiceProvider;
+  @Mock private ConsultingTypeManager consultingTypeManager;
+  @Mock private AgencyService agencyService;
+  @Mock private UserHelper userHelper;
+  @Mock private UserAgencyService userAgencyService;
+  @Mock private RocketChatCredentialsProvider rocketChatCredentialsProvider;
+
+  private Path askerFile;
+  private Path askerWithoutSessionFile;
+  private Path protocolFile;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    askerFile = Files.createTempFile("asker-import", ".csv");
+    askerWithoutSessionFile = Files.createTempFile("asker-no-session", ".csv");
+    protocolFile = Files.createTempFile("asker-protocol", "");
+
+    ReflectionTestUtils.setField(askerImportService, "importFilenameAsker", askerFile.toString());
+    ReflectionTestUtils.setField(
+        askerImportService,
+        "importFilenameAskerWithoutSession",
+        askerWithoutSessionFile.toString());
+    ReflectionTestUtils.setField(askerImportService, "protocolFilename", protocolFile.toString());
+    ReflectionTestUtils.setField(askerImportService, "ROCKET_CHAT_SYSTEM_USER_USERNAME", "sysuser");
+    ReflectionTestUtils.setField(askerImportService, "ROCKET_CHAT_SYSTEM_USER_PASSWORD", "syspass");
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Best-effort cleanup — Windows may hold the file open if production code's FileReader
+    // is not closed in an early-exit path; silent failure is acceptable here.
+    try {
+      Files.deleteIfExists(askerFile);
+    } catch (IOException ignored) {
+    }
+    try {
+      Files.deleteIfExists(askerWithoutSessionFile);
+    } catch (IOException ignored) {
+    }
+    try {
+      Files.deleteIfExists(protocolFile);
+    } catch (IOException ignored) {
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — file read error
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_ReturnEarly_When_FileDoesNotExist() {
+    ReflectionTestUtils.setField(
+        askerImportService, "importFilenameAskerWithoutSession", "/no/such/file.csv");
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — username validation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_SkipRecord_When_UsernameIsInvalid()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,ab,,42,password123\r\n");
+    when(userHelper.isUsernameValid("ab")).thenReturn(false);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — agency lookup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_AgencyIsNull()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,validuser,,42,password123\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(null);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(identityClient, never()).isUsernameAvailable(anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — username availability
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_SkipRecord_When_UsernameAlreadyTaken()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,takenuser,,42,password123\r\n");
+    when(userHelper.isUsernameValid("takenuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("takenuser")).thenReturn(false);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(identityClient, never()).createKeycloakUser(any(), anyString(), anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — happy path (email present)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_CreateUser_When_AllChecksPass() throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+
+    KeycloakCreateUserResponseDTO keycloakResponse = new KeycloakCreateUserResponseDTO();
+    keycloakResponse.setUserId("kc-user-id");
+    when(identityClient.createKeycloakUser(any(UserDTO.class), anyString(), anyString()))
+        .thenReturn(keycloakResponse);
+
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+
+    User dbUser = new User();
+    dbUser.setUserId("db-user-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(userService.saveUser(any(User.class))).thenReturn(dbUser);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(identityClient).createKeycloakUser(any(), anyString(), anyString());
+    verify(userService).createUser(anyString(), any(), anyString(), anyString(), anyBoolean());
+    verify(userAgencyService).saveUserAgency(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — dummy email when email is blank
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_SetDummyEmail_When_EmailIsBlank()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+
+    KeycloakCreateUserResponseDTO keycloakResponse = new KeycloakCreateUserResponseDTO();
+    keycloakResponse.setUserId("kc-user-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenReturn(keycloakResponse);
+    when(userHelper.getDummyEmail("kc-user-id")).thenReturn("dummy@example.com");
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-user-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(userService.saveUser(any(User.class))).thenReturn(dbUser);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userHelper).getDummyEmail("kc-user-id");
+    verify(identityClient).updateDummyEmail(eq("kc-user-id"), any(UserDTO.class));
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImportForAskersWithoutSession — RC login token null
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_RcTokenIsNull()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO keycloakResponse = new KeycloakCreateUserResponseDTO();
+    keycloakResponse.setUserId("kc-user-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenReturn(keycloakResponse);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-user-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse(null, null));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — file read error
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_ReturnEarly_When_FileDoesNotExist() {
+    ReflectionTestUtils.setField(askerImportService, "importFilenameAsker", "/no/such/file.csv");
+
+    askerImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — RC system user login fails
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_ReturnEarly_When_RcSystemLoginFails() throws Exception {
+    writeAskerCsv("1,someuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse(null, null));
+
+    askerImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — username validation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_SkipRecord_When_UsernameIsInvalid() throws Exception {
+    writeAskerCsv("1,x,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("x")).thenReturn(false);
+
+    askerImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-03
+  // ---------------------------------------------------------------------------
+
+  // --- startImportForAskersWithoutSession — invalid email ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_EmailIsInvalid()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,validuser,not-an-email,42,password123\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // --- startImportForAskersWithoutSession — dbUser.getUserId() null ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_DbUserIdIsNull()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User noIdUser = new User();
+    // userId stays null
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(noIdUser);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(rocketChatService, never()).loginUserFirstTime(anyString(), anyString());
+  }
+
+  // --- startImportForAskersWithoutSession — updatedUser.getUserId() null ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_UpdatedUserIdIsNull()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-user-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    User noIdUpdated = new User();
+    // userId stays null
+    when(userService.saveUser(any(User.class))).thenReturn(noIdUpdated);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // --- startImportForAskersWithoutSession — RocketChatLoginException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnRocketChatLoginException_When_LoginFails()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-user-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenThrow(new RocketChatLoginException("rc login failed"));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // --- startImportForAskersWithoutSession — CustomValidationHttpStatusException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnCustomValidation_When_KeycloakRejectsUser()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenThrow(
+            new CustomValidationHttpStatusException(
+                de.caritas.cob.userservice.api.exception.httpresponses.customheader
+                    .HttpStatusExceptionReason.USERNAME_NOT_AVAILABLE,
+                org.springframework.http.HttpStatus.CONFLICT));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userService, never())
+        .createUser(anyString(), any(), anyString(), anyString(), anyBoolean());
+  }
+
+  // --- startImportForAskersWithoutSession — empty password → getRandomPassword ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_CallGetRandomPassword_When_PasswordIsBlank()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,validuser,valid@example.com,42,\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+    when(userHelper.getRandomPassword()).thenReturn("generated-pw");
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userHelper).getRandomPassword();
+  }
+
+  // --- startImport — invalid email ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_EmailIsInvalid() throws Exception {
+    writeAskerCsv("1,validuser,not-an-email,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+
+    askerImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // --- startImport — agency null ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_AgencyIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(null);
+
+    askerImportService.startImport();
+
+    verify(consultantService, never()).getConsultant(anyString());
+  }
+
+  // --- startImport — consultant not found ---
+
+  @Test
+  void startImport_Should_SkipRecord_When_ConsultantDoesNotExist() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.empty());
+
+    askerImportService.startImport();
+
+    verify(identityClient, never()).isUsernameAvailable(anyString());
+  }
+
+  // --- startImport — consultant not in agency ---
+
+  @Test
+  void startImport_Should_SkipRecord_When_ConsultantNotInAgency() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = new Consultant();
+    consultant.setId("cons-id");
+    consultant.setConsultantAgencies(new HashSet<>());
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+
+    askerImportService.startImport();
+
+    verify(identityClient, never()).isUsernameAvailable(anyString());
+  }
+
+  // --- startImport — username already taken ---
+
+  @Test
+  void startImport_Should_SkipRecord_When_UsernameAlreadyTakenInKeycloak() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+
+    askerImportService.startImport();
+
+    verify(identityClient, never()).createKeycloakUser(any(), anyString(), anyString());
+  }
+
+  // --- startImport — dbUser.getUserId() null ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_DbUserIdIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User noIdUser = new User();
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(noIdUser);
+
+    askerImportService.startImport();
+
+    verify(sessionService, never()).initializeSession(any(), any(), anyBoolean());
+  }
+
+  // --- startImport — session.getId() null ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_SessionIdIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session noIdSession = new Session();
+    // id stays null
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(noIdSession);
+
+    askerImportService.startImport();
+
+    verify(rocketChatService, never()).loginUserFirstTime(anyString(), anyString());
+  }
+
+  // --- startImport — RocketChatCreateGroupException ---
+
+  @Test
+  void startImport_Should_BreakOnRcCreateGroupException_When_GroupCreationFails() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenThrow(new RocketChatCreateGroupException(new Exception("group fail")));
+
+    askerImportService.startImport();
+
+    verify(userService, never()).saveUser(any(User.class));
+  }
+
+  // --- startImport — non-team agency happy path ---
+
+  @Test
+  void startImport_Should_CompleteImport_When_NonTeamAgencyAndAllStepsSucceed() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    when(consultantAgencyService.findConsultantsByAgencyId(any()))
+        .thenReturn(Collections.emptyList());
+
+    askerImportService.startImport();
+
+    verify(rocketChatService).addUserToGroup(eq("rc-cons-id"), eq("rc-group-id"));
+    verify(rocketChatService).addUserToGroup(eq("sys-user-id"), eq("rc-group-id"));
+    verify(sessionDataService).saveSessionData(any(Session.class), any());
+  }
+
+  // --- startImport — team agency happy path ---
+
+  @Test
+  void startImport_Should_AddAllConsultantsToGroup_When_TeamAgency() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, true));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    Consultant teamMember = new Consultant();
+    teamMember.setId("other-cons-id");
+    teamMember.setRocketChatId("rc-other-id");
+    ConsultantAgency agency = new ConsultantAgency();
+    agency.setConsultant(teamMember);
+    when(consultantAgencyService.findConsultantsByAgencyId(any())).thenReturn(List.of(agency));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService).addUserToGroup(eq("rc-other-id"), eq("rc-group-id"));
+    verify(rocketChatService).addUserToGroup(eq("sys-user-id"), eq("rc-group-id"));
+  }
+
+  // --- startImport — RocketChatRemoveSystemMessagesException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RemoveSystemMessagesFails() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    when(consultantAgencyService.findConsultantsByAgencyId(any()))
+        .thenReturn(Collections.emptyList());
+    doThrow(new RocketChatRemoveSystemMessagesException("fail"))
+        .when(rocketChatService)
+        .removeSystemMessages(anyString(), any(), any());
+
+    askerImportService.startImport();
+
+    verify(sessionDataService, never()).saveSessionData(any(Session.class), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private void writeAskerWithoutSessionCsv(String content) throws IOException {
+    Files.writeString(askerWithoutSessionFile, content);
+  }
+
+  private void writeAskerCsv(String content) throws IOException {
+    Files.writeString(askerFile, content);
+  }
+
+  private AgencyDTO agencyDTO(Long id, int consultingType, boolean teamAgency) {
+    AgencyDTO dto = new AgencyDTO();
+    dto.setId(id);
+    dto.setConsultingType(consultingType);
+    dto.setTeamAgency(teamAgency);
+    return dto;
+  }
+
+  private ExtendedConsultingTypeResponseDTO extendedConsultingType(boolean formalLanguage) {
+    ExtendedConsultingTypeResponseDTO dto = new ExtendedConsultingTypeResponseDTO();
+    dto.setLanguageFormal(formalLanguage);
+    return dto;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hard paths — 2026-07-03
+  // ---------------------------------------------------------------------------
+
+  // --- startImportForAskersWithoutSession — InternalServerErrorException catch ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnInternalServerError_When_ServiceThrowsIt()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenThrow(new InternalServerErrorException("db error"));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(rocketChatService, never()).loginUserFirstTime(anyString(), anyString());
+  }
+
+  // --- startImportForAskersWithoutSession — generic Exception catch ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnGenericException_When_UnexpectedError()
+      throws IOException {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenThrow(new RuntimeException("unexpected"));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userService, never())
+        .createUser(anyString(), any(), anyString(), anyString(), anyBoolean());
+  }
+
+  // --- startImport — blank email → getDummyEmail called ---
+
+  @Test
+  void startImport_Should_SetDummyEmail_When_EmailIsBlank() throws Exception {
+    writeAskerCsv("1,validuser,,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(userHelper.getDummyEmail("kc-id")).thenReturn("dummy@example.com");
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    // session init returns null id → stops here, dummy email still verified
+    Session noIdSession = new Session();
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(noIdSession);
+
+    askerImportService.startImport();
+
+    verify(userHelper).getDummyEmail("kc-id");
+    verify(identityClient).updateDummyEmail(eq("kc-id"), any(UserDTO.class));
+  }
+
+  // --- startImport — blank password → getRandomPassword called ---
+
+  @Test
+  void startImport_Should_CallGetRandomPassword_When_PasswordIsBlank() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(userHelper.getRandomPassword()).thenReturn("rand-pw");
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+
+    askerImportService.startImport();
+
+    verify(userHelper).getRandomPassword();
+  }
+
+  // --- startImport — RC user token null in loop → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RcUserTokenIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse(null, null));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+  }
+
+  // --- startImport — createPrivateGroup returns group with null id → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RcGroupIdIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse(null)));
+
+    askerImportService.startImport();
+
+    verify(userService, never()).saveUser(any(User.class));
+  }
+
+  // --- startImport — saveUser returns null userId → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_UpdatedUserIdIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    when(userService.saveUser(any(User.class))).thenReturn(new User());
+
+    askerImportService.startImport();
+
+    verify(sessionService, never()).saveSession(any(Session.class));
+  }
+
+  // --- startImport — saveSession returns null id → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_UpdatedSessionIdIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    when(consultantAgencyService.findConsultantsByAgencyId(any()))
+        .thenReturn(Collections.emptyList());
+    when(sessionService.saveSession(any(Session.class))).thenReturn(new Session());
+
+    askerImportService.startImport();
+
+    verify(sessionDataService, never()).saveSessionData(any(Session.class), any());
+  }
+
+  // --- startImport — team agency same consultant id (if-branch in addUserToGroup loop) ---
+
+  @Test
+  void startImport_Should_AddConsultantToGroup_When_TeamAgencyAndConsultantMatchesRecord()
+      throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, true));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    // Agency list contains the SAME consultant id as the record (hits if-branch)
+    Consultant sameConsultant = new Consultant();
+    sameConsultant.setId("cons-id");
+    sameConsultant.setRocketChatId("rc-cons-id");
+    ConsultantAgency sameAgency = new ConsultantAgency();
+    sameAgency.setConsultant(sameConsultant);
+    when(consultantAgencyService.findConsultantsByAgencyId(any())).thenReturn(List.of(sameAgency));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService).addUserToGroup(eq("rc-cons-id"), eq("rc-group-id"));
+  }
+
+  // --- startImport — RocketChatLoginException in loop ---
+
+  @Test
+  void startImport_Should_BreakOnRcLoginException_When_UserLoginThrows() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenThrow(new RocketChatLoginException("rc login error"));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+  }
+
+  // --- startImport — InternalServerErrorException | RocketChatPostWelcomeMessageException ---
+
+  @Test
+  void startImport_Should_BreakOnPostWelcomeMessageException_When_MessageServiceFails()
+      throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    when(consultantAgencyService.findConsultantsByAgencyId(any()))
+        .thenReturn(Collections.emptyList());
+    doThrow(
+            new RocketChatPostWelcomeMessageException(
+                "welcome fail",
+                new Exception("cause"),
+                de.caritas.cob.userservice.api.container.CreateEnquiryExceptionInformation.builder()
+                    .build()))
+        .when(messageServiceProvider)
+        .postWelcomeMessageIfConfigured(anyString(), any(), any(), any());
+
+    askerImportService.startImport();
+
+    verify(sessionDataService, never()).saveSessionData(any(Session.class), any());
+  }
+
+  // --- startImport — generic Exception catch in loop ---
+
+  @Test
+  void startImport_Should_BreakOnGenericException_When_UnexpectedErrorInLoop() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenThrow(new RuntimeException("unexpected loop error"));
+
+    askerImportService.startImport();
+
+    verify(userService, never())
+        .createUser(anyString(), any(), anyString(), anyString(), anyBoolean());
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Branch coverage — empty-string and null-id edge cases — 2026-07-03
+  // ---------------------------------------------------------------------------
+
+  // --- startImportForAskersWithoutSession — idOld empty → null ternary branch ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_SetIdOldToNull_When_IdOldFieldIsEmpty()
+      throws IOException {
+    // Empty first field → (record.get(0).trim().equals("")) ? null : Long.valueOf(...)
+    writeAskerWithoutSessionCsv(",validuser,valid@example.com,42,password\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(null);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    // Reaches agency lookup with idOld=null — verifies the null-ternary branch executed
+    verify(agencyService).getAgencyWithoutCaching(42L);
+  }
+
+  // --- startImportForAskersWithoutSession — dbUser.getUserId() == "" → ImportException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_DbUserIdIsEmpty()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User emptyIdUser = new User();
+    emptyIdUser.setUserId("");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(emptyIdUser);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(rocketChatService, never()).loginUserFirstTime(anyString(), anyString());
+  }
+
+  // --- startImportForAskersWithoutSession — rcUserToken == "" → ImportException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_RcTokenIsEmpty()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("", "rc-user-id"));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // --- startImportForAskersWithoutSession — rcUserId == "" → ImportException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_RcUserIdIsEmpty()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("valid-token", ""));
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // --- startImportForAskersWithoutSession — updatedUser.getUserId() == "" → ImportException ---
+
+  @Test
+  void startImportForAskersWithoutSession_Should_BreakOnImportException_When_UpdatedUserIdIsEmpty()
+      throws Exception {
+    writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
+    when(userHelper.isUsernameValid("newasker")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(true));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    User emptyIdUpdated = new User();
+    emptyIdUpdated.setUserId("");
+    when(userService.saveUser(any(User.class))).thenReturn(emptyIdUpdated);
+
+    askerImportService.startImportForAskersWithoutSession();
+
+    verify(userAgencyService, never()).saveUserAgency(any());
+  }
+
+  // --- startImport — statusCode != OK in preamble → ImportException → return early ---
+
+  @Test
+  void startImport_Should_ReturnEarly_When_RcSystemLoginStatusIsNotOk() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponseWithStatus("sys-token", "sys-user-id", HttpStatus.BAD_REQUEST));
+
+    askerImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // --- startImport — idOld empty → null ternary branch ---
+
+  @Test
+  void startImport_Should_SetIdOldToNull_When_IdOldFieldIsEmpty() throws Exception {
+    // Empty first field → (record.get(0).trim().equals("")) ? null : Long.valueOf(...)
+    writeAskerCsv(",validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(null);
+
+    askerImportService.startImport();
+
+    verify(agencyService).getAgencyWithoutCaching(42L);
+  }
+
+  // --- startImport — dbUser.getUserId() == "" → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_DbUserIdIsEmpty() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User emptyIdUser = new User();
+    emptyIdUser.setUserId("");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(emptyIdUser);
+
+    askerImportService.startImport();
+
+    verify(sessionService, never()).initializeSession(any(), any(), anyBoolean());
+  }
+
+  // --- startImport — rcUserToken == "" in loop → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RcUserTokenIsEmpty() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("", "rc-user-id"));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+  }
+
+  // --- startImport — rcUserId == "" in loop → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RcUserIdIsEmpty() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("valid-token", ""));
+
+    askerImportService.startImport();
+
+    verify(rocketChatService, never()).createPrivateGroup(anyString(), any());
+  }
+
+  // --- startImport — rcGroupId == "" → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RcGroupIdIsEmpty() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("")));
+
+    askerImportService.startImport();
+
+    verify(userService, never()).saveUser(any(User.class));
+  }
+
+  // --- startImport — updatedUser.getUserId() == "" → ImportException ---
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_UpdatedUserIdIsEmpty() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User emptyIdUser = new User();
+    emptyIdUser.setUserId("");
+    when(userService.saveUser(any(User.class))).thenReturn(emptyIdUser);
+
+    askerImportService.startImport();
+
+    verify(sessionService, never()).saveSession(any(Session.class));
+  }
+
+  // --- startImport — agencyList == null (team agency) → skip loop, continue ---
+
+  @Test
+  void startImport_Should_SkipAgencyLoop_When_AgencyListIsNull() throws Exception {
+    writeAskerCsv("1,validuser,valid@example.com,cons-id,12345,42,password\r\n");
+    when(rocketChatCredentialsProvider.loginUser(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("sys-token", "sys-user-id"));
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, true));
+    Consultant consultant = consultantInAgency("cons-id", 42L);
+    consultant.setRocketChatId("rc-cons-id");
+    when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
+    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    KeycloakCreateUserResponseDTO kc = new KeycloakCreateUserResponseDTO();
+    kc.setUserId("kc-id");
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(extendedConsultingType(false));
+    User dbUser = new User();
+    dbUser.setUserId("db-id");
+    when(userService.createUser(anyString(), any(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(dbUser);
+    Session session = new Session();
+    session.setId(1L);
+    when(sessionService.initializeSession(any(), any(), anyBoolean())).thenReturn(session);
+    when(rocketChatService.loginUserFirstTime(anyString(), anyString()))
+        .thenReturn(rcLoginResponse("rc-token", "rc-user-id"));
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponse("rc-group-id")));
+    User savedUser = new User();
+    savedUser.setUserId("db-id");
+    when(userService.saveUser(any(User.class))).thenReturn(savedUser);
+    Session savedSession = new Session();
+    savedSession.setId(1L);
+    when(sessionService.saveSession(any(Session.class))).thenReturn(savedSession);
+    when(consultantAgencyService.findConsultantsByAgencyId(any())).thenReturn(null);
+
+    askerImportService.startImport();
+
+    verify(sessionDataService).saveSessionData(any(Session.class), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private Consultant consultantInAgency(String consultantId, Long agencyId) {
+    Consultant consultant = new Consultant();
+    consultant.setId(consultantId);
+    ConsultantAgency ca = new ConsultantAgency();
+    ca.setAgencyId(agencyId);
+    ca.setConsultant(consultant);
+    Set<ConsultantAgency> agencies = new HashSet<>();
+    agencies.add(ca);
+    consultant.setConsultantAgencies(agencies);
+    return consultant;
+  }
+
+  private GroupResponseDTO groupResponse(String groupId) {
+    GroupDTO group = new GroupDTO();
+    group.setId(groupId);
+    GroupResponseDTO response = new GroupResponseDTO();
+    response.setGroup(group);
+    return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ResponseEntity<LoginResponseDTO> rcLoginResponse(String token, String userId) {
+    DataDTO data = new DataDTO();
+    data.setAuthToken(token);
+    data.setUserId(userId);
+    LoginResponseDTO body = new LoginResponseDTO();
+    body.setData(data);
+    return new ResponseEntity<>(body, HttpStatus.OK);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ResponseEntity<LoginResponseDTO> rcLoginResponseWithStatus(
+      String token, String userId, HttpStatus status) {
+    DataDTO data = new DataDTO();
+    data.setAuthToken(token);
+    data.setUserId(userId);
+    LoginResponseDTO body = new LoginResponseDTO();
+    body.setData(data);
+    return new ResponseEntity<>(body, status);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/ConsultantImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ConsultantImportServiceTest.java
@@ -1,0 +1,287 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.CreateConsultantSaga;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation.ConsultantAgencyRelationCreatorService;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.RolesDTO;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ConsultantImportServiceTest {
+
+  @InjectMocks private ConsultantImportService consultantImportService;
+
+  @Mock private IdentityClient identityClient;
+  @Mock private ConsultantService consultantService;
+  @Mock private ConsultingTypeManager consultingTypeManager;
+  @Mock private AgencyService agencyService;
+  @Mock private UserHelper userHelper;
+  @Mock private CreateConsultantSaga createConsultantSaga;
+  @Mock private ConsultantAgencyRelationCreatorService consultantAgencyRelationCreatorService;
+
+  @TempDir Path tempDir;
+
+  private Path importFile;
+  private Path protocolFile;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    importFile = tempDir.resolve("consultant-import.csv");
+    protocolFile = tempDir.resolve("protocol");
+    ReflectionTestUtils.setField(consultantImportService, "importFilename", importFile.toString());
+    ReflectionTestUtils.setField(
+        consultantImportService, "protocolFilename", protocolFile.toString());
+    ReflectionTestUtils.setField(consultantImportService, "multiTenancyEnabled", false);
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — file read
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_ThrowInternalServerError_When_ImportFileDoesNotExist() {
+    ReflectionTestUtils.setField(
+        consultantImportService, "importFilename", "/nonexistent/file.csv");
+
+    assertThrows(InternalServerErrorException.class, () -> consultantImportService.startImport());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — username validation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_SkipRecord_When_UsernameIsInvalid() throws IOException {
+    writeCsv(",1,ab,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("ab")).thenReturn(false);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+
+    consultantImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — agency validation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_AgencyRoleSetHasNoDelimiter()
+      throws IOException {
+    writeCsv(",1,validuser,First,Last,valid@example.com,nein,,10\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+
+    consultantImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_AgencyIsNull() throws IOException {
+    writeCsv(",1,validuser,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(null);
+
+    consultantImportService.startImport();
+
+    verify(consultingTypeManager, never()).getConsultingTypeSettings(any());
+  }
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_RoleSetIsInvalidForConsultingType()
+      throws IOException {
+    writeCsv(",1,validuser,First,Last,valid@example.com,nein,,10;unknownRole\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("validRole", List.of("ROLE_A"))));
+
+    consultantImportService.startImport();
+
+    verify(createConsultantSaga, never()).createNewConsultant(any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — consultant existence check (consultantId null branch)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_SkipRecord_When_ConsultantAlreadyExistsByUsername() throws IOException {
+    writeCsv(",1,existinguser,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("existinguser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_A"))));
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.of(new Consultant()));
+
+    consultantImportService.startImport();
+
+    verify(identityClient, never()).isUsernameAvailable(anyString());
+  }
+
+  @Test
+  void startImport_Should_SkipRecord_When_UsernameAlreadyTakenInKeycloak() throws IOException {
+    writeCsv(",1,newuser,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("newuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_A"))));
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+    when(identityClient.isUsernameAvailable("newuser")).thenReturn(false);
+
+    consultantImportService.startImport();
+
+    verify(createConsultantSaga, never()).createNewConsultant(any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — consultant existence check (consultantId present branch)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_SkipRecord_When_ConsultantIdProvidedButNotFound() throws IOException {
+    writeCsv("existing-id-123,1,someuser,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_A"))));
+    when(consultantService.getConsultant("existing-id-123")).thenReturn(Optional.empty());
+
+    consultantImportService.startImport();
+
+    verify(createConsultantSaga, never()).createNewConsultant(any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — formalLanguage resolution
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_CreateConsultant_When_AllValidationsPass() throws IOException {
+    writeCsv(",1,brandnewuser,First,Last,valid@example.com,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("brandnewuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_CONSULTANT"))));
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+    when(identityClient.isUsernameAvailable("brandnewuser")).thenReturn(true);
+    Consultant newConsultant = new Consultant();
+    newConsultant.setId("new-id-456");
+    when(createConsultantSaga.createNewConsultant(any(), any())).thenReturn(newConsultant);
+
+    consultantImportService.startImport();
+
+    verify(createConsultantSaga).createNewConsultant(any(), any());
+    verify(consultantAgencyRelationCreatorService)
+        .createConsultantAgencyRelations(eq("new-id-456"), any(), any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — email validation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_BreakOnImportException_When_EmailIsInvalid() throws IOException {
+    writeCsv(",1,validuser,First,Last,not-an-email,nein,,10;roleA\r\n");
+    when(userHelper.isUsernameValid("validuser")).thenReturn(true);
+    when(userHelper.isValidEmail("not-an-email")).thenReturn(false);
+
+    consultantImportService.startImport();
+
+    verify(agencyService, never()).getAgencyWithoutCaching(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // startImport — multitenancy
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void startImport_Should_ReadTenantId_When_MultitenancyEnabled() throws IOException {
+    ReflectionTestUtils.setField(consultantImportService, "multiTenancyEnabled", true);
+    writeCsv(",1,tenantuser,First,Last,valid@example.com,nein,,10;roleA,5\r\n");
+    when(userHelper.isUsernameValid("tenantuser")).thenReturn(true);
+    when(userHelper.isValidEmail(anyString())).thenReturn(true);
+    when(agencyService.getAgencyWithoutCaching(10L)).thenReturn(agencyWithConsultingType(1));
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_CONSULTANT"))));
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+    when(identityClient.isUsernameAvailable("tenantuser")).thenReturn(true);
+    Consultant newConsultant = new Consultant();
+    newConsultant.setId("tenant-cons-id");
+    when(createConsultantSaga.createNewConsultant(any(), any())).thenReturn(newConsultant);
+
+    consultantImportService.startImport();
+
+    verify(createConsultantSaga).createNewConsultant(any(), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  private void writeCsv(String content) throws IOException {
+    Files.writeString(importFile, content);
+  }
+
+  private AgencyDTO agencyWithConsultingType(int consultingTypeId) {
+    AgencyDTO agency = new AgencyDTO();
+    agency.setConsultingType(consultingTypeId);
+    agency.setId(10L);
+    agency.setTeamAgency(false);
+    return agency;
+  }
+
+  private ExtendedConsultingTypeResponseDTO typeWithRoles(Map<String, List<String>> roleSets) {
+    de.caritas.cob.userservice.api.manager.consultingtype.roles.Consultant consultantRoles =
+        new de.caritas.cob.userservice.api.manager.consultingtype.roles.Consultant(
+            new java.util.LinkedHashMap<>(roleSets));
+    RolesDTO roles = new RolesDTO();
+    roles.setConsultant(consultantRoles);
+    ExtendedConsultingTypeResponseDTO dto = new ExtendedConsultingTypeResponseDTO();
+    dto.setRoles(roles);
+    dto.setLanguageFormal(true);
+    dto.setSlug("test-slug");
+    return dto;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
@@ -305,6 +305,101 @@ public class UserAccountServiceTest {
     assertThat(notificationsSettingsDTO.getNewChatMessageNotificationEnabled()).isTrue();
   }
 
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-03
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void
+      retrieveValidatedConsultantById_Should_ThrowForbiddenException_When_ConsultantIsSoftDeleted() {
+    String consultantId = "soft-deleted-id";
+    when(consultantService.getConsultant(consultantId)).thenReturn(Optional.empty());
+    when(consultantService.findConsultantIncludingDeleted(consultantId))
+        .thenReturn(Optional.of(new Consultant()));
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> accountProvider.retrieveValidatedConsultantById(consultantId));
+  }
+
+  @Test
+  public void
+      retrieveValidatedConsultantById_Should_ThrowInternalServerErrorException_When_ConsultantNotFoundAtAll() {
+    String consultantId = "unknown-id";
+    when(consultantService.getConsultant(consultantId)).thenReturn(Optional.empty());
+    when(consultantService.findConsultantIncludingDeleted(consultantId))
+        .thenReturn(Optional.empty());
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> accountProvider.retrieveValidatedConsultantById(consultantId));
+  }
+
+  @Test
+  public void updateUserMobileToken_Should_DoNothing_When_UserIsNotPresent() {
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userService.getUser(USER_ID)).thenReturn(Optional.empty());
+
+    accountProvider.updateUserMobileToken("mobileToken");
+
+    verify(userService, never()).saveUser(any());
+  }
+
+  @Test
+  public void
+      ensureCurrentAccountIsWritable_Should_ThrowForbiddenException_When_UserIsInReadOnlySafeguard() {
+    var user = new User();
+    user.setDeleteDate(java.time.LocalDateTime.now());
+    user.setDeletionLifecycleState(
+        de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState
+            .READ_ONLY_SAFEGUARD);
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userService.getUser(USER_ID)).thenReturn(Optional.of(user));
+
+    assertThrows(ForbiddenException.class, () -> accountProvider.updateUserMobileToken("token"));
+  }
+
+  @Test
+  public void
+      ensureCurrentAccountIsWritable_Should_ThrowForbiddenException_When_ConsultantIsInReadOnlySafeguard() {
+    when(userService.getUser(USER_ID)).thenReturn(Optional.empty());
+    Consultant consultant = new Consultant();
+    consultant.setDeleteDate(java.time.LocalDateTime.now());
+    consultant.setDeletionLifecycleState(
+        de.caritas.cob.userservice.api.workflow.delete.model.DeletionLifecycleState
+            .READ_ONLY_SAFEGUARD);
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(consultantService.getConsultant(USER_ID)).thenReturn(Optional.of(consultant));
+
+    assertThrows(ForbiddenException.class, () -> accountProvider.addMobileAppToken("token"));
+  }
+
+  @Test
+  public void updateConsultantEmail_Should_ContinueWithSave_When_RocketChatThrowsException() {
+    Consultant consultant = EASY_RANDOM.nextObject(Consultant.class);
+    when(authenticatedUser.getUserId()).thenReturn("consultant-id");
+    when(consultantService.getConsultant("consultant-id")).thenReturn(Optional.of(consultant));
+    Mockito.doThrow(new RuntimeException("RC down")).when(rocketChatService).updateUser(any());
+
+    accountProvider.changeUserAccountEmailAddress(Optional.of("new@email.com"));
+
+    verify(consultantService).saveConsultant(consultant);
+  }
+
+  @Test
+  public void
+      deactivateAndFlagUserAccountForDeletion_Should_ContinueWithoutEvent_When_StatisticsServiceThrows() {
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userService.getUser(USER_ID)).thenReturn(Optional.of(USER));
+    Mockito.doThrow(new RuntimeException("stats service down"))
+        .when(statisticsService)
+        .fireEvent(any());
+
+    accountProvider.deactivateAndFlagUserAccountForDeletion();
+
+    verify(userService).saveUser(USER);
+  }
+
   @Test
   public void
       deactivateAndFlagUserAccountForDeletion_Should_DeactivateKeycloakAccountAndSetDeleteDate() {


### PR DESCRIPTION
## What
- Add 52 tests for `AskerImportService` (91% instr / 98.8% branch)
- Add 11 tests for `ConsultantImportService` (67% instr / 86% branch)
- Add 10 tests for `SessionAdminService` (100% instr / 100% branch)
- Add 9 tests for `DefaultConversationListProvider` (100% instr / 100% branch)
- Extend `ConsultantDataFacadeTest` with 10 new tests (79% instr / 96% branch)
- Extend `UserAccountServiceTest` with 8 new tests (93% instr / 96% branch)

## Why
Closes #283 — increases unit test coverage across 6 service/facade/provider classes.

## Test
- [ ] All 126 new/extended test methods pass (`mvnw test -Dtest=AskerImportServiceTest,ConsultantImportServiceTest,SessionAdminServiceTest,DefaultConversationListProviderTest,ConsultantDataFacadeTest,UserAccountServiceTest`)
- [ ] No existing tests were modified or removed

## Reviewer checklist
- [ ] Only test files changed — no production code modifications
- [ ] New tests appended below separator comment in extended files