### PR TITLE
Make Matrix sync loop resilient to transient admin-token failure (B1)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -54,6 +54,17 @@ public class MatrixEventListenerService {
   // Flag to control sync loop
   private volatile boolean running = false;
 
+  // Backoff bounds (milliseconds) for both the token bootstrap and the sync error path.
+  static final long INITIAL_BACKOFF_MS = 5_000L;
+  static final long MAX_BACKOFF_MS = 60_000L;
+
+  // Emit a heartbeat every N successful sync iterations so a healthy/stuck loop is observable.
+  // performMatrixSync uses a 30s long-poll, so ~10 iterations is roughly every 5 minutes.
+  static final int HEARTBEAT_EVERY_N_ITERATIONS = 10;
+
+  // Re-bootstrap the admin token after this many consecutive sync failures (likely an auth issue).
+  static final int SYNC_FAILURES_BEFORE_REBOOTSTRAP = 3;
+
   @PostConstruct
   public void initialize() {
     log.info("🔷 Initializing Matrix Event Listener Service...");
@@ -111,23 +122,25 @@ public class MatrixEventListenerService {
   /**
    * Main sync loop - continuously polls Matrix /sync for new events. Uses long-polling with timeout
    * to get real-time updates.
+   *
+   * <p>Deployment is a single replica with no HPA, so no multi-replica leader election is needed
+   * here; a transient admin-token failure must not silently disable real-time events, so the loop
+   * bootstraps the token with backoff and re-acquires it on repeated sync failures.
    */
   private void startMatrixSyncLoop() {
     running = true;
     log.info("🔷 Starting Matrix sync loop...");
 
-    // Get admin token
-    try {
-      adminAccessToken = matrixSynapseService.getAdminToken();
-      if (adminAccessToken == null) {
-        log.error("❌ Failed to get admin token - sync loop cannot start");
-        return;
-      }
-      log.info("✅ Admin token obtained for Matrix sync");
-    } catch (Exception e) {
-      log.error("❌ Error getting admin token", e);
+    // Keep trying to obtain the admin token; a transient failure must not permanently kill events.
+    if (!bootstrapAdminToken()) {
+      // Only returns false on shutdown/interrupt.
+      log.info("🔷 Matrix sync loop stopped before obtaining admin token");
       return;
     }
+
+    long errorBackoffMs = INITIAL_BACKOFF_MS;
+    long iteration = 0;
+    int consecutiveSyncFailures = 0;
 
     while (running) {
       try {
@@ -137,10 +150,36 @@ public class MatrixEventListenerService {
         if (syncResult != null) {
           // Process events from sync result
           processMatrixSyncEvents(syncResult);
+          // Successful sync: reset the error backoff and failure counter.
+          errorBackoffMs = INITIAL_BACKOFF_MS;
+          consecutiveSyncFailures = 0;
+        } else {
+          // performMatrixSync swallows exceptions and returns null; treat as a soft failure so an
+          // auth problem eventually forces a token re-bootstrap instead of spinning forever.
+          consecutiveSyncFailures++;
+          if (consecutiveSyncFailures >= SYNC_FAILURES_BEFORE_REBOOTSTRAP) {
+            log.warn(
+                "⚠️ {} consecutive Matrix sync failures - re-acquiring admin token",
+                consecutiveSyncFailures);
+            adminAccessToken = null;
+            if (!bootstrapAdminToken()) {
+              break;
+            }
+            consecutiveSyncFailures = 0;
+          }
         }
 
-        // Small delay to prevent CPU spinning if sync fails immediately
-        Thread.sleep(100);
+        // Heartbeat so a healthy/stuck loop is observable without log-spamming.
+        iteration++;
+        if (iteration % HEARTBEAT_EVERY_N_ITERATIONS == 0) {
+          log.info(
+              "💓 Matrix sync loop healthy (iteration {}, {} registered rooms)",
+              iteration,
+              roomToSessionMap.size());
+        }
+
+        // Small delay to prevent CPU spinning if sync returns immediately.
+        sleep(100);
 
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -148,8 +187,9 @@ public class MatrixEventListenerService {
       } catch (Exception e) {
         log.error("❌ Error in Matrix sync loop", e);
         try {
-          // Wait before retrying on error
-          Thread.sleep(5000);
+          // Exponential backoff before retrying on error (5s→10s→…→60s cap).
+          sleep(errorBackoffMs);
+          errorBackoffMs = nextBackoffMillis(errorBackoffMs);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           break;
@@ -158,6 +198,62 @@ public class MatrixEventListenerService {
     }
 
     log.info("🔷 Matrix sync loop stopped");
+  }
+
+  /**
+   * Acquire the Matrix admin token, retrying with exponential backoff until it succeeds or the loop
+   * is shut down. On success {@link #adminAccessToken} is set.
+   *
+   * @return {@code true} once a token was obtained, {@code false} if the loop stopped (shutdown or
+   *     interrupt) before a token could be acquired
+   */
+  private boolean bootstrapAdminToken() {
+    long backoffMs = INITIAL_BACKOFF_MS;
+    while (running) {
+      try {
+        adminAccessToken = matrixSynapseService.getAdminToken();
+        if (adminAccessToken != null) {
+          log.info("✅ Admin token obtained for Matrix sync");
+          return true;
+        }
+        log.error(
+            "❌ Failed to get admin token - retrying in {}ms (sync loop not yet started)",
+            backoffMs);
+      } catch (Exception e) {
+        log.error("❌ Error getting admin token - retrying in {}ms", backoffMs, e);
+      }
+
+      try {
+        sleep(backoffMs);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+      backoffMs = nextBackoffMillis(backoffMs);
+    }
+    return false;
+  }
+
+  /**
+   * Compute the next backoff delay: double the current delay, capped at {@link #MAX_BACKOFF_MS}.
+   * Pure and side-effect free so it can be unit tested without real sleeps.
+   *
+   * @param currentMillis the current backoff delay in milliseconds
+   * @return the next backoff delay in milliseconds (5s→10s→20s→40s→60s→60s…)
+   */
+  static long nextBackoffMillis(long currentMillis) {
+    long doubled = currentMillis * 2;
+    return Math.min(doubled, MAX_BACKOFF_MS);
+  }
+
+  /**
+   * Sleep seam so the backoff timing can be stubbed out in unit tests (no real waiting).
+   *
+   * @param millis milliseconds to sleep
+   * @throws InterruptedException if the thread is interrupted while sleeping
+   */
+  void sleep(long millis) throws InterruptedException {
+    Thread.sleep(millis);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -1,0 +1,113 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Focused resilience tests for the Matrix sync loop bootstrap/backoff (hardening B1). These verify
+ * the backoff schedule and that a transient null admin token does not permanently stop retrying.
+ * They never sleep for real: the {@code sleep(long)} seam is stubbed to a no-op.
+ */
+@ExtendWith(MockitoExtension.class)
+class MatrixEventListenerServiceTest {
+
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private SessionService sessionService;
+  @Mock private LiveEventNotificationService liveEventNotificationService;
+  @Mock private EventNotificationService eventNotificationService;
+  @Mock private UserRepository userRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private SessionRepository sessionRepository;
+
+  private MatrixEventListenerService newService() {
+    return new MatrixEventListenerService(
+        matrixSynapseService,
+        sessionService,
+        liveEventNotificationService,
+        eventNotificationService,
+        Optional.empty(),
+        userRepository,
+        consultantRepository,
+        sessionRepository);
+  }
+
+  @Test
+  void nextBackoffMillis_shouldFollowExponentialScheduleCappedAt60s() {
+    assertThat(MatrixEventListenerService.nextBackoffMillis(5_000L)).isEqualTo(10_000L);
+    assertThat(MatrixEventListenerService.nextBackoffMillis(10_000L)).isEqualTo(20_000L);
+    assertThat(MatrixEventListenerService.nextBackoffMillis(20_000L)).isEqualTo(40_000L);
+    assertThat(MatrixEventListenerService.nextBackoffMillis(40_000L)).isEqualTo(60_000L);
+    // Capped: 40s doubles to 80s but is clamped to the 60s ceiling, and stays there.
+    assertThat(MatrixEventListenerService.nextBackoffMillis(60_000L)).isEqualTo(60_000L);
+  }
+
+  @Test
+  void backoffSchedule_startsAt5sAndCapsAt60s() {
+    long current = MatrixEventListenerService.INITIAL_BACKOFF_MS;
+    long[] expected = {5_000L, 10_000L, 20_000L, 40_000L, 60_000L, 60_000L, 60_000L};
+
+    assertThat(current).isEqualTo(expected[0]);
+    for (int i = 1; i < expected.length; i++) {
+      current = MatrixEventListenerService.nextBackoffMillis(current);
+      assertThat(current).as("backoff step %d", i).isEqualTo(expected[i]);
+    }
+    assertThat(MatrixEventListenerService.MAX_BACKOFF_MS).isEqualTo(60_000L);
+  }
+
+  @Test
+  void bootstrapAdminToken_shouldKeepRetryingUntilTokenBecomesAvailable() {
+    // No-op sleep so the retry loop does not wait for real backoff.
+    MatrixEventListenerService service =
+        new MatrixEventListenerService(
+            matrixSynapseService,
+            sessionService,
+            liveEventNotificationService,
+            eventNotificationService,
+            Optional.empty(),
+            userRepository,
+            consultantRepository,
+            sessionRepository) {
+          @Override
+          void sleep(long millis) {
+            // deterministic: never actually sleep in the test
+          }
+        };
+    ReflectionTestUtils.setField(service, "running", true);
+
+    // Two transient failures (null) then a real token: the loop must not give up on the first null.
+    when(matrixSynapseService.getAdminToken()).thenReturn(null, null, "admin-token-123");
+
+    boolean acquired = (boolean) ReflectionTestUtils.invokeMethod(service, "bootstrapAdminToken");
+
+    assertThat(acquired).isTrue();
+    assertThat(ReflectionTestUtils.getField(service, "adminAccessToken"))
+        .isEqualTo("admin-token-123");
+    // Proves it did not stop after the first null: getAdminToken was polled repeatedly.
+    verify(matrixSynapseService, atLeast(3)).getAdminToken();
+  }
+
+  @Test
+  void bootstrapAdminToken_shouldStopWhenNotRunning() {
+    MatrixEventListenerService service = newService();
+    // running defaults to false -> the bootstrap loop must exit immediately without polling.
+    boolean acquired = (boolean) ReflectionTestUtils.invokeMethod(service, "bootstrapAdminToken");
+
+    assertThat(acquired).isFalse();
+  }
+}


### PR DESCRIPTION
## Problem

`MatrixEventListenerService.startMatrixSyncLoop` is launched once from `@PostConstruct`. If `getAdminToken()` returns null at startup (e.g. Keycloak/Synapse briefly unavailable during boot), it logged an error and **returned** — the sync loop never started and **never recovered until a manual pod restart**. Real-time Matrix event delivery (unread updates, live messages) silently dies. The error path also used a flat 5s retry with no backoff.

## Change (resilience only — no sync-semantics change)

- **Admin-token bootstrap now retries with exponential backoff** (`bootstrapAdminToken()`): keeps trying `getAdminToken()` while the service is running, starts syncing once available; only stops on shutdown/interrupt. No more permanent silent death.
- **Re-bootstrap mid-loop**: after 3 consecutive failed syncs the token is dropped and re-acquired (handles token expiry/auth failure without changing sync semantics — `performMatrixSync` swallows exceptions and returns null, so recovery is driven off the null signal).
- **Exponential backoff on the error path**: 5s→10s→20s→40s→60s (cap), reset to 5s after a successful sync (was a flat 5s).
- **Heartbeat**: an INFO `Matrix sync loop healthy` line every ~10 iterations (≈5 min at the 30s long-poll) so a stuck/healthy loop is observable.
- Single-replica deployment (no HPA) → no leader election needed; noted in a comment. Interrupt handling preserved throughout.

## Tests

New `MatrixEventListenerServiceTest` (4, no real sleeps — pure `nextBackoffMillis` + overridable `sleep` seam): backoff schedule 5→10→20→40→60→60; bootstrap keeps retrying across null tokens until one is available (proves it doesn't give up on the first null); bootstrap exits when `running=false`. Green. Spotless clean.

Part of the Matrix hardening plan (item B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)