### PR TITLE
fix: single member leaving a group chat no longer deletes the chat for everyone

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -30,6 +30,7 @@ public class MatrixRoomClient {
   private static final String ENDPOINT_CREATE_ROOM = "/_matrix/client/r0/createRoom";
   private static final String ENDPOINT_INVITE_USER = "/_matrix/client/r0/rooms/{roomId}/invite";
   private static final String ENDPOINT_JOIN_ROOM = "/_matrix/client/r0/rooms/{roomId}/join";
+  private static final String ENDPOINT_LEAVE_ROOM = "/_matrix/client/r0/rooms/{roomId}/leave";
   private static final String ENDPOINT_POWER_LEVELS =
       "/_matrix/client/r0/rooms/{roomId}/state/m.room.power_levels";
   private static final String ENDPOINT_MEMBERSHIP =
@@ -160,6 +161,55 @@ public class MatrixRoomClient {
       return false;
     } catch (Exception ex) {
       log.error("Matrix Error: Could not join room ({}). Reason: {}", roomId, ex.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Leaves a Matrix room with the given user's own access token (the canonical self-leave, {@code
+   * POST /rooms/{roomId}/leave}).
+   *
+   * <p>Best-effort: never throws. Leaving a room the user is not (or no longer) a member of is
+   * treated as success, because the desired end state ("user is not in the room") already holds.
+   *
+   * @param roomId the Matrix room ID
+   * @param accessToken the access token of the leaving user
+   * @return true when the user is not in the room afterwards, false when the leave failed
+   */
+  public boolean leaveRoom(String roomId, String accessToken) {
+    try {
+      var headers = getClientHttpHeaders(accessToken);
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      HttpEntity<String> request = new HttpEntity<>("{}", headers);
+
+      var url = buildUrl(ENDPOINT_LEAVE_ROOM, Map.of("roomId", roomId));
+      log.info("Leaving Matrix room: {} at URL: {}", roomId, url);
+
+      var response = restTemplate.postForEntity(url, request, Map.class);
+
+      if (response.getStatusCode().is2xxSuccessful()) {
+        log.info("Successfully left Matrix room: {}", roomId);
+        return true;
+      }
+      log.warn("Failed to leave Matrix room: {}. Status: {}", roomId, response.getStatusCode());
+      return false;
+    } catch (HttpClientErrorException ex) {
+      if (ex.getStatusCode().value() == 403 || ex.getStatusCode().value() == 404) {
+        log.info(
+            "User was not in Matrix room {} (status {}); nothing to leave",
+            roomId,
+            ex.getStatusCode());
+        return true;
+      }
+      log.error(
+          "Matrix Error: Could not leave room ({}). Status: {}, Response: {}",
+          roomId,
+          ex.getStatusCode(),
+          ex.getResponseBodyAsString());
+      return false;
+    } catch (Exception ex) {
+      log.error("Matrix Error: Could not leave room ({}). Reason: {}", roomId, ex.getMessage());
       return false;
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -42,6 +42,7 @@ public class MatrixSynapseService {
   private static final String ENDPOINT_UPDATE_USER_ADMIN = "/_synapse/admin/v2/users/{userId}";
   private static final String ENDPOINT_DEACTIVATE_USER = "/_synapse/admin/v1/deactivate/{userId}";
   private static final String ENDPOINT_PURGE_ROOM = "/_synapse/admin/v2/rooms/{roomId}";
+  private static final String ENDPOINT_ROOM_MEMBERS = "/_synapse/admin/v1/rooms/{roomId}/members";
   private static final String ENDPOINT_JOINED_ROOMS = "/_matrix/client/r0/joined_rooms";
   private static final String ENDPOINT_PRESENCE = "/_matrix/client/r0/presence/{userId}/status";
   private static final String ENDPOINT_SEND_MESSAGE =
@@ -687,6 +688,63 @@ public class MatrixSynapseService {
    */
   public boolean joinRoom(String roomId, String accessToken) {
     return matrixRoomClient.joinRoom(roomId, accessToken);
+  }
+
+  /**
+   * Leaves a Matrix room with the given user's own access token.
+   *
+   * @param roomId the room ID
+   * @param accessToken the access token of the leaving user
+   * @return true when the user is not in the room afterwards, false when the leave failed
+   */
+  public boolean leaveRoom(String roomId, String accessToken) {
+    return matrixRoomClient.leaveRoom(roomId, accessToken);
+  }
+
+  /**
+   * Reads the current members of a Matrix room via the Synapse admin API ({@code GET
+   * /_synapse/admin/v1/rooms/{roomId}/members}).
+   *
+   * <p>Uses the admin token, so it works regardless of whether the admin user is a member of the
+   * room. Never throws.
+   *
+   * @param matrixRoomId the Matrix room ID
+   * @return the list of full Matrix user IDs currently joined to the room, or {@link
+   *     java.util.Optional#empty()} when the room state could not be determined (no admin token,
+   *     request failed, unexpected response shape). Callers must treat empty as "unknown", not as
+   *     "no members".
+   */
+  public java.util.Optional<java.util.List<String>> getRoomMembers(String matrixRoomId) {
+    String adminToken = getAdminAccessToken();
+    if (adminToken == null) {
+      log.warn("Could not get admin token for reading members of Matrix room {}", matrixRoomId);
+      return java.util.Optional.empty();
+    }
+
+    try {
+      String url =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_ROOM_MEMBERS, java.util.Map.of("roomId", matrixRoomId));
+
+      var headers = getClientHttpHeaders(adminToken);
+      var request = new HttpEntity<>(headers);
+
+      ResponseEntity<java.util.Map> response =
+          restTemplate.exchange(
+              url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
+
+      var body = response.getBody();
+      if (body == null || !(body.get("members") instanceof java.util.List<?> members)) {
+        log.warn("Unexpected response reading members of Matrix room {}", matrixRoomId);
+        return java.util.Optional.empty();
+      }
+
+      return java.util.Optional.of(members.stream().map(String::valueOf).toList());
+    } catch (Exception ex) {
+      log.warn(
+          "Matrix Error: Could not read members of room {}: {}", matrixRoomId, ex.getMessage());
+      return java.util.Optional.empty();
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
@@ -9,16 +9,18 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatAddUserToGroupException;
-import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatGetGroupMembersException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatRemoveUserFromGroupException;
-import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatUserNotInitializedException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.LogService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +36,7 @@ public class JoinAndLeaveChatFacade {
   private final UserService userService;
   private final RocketChatService rocketChatService;
   private final ChatReCreator chatReCreator;
+  private final GroupChatMembershipService groupChatMembershipService;
 
   /**
    * Join a chat.
@@ -60,6 +63,11 @@ public class JoinAndLeaveChatFacade {
   /**
    * Leave a chat.
    *
+   * <p>The "was this the last member?" decision is answered from the Matrix room state via {@link
+   * GroupChatMembershipService}, NOT from Rocket.Chat: with Rocket.Chat disabled (the default,
+   * ADR-004) its member query always returns an empty list, which made every single leave delete
+   * the whole chat for everyone.
+   *
    * @param chatId the id of the chat
    * @param authenticatedUser the authenticated user
    */
@@ -69,19 +77,35 @@ public class JoinAndLeaveChatFacade {
 
     try {
       rocketChatService.removeUserFromGroup(rcUserId, chat.getGroupId());
-      if (rocketChatService.getStandardMembersOfGroup(chat.getGroupId()).isEmpty()) {
-        deleteMessengerChat(chat.getGroupId());
-        if (chat.isRepetitive()) {
-          var rcGroupId = chatReCreator.recreateMessengerChat(chat);
-          chatReCreator.updateAsNextChat(chat, rcGroupId);
-        } else {
-          chatService.deleteChat(chat);
-        }
-      }
-    } catch (RocketChatRemoveUserFromGroupException
-        | RocketChatUserNotInitializedException
-        | RocketChatGetGroupMembersException e) {
+    } catch (RocketChatRemoveUserFromGroupException e) {
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
+    }
+
+    Optional<Consultant> leavingConsultant =
+        consultantService.getConsultantViaAuthenticatedUser(authenticatedUser);
+    Optional<User> leavingUser =
+        leavingConsultant.isPresent()
+            ? Optional.empty()
+            : userService.getUserViaAuthenticatedUser(authenticatedUser);
+    String leavingMatrixUserId =
+        leavingConsultant
+            .map(Consultant::getMatrixUserId)
+            .or(() -> leavingUser.map(User::getMatrixUserId))
+            .orElse(null);
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(chat, leavingMatrixUserId);
+    leavingUser.ifPresent(leaver -> chatService.deleteUserChatRelation(chat, leaver));
+
+    if (groupChatMembershipService.hasRemainingHumanMembers(chat, leavingMatrixUserId)) {
+      return;
+    }
+
+    deleteMessengerChat(chat.getGroupId());
+    if (chat.isRepetitive()) {
+      var rcGroupId = chatReCreator.recreateMessengerChat(chat);
+      chatReCreator.updateAsNextChat(chat, rcGroupId);
+    } else {
+      chatService.deleteChat(chat);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserChat;
 import de.caritas.cob.userservice.api.port.out.ChatAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
@@ -131,6 +132,17 @@ public class ChatService {
     } else {
       throw new ConflictException("User is already assigned to chat");
     }
+  }
+
+  /**
+   * Deletes the {@link UserChat} relation between the given chat and user, if one exists. Used when
+   * a user leaves a group chat so the assignment does not linger after the leave.
+   *
+   * @param chat the {@link Chat} that was left
+   * @param user the {@link User} who left
+   */
+  public void deleteUserChatRelation(Chat chat, User user) {
+    userChatRepository.findByChatAndUser(chat, user).ifPresent(userChatRepository::delete);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
@@ -1,0 +1,141 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.helper.MatrixIds;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Answers "who is (still) in this group chat?" from the Matrix room state.
+ *
+ * <p>Replaces the former Rocket.Chat member query in the leave-chat path: with Rocket.Chat disabled
+ * (the default since ADR-004), {@code getStandardMembersOfGroup} always returns an empty list,
+ * which made every single leave look like "the last member left" and deleted the chat for everyone.
+ *
+ * <p>The Matrix room membership (Synapse admin API) is the source of truth here because it is the
+ * only membership record that is reliably maintained in the Matrix-only world: consultants join the
+ * room on chat creation, askers join through their Matrix clients. The database relations are
+ * write-only snapshots ({@code group_chat_participant} records creation-time invitees only, {@code
+ * user_chat} was never cleaned up on leave) and would under-count, risking wrong deletion.
+ *
+ * <p>All decisions fail safe: when the room state cannot be determined, the chat is treated as
+ * still having members, so it is never deleted on uncertainty.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupChatMembershipService {
+
+  /**
+   * Prefix of the technical group chat system users created by {@code
+   * CreateChatFacade#resolveOrCreateGroupChatSystemUser} ({@code group-chat-system} and {@code
+   * group-chat-system-<tenantId>}). These accounts must never count as chat members.
+   */
+  private static final String GROUP_CHAT_SYSTEM_USER_PREFIX = "group-chat-system";
+
+  private final MatrixSynapseService matrixSynapseService;
+  private final ConsultantRepository consultantRepository;
+  private final UserRepository userRepository;
+
+  /**
+   * Best-effort removal of the leaving member from the chat's Matrix room. Failures are logged but
+   * never abort the leave operation.
+   *
+   * @param chat the group chat being left
+   * @param leavingMatrixUserId the full Matrix user ID of the leaving member, may be null
+   */
+  public void removeLeavingMemberFromRoom(Chat chat, String leavingMatrixUserId) {
+    var matrixRoomId = resolveMatrixRoomId(chat);
+    if (isBlank(matrixRoomId) || isBlank(leavingMatrixUserId)) {
+      return;
+    }
+
+    try {
+      var leaverToken = matrixSynapseService.loginAsUserAccessToken(leavingMatrixUserId);
+      if (leaverToken == null) {
+        log.warn(
+            "Could not mint Matrix token for {}; leaving member stays in room {} of chat {}",
+            leavingMatrixUserId,
+            matrixRoomId,
+            chat.getId());
+        return;
+      }
+      if (!matrixSynapseService.leaveRoom(matrixRoomId, leaverToken)) {
+        log.warn(
+            "Could not remove leaving member {} from Matrix room {} of chat {}",
+            leavingMatrixUserId,
+            matrixRoomId,
+            chat.getId());
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Matrix room leave failed for member {} in room {} of chat {}: {}",
+          leavingMatrixUserId,
+          matrixRoomId,
+          chat.getId(),
+          e.getMessage());
+    }
+  }
+
+  /**
+   * Determines whether any human member (consultant or adviceseeker) other than the leaving user is
+   * still joined to the chat's Matrix room. Technical accounts (Synapse admin, agency service
+   * accounts, group chat system users) do not count.
+   *
+   * @param chat the group chat being left
+   * @param leavingMatrixUserId the full Matrix user ID of the leaving member, may be null
+   * @return true when other human members remain or the room state cannot be determined (fail
+   *     safe), false only when the room is verifiably empty of other human members
+   */
+  public boolean hasRemainingHumanMembers(Chat chat, String leavingMatrixUserId) {
+    var matrixRoomId = resolveMatrixRoomId(chat);
+    if (isBlank(matrixRoomId)) {
+      log.warn(
+          "Chat {} has no Matrix room id; keeping the chat because remaining members cannot be"
+              + " determined",
+          chat.getId());
+      return true;
+    }
+
+    var members = matrixSynapseService.getRoomMembers(matrixRoomId);
+    if (members.isEmpty()) {
+      log.warn(
+          "Could not read members of Matrix room {} for chat {}; keeping the chat",
+          matrixRoomId,
+          chat.getId());
+      return true;
+    }
+
+    return members.get().stream()
+        .filter(memberId -> !memberId.equals(leavingMatrixUserId))
+        .anyMatch(this::isHumanAppMember);
+  }
+
+  private boolean isHumanAppMember(String matrixUserId) {
+    if (consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(matrixUserId).isPresent()) {
+      return true;
+    }
+    return userRepository
+        .findByMatrixUserIdAndDeleteDateIsNull(matrixUserId)
+        .map(user -> !isGroupChatSystemUser(user))
+        .orElse(false);
+  }
+
+  private boolean isGroupChatSystemUser(User user) {
+    return user.getUserId() != null && user.getUserId().startsWith(GROUP_CHAT_SYSTEM_USER_PREFIX);
+  }
+
+  private String resolveMatrixRoomId(Chat chat) {
+    if (!isBlank(chat.getMatrixRoomId())) {
+      return chat.getMatrixRoomId();
+    }
+    return MatrixIds.isRoomId(chat.getGroupId()) ? chat.getGroupId() : null;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
@@ -15,16 +15,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.actions.chat.ChatReCreator;
+import de.caritas.cob.userservice.api.adapters.rocketchat.DisabledRocketChatService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentialsProvider;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatMapper;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
-import de.caritas.cob.userservice.api.adapters.rocketchat.dto.group.GroupMemberDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.config.RocketChatConfig;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatAddUserToGroupException;
-import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatGetGroupMembersException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatRemoveUserFromGroupException;
-import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatUserNotInitializedException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
 import de.caritas.cob.userservice.api.model.Chat;
@@ -32,10 +34,9 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.user.UserService;
-import java.util.List;
 import java.util.Optional;
-import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,7 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class JoinAndLeaveChatFacadeTest {
 
-  private static final EasyRandom easyRandom = new EasyRandom();
+  private static final String MATRIX_USER_ID = "@leaver:matrix.oriso.org";
 
   @InjectMocks private JoinAndLeaveChatFacade joinAndLeaveChatFacade;
 
@@ -64,6 +65,10 @@ class JoinAndLeaveChatFacadeTest {
   @Mock private Consultant consultant;
 
   @Mock private RocketChatService rocketChatService;
+
+  @Mock private ChatReCreator chatReCreator;
+
+  @Mock private GroupChatMembershipService groupChatMembershipService;
 
   @Test
   void joinChat_Should_ThrowNotFoundException_WhenChatDoesNotExist() {
@@ -300,14 +305,12 @@ class JoinAndLeaveChatFacadeTest {
 
   @Test
   void leaveChat_Should_RemoveConsultantFromRocketChatGroup()
-      throws RocketChatRemoveUserFromGroupException,
-          RocketChatUserNotInitializedException,
-          RocketChatGetGroupMembersException {
+      throws RocketChatRemoveUserFromGroupException {
     when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
     when(consultantService.getConsultantViaAuthenticatedUser(authenticatedUser))
         .thenReturn(Optional.of(CONSULTANT));
-    when(rocketChatService.getStandardMembersOfGroup(eq(ACTIVE_CHAT.getGroupId())))
-        .thenReturn(List.of(easyRandom.nextObject(GroupMemberDTO.class)));
+    when(groupChatMembershipService.hasRemainingHumanMembers(eq(ACTIVE_CHAT), any()))
+        .thenReturn(true);
 
     joinAndLeaveChatFacade.leaveChat(ACTIVE_CHAT.getId(), authenticatedUser);
 
@@ -334,17 +337,120 @@ class JoinAndLeaveChatFacadeTest {
   }
 
   @Test
-  void leaveChatShouldNotDeleteChatsWhenStandardMemberInChat()
-      throws RocketChatUserNotInitializedException, RocketChatGetGroupMembersException {
+  void leaveChat_Should_NotDeleteChat_When_OtherHumanMembersRemain() {
     when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
     when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
     when(user.getRcUserId()).thenReturn(RC_USER_ID);
-    when(rocketChatService.getStandardMembersOfGroup(eq(ACTIVE_CHAT.getGroupId())))
-        .thenReturn(List.of(easyRandom.nextObject(GroupMemberDTO.class)));
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(ACTIVE_CHAT, MATRIX_USER_ID))
+        .thenReturn(true);
 
     joinAndLeaveChatFacade.leaveChat(ACTIVE_CHAT.getId(), authenticatedUser);
 
     verify(rocketChatService, never()).deleteGroupAsSystemUser(anyString());
+    verify(chatService, never()).deleteChat(any());
+  }
+
+  @Test
+  void leaveChat_Should_RemoveLeaverFromMatrixRoomAndUserChatRelation() {
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(ACTIVE_CHAT, MATRIX_USER_ID))
+        .thenReturn(true);
+
+    joinAndLeaveChatFacade.leaveChat(ACTIVE_CHAT.getId(), authenticatedUser);
+
+    verify(groupChatMembershipService, times(1))
+        .removeLeavingMemberFromRoom(ACTIVE_CHAT, MATRIX_USER_ID);
+    verify(chatService, times(1)).deleteUserChatRelation(ACTIVE_CHAT, user);
+  }
+
+  @Test
+  void leaveChat_Should_DeleteChat_When_NoHumanMembersRemain() {
+    Chat singleChat = mock(Chat.class);
+    when(singleChat.isActive()).thenReturn(true);
+    when(singleChat.isRepetitive()).thenReturn(false);
+    when(singleChat.getGroupId()).thenReturn("groupId");
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(singleChat));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(singleChat, MATRIX_USER_ID))
+        .thenReturn(false);
+    when(rocketChatService.deleteGroupAsSystemUser("groupId")).thenReturn(true);
+
+    joinAndLeaveChatFacade.leaveChat(CHAT_ID, authenticatedUser);
+
+    verify(chatService, times(1)).deleteChat(singleChat);
+  }
+
+  @Test
+  void leaveChat_Should_RecreateChat_When_NoHumanMembersRemainInRepetitiveChat() {
+    Chat repetitiveChat = mock(Chat.class);
+    when(repetitiveChat.isActive()).thenReturn(true);
+    when(repetitiveChat.isRepetitive()).thenReturn(true);
+    when(repetitiveChat.getGroupId()).thenReturn("groupId");
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(repetitiveChat));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(repetitiveChat, MATRIX_USER_ID))
+        .thenReturn(false);
+    when(rocketChatService.deleteGroupAsSystemUser("groupId")).thenReturn(true);
+    when(chatReCreator.recreateMessengerChat(repetitiveChat)).thenReturn("newGroupId");
+
+    joinAndLeaveChatFacade.leaveChat(CHAT_ID, authenticatedUser);
+
+    verify(chatReCreator, times(1)).updateAsNextChat(repetitiveChat, "newGroupId");
+    verify(chatService, never()).deleteChat(any());
+  }
+
+  @Test
+  void leaveChat_Should_NotUseRocketChatMemberQueryForTheDeleteDecision() throws Exception {
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(ACTIVE_CHAT, MATRIX_USER_ID))
+        .thenReturn(true);
+
+    joinAndLeaveChatFacade.leaveChat(ACTIVE_CHAT.getId(), authenticatedUser);
+
+    verify(rocketChatService, never()).getStandardMembersOfGroup(anyString());
+  }
+
+  /**
+   * Regression test for the Matrix-only environment (rocket-chat.enabled=false, the default): the
+   * inert Rocket.Chat adapter reports an empty member list for every group. Before this fix, that
+   * made every single leave look like "the last member left" and deleted the chat for everyone.
+   */
+  @Test
+  void leaveChat_Should_NotDeleteChat_When_RocketChatIsDisabledAndHumanMembersRemain() {
+    var disabledRocketChatService =
+        new DisabledRocketChatService(
+            mock(RocketChatCredentialsProvider.class),
+            mock(RocketChatConfig.class),
+            mock(RocketChatMapper.class));
+    var facade =
+        new JoinAndLeaveChatFacade(
+            chatService,
+            chatPermissionVerifier,
+            consultantService,
+            userService,
+            disabledRocketChatService,
+            chatReCreator,
+            groupChatMembershipService);
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(ACTIVE_CHAT, MATRIX_USER_ID))
+        .thenReturn(true);
+
+    facade.leaveChat(ACTIVE_CHAT.getId(), authenticatedUser);
+
     verify(chatService, never()).deleteChat(any());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
@@ -1,0 +1,216 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatMembershipServiceTest {
+
+  private static final String MATRIX_ROOM_ID = "!room:matrix.oriso.org";
+  private static final String LEAVER_MATRIX_ID = "@leaver:matrix.oriso.org";
+  private static final String CONSULTANT_MATRIX_ID = "@consultant:matrix.oriso.org";
+  private static final String ASKER_MATRIX_ID = "@asker:matrix.oriso.org";
+  private static final String AGENCY_BOT_MATRIX_ID = "@agency-1:matrix.oriso.org";
+  private static final String SYSTEM_USER_MATRIX_ID = "@group-chat-system-1:matrix.oriso.org";
+
+  @InjectMocks private GroupChatMembershipService groupChatMembershipService;
+
+  @Mock private MatrixSynapseService matrixSynapseService;
+
+  @Mock private ConsultantRepository consultantRepository;
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private Consultant consultant;
+
+  @Mock private User user;
+
+  private Chat.ChatBuilder chatBuilder() {
+    return Chat.builder()
+        .id(1L)
+        .topic("topic")
+        .initialStartDate(java.time.LocalDateTime.now())
+        .startDate(java.time.LocalDateTime.now())
+        .duration(60);
+  }
+
+  private Chat chatWithMatrixRoom() {
+    return chatBuilder().matrixRoomId(MATRIX_ROOM_ID).groupId(MATRIX_ROOM_ID).build();
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnTrue_When_AnotherConsultantIsInRoom() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID, CONSULTANT_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultant));
+
+    assertTrue(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnTrue_When_AnotherAskerIsInRoom() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID, ASKER_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(ASKER_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(ASKER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+    when(user.getUserId()).thenReturn("asker-user-id");
+
+    assertTrue(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnFalse_When_OnlyTheLeaverIsInRoom() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID)));
+
+    assertFalse(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnFalse_When_RoomIsEmpty() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID)).thenReturn(Optional.of(List.of()));
+
+    assertFalse(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnFalse_When_OnlyServiceAccountsRemain() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID, AGENCY_BOT_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(AGENCY_BOT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(AGENCY_BOT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+
+    assertFalse(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_ReturnFalse_When_OnlyGroupChatSystemUserRemains() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID, SYSTEM_USER_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(SYSTEM_USER_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SYSTEM_USER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+    when(user.getUserId()).thenReturn("group-chat-system-1");
+
+    assertFalse(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_FailSafeToTrue_When_MemberQueryFails() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID)).thenReturn(Optional.empty());
+
+    assertTrue(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_FailSafeToTrue_When_ChatHasNoMatrixRoom() {
+    var legacyChat = chatBuilder().groupId("rcGroupId4711").build();
+
+    assertTrue(groupChatMembershipService.hasRemainingHumanMembers(legacyChat, LEAVER_MATRIX_ID));
+    verifyNoInteractions(matrixSynapseService);
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_FallBackToGroupId_When_ItIsAMatrixRoomId() {
+    var chat = chatBuilder().groupId(MATRIX_ROOM_ID).build();
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID)));
+
+    assertFalse(groupChatMembershipService.hasRemainingHumanMembers(chat, LEAVER_MATRIX_ID));
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_CountAllHumans_When_LeaverIdIsUnknown() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(CONSULTANT_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultant));
+
+    assertTrue(groupChatMembershipService.hasRemainingHumanMembers(chatWithMatrixRoom(), null));
+  }
+
+  @Test
+  void removeLeavingMemberFromRoom_Should_LeaveRoomWithLeaversOwnToken() {
+    when(matrixSynapseService.loginAsUserAccessToken(LEAVER_MATRIX_ID)).thenReturn("token");
+    when(matrixSynapseService.leaveRoom(MATRIX_ROOM_ID, "token")).thenReturn(true);
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(chatWithMatrixRoom(), LEAVER_MATRIX_ID);
+
+    verify(matrixSynapseService).leaveRoom(MATRIX_ROOM_ID, "token");
+  }
+
+  @Test
+  void removeLeavingMemberFromRoom_Should_DoNothing_When_LeaverHasNoMatrixId() {
+    groupChatMembershipService.removeLeavingMemberFromRoom(chatWithMatrixRoom(), null);
+
+    verifyNoInteractions(matrixSynapseService);
+  }
+
+  @Test
+  void removeLeavingMemberFromRoom_Should_DoNothing_When_ChatHasNoMatrixRoom() {
+    var legacyChat = chatBuilder().groupId("rcGroupId4711").build();
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(legacyChat, LEAVER_MATRIX_ID);
+
+    verifyNoInteractions(matrixSynapseService);
+  }
+
+  @Test
+  void removeLeavingMemberFromRoom_Should_NotThrow_When_TokenMintingFails() {
+    when(matrixSynapseService.loginAsUserAccessToken(LEAVER_MATRIX_ID)).thenReturn(null);
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(chatWithMatrixRoom(), LEAVER_MATRIX_ID);
+
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
+  }
+
+  @Test
+  void removeLeavingMemberFromRoom_Should_NotThrow_When_MatrixCallFails() {
+    when(matrixSynapseService.loginAsUserAccessToken(LEAVER_MATRIX_ID))
+        .thenThrow(new RuntimeException("synapse down"));
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(chatWithMatrixRoom(), LEAVER_MATRIX_ID);
+
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
+  }
+}


### PR DESCRIPTION
## What users experienced

One person leaving a group chat made the whole chat disappear for everyone.

Since the Matrix migration the backend still asked Rocket.Chat "who is left in this group?" after every leave. Rocket.Chat is disabled (`rocket-chat.enabled=false`, the default since ADR-004), so the inert adapter always answered with an empty list. The code read that as "the last member just left" and deleted the chat - on **every single leave**.

## The fix

The leave path no longer asks Rocket.Chat. It asks the Matrix room.

**Chosen source of truth: Matrix room membership via the Synapse admin API** (`GET /_synapse/admin/v1/rooms/{roomId}/members`), filtered down to members that map to a real consultant or adviceseeker account in our database.

Why not the database relations? They are not reliably maintained: `group_chat_participant` only records who was invited at creation time, and `user_chat` rows were never removed on leave. Counting them could say "empty" while people are still in the room - the dangerous direction. The Matrix room is what the clients actually see, and consultants/askers really join it.

Behavior now:

1. The leaving member is **actually removed from the Matrix room** (best-effort self-leave with a short-lived impersonation token). Before this fix nothing removed the leaver from the room at all.
2. A leaving adviceseeker's `user_chat` row is deleted, so the assignment does not linger.
3. Remaining members are counted from the room. Technical accounts do **not** count: agency service accounts, the Synapse admin, and the `group-chat-system*` users.
4. Only when verifiably nobody human remains does the existing delete/recreate branch run - the original Rocket.Chat-era semantics.
5. **Fail safe:** if the room state cannot be read (Synapse down, no admin token, chat without a Matrix room), the chat is kept. We never delete on uncertainty.

## Interaction with #295

#295 (open) wires `MatrixChatShutdownService.shutdownRoom` into the same delete branch. The two changes are orthogonal and both wanted: #295 makes the delete branch also shut the Matrix room down, this PR makes sure that branch only fires when the chat is really empty. Without this PR, #295's room shutdown would fire on every single leave too. Expect a small merge conflict in `JoinAndLeaveChatFacade.leaveChat` (same lines); resolution is to keep both: membership gate from this PR, `shutdownRoom` call inside the delete branch from #295.

Also related: the review discussion on the frontend Matrix-only teardown PR (OpenResilienceInitiative/ORISO-Frontend#359), where the RC facade teardown made this backend trap load-bearing.

## Other callers of the same Rocket.Chat member queries (flagged, NOT fixed here - 1 PR per task)

These also get empty/no results with Rocket.Chat disabled and should be migrated to Matrix-native sources in follow-ups:

- `GetChatMembersFacade.getChatMembers` - the group chat member list shown to users is always empty.
- `RemoveConsultantFromRocketChatService.observeConsultantsToRemove` (via `RocketChatFacade.getStandardMembersOfGroup`) - removing a consultant from an agency silently removes nobody from the rooms; leftover room access.
- `Messenger.banUserFromChat`/`findChatMetaInfo` path (`messageClient.findMembers(...).orElseThrow()`) - banning a user from a chat cannot work.
- `RelevantUserAccountIdsByChatProvider` (uses `getChatUsers`) - live-event notifications for group chats go to nobody.
- `RocketChatRollbackService` (uses `getChatUsers`) - RC-only rollback path, inert by design.

## Test evidence (TDD)

New/updated tests (red first, then green):

- `GroupChatMembershipServiceTest` (15 tests): remaining consultant/asker counts as human; leaver excluded; agency bot / `group-chat-system*` remainder counts as empty; empty room counts as empty; fail-safe on query failure and on missing Matrix room id; room-id fallback to `group_id`; best-effort room leave never throws.
- `JoinAndLeaveChatFacadeTest` (22 tests): leave with other members -> chat survives, leaver removed from room and `user_chat`; last member leaves -> delete branch fires; repetitive chat -> recreate branch fires; the delete decision provably never calls `getStandardMembersOfGroup`; explicit regression test with the real `DisabledRocketChatService` (the RC-disabled default environment).

Full build: `./mvnw -B package` -> **2200 tests, 0 failures, 0 errors, BUILD SUCCESS** (JDK 21, spotless applied).
