### PR TITLE
fix: restore explicit chat-agency loading to avoid LazyInitializationException on consultant session list

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ChatAgencyRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ChatAgencyRepository.java
@@ -1,6 +1,17 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.ChatAgency;
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
-public interface ChatAgencyRepository extends CrudRepository<ChatAgency, Long> {}
+public interface ChatAgencyRepository extends CrudRepository<ChatAgency, Long> {
+
+  @Query("SELECT ca FROM ChatAgency ca JOIN FETCH ca.chat WHERE ca.chat.id = :chatId")
+  List<ChatAgency> findByChat_Id(@Param("chatId") Long chatId);
+
+  @Query("SELECT ca FROM ChatAgency ca JOIN FETCH ca.chat WHERE ca.chat.id IN :chatIds")
+  List<ChatAgency> findByChat_IdIn(@Param("chatIds") Set<Long> chatIds);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -25,7 +25,9 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -76,20 +78,30 @@ public class ChatService {
                 chat.getChatOwner() != null ? chat.getChatOwner().getId() : null,
                 chat.isActive()));
 
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
+
     return chats.stream()
-        .map(this::convertChatToConsultantSessionResponseDTO)
+        .map(
+            chat ->
+                convertChatToConsultantSessionResponseDTO(
+                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
         .collect(Collectors.toList());
   }
 
-  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(Chat chat) {
+  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(
+      Chat chat, Set<ChatAgency> chatAgencies) {
     return new ConsultantSessionResponseDTO()
-        .chat(createUserChat(chat))
+        .chat(createUserChat(chat, chatAgencies))
         .consultant(
             new SessionConsultantForConsultantDTO()
                 .id(chat.getChatOwner().getId())
                 .firstName(chat.getChatOwner().getFirstName())
                 .lastName(chat.getChatOwner().getLastName())
                 .username(chat.getChatOwner().getUsername()));
+  }
+
+  private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(Chat chat) {
+    return convertChatToConsultantSessionResponseDTO(chat, loadChatAgencies(chat.getId()));
   }
 
   private String[] getChatModerators(Set<ChatAgency> chatAgencies) {
@@ -144,29 +156,51 @@ public class ChatService {
   public List<UserSessionResponseDTO> getChatsForUserId(String userId) {
     List<Chat> chats = chatRepository.findByUserId(userId);
     List<Chat> assignedChats = chatRepository.findAssignedByUserId(userId);
-    return Stream.concat(chats.stream(), assignedChats.stream())
-        .map(this::convertChatToUserSessionResponseDTO)
+    var allChats =
+        Stream.concat(chats.stream(), assignedChats.stream()).collect(Collectors.toList());
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(allChats);
+    return allChats.stream()
+        .map(
+            chat ->
+                convertChatToUserSessionResponseDTO(
+                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
         .collect(Collectors.toList());
   }
 
   public List<UserSessionResponseDTO> getChatSessionsByIds(Set<Long> chatIds) {
-    return StreamSupport.stream(chatRepository.findAllById(chatIds).spliterator(), false)
-        .map(this::convertChatToUserSessionResponseDTO)
+    var chats =
+        StreamSupport.stream(chatRepository.findAllById(chatIds).spliterator(), false)
+            .collect(Collectors.toList());
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
+    return chats.stream()
+        .map(
+            chat ->
+                convertChatToUserSessionResponseDTO(
+                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
         .collect(Collectors.toList());
   }
 
+  private UserSessionResponseDTO convertChatToUserSessionResponseDTO(
+      Chat chat, Set<ChatAgency> chatAgencies) {
+    return new UserSessionResponseDTO().chat(createUserChat(chat, chatAgencies));
+  }
+
   private UserSessionResponseDTO convertChatToUserSessionResponseDTO(Chat chat) {
-    return new UserSessionResponseDTO().chat(createUserChat(chat));
+    return convertChatToUserSessionResponseDTO(chat, loadChatAgencies(chat.getId()));
   }
 
   private UserChatDTO createUserChat(Chat chat) {
-    if (chat.getChatAgencies().size() > 1) {
+    return createUserChat(chat, loadChatAgencies(chat.getId()));
+  }
+
+  private UserChatDTO createUserChat(Chat chat, Set<ChatAgency> chatAgencies) {
+    if (chatAgencies.size() > 1) {
       log.warn(
           "Chat with id {} has more than one agency assigned. " + "This should not be the case.",
           chat.getId());
     }
-    var chatAgencies =
-        chat.getChatAgencies().stream()
+    var agencies =
+        chatAgencies.stream()
             .map(chatAgency -> agencyService.getAgency(chatAgency.getAgencyId()))
             .collect(Collectors.toList());
 
@@ -191,12 +225,28 @@ public class ChatService {
         chat.getGroupId(),
         null,
         false,
-        getChatModerators(chat.getChatAgencies()),
+        getChatModerators(chatAgencies),
         chat.getStartDate(),
         null,
         chat.getCreateDate() != null ? chat.getCreateDate().toString() : null,
-        chatAgencies,
+        agencies,
         chat.getHintMessage());
+  }
+
+  private Set<ChatAgency> loadChatAgencies(Long chatId) {
+    return new HashSet<>(chatAgencyRepository.findByChat_Id(chatId));
+  }
+
+  private Map<Long, Set<ChatAgency>> loadChatAgenciesByChatId(List<Chat> chats) {
+    var chatIds = chats.stream().map(Chat::getId).collect(Collectors.toSet());
+    if (chatIds.isEmpty()) {
+      return Map.of();
+    }
+
+    return chatAgencyRepository.findByChat_IdIn(chatIds).stream()
+        .collect(
+            Collectors.groupingBy(
+                chatAgency -> chatAgency.getChat().getId(), Collectors.toCollection(HashSet::new)));
   }
 
   /**
@@ -245,9 +295,14 @@ public class ChatService {
                 chat.getChatOwner() != null ? chat.getChatOwner().getId() : null,
                 chat.isActive()));
 
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
+
     var result =
         chats.stream()
-            .map(this::convertChatToConsultantSessionResponseDTO)
+            .map(
+                chat ->
+                    convertChatToConsultantSessionResponseDTO(
+                        chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
             .collect(Collectors.toList());
 
     log.info("🔍 ChatService: Converted to {} ConsultantSessionResponseDTO", result.size());
@@ -262,15 +317,25 @@ public class ChatService {
    * @return {@link List<UserSessionResponseDTO>}
    */
   public List<UserSessionResponseDTO> getChatSessionsByGroupIds(Set<String> groupIds) {
-    return chatRepository.findByGroupIds(groupIds).stream()
-        .map(this::convertChatToUserSessionResponseDTO)
+    var chats = chatRepository.findByGroupIds(groupIds);
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
+    return chats.stream()
+        .map(
+            chat ->
+                convertChatToUserSessionResponseDTO(
+                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
         .collect(Collectors.toList());
   }
 
   public List<ConsultantSessionResponseDTO> getChatSessionsForConsultantByGroupIds(
       Set<String> groupIds) {
-    return chatRepository.findByGroupIds(groupIds).stream()
-        .map(this::convertChatToConsultantSessionResponseDTO)
+    var chats = chatRepository.findByGroupIds(groupIds);
+    var chatAgenciesByChatId = loadChatAgenciesByChatId(chats);
+    return chats.stream()
+        .map(
+            chat ->
+                convertChatToConsultantSessionResponseDTO(
+                    chat, chatAgenciesByChatId.getOrDefault(chat.getId(), Set.of())))
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -7,6 +7,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.AUTHENTICA
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_DTO;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_HINT_MESSAGE;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID_3;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_V2;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.INACTIVE_CHAT;
@@ -18,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,9 +40,11 @@ import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -65,6 +69,44 @@ class ChatServiceTest {
   @Mock private AgencyService agencyService;
 
   private static final long LOCAL_CHAT_AGENCY_ID = 1L;
+
+  @BeforeEach
+  void stubChatAgencyRepository() {
+    lenient()
+        .when(chatAgencyRepository.findByChat_IdIn(Mockito.anySet()))
+        .thenAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              Set<Long> chatIds = invocation.getArgument(0);
+              List<ChatAgency> agencies = new ArrayList<>();
+              if (chatIds.contains(ACTIVE_CHAT.getId())) {
+                agencies.add(chatAgencyFor(ACTIVE_CHAT.getId(), LOCAL_CHAT_AGENCY_ID));
+              }
+              if (chatIds.contains(CHAT_ID_3)) {
+                agencies.add(chatAgencyFor(CHAT_ID_3, LOCAL_CHAT_AGENCY_ID));
+              }
+              return agencies;
+            });
+    lenient()
+        .when(chatAgencyRepository.findByChat_Id(Mockito.anyLong()))
+        .thenAnswer(
+            invocation -> {
+              Long chatId = invocation.getArgument(0);
+              if (ACTIVE_CHAT.getId().equals(chatId)) {
+                return List.of(chatAgencyFor(chatId, LOCAL_CHAT_AGENCY_ID));
+              }
+              if (CHAT_ID_3.equals(chatId)) {
+                return List.of(chatAgencyFor(chatId, LOCAL_CHAT_AGENCY_ID));
+              }
+              return List.of();
+            });
+  }
+
+  private ChatAgency chatAgencyFor(Long chatId, Long agencyId) {
+    Chat chat = Mockito.mock(Chat.class);
+    Mockito.when(chat.getId()).thenReturn(chatId);
+    return new ChatAgency(chat, agencyId);
+  }
 
   /**
    * Returns a fresh {@link Chat} that mirrors the shared {@code ACTIVE_CHAT} fixture but, unlike


### PR DESCRIPTION
## Why

Consultants who own or belong to a **group chat** currently get **HTTP 500** on
`GET /service/users/sessions/consultants?status=2&…`. In the app their session
list shows *"keine aktiven Beratungen"* even though the groups exist.

Root cause:

```
org.hibernate.LazyInitializationException: Cannot lazily initialize collection
of role 'de.caritas.cob.userservice.api.model.Chat.chatAgencies' (no session)
    at ChatService.createUserChat (ChatService.java)
```

`spring.jpa.open-in-view=false`, and the native `findByAgencyIds` query returns
**detached** `Chat` entities. `createUserChat` then accesses
`chat.getChatAgencies()` after the session is closed → exception → 500.

## What

Re-applies **@shazia-k's fix from PR #273** (commit `9a4db13a`): fetch chat
agencies explicitly via `ChatAgencyRepository` (`findByChat_Id` /
`findByChat_IdIn`, bulk-loaded once per chat list) and thread the preloaded set
through DTO construction, instead of lazy-accessing the detached collection.

Touches only the three files of the original fix:
- `ChatService.java`
- `ChatAgencyRepository.java`
- `ChatServiceTest.java`

## ⚠️ Please confirm before merge (@shazia-k)

PR #273 — **exactly this change** — was merged on 2026-07-02 07:24 and then
**reverted ~5h later** (`6bd71b0a`, "Revert Merge PR #273") with **no stated
reason**. The revert reverted the whole PR (which contained only this lazy-init
fix — nothing else). Before this is re-merged, please confirm there wasn't a
known problem that caused the revert. If there was, say so and I'll address it;
if it was collateral / to unblock another merge, this simply restores it.

## Verification

- Rebased onto current `dev` (incl. the Matrix-only teardown, #281) — applies
  cleanly.
- `ChatServiceTest` green **21/21** (JDK25 + `-Dnet.bytebuddy.experimental=true`).
- Hot-deployed to Pre-Dev and confirmed in the browser: the consultant session
  list returns **200 with data** (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)