### PR TITLE
fix: persist Matrix group chat rooms

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -77,7 +77,7 @@ public class CreateChatFacade {
       return createSimplifiedGroupChat(chatDTO, consultant);
     }
     // Otherwise, use the old Rocket.Chat flow
-    return createChat(chatDTO, consultant, this::saveChatV1);
+    return createChat(chatDTO, consultant, this::saveChatV1, this::resolveChatAgencyForV1);
   }
 
   /**
@@ -97,11 +97,14 @@ public class CreateChatFacade {
       return createSimplifiedGroupChat(chatDTO, consultant);
     }
     // Otherwise, use the old flow
-    return createChat(chatDTO, consultant, this::saveChatV2);
+    return createChat(chatDTO, consultant, this::saveChatV2, this::resolveChatAgencyForV2);
   }
 
   private CreateChatResponseDTO createChat(
-      ChatDTO chatDTO, Consultant consultant, BiFunction<Consultant, ChatDTO, Chat> saveChat) {
+      ChatDTO chatDTO,
+      Consultant consultant,
+      BiFunction<Consultant, ChatDTO, Chat> saveChat,
+      BiFunction<Consultant, ChatDTO, Long> resolveAgencyId) {
     Chat chat = null;
     String rcGroupId = null;
 
@@ -110,6 +113,7 @@ public class CreateChatFacade {
       rcGroupId = createRocketChatGroupWithTechnicalUser(chatDTO, chat);
       chat.setGroupId(rcGroupId);
       chatService.saveChat(chat);
+      createChatAgencyRelation(chat, resolveAgencyId.apply(consultant, chatDTO));
 
       return new CreateChatResponseDTO()
           .groupId(rcGroupId)
@@ -128,18 +132,26 @@ public class CreateChatFacade {
     Long agencyId = consultant.getConsultantAgencies().iterator().next().getAgencyId();
     AgencyDTO agency = this.agencyService.getAgency(agencyId);
 
-    Chat chat = chatService.saveChat(chatConverter.convertToEntity(chatDTO, consultant, agency));
-    createChatAgencyRelation(chat, agencyId);
-    return chat;
+    return chatService.saveChat(chatConverter.convertToEntity(chatDTO, consultant, agency));
   }
 
   private Chat saveChatV2(Consultant consultant, ChatDTO chatDTO) {
     assertAgencyIdIsNotNull(chatDTO);
-    Chat chat = chatService.saveChat(chatConverter.convertToEntity(chatDTO, consultant));
-    ConsultantAgency foundConsultantAgency =
-        findConsultantAgencyForGivenChatAgency(consultant, chatDTO);
-    createChatAgencyRelation(chat, foundConsultantAgency.getAgencyId());
-    return chat;
+    findConsultantAgencyForGivenChatAgency(consultant, chatDTO);
+    return chatService.saveChat(chatConverter.convertToEntity(chatDTO, consultant));
+  }
+
+  private Long resolveChatAgencyForV1(Consultant consultant, ChatDTO chatDTO) {
+    if (isEmpty(consultant.getConsultantAgencies())) {
+      throw new InternalServerErrorException(
+          String.format("Consultant with id %s is not assigned to any agency", consultant.getId()));
+    }
+    return consultant.getConsultantAgencies().iterator().next().getAgencyId();
+  }
+
+  private Long resolveChatAgencyForV2(Consultant consultant, ChatDTO chatDTO) {
+    assertAgencyIdIsNotNull(chatDTO);
+    return findConsultantAgencyForGivenChatAgency(consultant, chatDTO).getAgencyId();
   }
 
   private void assertAgencyIdIsNotNull(ChatDTO chatDTO) {
@@ -265,9 +277,6 @@ public class CreateChatFacade {
     Long chatId = chat.getId();
     log.info("Created chat {} for group chat", chatId);
 
-    // Create chat-agency relation
-    createChatAgencyRelation(chat, agencyId);
-
     String matrixRoomId = null;
 
     try {
@@ -294,6 +303,7 @@ public class CreateChatFacade {
       chat.setGroupId(matrixRoomId); // Set rc_group_id for backwards compatibility
       chat.setMatrixRoomId(matrixRoomId); // Set matrix_room_id for Matrix
       chatService.saveChat(chat);
+      createChatAgencyRelation(chat, agencyId);
 
       // Get consultant token for inviting others
       String consultantToken =

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ChatRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ChatRepository.java
@@ -30,18 +30,17 @@ public interface ChatRepository extends CrudRepository<Chat, Long> {
   List<Chat> findAssignedByUserId(@Param(value = "user_id") String userId);
 
   @Query(
-      value =
-          "SELECT c.id, c.topic, c.consulting_type, c.initial_start_date, c.start_date, "
-              + "c.duration, c.is_repetitive, c.chat_interval, c.is_active, c.max_participants, "
-              + "c.consultant_id_owner, c.rc_group_id, c.matrix_room_id, c.update_date, c.create_date, c.hint_message FROM chat c JOIN chat_agency ca ON c"
-              + ".id = ca.chat_id AND ca.agency_id IN :agency_ids",
-      nativeQuery = true)
+      "select distinct c from Chat c join fetch c.chatAgencies ca where ca.agencyId in :agency_ids")
   List<Chat> findByAgencyIds(@Param(value = "agency_ids") Set<Long> agencyIds);
 
   Optional<Chat> findByGroupId(String groupId);
 
-  @Query(value = "SELECT * FROM chat c WHERE c.rc_group_id IN :group_ids", nativeQuery = true)
+  @Query(
+      "select distinct c from Chat c left join fetch c.chatAgencies where c.groupId in :group_ids")
   List<Chat> findByGroupIds(@Param(value = "group_ids") Set<String> groupIds);
+
+  @Query("select distinct c from Chat c left join fetch c.chatAgencies where c.id in :chat_ids")
+  List<Chat> findByIdsWithChatAgencies(@Param(value = "chat_ids") Set<Long> chatIds);
 
   List<Chat> findByChatOwner(Consultant chatOwner);
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -230,9 +230,7 @@ public class ChatService {
   public List<ConsultantSessionResponseDTO> getChatSessionsForConsultantByIds(Set<Long> chatIds) {
     log.info("🔍 ChatService.getChatSessionsForConsultantByIds - chatIds: {}", chatIds);
 
-    var chats =
-        StreamSupport.stream(chatRepository.findAllById(chatIds).spliterator(), false)
-            .collect(Collectors.toList());
+    var chats = chatRepository.findByIdsWithChatAgencies(chatIds);
 
     log.info("🔍 ChatService: Found {} chats in database", chats.size());
     chats.forEach(

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV1FacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatV1FacadeTest.java
@@ -271,6 +271,8 @@ public class CreateChatV1FacadeTest {
           when(rocketChatService.createPrivateGroupWithSystemUser(Mockito.any()))
               .thenReturn(Optional.of(groupResponseDTO));
           when(chatService.saveChat(Mockito.any())).thenReturn(chat);
+          when(groupResponseDTO.getGroup()).thenReturn(groupDTO);
+          when(groupDTO.getId()).thenReturn(RC_GROUP_ID);
           when(chatService.saveChatAgencyRelation(Mockito.any()))
               .thenThrow(new InternalServerErrorException(""));
 

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/ChatRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/ChatRepositoryIT.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import java.time.LocalDateTime;
+import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.hibernate.Hibernate;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -63,6 +65,38 @@ class ChatRepositoryIT {
 
     assertEquals(1, chats.size());
     assertEquals(2, chats.get(0).getId());
+  }
+
+  @Test
+  @Sql(value = "/database/chatAndRelationData.sql")
+  void findByAgencyIds_Should_FetchChatAgencies() {
+    var chats = underTest.findByAgencyIds(Set.of(1731L));
+
+    assertEquals(2, chats.size());
+    assertTrue(Hibernate.isInitialized(chats.get(0).getChatAgencies()));
+    assertTrue(Hibernate.isInitialized(chats.get(1).getChatAgencies()));
+  }
+
+  @Test
+  @Sql(value = "/database/chatAndRelationData.sql")
+  void findByGroupIds_Should_FetchChatAgencies() {
+    var chats = underTest.findByGroupIds(Set.of("x"));
+
+    assertEquals(1, chats.size());
+    assertEquals(0, chats.get(0).getId());
+    assertTrue(Hibernate.isInitialized(chats.get(0).getChatAgencies()));
+    assertEquals(2, chats.get(0).getChatAgencies().size());
+  }
+
+  @Test
+  @Sql(value = "/database/chatAndRelationData.sql")
+  void findByIdsWithChatAgencies_Should_FetchChatAgencies() {
+    var chats = underTest.findByIdsWithChatAgencies(Set.of(0L));
+
+    assertEquals(1, chats.size());
+    assertEquals(0, chats.get(0).getId());
+    assertTrue(Hibernate.isInitialized(chats.get(0).getChatAgencies()));
+    assertEquals(2, chats.get(0).getChatAgencies().size());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -374,7 +374,8 @@ class ChatServiceTest {
 
   @Test
   void getChatSessionsForConsultantByIds_Should_returnConsultantSessionsForGivenIds() {
-    when(chatRepository.findAllById(Set.of(CHAT_ID))).thenReturn(List.of(activeChatWithAgency()));
+    when(chatRepository.findByIdsWithChatAgencies(Set.of(CHAT_ID)))
+        .thenReturn(List.of(activeChatWithAgency()));
 
     List<ConsultantSessionResponseDTO> result =
         chatService.getChatSessionsForConsultantByIds(Set.of(CHAT_ID));


### PR DESCRIPTION
## What changed
- Persist the chat-agency relation only after the Matrix room was created and saved on the chat/session.
- Resolve the agency once for the Matrix group-chat flow so legacy V1 fallback and V2 agency selection use the same persisted agency.
- Fetch chat agency relations with chat lookups used by group chat/session responses.

## Why
The rescued local fix prevents group chat sessions from being visible without their agency relation or Matrix room data after creation. This keeps Matrix group-room creation, persistence, and consultant session retrieval aligned.

## Validation
- `./mvnw -q -Dspotless.check.skip=true -Djacoco.skip=true -DskipTests compile`
- `./mvnw -q -Dspotless.check.skip=true -Djacoco.skip=true -Dtest=ChatRepositoryIT test`
- Local full `ChatServiceTest,ChatRepositoryIT` run is blocked on this machine by JDK 25 / Mockito / JaCoCo compatibility; GitHub Actions should run the full gate on the CI Java version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
