### PR TITLE
Move supervisor asides to a separate room the client is never in (ADR-008 safeguarding)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -136,7 +136,20 @@ public class SessionSupervisorFacade {
       throw new InternalServerErrorException("Failed to create consultant Matrix token");
     }
 
-    // Invite supervisor to Matrix room
+    // ADR-008: provision (or reuse) a SEPARATE supervision side room that the client is NEVER
+    // invited to. Supervisor↔counsellor feedback and coordinator↔peer asides live here, so they
+    // are never delivered to the client's Matrix device. Do this BEFORE touching the client room
+    // so a failure leaves no half state. The supervisor still joins the client room read-only
+    // (below) for observation — only their feedback moves out.
+    String sideRoomId =
+        ensureSupervisionSideRoom(
+            session,
+            addedByConsultant,
+            supervisorConsultant,
+            supervisorMatrixUserId,
+            consultantToken);
+
+    // Invite supervisor to the CLIENT room as a read-only observer.
     try {
       matrixSynapseService.inviteUserToRoom(matrixRoomId, supervisorMatrixUserId, consultantToken);
       log.info(
@@ -182,7 +195,10 @@ public class SessionSupervisorFacade {
       }
     }
 
-    // Create SessionSupervisor entity
+    // Create SessionSupervisor entity. NOTE: matrixRoomId now holds the SUPERVISION SIDE ROOM id
+    // (ADR-008), not the client room — the client room is always available via
+    // session.getMatrixRoomId(). This reuses the existing column (no schema change; ddl-auto is
+    // validate everywhere, so a new column would crash on boot — ADR-006 hazard).
     SessionSupervisor sessionSupervisor =
         SessionSupervisor.builder()
             .session(session)
@@ -190,7 +206,7 @@ public class SessionSupervisorFacade {
             .addedByConsultant(addedByConsultant)
             .addedDate(LocalDateTime.now())
             .isActive(true)
-            .matrixRoomId(matrixRoomId)
+            .matrixRoomId(sideRoomId)
             .notes(notes)
             .build();
 
@@ -239,31 +255,21 @@ public class SessionSupervisorFacade {
       throw new BadRequestException("Supervisor is already removed");
     }
 
-    // Remove from Matrix room
-    String matrixRoomId = supervisor.getMatrixRoomId();
-    if (matrixRoomId != null && !matrixRoomId.isEmpty()) {
-      String supervisorMatrixUserId = supervisor.getSupervisorConsultant().getMatrixUserId();
-      if (supervisorMatrixUserId != null && !supervisorMatrixUserId.isEmpty()) {
-        if (removedByConsultant.getMatrixUserId() != null) {
-          String consultantToken =
-              matrixSynapseService.loginAsUserAccessToken(removedByConsultant.getMatrixUserId());
-          if (consultantToken != null) {
-            boolean removed =
-                matrixSynapseService.removeUserFromRoom(
-                    matrixRoomId, supervisorMatrixUserId, consultantToken);
-            if (removed) {
-              log.info(
-                  "Removed supervisor {} from Matrix room {}",
-                  supervisor.getSupervisorConsultant().getUsername(),
-                  matrixRoomId);
-            } else {
-              log.warn(
-                  "Failed to remove supervisor {} from Matrix room {}, but continuing",
-                  supervisor.getSupervisorConsultant().getUsername(),
-                  matrixRoomId);
-            }
-          }
-        }
+    // Remove the supervisor from BOTH rooms: the supervision side room (stored in
+    // supervisor.matrixRoomId, ADR-008) and the client room they observed (session.matrixRoomId).
+    String sideRoomId = supervisor.getMatrixRoomId();
+    String clientRoomId = session.getMatrixRoomId();
+    String supervisorMatrixUserId = supervisor.getSupervisorConsultant().getMatrixUserId();
+    if (supervisorMatrixUserId != null
+        && !supervisorMatrixUserId.isEmpty()
+        && removedByConsultant.getMatrixUserId() != null) {
+      String consultantToken =
+          matrixSynapseService.loginAsUserAccessToken(removedByConsultant.getMatrixUserId());
+      if (consultantToken != null) {
+        removeFromRoomIfPresent(
+            sideRoomId, supervisorMatrixUserId, consultantToken, supervisor, "supervision side");
+        removeFromRoomIfPresent(
+            clientRoomId, supervisorMatrixUserId, consultantToken, supervisor, "client");
       }
     }
 
@@ -287,6 +293,114 @@ public class SessionSupervisorFacade {
    */
   public List<SessionSupervisor> getSupervisors(Long sessionId) {
     return sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(sessionId);
+  }
+
+  /**
+   * ADR-008: ensure a supervision side room exists for the session and the supervisor is a member
+   * of it. One side room is shared by all supervisors of a session. The client is NEVER invited, so
+   * asides sent here are never delivered to the client's Matrix device. The room is created with
+   * the {@code private_chat} preset (join_rule = invite), so the client cannot join even if the id
+   * leaks.
+   *
+   * @return the side room id (existing, reused, or newly created)
+   */
+  private String ensureSupervisionSideRoom(
+      Session session,
+      Consultant addedByConsultant,
+      Consultant supervisorConsultant,
+      String supervisorMatrixUserId,
+      String consultantToken) {
+
+    String clientRoomId = session.getMatrixRoomId();
+
+    // Reuse an existing side room if another active supervisor already has one for this session.
+    // Old-style rows stored the CLIENT room id in matrixRoomId — never reuse that as a side room.
+    String sideRoomId =
+        sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(session.getId()).stream()
+            .map(SessionSupervisor::getMatrixRoomId)
+            .filter(id -> id != null && !id.isEmpty() && !id.equals(clientRoomId))
+            .findFirst()
+            .orElse(null);
+
+    if (sideRoomId == null) {
+      // Create the side room as the acting consultant (they become an owner/member).
+      String alias = "supervision_" + session.getId() + "_" + System.nanoTime();
+      try {
+        var response =
+            matrixSynapseService.createRoom(
+                "Supervision – Session " + session.getId(), alias, consultantToken);
+        sideRoomId =
+            response != null && response.getBody() != null ? response.getBody().getRoomId() : null;
+      } catch (Exception e) {
+        throw new InternalServerErrorException(
+            "Failed to create supervision side room: " + e.getMessage());
+      }
+      if (sideRoomId == null || sideRoomId.isEmpty()) {
+        throw new InternalServerErrorException(
+            "Supervision side room creation returned no room id");
+      }
+      log.info("Created supervision side room {} for session {}", sideRoomId, session.getId());
+
+      // Ensure the assigned consultant (who handles the case) is also in the side room, in case a
+      // different same-agency consultant created it.
+      Consultant assigned = session.getConsultant();
+      if (assigned != null
+          && assigned.getMatrixUserId() != null
+          && !assigned.getId().equals(addedByConsultant.getId())) {
+        inviteAndJoin(sideRoomId, assigned.getMatrixUserId(), consultantToken);
+      }
+    }
+
+    // Invite + join the supervisor into the side room (full member — this is their feedback
+    // back-channel, not a read-only observation room).
+    inviteAndJoin(sideRoomId, supervisorMatrixUserId, consultantToken);
+    log.info(
+        "Supervisor {} added to supervision side room {} for session {}",
+        supervisorConsultant.getUsername(),
+        sideRoomId,
+        session.getId());
+    return sideRoomId;
+  }
+
+  /** Invite a Matrix user to a room and accept the invite on their behalf. */
+  private void inviteAndJoin(String roomId, String matrixUserId, String inviterToken) {
+    try {
+      matrixSynapseService.inviteUserToRoom(roomId, matrixUserId, inviterToken);
+    } catch (Exception e) {
+      throw new InternalServerErrorException(
+          "Failed to invite user to supervision side room: " + e.getMessage());
+    }
+    String userToken = matrixSynapseService.loginAsUserAccessToken(matrixUserId);
+    if (userToken != null) {
+      matrixSynapseService.joinRoom(roomId, userToken);
+    }
+  }
+
+  /** Remove a user from a room if a room id is present; log but never fail the removal flow. */
+  private void removeFromRoomIfPresent(
+      String roomId,
+      String supervisorMatrixUserId,
+      String consultantToken,
+      SessionSupervisor supervisor,
+      String roomLabel) {
+    if (roomId == null || roomId.isEmpty()) {
+      return;
+    }
+    boolean removed =
+        matrixSynapseService.removeUserFromRoom(roomId, supervisorMatrixUserId, consultantToken);
+    if (removed) {
+      log.info(
+          "Removed supervisor {} from {} room {}",
+          supervisor.getSupervisorConsultant().getUsername(),
+          roomLabel,
+          roomId);
+    } else {
+      log.warn(
+          "Failed to remove supervisor {} from {} room {}, but continuing",
+          supervisor.getSupervisorConsultant().getUsername(),
+          roomLabel,
+          roomId);
+    }
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -1,0 +1,158 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.SessionSupervisor;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * ADR-008 safety contract: supervisor feedback / asides must live in a SEPARATE Matrix room the
+ * client is never invited to. These tests lock the behaviour that {@code addSupervisor} stores the
+ * SIDE room id (never the client room id) on the entity and provisions the side room, so a later
+ * regression can't silently route asides back into the client room.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SessionSupervisorFacadeTest {
+
+  private static final Long SESSION_ID = 42L;
+  private static final String CLIENT_ROOM = "!clientroom:oriso";
+  private static final String SIDE_ROOM = "!sideroom:oriso";
+  private static final String SUPERVISOR_ID = "sup-1";
+  private static final String SUPERVISOR_MXID = "@sup:oriso";
+  private static final String CONSULTANT_MXID = "@con:oriso";
+
+  @InjectMocks private SessionSupervisorFacade facade;
+
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+  @Mock private SessionRepository sessionRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private ConsultantAgencyRepository consultantAgencyRepository;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private de.caritas.cob.userservice.api.service.user.UserAccountService userAccountService;
+  @Mock private de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
+
+  private Session session;
+  private Consultant addedBy;
+  private Consultant supervisor;
+
+  @BeforeEach
+  void setup() throws Exception {
+    addedBy = new Consultant();
+    addedBy.setId("con-1");
+    addedBy.setMatrixUserId(CONSULTANT_MXID);
+
+    supervisor = new Consultant();
+    supervisor.setId(SUPERVISOR_ID);
+    supervisor.setUsername("sup");
+    supervisor.setMatrixUserId(SUPERVISOR_MXID);
+    supervisor.setSupervisor(true);
+
+    session = new Session();
+    session.setId(SESSION_ID);
+    session.setMatrixRoomId(CLIENT_ROOM);
+    session.setAgencyId(7L);
+    session.setConsultant(addedBy); // assigned consultant == addedBy → has permission
+
+    when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultantRepository.findById(SUPERVISOR_ID)).thenReturn(Optional.of(supervisor));
+    when(sessionSupervisorRepository.findBySessionIdAndSupervisorConsultantIdAndIsActiveTrue(
+            SESSION_ID, SUPERVISOR_ID))
+        .thenReturn(Optional.empty());
+    // supervisor is in the same agency (7L) as the session
+    when(consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull(SUPERVISOR_ID))
+        .thenReturn(
+            List.of(
+                de.caritas.cob.userservice.api.model.ConsultantAgency.builder()
+                    .agencyId(7L)
+                    .build()));
+    when(sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(SESSION_ID))
+        .thenReturn(List.of());
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("tok");
+    var roomResponse = new MatrixCreateRoomResponseDTO();
+    roomResponse.setRoomId(SIDE_ROOM);
+    when(matrixSynapseService.createRoom(any(), any(), any()))
+        .thenReturn(ResponseEntity.ok(roomResponse));
+    when(matrixSynapseService.setUserPowerLevel(
+            any(), any(), org.mockito.ArgumentMatchers.anyInt(), any()))
+        .thenReturn(true);
+    when(matrixSynapseService.joinRoom(any(), any())).thenReturn(true);
+    when(sessionSupervisorRepository.save(any()))
+        .thenAnswer(inv -> inv.getArgument(0, SessionSupervisor.class));
+  }
+
+  @Test
+  void addSupervisor_Should_storeSideRoomId_notClientRoomId() throws Exception {
+    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+
+    assertThat(saved.getMatrixRoomId())
+        .as("entity must hold the supervision SIDE room, never the client room")
+        .isEqualTo(SIDE_ROOM)
+        .isNotEqualTo(CLIENT_ROOM);
+  }
+
+  @Test
+  void addSupervisor_Should_provisionSideRoom_andNeverInviteIntoItAsClientRoom() throws Exception {
+    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+
+    // A side room was created...
+    verify(matrixSynapseService).createRoom(any(), any(), any());
+    // ...and the supervisor was invited to BOTH the client room (observation) and the side room.
+    ArgumentCaptor<String> rooms = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService, org.mockito.Mockito.atLeast(2))
+        .inviteUserToRoom(rooms.capture(), eq(SUPERVISOR_MXID), any());
+    assertThat(rooms.getAllValues()).contains(CLIENT_ROOM, SIDE_ROOM);
+  }
+
+  @Test
+  void addSupervisor_Should_reuseExistingSideRoom_when_anotherSupervisorAlreadyHasOne()
+      throws Exception {
+    SessionSupervisor existing = SessionSupervisor.builder().matrixRoomId(SIDE_ROOM).build();
+    when(sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(SESSION_ID))
+        .thenReturn(List.of(existing));
+
+    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+
+    assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM);
+    // no NEW room created — the existing side room is reused
+    verify(matrixSynapseService, never()).createRoom(any(), any(), any());
+  }
+
+  @Test
+  void addSupervisor_Should_notTreatOldStyleClientRoomRow_asASideRoom() throws Exception {
+    // A pre-ADR-008 row stored the CLIENT room id in matrixRoomId. It must NOT be reused as a side
+    // room (that would re-open the leak) — a fresh side room is created instead.
+    SessionSupervisor oldStyle = SessionSupervisor.builder().matrixRoomId(CLIENT_ROOM).build();
+    when(sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(SESSION_ID))
+        .thenReturn(List.of(oldStyle));
+
+    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+
+    assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM).isNotEqualTo(CLIENT_ROOM);
+    verify(matrixSynapseService).createRoom(any(), any(), any());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomRespon
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.SessionSupervisor;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -45,6 +46,7 @@ class SessionSupervisorFacadeTest {
   private static final String SUPERVISOR_ID = "sup-1";
   private static final String SUPERVISOR_MXID = "@sup:oriso";
   private static final String CONSULTANT_MXID = "@con:oriso";
+  private static final String CLIENT_MXID = "@client:oriso";
 
   @InjectMocks private SessionSupervisorFacade facade;
 
@@ -154,5 +156,29 @@ class SessionSupervisorFacadeTest {
 
     assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM).isNotEqualTo(CLIENT_ROOM);
     verify(matrixSynapseService).createRoom(any(), any(), any());
+  }
+
+  @Test
+  void addSupervisor_Should_neverInviteTheClient_intoTheSideRoom() throws Exception {
+    // ADR-008 safeguarding regression guard. The asker (client) must NEVER be invited into the
+    // supervision side room — nor anywhere by this flow. We give the session's client a Matrix id
+    // so that a future change which started inviting it would be caught here. Today only the
+    // supervisor is ever invited (client-room observation + side-room membership), so every
+    // captured
+    // invitee must be the supervisor and never the client.
+    User client = new User();
+    client.setMatrixUserId(CLIENT_MXID);
+    session.setUser(client);
+
+    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+
+    ArgumentCaptor<String> invitedUsers = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService, org.mockito.Mockito.atLeastOnce())
+        .inviteUserToRoom(any(), invitedUsers.capture(), any());
+    assertThat(invitedUsers.getAllValues())
+        .as("only the supervisor is ever invited; the client is never invited into any room")
+        .containsOnly(SUPERVISOR_MXID)
+        .doesNotContain(CLIENT_MXID);
+    verify(matrixSynapseService, never()).inviteUserToRoom(eq(SIDE_ROOM), eq(CLIENT_MXID), any());
   }
 }


### PR DESCRIPTION
## Summary

Closes the ADR-008 side-channel leak on the backend: supervisor feedback (`[SUPERVISOR_FEEDBACK]`) and coordinator↔peer asides (`[VISIBLE_TO:…]`) were posted into the **same Matrix room as the client** and hidden only by a React `return null`. With Megolm off, the plaintext aside is delivered to the client's own device and is trivially recoverable (DevTools `/sync`, any Matrix client). For U25 minors this is a safeguarding hazard, not a cosmetic bug.

This is the **backend half** — it provisions the separate room so asides can be routed out of the client's room. The paired frontend change (routing aside *sends* to this room + rendering it for authorized members) is a follow-up on the Matrix-only frontend branch.

## What changed

`SessionSupervisorFacade.addSupervisor` now:
- provisions (or reuses) a **per-session supervision side room** the client is **never** invited to. It is created with the `private_chat` preset → `join_rule: invite`, so the client cannot join even if the room id leaks. One side room is shared by all supervisors of a session.
- invites + joins the supervisor (and, if different, the assigned consultant) into that side room;
- **still** invites the supervisor to the client room read-only (power level 10) for observation — only their *feedback* moves out (exactly the ADR-008 decision);
- stores the **side-room id** in `SessionSupervisor.matrix_room_id`, **reusing the existing column** — no schema change (a new `@Column` would crash on boot: `ddl-auto=validate` is on everywhere, the ADR-006 hazard). The client room id is always available via `session.getMatrixRoomId()`.
- provisions the side room **before** touching the client room, so a failure leaves no half state.

`removeSupervisor` now removes the supervisor from **both** rooms (side + client). Old-style rows that stored the client room id in `matrix_room_id` are **never** reused as a side room (that would re-open the leak) — a fresh side room is created.

## Validation (verified live on Pre-Dev)

- New `SessionSupervisorFacadeTest` (4 tests): stores side-room id not client-room id; provisions the side room and invites into both rooms; reuses an existing side room; never treats an old-style client-room row as a side room. Green.
- Live proof on Pre-Dev (hot-deployed image): added a supervisor → a **new** side room `!Zrr…` distinct from the client room `!DbE…`; the side room contains only the two counsellors, **not the asker** (`join_rule: invite`). Sent a `[SUPERVISOR_FEEDBACK]` aside to the side room → the **asker's `/sync` does not contain it** (leak closed), while a side-room member's `/sync` does.

## Follow-ups (tracked, not in this PR)

- Frontend: route aside sends (`isSupervisor` / `VISIBLE_TO`) to the side room and render it for authorized members (pairs with ORISO-Frontend Matrix-only branch).
- ADR-008 AXIS 2 (separate): tighten `addSupervisor` authority (assigned-consultant-only) + record consent/justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
