### PR TITLE
fix: add Liquibase changesets for Matrix columns and missing fast-track tables

### DIFF
--- a/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+  <changeSet id="0056_matrix_columns_and_missing_tables" author="caritas">
+    <sqlFile
+      path="db/changelog/changeset/0056_matrix_columns_and_missing_tables/add-missing-columns.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <sqlFile
+      path="db/changelog/changeset/0056_matrix_columns_and_missing_tables/create-missing-tables.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sqlFile
+        path="db/changelog/changeset/0056_matrix_columns_and_missing_tables/rollback.sql"
+        relativeToChangelogFile="false"
+        splitStatements="true"
+        stripComments="true"
+        endDelimiter=";"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/add-missing-columns.sql
+++ b/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/add-missing-columns.sql
@@ -1,0 +1,23 @@
+-- Columns that exist on live databases only via manual ALTERs — no Liquibase
+-- changeset ever created them, so a fresh bootstrap does not match the JPA
+-- entities (found 2026-07-04 while bootstrapping the full platform from empty
+-- databases: UserService was the only service that additionally needed
+-- ddl-auto=update). Types match the entity definitions. Idempotent so it is
+-- safe on databases where the columns were already added by hand.
+
+-- Chat.matrixRoomId
+ALTER TABLE chat ADD COLUMN IF NOT EXISTS matrix_room_id VARCHAR(255) NULL;
+
+-- Session.matrixRoomId
+ALTER TABLE session ADD COLUMN IF NOT EXISTS matrix_room_id VARCHAR(255) NULL;
+
+-- User.matrixUserId, User.magicLinkLoginEnabled
+ALTER TABLE user ADD COLUMN IF NOT EXISTS matrix_user_id VARCHAR(255) NULL;
+ALTER TABLE user ADD COLUMN IF NOT EXISTS magic_link_login_enabled BIT NOT NULL DEFAULT b'0';
+
+-- Consultant.matrixUserId, Consultant.displayName, Consultant.isSupervisor,
+-- Consultant.magicLinkLoginEnabled
+ALTER TABLE consultant ADD COLUMN IF NOT EXISTS matrix_user_id VARCHAR(255) NULL;
+ALTER TABLE consultant ADD COLUMN IF NOT EXISTS display_name VARCHAR(255) NULL;
+ALTER TABLE consultant ADD COLUMN IF NOT EXISTS is_supervisor TINYINT NOT NULL DEFAULT 0;
+ALTER TABLE consultant ADD COLUMN IF NOT EXISTS magic_link_login_enabled BIT NOT NULL DEFAULT b'0';

--- a/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/create-missing-tables.sql
+++ b/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/create-missing-tables.sql
@@ -1,0 +1,40 @@
+-- Tables that exist on live databases only because Hibernate ddl-auto=update
+-- created them — no Liquibase changeset does. DDL matches the JPA entities
+-- (DraftMessage, GroupChatParticipant, SessionSupervisor; all use IDENTITY
+-- id generation). Idempotent.
+
+CREATE TABLE IF NOT EXISTS draft_message (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  user_id VARCHAR(64) NOT NULL,
+  scope_key VARCHAR(255) NOT NULL,
+  text TEXT NULL,
+  action_path VARCHAR(512) NULL,
+  title VARCHAR(255) NULL,
+  source_session_id BIGINT NULL,
+  room_ref VARCHAR(255) NULL,
+  thread_root_id VARCHAR(255) NULL,
+  create_date DATETIME NOT NULL,
+  update_date DATETIME NOT NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS group_chat_participant (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  chat_id BIGINT NOT NULL,
+  consultant_id VARCHAR(36) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS session_supervisor (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  session_id BIGINT NOT NULL,
+  supervisor_consultant_id VARCHAR(255) NOT NULL,
+  added_by_consultant_id VARCHAR(255) NOT NULL,
+  added_date DATETIME(6) NOT NULL,
+  removed_date DATETIME(6) NULL,
+  is_active TINYINT NOT NULL DEFAULT 1,
+  matrix_room_id VARCHAR(255) NULL,
+  notes TEXT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0056_matrix_columns_and_missing_tables/rollback.sql
@@ -1,0 +1,11 @@
+ALTER TABLE chat DROP COLUMN IF EXISTS matrix_room_id;
+ALTER TABLE session DROP COLUMN IF EXISTS matrix_room_id;
+ALTER TABLE user DROP COLUMN IF EXISTS matrix_user_id;
+ALTER TABLE user DROP COLUMN IF EXISTS magic_link_login_enabled;
+ALTER TABLE consultant DROP COLUMN IF EXISTS matrix_user_id;
+ALTER TABLE consultant DROP COLUMN IF EXISTS display_name;
+ALTER TABLE consultant DROP COLUMN IF EXISTS is_supervisor;
+ALTER TABLE consultant DROP COLUMN IF EXISTS magic_link_login_enabled;
+DROP TABLE IF EXISTS draft_message;
+DROP TABLE IF EXISTS group_chat_participant;
+DROP TABLE IF EXISTS session_supervisor;

--- a/src/main/resources/db/changelog/userservice-dev-master.xml
+++ b/src/main/resources/db/changelog/userservice-dev-master.xml
@@ -53,9 +53,12 @@
 	<include file="db/changelog/changeset/0045_add_hint_and_create_date_to_chat/0045_changeSet.xml"/>
 	<include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
         <include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
+  <include file="db/changelog/changeset/0048_add_event_notifications/0048_changeSet.xml"/>
   <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
   <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
+  <include file="db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-local-master.xml
+++ b/src/main/resources/db/changelog/userservice-local-master.xml
@@ -53,9 +53,12 @@
 	<include file="db/changelog/changeset/0045_add_hint_and_create_date_to_chat/0045_changeSet.xml"/>
 	<include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
 	<include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
+  <include file="db/changelog/changeset/0048_add_event_notifications/0048_changeSet.xml"/>
   <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
+  <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
   <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
+  <include file="db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-prod-master.xml
+++ b/src/main/resources/db/changelog/userservice-prod-master.xml
@@ -53,11 +53,11 @@
   <include file="db/changelog/changeset/0046_remove_feeback_related_columns/0046_changeSet.xml"/>
   <include file="db/changelog/changeset/0047_add_matrix_password/0047_changeSet.xml"/>
   <include file="db/changelog/changeset/0048_add_event_notifications/0048_changeSet.xml"/>
-  <include file="db/changelog/changeset/0049_add_magic_link_login_toggle/0049_changeSet.xml"/>
   <include file="db/changelog/changeset/0050_security05_deletion_lifecycle/0050_changeSet.xml"/>
   <include file="db/changelog/changeset/0051_backfill_deletion_read_only_until/0051_changeSet.xml"/>
   <include file="db/changelog/changeset/0052_invite_links_topic/0052_changeSet.xml"/>
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
   <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
   <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
+  <include file="db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-staging-master.xml
+++ b/src/main/resources/db/changelog/userservice-staging-master.xml
@@ -58,4 +58,5 @@
   <include file="db/changelog/changeset/0053_consultant_topic/0053_changeSet.xml"/>
   <include file="db/changelog/changeset/0054_event_notification_params/0054_changeSet.xml"/>
   <include file="db/changelog/changeset/0055_account_invites/0055_changeSet.xml"/>
+  <include file="db/changelog/changeset/0056_matrix_columns_and_missing_tables/0056_changeSet.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## What breaks without this

A fresh database is missing the Matrix columns (and a few sibling columns and tables) because they were only ever added by hand or by Hibernate `ddl-auto=update` — no Liquibase changeset creates them. A clean bootstrap of the dev chain produces a schema that does not match the JPA entities, so UserService cannot run against a fresh database without `ddl-auto=update`.

## How it was found

Full-platform bootstrap from empty databases on the local fast-track stack (2026-07-04). UserService was the only service that still needed `ddl-auto=update` after its Liquibase chain ran. Diffing the chain-only schema against the entity-driven schema (what Hibernate had to add) gave the exact delta.

## The delta (all covered by new changeset 0056)

Missing columns on existing tables:

| Table | Column | Type |
|---|---|---|
| chat | matrix_room_id | VARCHAR(255) NULL |
| session | matrix_room_id | VARCHAR(255) NULL |
| user | matrix_user_id | VARCHAR(255) NULL |
| user | magic_link_login_enabled | BIT NOT NULL DEFAULT 0 |
| consultant | matrix_user_id | VARCHAR(255) NULL |
| consultant | display_name | VARCHAR(255) NULL |
| consultant | is_supervisor | TINYINT NOT NULL DEFAULT 0 |
| consultant | magic_link_login_enabled | BIT NOT NULL DEFAULT 0 |

Missing tables: `draft_message`, `group_chat_participant`, `session_supervisor` — created with DDL matching the entities.

Everything is idempotent (`ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`), so it is safe on live databases where the columns were already added by hand.

## Two wiring bugs fixed on the way

- `0048_add_event_notifications` and `0054_event_notification_params` were only wired into the prod/staging masters. Added to dev/local masters, so a fresh dev bootstrap gets `event_notification` too.
- The prod master included `0049_add_magic_link_login_toggle`, but that changeset file does not exist in the repo — every fresh prod-chain run dies with `ChangeLogParseException` (reproduced). Removed the dangling include; the magic-link columns are covered idempotently by 0056.

Not touched: the orphaned `0048_remove_matrix_password` changeset (wired into no master). It only drops leftover columns, which is out of scope here.

## Validation (throwaway MariaDB 10.11, liquibase/liquibase:4.29)

- Fresh bootstrap with the dev master: **57/57 changesets OK**
- Idempotency re-run: 0 pending, 57 previously run
- Upgrade path from the old 54-changeset state: exactly 3 new changesets applied
- `liquibase validate` on prod and staging masters: no errors (prod failed with `ChangeLogParseException` before)
- Column inventory of the bootstrapped schema now matches the entity-driven reference schema — the only remaining differences are pre-existing varchar-length drift where the changelog is the intended source of truth
- `./mvnw compile` green (JDK 21); `ChatRepositoryIT` + `UserChatRepositoryIT`: 5/5 tests pass
- `spotless:apply` run before push

Sibling migration-hygiene fixes from the same bootstrap: OpenResilienceInitiative/ORISO-AgencyService#91, OpenResilienceInitiative/ORISO-AgencyService#92, OpenResilienceInitiative/ORISO-TenantService#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)