### PR TITLE
Fix invite email body column mapping

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailDelivery.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailDelivery.java
@@ -51,7 +51,7 @@ public class InviteEmailDelivery {
   private String subjectSnapshot;
 
   @Lob
-  @Column(name = "body_snapshot", nullable = false)
+  @Column(name = "body_snapshot", nullable = false, columnDefinition = "LONGTEXT")
   private String bodySnapshot;
 
   @Column(name = "recipient_snapshot", nullable = false)

--- a/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailTemplate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/InviteEmailTemplate.java
@@ -50,7 +50,7 @@ public class InviteEmailTemplate {
   private String subject;
 
   @Lob
-  @Column(name = "body", nullable = false)
+  @Column(name = "body", nullable = false, columnDefinition = "LONGTEXT")
   private String body;
 
   @Column(name = "active", nullable = false)


### PR DESCRIPTION
## Summary

- Sets explicit `LONGTEXT` column definitions on invite email template and delivery body fields.
- Fixes Pre-Dev startup after ORISO-UserService#286, where Hibernate schema validation expected a different text type for `invite_email_delivery.body_snapshot`.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -B -Dtest=AccountInviteServiceTest test`
- `git diff --check`

Tracked in OpenResilienceInitiative/ORISO-Frontend#362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
