### PR TITLE
Bound the Matrix access-token cache with a TTL (B3)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -55,11 +55,35 @@ public class MatrixSynapseService {
   private final MatrixRoomClient matrixRoomClient;
   private final MatrixMediaClient matrixMediaClient;
 
-  // Cache for Matrix access tokens (username -> access token)
-  private final java.util.Map<String, String> accessTokenCache =
+  // Time source for cache-expiry checks. Real deployment uses the wall clock; tests inject a
+  // controllable supplier so TTL expiry can be exercised deterministically without sleeping.
+  private final java.util.function.LongSupplier nowSupplier;
+
+  // Cache for Matrix access tokens (username -> access token + expiry). Bounded by a TTL so entries
+  // cannot accumulate forever and, crucially, so a token invalidated on the homeserver (e.g. after
+  // a
+  // password reset) is not served indefinitely. Mirrors the impersonationTokenCache mechanism
+  // below.
+  private final java.util.Map<String, CachedAccessToken> accessTokenCache =
       new java.util.concurrent.ConcurrentHashMap<>();
 
-  // Cache for Matrix sync tokens (username -> next_batch token)
+  private static final long ACCESS_TOKEN_CACHE_TTL_MS = 50 * 60 * 1000L;
+
+  private static final class CachedAccessToken {
+    private final String token;
+    private final long expiryMs;
+
+    private CachedAccessToken(String token, long expiryMs) {
+      this.token = token;
+      this.expiryMs = expiryMs;
+    }
+  }
+
+  // Cache for Matrix sync tokens (username -> next_batch cursor). Intentionally left without a TTL:
+  // a next_batch is an opaque /sync cursor, not an auth credential — it cannot leak access and
+  // never
+  // becomes dangerous when stale; losing it merely triggers a full re-sync from the current
+  // position.
   private final java.util.Map<String, String> syncTokenCache =
       new java.util.concurrent.ConcurrentHashMap<>();
 
@@ -109,11 +133,40 @@ public class MatrixSynapseService {
       @Qualifier("matrixLongPollRestTemplate") RestTemplate matrixLongPollRestTemplate,
       MatrixRoomClient matrixRoomClient,
       MatrixMediaClient matrixMediaClient) {
+    this(
+        matrixConfig,
+        restTemplate,
+        matrixLongPollRestTemplate,
+        matrixRoomClient,
+        matrixMediaClient,
+        System::currentTimeMillis);
+  }
+
+  // Package-private constructor allowing tests to inject a controllable clock for TTL assertions.
+  MatrixSynapseService(
+      MatrixConfig matrixConfig,
+      RestTemplate restTemplate,
+      RestTemplate matrixLongPollRestTemplate,
+      MatrixRoomClient matrixRoomClient,
+      MatrixMediaClient matrixMediaClient,
+      java.util.function.LongSupplier nowSupplier) {
     this.matrixConfig = matrixConfig;
     this.restTemplate = restTemplate;
     this.matrixLongPollRestTemplate = matrixLongPollRestTemplate;
     this.matrixRoomClient = matrixRoomClient;
     this.matrixMediaClient = matrixMediaClient;
+    this.nowSupplier = nowSupplier;
+  }
+
+  /**
+   * Pure, testable expiry predicate for time-based cache entries.
+   *
+   * @param expiryMs the wall-clock time (epoch millis) at which the entry expires
+   * @param nowMs the current wall-clock time (epoch millis)
+   * @return {@code true} when the entry is expired and must be treated as a cache miss
+   */
+  static boolean isExpired(long expiryMs, long nowMs) {
+    return nowMs >= expiryMs;
   }
 
   /**
@@ -337,8 +390,8 @@ public class MatrixSynapseService {
   private String getAdminAccessToken() {
     // Check if cached token is still valid (expires in 1 hour, we refresh after 50
     // minutes)
-    long now = System.currentTimeMillis();
-    if (cachedAdminToken != null && now < adminTokenExpiry) {
+    long now = nowSupplier.getAsLong();
+    if (cachedAdminToken != null && !isExpired(adminTokenExpiry, now)) {
       return cachedAdminToken;
     }
 
@@ -524,8 +577,8 @@ public class MatrixSynapseService {
       return null;
     }
 
-    long now = System.currentTimeMillis();
-    impersonationTokenCache.entrySet().removeIf(e -> now >= e.getValue().expiryMs);
+    long now = nowSupplier.getAsLong();
+    impersonationTokenCache.entrySet().removeIf(e -> isExpired(e.getValue().expiryMs, now));
 
     CachedImpersonationToken cached = impersonationTokenCache.get(matrixUserId);
     if (cached != null) {
@@ -576,9 +629,14 @@ public class MatrixSynapseService {
    * @return the access token
    */
   public String loginUser(String username, String password) {
-    // Check cache first
-    if (accessTokenCache.containsKey(username)) {
-      return accessTokenCache.get(username);
+    // Check cache first, evicting expired entries so a token invalidated on the homeserver
+    // (e.g. after a password reset) is never served past its TTL and a fresh login is forced.
+    long now = nowSupplier.getAsLong();
+    accessTokenCache.entrySet().removeIf(e -> isExpired(e.getValue().expiryMs, now));
+
+    CachedAccessToken cached = accessTokenCache.get(username);
+    if (cached != null) {
+      return cached.token;
     }
 
     try {
@@ -599,7 +657,8 @@ public class MatrixSynapseService {
 
       if (response.getBody() != null && response.getBody().containsKey("access_token")) {
         String accessToken = (String) response.getBody().get("access_token");
-        accessTokenCache.put(username, accessToken);
+        accessTokenCache.put(
+            username, new CachedAccessToken(accessToken, now + ACCESS_TOKEN_CACHE_TTL_MS));
         log.info("Successfully logged in Matrix user: {}", username);
         return accessToken;
       }
@@ -1192,9 +1251,9 @@ public class MatrixSynapseService {
       return java.util.Optional.empty();
     }
 
-    long now = System.currentTimeMillis();
+    long now = nowSupplier.getAsLong();
     CachedPresence cached = presenceCache.get(matrixUserId);
-    if (cached != null && now < cached.expiresAt) {
+    if (cached != null && !isExpired(cached.expiresAt, now)) {
       return java.util.Optional.of(cached);
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -18,6 +18,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -127,6 +128,7 @@ public class MatrixSynapseService {
     }
   }
 
+  @Autowired
   public MatrixSynapseService(
       MatrixConfig matrixConfig,
       RestTemplate restTemplate,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -12,6 +12,8 @@ import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -284,6 +286,83 @@ class MatrixSynapseServiceTest {
     when(restTemplate.postForEntity(
             eq(expectedLoginAsUserUri), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_USER_TOKEN)));
+  }
+
+  @Test
+  void isExpiredShouldTreatEntryAsExpiredOnlyOnceNowReachesExpiry() {
+    assertThat(MatrixSynapseService.isExpired(1000L, 999L)).isFalse();
+    assertThat(MatrixSynapseService.isExpired(1000L, 1000L)).isTrue();
+    assertThat(MatrixSynapseService.isExpired(1000L, 1001L)).isTrue();
+  }
+
+  @Test
+  void loginUserShouldServeAccessTokenFromCacheWhileWithinTtl() {
+    var clock = new AtomicLong(0L);
+    var service = matrixSynapseServiceWithClock(clock::get);
+    stubPasswordLogin("fresh-token");
+
+    var first = service.loginUser("alice", "secret");
+    // Advance well within the 50-minute TTL: still a cache hit, no second HTTP login.
+    clock.set(10 * 60 * 1000L);
+    var second = service.loginUser("alice", "secret");
+
+    assertThat(first).isEqualTo("fresh-token");
+    assertThat(second).isEqualTo("fresh-token");
+    verify(restTemplate, times(1))
+        .postForEntity(
+            eq("https://matrix.example/_matrix/client/r0/login"),
+            any(HttpEntity.class),
+            eq(Map.class));
+  }
+
+  @Test
+  void loginUserShouldNotServeExpiredAccessTokenAndFetchesAFreshOne() {
+    var clock = new AtomicLong(0L);
+    var service = matrixSynapseServiceWithClock(clock::get);
+    // First login caches "stale-token"; after TTL elapses, a second login must fetch "fresh-token".
+    when(restTemplate.postForEntity(
+            eq("https://matrix.example/_matrix/client/r0/login"),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "stale-token")))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "fresh-token")));
+    when(matrixConfig.getApiUrl("/_matrix/client/r0/login"))
+        .thenReturn("https://matrix.example/_matrix/client/r0/login");
+
+    var stale = service.loginUser("alice", "secret");
+    // Jump just past the 50-minute TTL so the cached entry is expired on the next read.
+    clock.set(50 * 60 * 1000L + 1L);
+    var fresh = service.loginUser("alice", "secret");
+
+    assertThat(stale).isEqualTo("stale-token");
+    assertThat(fresh)
+        .as("expired cache entry must not be served; a fresh token is fetched")
+        .isEqualTo("fresh-token");
+    verify(restTemplate, times(2))
+        .postForEntity(
+            eq("https://matrix.example/_matrix/client/r0/login"),
+            any(HttpEntity.class),
+            eq(Map.class));
+  }
+
+  private void stubPasswordLogin(String accessToken) {
+    when(matrixConfig.getApiUrl("/_matrix/client/r0/login"))
+        .thenReturn("https://matrix.example/_matrix/client/r0/login");
+    when(restTemplate.postForEntity(
+            eq("https://matrix.example/_matrix/client/r0/login"),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", accessToken)));
+  }
+
+  private MatrixSynapseService matrixSynapseServiceWithClock(LongSupplier nowSupplier) {
+    return new MatrixSynapseService(
+        matrixConfig,
+        restTemplate,
+        matrixLongPollRestTemplate,
+        matrixRoomClient,
+        matrixMediaClient,
+        nowSupplier);
   }
 
   private MatrixSynapseService matrixSynapseService() {


### PR DESCRIPTION
## Problem
`MatrixSynapseService.accessTokenCache` was a plain unbounded `ConcurrentHashMap` holding per-user Matrix access tokens keyed by username — no eviction. Over long uptime it grows without bound, and it could serve a stale token indefinitely after a homeserver-side password reset.

## Change
- `accessTokenCache` entries are now wrapped in a `CachedAccessToken(token, expiryMs)` with a **50-minute TTL** (matching the impersonation-cache / admin-token windows) and **evicted-on-read** (expired entries sweep, then an expired/absent entry falls through to a fresh login). Reused the existing `impersonationTokenCache` hand-rolled expiry idiom — **no new dependency** (Caffeine isn't on the classpath).
- `syncTokenCache` is **left untouched deliberately**: it holds Matrix `/sync` `next_batch` cursors, not auth credentials — a stale cursor can't leak access and just triggers a re-sync. Documented inline.
- Routed the pre-existing impersonation/admin/presence expiry checks through one injectable `nowSupplier` clock + a pure `isExpired(expiryMs, now)` predicate for deterministic testing. Public method signatures and issued tokens unchanged; the `valid_until_ms` sent to Synapse stays real wall-clock.

## Tests
`MatrixSynapseServiceTest` 15/15 (3 new, no real sleeps via the injected clock): expired access token misses + fetches fresh; within-TTL serves from cache; `isExpired` boundary. Spotless clean.

Part of the Matrix hardening plan (item B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)