### PR TITLE
Add account invite status domain

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -1,0 +1,362 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountAccessGateStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.InviteSendResult;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService.TemplateCommand;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountInviteController {
+
+  private static final String ADMIN_AUTH =
+      "hasAnyAuthority('AUTHORIZATION_TENANT_ADMIN', 'AUTHORIZATION_USER_ADMIN',"
+          + " 'AUTHORIZATION_RESTRICTED_AGENCY_ADMIN')";
+
+  private final @NonNull AccountInviteService accountInviteService;
+  private final @NonNull InviteEmailTemplateService templateService;
+  private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/account-invites")
+  public ResponseEntity<AccountInviteResponseDTO> createInvite(
+      @RequestBody(required = false) CreateAccountInviteRequestDTO request) {
+    CreateAccountInviteRequestDTO safe =
+        request == null ? new CreateAccountInviteRequestDTO() : request;
+    AccountInvite invite =
+        accountInviteService.createInvite(
+            new CreateAccountInviteCommand(
+                parseEnum(AccountInviteTargetRole.class, safe.targetRole, "targetRole"),
+                safe.tenantId,
+                safe.recipientEmail,
+                safe.firstName,
+                safe.lastName,
+                safe.agencyId,
+                safe.departmentId,
+                safe.expiresInDays));
+
+    if (safe.templateId != null) {
+      InviteSendResult result =
+          accountInviteService.sendInvite(
+              new SendInviteCommand(invite.getId(), safe.templateId, safe.acceptBaseUrl));
+      return new ResponseEntity<>(AccountInviteResponseDTO.from(result), HttpStatus.CREATED);
+    }
+
+    return new ResponseEntity<>(
+        AccountInviteResponseDTO.from(
+            invite, null, accountInviteService.calculateAccessGate(invite)),
+        HttpStatus.CREATED);
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @GetMapping("/useradmin/account-invites")
+  public ResponseEntity<PagedAccountInviteResponseDTO> listInvites(
+      @RequestParam(value = "target_role", required = false) String targetRole,
+      @RequestParam(value = "status", required = false) String status,
+      @RequestParam(value = "tenant_id", required = false) Long tenantId,
+      @RequestParam(value = "page", required = false) Integer page,
+      @RequestParam(value = "size", required = false) Integer size) {
+    Page<AccountInvite> result =
+        accountInviteService.listInvites(
+            parseOptionalEnum(AccountInviteTargetRole.class, targetRole, "target_role"),
+            parseOptionalEnum(AccountInviteStatus.class, status, "status"),
+            tenantId,
+            page == null ? 0 : page,
+            size == null ? 20 : size);
+    List<AccountInviteResponseDTO> content =
+        result.getContent().stream()
+            .map(
+                invite ->
+                    AccountInviteResponseDTO.from(
+                        invite,
+                        latestDeliveryStatus(invite),
+                        accountInviteService.calculateAccessGate(invite)))
+            .toList();
+    PagedAccountInviteResponseDTO response = new PagedAccountInviteResponseDTO();
+    response.content = content;
+    response.totalElements = result.getTotalElements();
+    response.totalPages = result.getTotalPages();
+    response.page = result.getNumber();
+    response.size = result.getSize();
+    return ResponseEntity.ok(response);
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/account-invites/{inviteId}/send")
+  public ResponseEntity<AccountInviteResponseDTO> sendInvite(
+      @PathVariable Long inviteId, @RequestBody SendInviteRequestDTO request) {
+    SendInviteRequestDTO safe = request == null ? new SendInviteRequestDTO() : request;
+    InviteSendResult result =
+        accountInviteService.sendInvite(
+            new SendInviteCommand(inviteId, safe.templateId, safe.acceptBaseUrl));
+    return ResponseEntity.ok(AccountInviteResponseDTO.from(result));
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/account-invites/{inviteId}/resend")
+  public ResponseEntity<AccountInviteResponseDTO> resendInvite(
+      @PathVariable Long inviteId, @RequestBody SendInviteRequestDTO request) {
+    SendInviteRequestDTO safe = request == null ? new SendInviteRequestDTO() : request;
+    InviteSendResult result =
+        accountInviteService.resendInvite(
+            new SendInviteCommand(inviteId, safe.templateId, safe.acceptBaseUrl));
+    return ResponseEntity.ok(AccountInviteResponseDTO.from(result));
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/account-invites/{inviteId}/revoke")
+  public ResponseEntity<AccountInviteResponseDTO> revokeInvite(@PathVariable Long inviteId) {
+    AccountInvite invite = accountInviteService.revokeInvite(inviteId);
+    return ResponseEntity.ok(
+        AccountInviteResponseDTO.from(
+            invite,
+            latestDeliveryStatus(invite),
+            accountInviteService.calculateAccessGate(invite)));
+  }
+
+  @PostMapping("/users/account-invites/{token}/accept")
+  public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
+      @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
+    String acceptedByUserId = request == null ? null : request.acceptedByUserId;
+    AccountInvite invite = accountInviteService.acceptInvite(token, acceptedByUserId);
+    return ResponseEntity.ok(
+        AccountInviteResponseDTO.from(
+            invite,
+            latestDeliveryStatus(invite),
+            accountInviteService.calculateAccessGate(invite)));
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/invite-email-templates")
+  public ResponseEntity<InviteEmailTemplateResponseDTO> createTemplate(
+      @RequestBody TemplateRequestDTO request) {
+    InviteEmailTemplate template = templateService.createTemplate(toCommand(request));
+    return new ResponseEntity<>(InviteEmailTemplateResponseDTO.from(template), HttpStatus.CREATED);
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PutMapping("/useradmin/invite-email-templates/{templateId}")
+  public ResponseEntity<InviteEmailTemplateResponseDTO> updateTemplate(
+      @PathVariable Long templateId, @RequestBody TemplateRequestDTO request) {
+    InviteEmailTemplate template = templateService.updateTemplate(templateId, toCommand(request));
+    return ResponseEntity.ok(InviteEmailTemplateResponseDTO.from(template));
+  }
+
+  @PreAuthorize(ADMIN_AUTH)
+  @GetMapping("/useradmin/invite-email-templates")
+  public ResponseEntity<List<InviteEmailTemplateResponseDTO>> listTemplates(
+      @RequestParam(value = "kind", required = false) String kind) {
+    List<InviteEmailTemplateResponseDTO> response =
+        templateService
+            .listTemplates(parseOptionalEnum(InviteEmailTemplateKind.class, kind, "kind"))
+            .stream()
+            .map(InviteEmailTemplateResponseDTO::from)
+            .toList();
+    return ResponseEntity.ok(response);
+  }
+
+  private InviteEmailDeliveryStatus latestDeliveryStatus(AccountInvite invite) {
+    if (invite.getId() == null) {
+      return null;
+    }
+    return deliveryRepository
+        .findFirstByAccountInviteIdOrderByCreateDateDesc(invite.getId())
+        .map(InviteEmailDelivery::getStatus)
+        .orElse(null);
+  }
+
+  private static TemplateCommand toCommand(TemplateRequestDTO request) {
+    TemplateRequestDTO safe = request == null ? new TemplateRequestDTO() : request;
+    return new TemplateCommand(
+        parseEnum(InviteEmailTemplateKind.class, safe.kind, "kind"),
+        safe.name,
+        safe.language,
+        safe.subject,
+        safe.body,
+        safe.active);
+  }
+
+  private static <E extends Enum<E>> E parseEnum(
+      Class<E> enumType, String value, String fieldName) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new BadRequestException(fieldName + " is required");
+    }
+    return parseOptionalEnum(enumType, value, fieldName);
+  }
+
+  private static <E extends Enum<E>> E parseOptionalEnum(
+      Class<E> enumType, String value, String fieldName) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      return Enum.valueOf(enumType, value.trim());
+    } catch (IllegalArgumentException exception) {
+      throw new BadRequestException("Unknown " + fieldName + ": " + value, exception);
+    }
+  }
+
+  public static class CreateAccountInviteRequestDTO {
+    public String targetRole;
+    public Long tenantId;
+    public String recipientEmail;
+    public String firstName;
+    public String lastName;
+    public Long agencyId;
+    public Long departmentId;
+    public Long expiresInDays;
+    public Long templateId;
+    public String acceptBaseUrl;
+  }
+
+  public static class SendInviteRequestDTO {
+    public Long templateId;
+    public String acceptBaseUrl;
+  }
+
+  public static class AcceptInviteRequestDTO {
+    public String acceptedByUserId;
+  }
+
+  public static class TemplateRequestDTO {
+    public String kind;
+    public String name;
+    public String language;
+    public String subject;
+    public String body;
+    public Boolean active;
+  }
+
+  public static class AccountInviteResponseDTO {
+    public Long id;
+    public String targetRole;
+    public Long tenantId;
+    public String recipientEmail;
+    public String firstName;
+    public String lastName;
+    public Long agencyId;
+    public Long departmentId;
+    public String provisioningStatus;
+    public String inviteStatus;
+    public String emailVerificationStatus;
+    public String emailDeliveryStatus;
+    public String twoFactorStatus;
+    public String accessGateStatus;
+    public LocalDateTime expiresAt;
+    public LocalDateTime acceptedAt;
+    public LocalDateTime revokedAt;
+    public LocalDateTime supersededAt;
+    public String twoFactorWaivedBy;
+    public LocalDateTime twoFactorWaivedAt;
+    public String twoFactorWaiverReason;
+    public LocalDateTime createDate;
+    public String rawToken;
+    public String acceptUrl;
+
+    static AccountInviteResponseDTO from(InviteSendResult result) {
+      AccountInviteResponseDTO dto =
+          from(
+              result.invite(),
+              result.delivery().getStatus(),
+              result.invite() == null ? null : AccountAccessGateStatus.BLOCKED_INVITE);
+      dto.rawToken = result.rawToken();
+      dto.acceptUrl = result.acceptUrl();
+      return dto;
+    }
+
+    static AccountInviteResponseDTO from(
+        AccountInvite invite,
+        InviteEmailDeliveryStatus deliveryStatus,
+        AccountAccessGateStatus accessGateStatus) {
+      AccountInviteResponseDTO dto = new AccountInviteResponseDTO();
+      dto.id = invite.getId();
+      dto.targetRole = invite.getTargetRole() == null ? null : invite.getTargetRole().name();
+      dto.tenantId = invite.getTenantId();
+      dto.recipientEmail = invite.getRecipientEmail();
+      dto.firstName = invite.getFirstName();
+      dto.lastName = invite.getLastName();
+      dto.agencyId = invite.getAgencyId();
+      dto.departmentId = invite.getDepartmentId();
+      dto.provisioningStatus = null;
+      dto.inviteStatus = invite.getStatus() == null ? null : invite.getStatus().name();
+      dto.emailVerificationStatus =
+          invite.getEmailVerificationStatus() == null
+              ? null
+              : invite.getEmailVerificationStatus().name();
+      dto.emailDeliveryStatus = deliveryStatus == null ? null : deliveryStatus.name();
+      dto.twoFactorStatus =
+          invite.getTwoFactorStatus() == null ? null : invite.getTwoFactorStatus().name();
+      dto.accessGateStatus = accessGateStatus == null ? null : accessGateStatus.name();
+      dto.expiresAt = invite.getExpiresAt();
+      dto.acceptedAt = invite.getAcceptedAt();
+      dto.revokedAt = invite.getRevokedAt();
+      dto.supersededAt = invite.getSupersededAt();
+      dto.twoFactorWaivedBy = invite.getTwoFactorWaivedBy();
+      dto.twoFactorWaivedAt = invite.getTwoFactorWaivedAt();
+      dto.twoFactorWaiverReason = invite.getTwoFactorWaiverReason();
+      dto.createDate = invite.getCreateDate();
+      return dto;
+    }
+  }
+
+  public static class PagedAccountInviteResponseDTO {
+    public List<AccountInviteResponseDTO> content;
+    public long totalElements;
+    public int totalPages;
+    public int page;
+    public int size;
+  }
+
+  public static class InviteEmailTemplateResponseDTO {
+    public Long id;
+    public String kind;
+    public String name;
+    public String language;
+    public String subject;
+    public String body;
+    public Boolean active;
+    public LocalDateTime createDate;
+    public LocalDateTime updateDate;
+
+    static InviteEmailTemplateResponseDTO from(InviteEmailTemplate template) {
+      InviteEmailTemplateResponseDTO dto = new InviteEmailTemplateResponseDTO();
+      dto.id = template.getId();
+      dto.kind = template.getKind() == null ? null : template.getKind().name();
+      dto.name = template.getName();
+      dto.language = template.getLanguage();
+      dto.subject = template.getSubject();
+      dto.body = template.getBody();
+      dto.active = template.getActive();
+      dto.createDate = template.getCreateDate();
+      dto.updateDate = template.getUpdateDate();
+      return dto;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -1,0 +1,129 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(
+    name = "account_invite",
+    indexes = {
+      @Index(name = "idx_account_invite_tenant_status", columnList = "tenant_id,status"),
+      @Index(name = "idx_account_invite_target_role", columnList = "target_role"),
+      @Index(name = "idx_account_invite_token_hash", columnList = "token_hash", unique = true)
+    })
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = "tokenHash")
+public class AccountInvite {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "target_role", nullable = false, length = 64)
+  private AccountInviteTargetRole targetRole;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Column(name = "recipient_email", nullable = false)
+  private String recipientEmail;
+
+  @Column(name = "first_name")
+  private String firstName;
+
+  @Column(name = "last_name")
+  private String lastName;
+
+  @Column(name = "agency_id")
+  private Long agencyId;
+
+  @Column(name = "department_id")
+  private Long departmentId;
+
+  @Column(name = "token_hash", length = 64)
+  private String tokenHash;
+
+  @Column(name = "expires_at", columnDefinition = "datetime")
+  private LocalDateTime expiresAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 32)
+  @Builder.Default
+  private AccountInviteStatus status = AccountInviteStatus.DRAFT;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "email_verification_status", nullable = false, length = 32)
+  @Builder.Default
+  private EmailVerificationStatus emailVerificationStatus = EmailVerificationStatus.PENDING;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "two_factor_status", nullable = false, length = 32)
+  @Builder.Default
+  private TwoFactorGateStatus twoFactorStatus = TwoFactorGateStatus.NOT_REQUIRED;
+
+  @Column(name = "accepted_at", columnDefinition = "datetime")
+  private LocalDateTime acceptedAt;
+
+  @Column(name = "accepted_by_user_id", length = 36)
+  private String acceptedByUserId;
+
+  @Column(name = "revoked_at", columnDefinition = "datetime")
+  private LocalDateTime revokedAt;
+
+  @Column(name = "revoked_by_user_id", length = 36)
+  private String revokedByUserId;
+
+  @Column(name = "superseded_at", columnDefinition = "datetime")
+  private LocalDateTime supersededAt;
+
+  @Column(name = "superseded_by_user_id", length = 36)
+  private String supersededByUserId;
+
+  @Column(name = "superseded_by_invite_id")
+  private Long supersededByInviteId;
+
+  @Column(name = "two_factor_waived_by", length = 36)
+  private String twoFactorWaivedBy;
+
+  @Column(name = "two_factor_waived_at", columnDefinition = "datetime")
+  private LocalDateTime twoFactorWaivedAt;
+
+  @Column(name = "two_factor_waiver_reason", length = 512)
+  private String twoFactorWaiverReason;
+
+  @Column(name = "created_by_user_id", length = 36)
+  private String createdByUserId;
+
+  @Column(name = "created_by_username")
+  private String createdByUsername;
+
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime")
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date", columnDefinition = "datetime")
+  private LocalDateTime updateDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailDelivery.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailDelivery.java
@@ -1,0 +1,72 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(
+    name = "invite_email_delivery",
+    indexes = {@Index(name = "idx_invite_email_delivery_invite", columnList = "account_invite_id")})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class InviteEmailDelivery {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  @Column(name = "account_invite_id", nullable = false)
+  private Long accountInviteId;
+
+  @Column(name = "template_id")
+  private Long templateId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "template_kind", nullable = false, length = 32)
+  private InviteEmailTemplateKind templateKind;
+
+  @Column(name = "subject_snapshot", nullable = false)
+  private String subjectSnapshot;
+
+  @Lob
+  @Column(name = "body_snapshot", nullable = false)
+  private String bodySnapshot;
+
+  @Column(name = "recipient_snapshot", nullable = false)
+  private String recipientSnapshot;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 32)
+  private InviteEmailDeliveryStatus status;
+
+  @Column(name = "sent_at", columnDefinition = "datetime")
+  private LocalDateTime sentAt;
+
+  @Column(name = "failure_reason", length = 1024)
+  private String failureReason;
+
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime")
+  private LocalDateTime createDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailTemplate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailTemplate.java
@@ -1,0 +1,68 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(
+    name = "invite_email_template",
+    indexes = {@Index(name = "idx_invite_email_template_kind", columnList = "kind,active")})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class InviteEmailTemplate {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false, length = 32)
+  private InviteEmailTemplateKind kind;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Column(name = "language", length = 16)
+  private String language;
+
+  @Column(name = "subject", nullable = false)
+  private String subject;
+
+  @Lob
+  @Column(name = "body", nullable = false)
+  private String body;
+
+  @Column(name = "active", nullable = false)
+  @Builder.Default
+  private Boolean active = true;
+
+  @Column(name = "created_by_user_id", length = 36)
+  private String createdByUserId;
+
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime")
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date", columnDefinition = "datetime")
+  private LocalDateTime updateDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -1,0 +1,31 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AccountInviteRepository extends JpaRepository<AccountInvite, Long> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  Optional<AccountInvite> findByTokenHash(String tokenHash);
+
+  @Query(
+      "SELECT i FROM AccountInvite i"
+          + " WHERE (:tenantId IS NULL OR i.tenantId = :tenantId)"
+          + " AND (:targetRole IS NULL OR i.targetRole = :targetRole)"
+          + " AND (:status IS NULL OR i.status = :status)"
+          + " ORDER BY i.createDate DESC")
+  Page<AccountInvite> findAllByFilters(
+      @Param("tenantId") Long tenantId,
+      @Param("targetRole") AccountInviteTargetRole targetRole,
+      @Param("status") AccountInviteStatus status,
+      Pageable pageable);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/InviteEmailDeliveryRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/InviteEmailDeliveryRepository.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InviteEmailDeliveryRepository extends JpaRepository<InviteEmailDelivery, Long> {
+
+  List<InviteEmailDelivery> findByAccountInviteIdOrderByCreateDateDesc(Long accountInviteId);
+
+  Optional<InviteEmailDelivery> findFirstByAccountInviteIdOrderByCreateDateDesc(
+      Long accountInviteId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/InviteEmailTemplateRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/InviteEmailTemplateRepository.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InviteEmailTemplateRepository extends JpaRepository<InviteEmailTemplate, Long> {
+
+  List<InviteEmailTemplate> findByKindOrderByCreateDateDesc(InviteEmailTemplateKind kind);
+
+  List<InviteEmailTemplate> findByKindAndActiveTrueOrderByCreateDateDesc(
+      InviteEmailTemplateKind kind);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountAccessGateStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountAccessGateStatus.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum AccountAccessGateStatus {
+  BLOCKED_INVITE,
+  BLOCKED_EMAIL,
+  BLOCKED_TWO_FACTOR,
+  READY
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -1,0 +1,363 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
+import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountInviteService {
+
+  private static final int TOKEN_BYTES = 32;
+  private static final long DEFAULT_EXPIRY_DAYS = 30L;
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final @NonNull AccountInviteRepository accountInviteRepository;
+  private final @NonNull InviteEmailTemplateRepository templateRepository;
+  private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  @Transactional
+  public AccountInvite createInvite(CreateAccountInviteCommand command) {
+    if (command == null) {
+      throw new BadRequestException("Request body is required");
+    }
+    if (command.targetRole() == null) {
+      throw new BadRequestException("targetRole is required");
+    }
+    if (isBlank(command.recipientEmail())) {
+      throw new BadRequestException("recipientEmail is required");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    AccountInvite invite =
+        AccountInvite.builder()
+            .targetRole(command.targetRole())
+            .tenantId(command.tenantId())
+            .recipientEmail(command.recipientEmail().trim())
+            .firstName(trimToNull(command.firstName()))
+            .lastName(trimToNull(command.lastName()))
+            .agencyId(command.agencyId())
+            .departmentId(command.departmentId())
+            .expiresAt(resolveExpiry(now, command.expiresInDays()))
+            .status(AccountInviteStatus.DRAFT)
+            .emailVerificationStatus(EmailVerificationStatus.PENDING)
+            .twoFactorStatus(defaultTwoFactorStatus(command.targetRole()))
+            .createdByUserId(authenticatedUser.getUserId())
+            .createdByUsername(authenticatedUser.getUsername())
+            .createDate(now)
+            .updateDate(now)
+            .build();
+    return accountInviteRepository.save(invite);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<AccountInvite> listInvites(
+      AccountInviteTargetRole targetRole,
+      AccountInviteStatus status,
+      Long tenantId,
+      int page,
+      int size) {
+    return accountInviteRepository.findAllByFilters(
+        tenantId, targetRole, status, PageRequest.of(Math.max(page, 0), clampSize(size)));
+  }
+
+  @Transactional
+  public InviteSendResult sendInvite(SendInviteCommand command) {
+    AccountInvite invite = findInvite(command.inviteId());
+    InviteEmailTemplate template = findTemplate(command.templateId());
+    return sendInvite(invite, template, command.acceptBaseUrl());
+  }
+
+  @Transactional
+  public InviteSendResult resendInvite(SendInviteCommand command) {
+    AccountInvite oldInvite = findInvite(command.inviteId());
+    if (oldInvite.getStatus() == AccountInviteStatus.ACCEPTED) {
+      throw new BadRequestException("Accepted invites cannot be resent");
+    }
+    if (oldInvite.getStatus() == AccountInviteStatus.REVOKED) {
+      throw new BadRequestException("Revoked invites cannot be resent");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
+    oldInvite.setSupersededAt(now);
+    oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
+    oldInvite.setUpdateDate(now);
+    accountInviteRepository.save(oldInvite);
+
+    AccountInvite replacement =
+        AccountInvite.builder()
+            .targetRole(oldInvite.getTargetRole())
+            .tenantId(oldInvite.getTenantId())
+            .recipientEmail(oldInvite.getRecipientEmail())
+            .firstName(oldInvite.getFirstName())
+            .lastName(oldInvite.getLastName())
+            .agencyId(oldInvite.getAgencyId())
+            .departmentId(oldInvite.getDepartmentId())
+            .expiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS))
+            .status(AccountInviteStatus.DRAFT)
+            .emailVerificationStatus(oldInvite.getEmailVerificationStatus())
+            .twoFactorStatus(oldInvite.getTwoFactorStatus())
+            .createdByUserId(authenticatedUser.getUserId())
+            .createdByUsername(authenticatedUser.getUsername())
+            .createDate(now)
+            .updateDate(now)
+            .build();
+    replacement = accountInviteRepository.save(replacement);
+    oldInvite.setSupersededByInviteId(replacement.getId());
+    accountInviteRepository.save(oldInvite);
+
+    InviteEmailTemplate template = findTemplate(command.templateId());
+    return sendInvite(replacement, template, command.acceptBaseUrl());
+  }
+
+  @Transactional
+  public AccountInvite revokeInvite(Long inviteId) {
+    AccountInvite invite = findInvite(inviteId);
+    if (invite.getStatus() == AccountInviteStatus.ACCEPTED) {
+      throw new BadRequestException("Accepted invites cannot be revoked");
+    }
+    LocalDateTime now = LocalDateTime.now();
+    invite.setStatus(AccountInviteStatus.REVOKED);
+    invite.setRevokedAt(now);
+    invite.setRevokedByUserId(authenticatedUser.getUserId());
+    invite.setUpdateDate(now);
+    return accountInviteRepository.save(invite);
+  }
+
+  @Transactional
+  public AccountInvite acceptInvite(String rawToken, String acceptedByUserId) {
+    if (isBlank(rawToken)) {
+      throw new BadRequestException("Invite token is required");
+    }
+    AccountInvite invite =
+        accountInviteRepository
+            .findByTokenHash(hash(rawToken))
+            .orElseThrow(() -> new NotFoundException("Account invite not found"));
+
+    LocalDateTime now = LocalDateTime.now();
+    if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
+      invite.setStatus(AccountInviteStatus.EXPIRED);
+      invite.setUpdateDate(now);
+      accountInviteRepository.save(invite);
+      throw new BadRequestException("Account invite expired");
+    }
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT
+        && invite.getStatus() != AccountInviteStatus.DRAFT) {
+      throw new BadRequestException("Account invite is not active");
+    }
+
+    invite.setStatus(AccountInviteStatus.ACCEPTED);
+    invite.setAcceptedAt(now);
+    invite.setAcceptedByUserId(acceptedByUserId);
+    invite.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
+    invite.setUpdateDate(now);
+    return accountInviteRepository.save(invite);
+  }
+
+  public AccountAccessGateStatus calculateAccessGate(AccountInvite invite) {
+    if (invite == null || invite.getStatus() != AccountInviteStatus.ACCEPTED) {
+      return AccountAccessGateStatus.BLOCKED_INVITE;
+    }
+    if (!isEmailGateSatisfied(invite.getEmailVerificationStatus())) {
+      return AccountAccessGateStatus.BLOCKED_EMAIL;
+    }
+    if (!isTwoFactorGateSatisfied(invite.getTwoFactorStatus())) {
+      return AccountAccessGateStatus.BLOCKED_TWO_FACTOR;
+    }
+    return AccountAccessGateStatus.READY;
+  }
+
+  public AccountInvite waiveTwoFactor(AccountInvite invite, WaiveTwoFactorCommand command) {
+    if (invite == null) {
+      throw new BadRequestException("Invite is required");
+    }
+    if (command == null || isBlank(command.reason())) {
+      throw new BadRequestException("Waiver reason is required");
+    }
+    invite.setTwoFactorStatus(TwoFactorGateStatus.WAIVED);
+    invite.setTwoFactorWaivedBy(authenticatedUser.getUserId());
+    invite.setTwoFactorWaivedAt(LocalDateTime.now());
+    invite.setTwoFactorWaiverReason(command.reason());
+    return invite;
+  }
+
+  private InviteSendResult sendInvite(
+      AccountInvite invite, InviteEmailTemplate template, String acceptBaseUrl) {
+    if (invite.getStatus() == AccountInviteStatus.ACCEPTED) {
+      throw new BadRequestException("Accepted invites cannot be sent");
+    }
+    if (invite.getStatus() == AccountInviteStatus.REVOKED
+        || invite.getStatus() == AccountInviteStatus.SUPERSEDED) {
+      throw new BadRequestException("Inactive invites cannot be sent");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    String rawToken = generateToken();
+    String acceptUrl = buildAcceptUrl(acceptBaseUrl, rawToken);
+    invite.setTokenHash(hash(rawToken));
+    if (invite.getExpiresAt() == null || invite.getExpiresAt().isBefore(now)) {
+      invite.setExpiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS));
+    }
+    invite.setStatus(AccountInviteStatus.EMAIL_SENT);
+    invite.setUpdateDate(now);
+    invite = accountInviteRepository.save(invite);
+
+    InviteEmailDelivery delivery =
+        InviteEmailDelivery.builder()
+            .accountInviteId(invite.getId())
+            .templateId(template.getId())
+            .templateKind(template.getKind())
+            .recipientSnapshot(invite.getRecipientEmail())
+            .subjectSnapshot(render(template.getSubject(), invite, acceptUrl))
+            .bodySnapshot(render(template.getBody(), invite, acceptUrl))
+            .status(InviteEmailDeliveryStatus.SENT)
+            .sentAt(now)
+            .createDate(now)
+            .build();
+    delivery = deliveryRepository.save(delivery);
+    return new InviteSendResult(invite, delivery, rawToken, acceptUrl);
+  }
+
+  private AccountInvite findInvite(Long inviteId) {
+    if (inviteId == null) {
+      throw new BadRequestException("inviteId is required");
+    }
+    return accountInviteRepository
+        .findById(inviteId)
+        .orElseThrow(() -> new NotFoundException("Account invite not found"));
+  }
+
+  private InviteEmailTemplate findTemplate(Long templateId) {
+    if (templateId == null) {
+      throw new BadRequestException("templateId is required");
+    }
+    return templateRepository
+        .findById(templateId)
+        .orElseThrow(() -> new NotFoundException("Invite e-mail template not found"));
+  }
+
+  private static TwoFactorGateStatus defaultTwoFactorStatus(AccountInviteTargetRole targetRole) {
+    return targetRole == AccountInviteTargetRole.COUNSELLOR
+        ? TwoFactorGateStatus.PENDING_SETUP
+        : TwoFactorGateStatus.NOT_REQUIRED;
+  }
+
+  private static boolean isEmailGateSatisfied(EmailVerificationStatus status) {
+    return status == EmailVerificationStatus.NOT_REQUIRED
+        || status == EmailVerificationStatus.VERIFIED;
+  }
+
+  private static boolean isTwoFactorGateSatisfied(TwoFactorGateStatus status) {
+    return status == TwoFactorGateStatus.NOT_REQUIRED
+        || status == TwoFactorGateStatus.ACTIVE
+        || status == TwoFactorGateStatus.WAIVED
+        || status == TwoFactorGateStatus.DISABLED_BY_POLICY;
+  }
+
+  private static LocalDateTime resolveExpiry(LocalDateTime now, Long expiresInDays) {
+    long days = expiresInDays == null ? DEFAULT_EXPIRY_DAYS : expiresInDays;
+    if (days < 1 || days > 365) {
+      throw new BadRequestException("expiresInDays must be between 1 and 365");
+    }
+    return now.plusDays(days);
+  }
+
+  private static int clampSize(int size) {
+    if (size < 1) {
+      return 20;
+    }
+    return Math.min(size, 100);
+  }
+
+  private static String render(String value, AccountInvite invite, String acceptUrl) {
+    if (value == null) {
+      return "";
+    }
+    Map<String, String> placeholders =
+        Map.of(
+            "inviteLink", acceptUrl,
+            "email", safe(invite.getRecipientEmail()),
+            "firstName", safe(invite.getFirstName()),
+            "lastName", safe(invite.getLastName()),
+            "tenantId", invite.getTenantId() == null ? "" : String.valueOf(invite.getTenantId()));
+    String rendered = value;
+    for (var entry : placeholders.entrySet()) {
+      rendered = rendered.replace("{{" + entry.getKey() + "}}", entry.getValue());
+    }
+    return rendered;
+  }
+
+  private static String buildAcceptUrl(String acceptBaseUrl, String rawToken) {
+    String base = isBlank(acceptBaseUrl) ? "/account-invite" : acceptBaseUrl.trim();
+    while (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    return base + "/" + rawToken;
+  }
+
+  public static String hash(String rawToken) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(rawToken.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required", exception);
+    }
+  }
+
+  private static String generateToken() {
+    byte[] token = new byte[TOKEN_BYTES];
+    RANDOM.nextBytes(token);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(token);
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  private static String trimToNull(String value) {
+    return isBlank(value) ? null : value.trim();
+  }
+
+  private static String safe(String value) {
+    return value == null ? "" : value;
+  }
+
+  public record CreateAccountInviteCommand(
+      AccountInviteTargetRole targetRole,
+      Long tenantId,
+      String recipientEmail,
+      String firstName,
+      String lastName,
+      Long agencyId,
+      Long departmentId,
+      Long expiresInDays) {}
+
+  public record SendInviteCommand(Long inviteId, Long templateId, String acceptBaseUrl) {}
+
+  public record InviteSendResult(
+      AccountInvite invite, InviteEmailDelivery delivery, String rawToken, String acceptUrl) {}
+
+  public record WaiveTwoFactorCommand(String reason) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteStatus.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+/** Lifecycle state of an account invite. This is not the technical provisioning status. */
+public enum AccountInviteStatus {
+  DRAFT,
+  EMAIL_SENT,
+  ACCEPTED,
+  EXPIRED,
+  REVOKED,
+  SUPERSEDED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteTargetRole.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteTargetRole.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+/** Target account type for an invite. Platform/app access is still decided separately. */
+public enum AccountInviteTargetRole {
+  TENANT_ADMIN,
+  AGENCY_ADMIN,
+  COUNSELLOR,
+  PLATFORM_ADMIN,
+  ADVICE_SEEKER
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/EmailVerificationStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/EmailVerificationStatus.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum EmailVerificationStatus {
+  NOT_REQUIRED,
+  PENDING,
+  VERIFIED,
+  FAILED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailDeliveryStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailDeliveryStatus.java
@@ -1,0 +1,6 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum InviteEmailDeliveryStatus {
+  SENT,
+  FAILED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailTemplateKind.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailTemplateKind.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum InviteEmailTemplateKind {
+  TENANT_INVITE,
+  COUNSELLOR_INVITE,
+  DPA_FORWARD
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailTemplateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailTemplateService.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InviteEmailTemplateService {
+
+  private final @NonNull InviteEmailTemplateRepository templateRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  @Transactional
+  public InviteEmailTemplate createTemplate(TemplateCommand command) {
+    validate(command);
+    LocalDateTime now = LocalDateTime.now();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .kind(command.kind())
+            .name(command.name().trim())
+            .language(trimToNull(command.language()))
+            .subject(command.subject().trim())
+            .body(command.body())
+            .active(command.active() == null || command.active())
+            .createdByUserId(authenticatedUser.getUserId())
+            .createDate(now)
+            .updateDate(now)
+            .build();
+    return templateRepository.save(template);
+  }
+
+  @Transactional
+  public InviteEmailTemplate updateTemplate(Long templateId, TemplateCommand command) {
+    validate(command);
+    InviteEmailTemplate template =
+        templateRepository
+            .findById(templateId)
+            .orElseThrow(() -> new NotFoundException("Invite e-mail template not found"));
+    template.setKind(command.kind());
+    template.setName(command.name().trim());
+    template.setLanguage(trimToNull(command.language()));
+    template.setSubject(command.subject().trim());
+    template.setBody(command.body());
+    template.setActive(command.active() == null || command.active());
+    template.setUpdateDate(LocalDateTime.now());
+    return templateRepository.save(template);
+  }
+
+  @Transactional(readOnly = true)
+  public List<InviteEmailTemplate> listTemplates(InviteEmailTemplateKind kind) {
+    if (kind == null) {
+      return templateRepository.findAll();
+    }
+    return templateRepository.findByKindOrderByCreateDateDesc(kind);
+  }
+
+  private static void validate(TemplateCommand command) {
+    if (command == null) {
+      throw new BadRequestException("Request body is required");
+    }
+    if (command.kind() == null) {
+      throw new BadRequestException("kind is required");
+    }
+    if (isBlank(command.name())) {
+      throw new BadRequestException("name is required");
+    }
+    if (isBlank(command.subject())) {
+      throw new BadRequestException("subject is required");
+    }
+    if (isBlank(command.body())) {
+      throw new BadRequestException("body is required");
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  private static String trimToNull(String value) {
+    return isBlank(value) ? null : value.trim();
+  }
+
+  public record TemplateCommand(
+      InviteEmailTemplateKind kind,
+      String name,
+      String language,
+      String subject,
+      String body,
+      Boolean active) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/TwoFactorGateStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/TwoFactorGateStatus.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum TwoFactorGateStatus {
+  NOT_REQUIRED,
+  PENDING_SETUP,
+  ACTIVE,
+  WAIVED,
+  DISABLED_BY_POLICY
+}

--- a/src/main/resources/db/changelog/changeset/0055_account_invites/0055_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0055_account_invites/0055_changeSet.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+  <changeSet id="0055_account_invites" author="codex">
+    <sqlFile
+      path="db/changelog/changeset/0055_account_invites/create-account-invites.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sqlFile
+        path="db/changelog/changeset/0055_account_invites/create-account-invites-rollback.sql"
+        relativeToChangelogFile="false"
+        splitStatements="true"
+        stripComments="true"
+        endDelimiter=";"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0055_account_invites/create-account-invites-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0055_account_invites/create-account-invites-rollback.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS invite_email_delivery;
+DROP TABLE IF EXISTS invite_email_template;
+DROP TABLE IF EXISTS account_invite;

--- a/src/main/resources/db/changelog/changeset/0055_account_invites/create-account-invites.sql
+++ b/src/main/resources/db/changelog/changeset/0055_account_invites/create-account-invites.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS account_invite (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  target_role VARCHAR(64) NOT NULL,
+  tenant_id BIGINT NULL,
+  recipient_email VARCHAR(255) NOT NULL,
+  first_name VARCHAR(255) NULL,
+  last_name VARCHAR(255) NULL,
+  agency_id BIGINT NULL,
+  department_id BIGINT NULL,
+  token_hash VARCHAR(64) NULL,
+  expires_at DATETIME NULL,
+  status VARCHAR(32) NOT NULL,
+  email_verification_status VARCHAR(32) NOT NULL,
+  two_factor_status VARCHAR(32) NOT NULL,
+  accepted_at DATETIME NULL,
+  accepted_by_user_id VARCHAR(36) NULL,
+  revoked_at DATETIME NULL,
+  revoked_by_user_id VARCHAR(36) NULL,
+  superseded_at DATETIME NULL,
+  superseded_by_user_id VARCHAR(36) NULL,
+  superseded_by_invite_id BIGINT NULL,
+  two_factor_waived_by VARCHAR(36) NULL,
+  two_factor_waived_at DATETIME NULL,
+  two_factor_waiver_reason VARCHAR(512) NULL,
+  created_by_user_id VARCHAR(36) NULL,
+  created_by_username VARCHAR(255) NULL,
+  create_date DATETIME NOT NULL,
+  update_date DATETIME NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_account_invite_token_hash (token_hash),
+  KEY idx_account_invite_tenant_status (tenant_id, status),
+  KEY idx_account_invite_target_role (target_role)
+);
+
+CREATE TABLE IF NOT EXISTS invite_email_template (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  kind VARCHAR(32) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  language VARCHAR(16) NULL,
+  subject VARCHAR(255) NOT NULL,
+  body LONGTEXT NOT NULL,
+  active BIT NOT NULL DEFAULT 1,
+  created_by_user_id VARCHAR(36) NULL,
+  create_date DATETIME NOT NULL,
+  update_date DATETIME NULL,
+  PRIMARY KEY (id),
+  KEY idx_invite_email_template_kind (kind, active)
+);
+
+CREATE TABLE IF NOT EXISTS invite_email_delivery (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  account_invite_id BIGINT NOT NULL,
+  template_id BIGINT NULL,
+  template_kind VARCHAR(32) NOT NULL,
+  subject_snapshot VARCHAR(255) NOT NULL,
+  body_snapshot LONGTEXT NOT NULL,
+  recipient_snapshot VARCHAR(255) NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  sent_at DATETIME NULL,
+  failure_reason VARCHAR(1024) NULL,
+  create_date DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_invite_email_delivery_invite (account_invite_id),
+  CONSTRAINT fk_invite_email_delivery_account_invite FOREIGN KEY (account_invite_id)
+    REFERENCES account_invite (id)
+);

--- a/src/main/resources/db/changelog/userservice-dev-master.xml
+++ b/src/main/resources/db/changelog/userservice-dev-master.xml
@@ -57,4 +57,5 @@
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-local-master.xml
+++ b/src/main/resources/db/changelog/userservice-local-master.xml
@@ -57,4 +57,5 @@
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-prod-master.xml
+++ b/src/main/resources/db/changelog/userservice-prod-master.xml
@@ -59,4 +59,5 @@
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
   <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
+  <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-staging-master.xml
+++ b/src/main/resources/db/changelog/userservice-staging-master.xml
@@ -57,4 +57,5 @@
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
   <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
+  <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -1,0 +1,188 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
+import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountInviteServiceTest {
+
+  @Mock private AccountInviteRepository accountInviteRepository;
+  @Mock private InviteEmailTemplateRepository templateRepository;
+  @Mock private InviteEmailDeliveryRepository deliveryRepository;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private AccountInviteService service;
+
+  @Test
+  void sendInvite_Should_SetEmailSentAndPersistSnapshot_When_TemplateExists() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .tenantId(7L)
+            .recipientEmail("owner@example.org")
+            .firstName("Ada")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.TENANT_INVITE)
+            .subject("Welcome {{firstName}}")
+            .body("Use {{inviteLink}}")
+            .active(true)
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.sendInvite(new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+
+    assertThat(result.invite().getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+    assertThat(result.rawToken()).isNotBlank();
+    assertThat(result.invite().getTokenHash()).isNotEqualTo(result.rawToken());
+    ArgumentCaptor<InviteEmailDelivery> deliveryCaptor =
+        ArgumentCaptor.forClass(InviteEmailDelivery.class);
+    verify(deliveryRepository).save(deliveryCaptor.capture());
+    assertThat(deliveryCaptor.getValue().getSubjectSnapshot()).isEqualTo("Welcome Ada");
+    assertThat(deliveryCaptor.getValue().getBodySnapshot()).contains(result.rawToken());
+    assertThat(deliveryCaptor.getValue().getRecipientSnapshot()).isEqualTo("owner@example.org");
+    assertThat(deliveryCaptor.getValue().getStatus()).isEqualTo(InviteEmailDeliveryStatus.SENT);
+  }
+
+  @Test
+  void resendInvite_Should_SupersedeOldInviteAndCreateNewEmailSentInvite() {
+    AccountInvite oldInvite =
+        AccountInvite.builder()
+            .id(10L)
+            .tenantId(7L)
+            .recipientEmail("counsellor@example.org")
+            .firstName("Grace")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.COUNSELLOR_INVITE)
+            .subject("Again")
+            .body("Use {{inviteLink}}")
+            .active(true)
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.resendInvite(
+            new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+
+    assertThat(oldInvite.getStatus()).isEqualTo(AccountInviteStatus.SUPERSEDED);
+    assertThat(result.invite()).isNotSameAs(oldInvite);
+    assertThat(result.invite().getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+    assertThat(result.invite().getSupersededByInviteId()).isNull();
+    assertThat(result.invite().getRecipientEmail()).isEqualTo(oldInvite.getRecipientEmail());
+  }
+
+  @Test
+  void deliverySnapshot_Should_RemainUnchanged_When_TemplateIsChangedLater() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.TENANT_INVITE)
+            .subject("Original {{email}}")
+            .body("Original body")
+            .active(true)
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.sendInvite(new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+    template.setSubject("Changed");
+    template.setBody("Changed");
+
+    ArgumentCaptor<InviteEmailDelivery> deliveryCaptor =
+        ArgumentCaptor.forClass(InviteEmailDelivery.class);
+    verify(deliveryRepository).save(deliveryCaptor.capture());
+    assertThat(deliveryCaptor.getValue().getSubjectSnapshot())
+        .isEqualTo("Original owner@example.org");
+    assertThat(deliveryCaptor.getValue().getBodySnapshot()).isEqualTo("Original body");
+  }
+
+  @Test
+  void calculateAccessGate_Should_BlockRequiredTwoFactorUntilWaived() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .status(AccountInviteStatus.ACCEPTED)
+            .emailVerificationStatus(EmailVerificationStatus.VERIFIED)
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .build();
+
+    assertThat(service.calculateAccessGate(invite))
+        .isEqualTo(AccountAccessGateStatus.BLOCKED_TWO_FACTOR);
+
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    service.waiveTwoFactor(invite, new WaiveTwoFactorCommand("Temporary migration waiver"));
+
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.WAIVED);
+    assertThat(invite.getTwoFactorWaivedBy()).isEqualTo("admin-1");
+    assertThat(invite.getTwoFactorWaiverReason()).isEqualTo("Temporary migration waiver");
+    assertThat(service.calculateAccessGate(invite)).isEqualTo(AccountAccessGateStatus.READY);
+  }
+
+  @Test
+  void createInvite_Should_StartAsDraftAndKeepProvisioningSeparate() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.COUNSELLOR,
+                7L,
+                "new@example.org",
+                "New",
+                "Counsellor",
+                null,
+                null,
+                30L));
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getEmailVerificationStatus()).isEqualTo(EmailVerificationStatus.PENDING);
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+    assertThat(invite.getTokenHash()).isNull();
+  }
+}


### PR DESCRIPTION
## Problem
Invite state was being conflated with provisioning state. Tenant and counsellor invites need a real account-invite lifecycle with delivery snapshots and access-gate inputs.

## Solution
- Add account_invite, invite_email_template and invite_email_delivery persistence.
- Store only token hashes and create a fresh token on send/resend.
- Track invite, e-mail verification and 2FA gate status separately.
- Expose account invite and invite template endpoints under useradmin.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -B -Dtest=AccountInviteServiceTest test`

## Coordination
Companion PRs update Admin, TenantService and Frontend. Merge before deploying the dev images to Pre-Dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)