### PR TITLE
Address shazia-k review follow-up for RC teardown (#281)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/rocketchat/DisabledRocketChatService.java
@@ -37,6 +37,14 @@ import org.springframework.web.client.RestTemplate;
  * <p>No Rocket.Chat REST call, MongoDB connection or credential cron ever happens: the overridden
  * {@link #updateCredentials()} carries neither {@code @PostConstruct} nor {@code @Scheduled}
  * semantics at runtime because scheduling only considers the most specific method declaration.
+ *
+ * <p><b>Maintenance warning — the null-collaborator trap:</b> the constructor deliberately passes
+ * {@code null} for several {@link RocketChatService} collaborators (the REST/HTTP clients and the
+ * MongoDB client). Those nulls are only safe because every inherited method that would dereference
+ * one of them is overridden here with an inert no-op. If you add a new method to {@link
+ * RocketChatService} that touches a null collaborator — or remove an override below — this adapter
+ * will throw {@link NullPointerException} at runtime instead of no-opping. When extending the
+ * superclass, always add a matching inert override here.
  */
 @Slf4j
 @Service

--- a/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
@@ -31,8 +31,15 @@ public class GroupChatParticipant {
   @Column(name = "id", updatable = false, nullable = false)
   private Long id;
 
+  /**
+   * Identifier of the group chat this participation belongs to. Depending on the caller this holds
+   * either a {@code chat.id} (group chats) or a {@code session.id} (team sessions, where {@code
+   * is_team_session = true}). The two id spaces are distinct and are NOT interchangeable, so the
+   * owning context determines which one is stored. There is no DB-level foreign key, so callers are
+   * responsible for resolving it against the correct table.
+   */
   @Column(name = "chat_id", nullable = false)
-  private Long chatId; // References chat.id or session.id
+  private Long chatId;
 
   @Column(name = "consultant_id", nullable = false, length = 36)
   private String consultantId;

--- a/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
@@ -32,11 +32,12 @@ public class GroupChatParticipant {
   private Long id;
 
   /**
-   * Identifier of the group chat this participation belongs to. Depending on the caller this holds
-   * either a {@code chat.id} (group chats) or a {@code session.id} (team sessions, where {@code
-   * is_team_session = true}). The two id spaces are distinct and are NOT interchangeable, so the
-   * owning context determines which one is stored. There is no DB-level foreign key, so callers are
-   * responsible for resolving it against the correct table.
+   * References {@code session.id} of the team session this participation belongs to (where {@code
+   * is_team_session = true}). The column is named {@code chat_id} for historical reasons; despite
+   * the name it does <b>not</b> reference {@code chat.id}. All current write paths (via {@link
+   * de.caritas.cob.userservice.api.facade.CreateChatFacade}) store the session ID, and readers
+   * (e.g. {@link de.caritas.cob.userservice.api.service.session.SessionService}) pass this value
+   * directly to {@code sessionRepository.findAllById}. There is no DB-level foreign key.
    */
   @Column(name = "chat_id", nullable = false)
   private Long chatId;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/rocketchat/config/RocketChatDisabledBootTest.java
@@ -1,15 +1,20 @@
 package de.caritas.cob.userservice.api.adapters.rocketchat.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.mongodb.client.MongoClient;
 import de.caritas.cob.userservice.api.adapters.rocketchat.DisabledRocketChatService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentialsProvider;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * ADR-004 proof: the service boots Matrix-only with {@code rocket-chat.enabled=false} (the default)
@@ -24,10 +29,22 @@ class RocketChatDisabledBootTest {
 
   @Autowired private ApplicationContext context;
 
+  @MockitoBean private RocketChatCredentialsProvider credentialsProvider;
+
   @Test
   void contextShouldBootWithInertRocketChatAdapterAndNoMongoClient() {
     assertThat(context.getBean(RocketChatService.class))
         .isInstanceOf(DisabledRocketChatService.class);
     assertThat(context.getBeanNamesForType(MongoClient.class)).isEmpty();
+  }
+
+  @Test
+  void updateCredentialsShouldBeInertAndNeverRotateRocketChatCredentials()
+      throws RocketChatLoginException {
+    var rocketChatService = context.getBean(RocketChatService.class);
+
+    rocketChatService.updateCredentials();
+
+    verify(credentialsProvider, never()).updateCredentials();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -1,8 +1,12 @@
 package de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
@@ -10,8 +14,10 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
+import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.util.Optional;
 import org.jeasy.random.EasyRandom;
@@ -20,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsultantAgencyRelationCreatorServiceTest {
@@ -63,5 +70,34 @@ public class ConsultantAgencyRelationCreatorServiceTest {
         () ->
             this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
                 "consultant Id", createConsultantAgencyDTO));
+  }
+
+  @Test
+  public void
+      completeConsultantAgencyAssigment_Should_finalizeSynchronously_When_rocketChatDisabled() {
+    ReflectionTestUtils.setField(
+        consultantAgencyRelationCreatorService, "rocketChatEnabled", false);
+
+    var consultant = new Consultant();
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(false);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+        input, LogService::logInfo);
+
+    // Matrix-only path: status is finalized synchronously in the caller's transaction, not via the
+    // Rocket.Chat async assignment.
+    verify(rocketChatAsyncHelper).finalizeConsultantAgencyRelation(consultant, agencyDTO);
+    verify(rocketChatAsyncHelper, never()).addConsultantToSessions(any(), any(), any(), any());
+    assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.IN_PROGRESS);
+    verify(consultantRepository).save(consultant);
   }
 }


### PR DESCRIPTION
## Why

PR #281 (Matrix-only backend, `rocket-chat.enabled=false`) was merged before @shazia-k's review was addressed. Per her guidance we do **not** revert/restore #281 — we apply the four action items on top of `dev` in this follow-up PR.

Original review: https://github.com/OpenResilienceInitiative/ORISO-UserService/pull/281#pullrequestreview-4625093111

## What

| Priority | Issue | Change |
| -- | -- | -- |
| Required | 1 | Unit test for `completeConsultantAgencyAssigment` with `rocket-chat.enabled=false`: asserts the Matrix-only path finalizes synchronously via `finalizeConsultantAgencyRelation`, never calls the async `addConsultantToSessions`, and sets the consultant to `IN_PROGRESS`. |
| Required | 2 | `RocketChatDisabledBootTest` proves the overridden `DisabledRocketChatService.updateCredentials()` is inert — `verify(credentialsProvider, never()).updateCredentials()`. |
| Recommended | 3 | Maintenance Javadoc on `DisabledRocketChatService` documenting the null-collaborator trap (inherited methods dereferencing a null collaborator must be overridden with an inert no-op). |
| Recommended | 4 | `GroupChatParticipant.chatId` Javadoc documents the `chat.id` vs `session.id` semantics. |

## Acceptance

- [x] `ConsultantAgencyRelationCreatorServiceTest` — 2/2 green (JDK 21)
- [x] `RocketChatDisabledBootTest` — 2/2 green, full context boots Matrix-only
- [x] `spotless:apply` clean

**Affected repos:** ORISO-UserService

🤖 Generated with [Claude Code](https://claude.com/claude-code)