### PR TITLE
supervisor add — reason + consent + Berater-Admin authority (ADR-008 item 4)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -8,10 +8,13 @@ import de.caritas.cob.userservice.api.service.notification.EventNotificationServ
 import de.caritas.cob.userservice.api.service.notification.SupervisorAddedEmailNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.supervision.SupervisionNotes;
+import de.caritas.cob.userservice.api.supervision.SupervisionReason;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -68,7 +71,11 @@ public class SessionSupervisorController {
 
     SessionSupervisor supervisor =
         sessionSupervisorFacade.addSupervisor(
-            sessionId, request.getSupervisorConsultantId(), currentConsultant, request.getNotes());
+            sessionId,
+            request.getSupervisorConsultantId(),
+            currentConsultant,
+            request.getReasonCode(),
+            request.getNotes());
     String accessToken = authenticatedUser.getAccessToken();
     String supervisorDisplayName =
         supervisor.getSupervisorConsultant().getDisplayName() != null
@@ -171,6 +178,24 @@ public class SessionSupervisorController {
     return ResponseEntity.ok(response);
   }
 
+  /**
+   * List the ADR-008 supervision reasons a client may choose from, mirroring how case-handover
+   * serves its reasons. Static enum data — no session context needed.
+   *
+   * @return the reason list as {@link SupervisionReasonDTO}s
+   */
+  @GetMapping("/supervision/reasons")
+  public ResponseEntity<List<SupervisionReasonDTO>> getSupervisionReasons() {
+    List<SupervisionReasonDTO> reasons =
+        Arrays.stream(SupervisionReason.values())
+            .map(
+                reason ->
+                    new SupervisionReasonDTO(
+                        reason.name(), reason.getLabelKey(), reason.isClientConsentRequired()))
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(reasons);
+  }
+
   private SessionSupervisorResponseDTO mapToDTO(SessionSupervisor supervisor) {
     SessionSupervisorResponseDTO dto = new SessionSupervisorResponseDTO();
     dto.setId(supervisor.getId());
@@ -180,13 +205,33 @@ public class SessionSupervisorController {
     dto.setAddedByConsultantId(supervisor.getAddedByConsultant().getId());
     dto.setAddedDate(supervisor.getAddedDate());
     dto.setMatrixRoomId(supervisor.getMatrixRoomId());
+    // Keep the raw stored value for backward compatibility, but also surface the decoded
+    // structured fields (ADR-008): reasonCode, justification, consent. A legacy free-text note
+    // decodes to a justification with a null reason and NOT_REQUIRED consent.
     dto.setNotes(supervisor.getNotes());
+    SupervisionNotes.Payload payload = SupervisionNotes.decode(supervisor.getNotes());
+    dto.setReasonCode(payload.reasonCode);
+    dto.setJustification(payload.justification);
+    dto.setConsent(payload.consent);
     return dto;
   }
 
   /** Request DTO for adding a supervisor. */
   public static class AddSupervisorRequestDTO {
     @NotNull private String supervisorConsultantId;
+
+    /**
+     * ADR-008 item 4 (DRAFT): optional supervision reason code (e.g. {@code SAFEGUARDING_U25}).
+     * Intentionally OPTIONAL — the current supervisor modal does not send one yet, so requiring it
+     * would 400 add-supervisor in the running app. Validated by the facade only when present. The
+     * productionised version makes this required once the paired FE reason-picker ships.
+     */
+    private String reasonCode;
+
+    /**
+     * The justification for adding the supervisor (free text). This is the human-readable reason;
+     * it is required by the facade only on the explicit path (when a {@link #reasonCode} is sent).
+     */
     private String notes;
 
     public String getSupervisorConsultantId() {
@@ -197,12 +242,59 @@ public class SessionSupervisorController {
       this.supervisorConsultantId = supervisorConsultantId;
     }
 
+    public String getReasonCode() {
+      return reasonCode;
+    }
+
+    public void setReasonCode(String reasonCode) {
+      this.reasonCode = reasonCode;
+    }
+
     public String getNotes() {
       return notes;
     }
 
     public void setNotes(String notes) {
       this.notes = notes;
+    }
+  }
+
+  /** Response DTO for an ADR-008 supervision reason option. */
+  public static class SupervisionReasonDTO {
+    private String code;
+    private String labelKey;
+    private boolean clientConsentRequired;
+
+    public SupervisionReasonDTO() {}
+
+    public SupervisionReasonDTO(String code, String labelKey, boolean clientConsentRequired) {
+      this.code = code;
+      this.labelKey = labelKey;
+      this.clientConsentRequired = clientConsentRequired;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public void setCode(String code) {
+      this.code = code;
+    }
+
+    public String getLabelKey() {
+      return labelKey;
+    }
+
+    public void setLabelKey(String labelKey) {
+      this.labelKey = labelKey;
+    }
+
+    public boolean isClientConsentRequired() {
+      return clientConsentRequired;
+    }
+
+    public void setClientConsentRequired(boolean clientConsentRequired) {
+      this.clientConsentRequired = clientConsentRequired;
     }
   }
 
@@ -216,6 +308,10 @@ public class SessionSupervisorController {
     private java.time.LocalDateTime addedDate;
     private String matrixRoomId;
     private String notes;
+    // ADR-008 item 4 (DRAFT): decoded structured fields from the stored note.
+    private String reasonCode;
+    private String justification;
+    private String consent;
 
     public Long getId() {
       return id;
@@ -279,6 +375,30 @@ public class SessionSupervisorController {
 
     public void setNotes(String notes) {
       this.notes = notes;
+    }
+
+    public String getReasonCode() {
+      return reasonCode;
+    }
+
+    public void setReasonCode(String reasonCode) {
+      this.reasonCode = reasonCode;
+    }
+
+    public String getJustification() {
+      return justification;
+    }
+
+    public void setJustification(String justification) {
+      this.justification = justification;
+    }
+
+    public String getConsent() {
+      return consent;
+    }
+
+    public void setConsent(String consent) {
+      this.consent = consent;
     }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.SessionSupervisor;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.notification.SupervisorAddedEmailNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -76,6 +77,86 @@ public class SessionSupervisorController {
             currentConsultant,
             request.getReasonCode(),
             request.getNotes());
+    // Only notify "supervisor added" when the supervisor actually became active. For a
+    // consent-gated add (ADR-008 item 4) the supervisor is PENDING with no room access yet — those
+    // notifications fire later, when the client approves consent.
+    if (Boolean.TRUE.equals(supervisor.getIsActive())) {
+      fireSupervisorActivatedNotifications(supervisor);
+    }
+
+    SessionSupervisorResponseDTO response = mapToDTO(supervisor);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * The ratsuchende approves or declines a PENDING supervision-consent request (ADR-008 item 4).
+   * Only the session's own client may decide. On approval the supervisor is provisioned into the
+   * rooms and the "supervisor added" notifications fire (deferred from add time).
+   *
+   * @param sessionId the session ID
+   * @param supervisorId the pending supervisor row id
+   * @param request the decision (APPROVED / DECLINED)
+   * @return the updated supervisor
+   */
+  @PostMapping("/{sessionId}/supervisors/{supervisorId}/consent")
+  public ResponseEntity<SessionSupervisorResponseDTO> decideSupervisionConsent(
+      @PathVariable @NotNull Long sessionId,
+      @PathVariable @NotNull Long supervisorId,
+      @Valid @RequestBody SupervisionConsentDecisionDTO request) {
+    User client = userAccountService.retrieveValidatedUser();
+    if (client == null || !isClientOfSession(client, sessionId)) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+    boolean approve;
+    if ("APPROVED".equalsIgnoreCase(request.getDecision())) {
+      approve = true;
+    } else if ("DECLINED".equalsIgnoreCase(request.getDecision())) {
+      approve = false;
+    } else {
+      return ResponseEntity.badRequest().build();
+    }
+
+    SessionSupervisor updated =
+        sessionSupervisorFacade.decideSupervisionConsent(sessionId, supervisorId, approve);
+    if (approve && Boolean.TRUE.equals(updated.getIsActive())) {
+      fireSupervisorActivatedNotifications(updated);
+    }
+    return ResponseEntity.ok(mapToDTO(updated));
+  }
+
+  /**
+   * List the supervision requests for a session that are still awaiting the client's consent
+   * (ADR-008 item 4). Only the session's own client may read this.
+   *
+   * @param sessionId the session ID
+   * @return the pending-consent supervisor requests
+   */
+  @GetMapping("/{sessionId}/supervisors/pending-consent")
+  public ResponseEntity<List<SessionSupervisorResponseDTO>> getPendingConsentSupervisors(
+      @PathVariable @NotNull Long sessionId) {
+    User client = userAccountService.retrieveValidatedUser();
+    if (client == null || !isClientOfSession(client, sessionId)) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+    List<SessionSupervisorResponseDTO> response =
+        sessionSupervisorFacade.getPendingConsentSupervisors(sessionId).stream()
+            .map(this::mapToDTO)
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(response);
+  }
+
+  /** True when the authenticated user is the ratsuchende (asker) that owns the session. */
+  private boolean isClientOfSession(User client, Long sessionId) {
+    return sessionService
+        .getSession(sessionId)
+        .map(session -> session.getUser())
+        .map(User::getUserId)
+        .filter(ownerId -> ownerId.equals(client.getUserId()))
+        .isPresent();
+  }
+
+  /** Fire the "supervisor added / assigned" notifications for a now-active supervisor. */
+  private void fireSupervisorActivatedNotifications(SessionSupervisor supervisor) {
     String accessToken = authenticatedUser.getAccessToken();
     String supervisorDisplayName =
         supervisor.getSupervisorConsultant().getDisplayName() != null
@@ -105,9 +186,6 @@ public class SessionSupervisorController {
       eventNotificationService.createSupervisorAssignedNotification(
           supervisor.getSession(), supervisor.getSupervisorConsultant().getId());
     }
-
-    SessionSupervisorResponseDTO response = mapToDTO(supervisor);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   /**
@@ -256,6 +334,20 @@ public class SessionSupervisorController {
 
     public void setNotes(String notes) {
       this.notes = notes;
+    }
+  }
+
+  /** Request DTO for the client's decision on a pending supervision-consent request. */
+  public static class SupervisionConsentDecisionDTO {
+    /** The decision: {@code APPROVED} or {@code DECLINED} (case-insensitive). */
+    @NotNull private String decision;
+
+    public String getDecision() {
+      return decision;
+    }
+
+    public void setDecision(String decision) {
+      this.decision = decision;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -283,11 +283,11 @@ public class SessionSupervisorController {
     dto.setAddedByConsultantId(supervisor.getAddedByConsultant().getId());
     dto.setAddedDate(supervisor.getAddedDate());
     dto.setMatrixRoomId(supervisor.getMatrixRoomId());
-    // Keep the raw stored value for backward compatibility, but also surface the decoded
-    // structured fields (ADR-008): reasonCode, justification, consent. A legacy free-text note
-    // decodes to a justification with a null reason and NOT_REQUIRED consent.
-    dto.setNotes(supervisor.getNotes());
+    // Expose the decoded, human-readable justification as `notes` — never the raw stored value,
+    // which is JSON for rows written since ADR-008. Legacy free-text notes decode to themselves
+    // (null reason, NOT_REQUIRED consent), so existing clients see unchanged output.
     SupervisionNotes.Payload payload = SupervisionNotes.decode(supervisor.getNotes());
+    dto.setNotes(payload.justification);
     dto.setReasonCode(payload.reasonCode);
     dto.setJustification(payload.justification);
     dto.setConsent(payload.consent);

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -182,7 +182,11 @@ public class SecurityConfig {
                     "/users/mobiletoken",
                     "/users/sessions/{sessionId:[0-9]+}/data",
                     "/users/sessions/{sessionId:[0-9]+}/case-handover/{requestId:[0-9]+}/client-consent",
-                    "/service/users/sessions/{sessionId:[0-9]+}/case-handover/{requestId:[0-9]+}/client-consent")
+                    "/service/users/sessions/{sessionId:[0-9]+}/case-handover/{requestId:[0-9]+}/client-consent",
+                    "/users/sessions/{sessionId:[0-9]+}/supervisors/{supervisorId:[0-9]+}/consent",
+                    "/service/users/sessions/{sessionId:[0-9]+}/supervisors/{supervisorId:[0-9]+}/consent",
+                    "/users/sessions/{sessionId:[0-9]+}/supervisors/pending-consent",
+                    "/service/users/sessions/{sessionId:[0-9]+}/supervisors/pending-consent")
                 .hasAuthority(USER_DEFAULT)
                 .requestMatchers(
                     RegexRequestMatcher.regexMatcher(

--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -16,6 +16,9 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.supervision.SupervisionConsent;
+import de.caritas.cob.userservice.api.supervision.SupervisionNotes;
+import de.caritas.cob.userservice.api.supervision.SupervisionReason;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +26,7 @@ import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,20 +47,60 @@ public class SessionSupervisorFacade {
   private final @NonNull UserAccountService userAccountService;
   private final @NonNull IdentityClient identityClient;
 
+  /**
+   * ADR-008 item 4 (DRAFT): when true, only the assigned consultant may add supervisors. Defaults
+   * false → assigned OR same agency (current behaviour), so the draft is inert at runtime until
+   * flipped. Field-injected (not a constructor arg) so existing @RequiredArgsConstructor callers
+   * and unit tests are unaffected; tests set it via ReflectionTestUtils.
+   */
+  @Value("${supervision.restrict-add-to-assigned-consultant:false}")
+  private boolean restrictAddToAssignedConsultant;
+
   private static final int SUPERVISOR_POWER_LEVEL = 10; // Read-only observer level
 
   /**
    * Add a supervisor to a session. The supervisor must be from the same agency as the session.
    *
+   * <p>ADR-008 item 4 (DRAFT): {@code reasonCode} + {@code notes} (the justification) + the
+   * computed consent state are recorded together in the existing {@code notes} column via {@link
+   * SupervisionNotes}. {@code reasonCode} is OPTIONAL and fully backward-compatible: when a caller
+   * supplies one it is validated and consent is computed (the new explicit path); when it is
+   * absent/blank the legacy path applies (reason null, consent NOT_REQUIRED, justification stored
+   * as-is) so the running frontend — which does not yet send a reason — keeps working. The
+   * productionised version makes {@code reasonCode} required once the paired FE reason-picker
+   * ships.
+   *
    * @param sessionId the session ID
    * @param supervisorConsultantId the consultant ID to add as supervisor
    * @param addedByConsultant the consultant adding the supervisor
-   * @param notes optional notes/reason for supervision
+   * @param reasonCode optional ADR-008 supervision reason code (validated when present)
+   * @param notes the justification for supervision (required only when a reasonCode is supplied)
    * @return the created SessionSupervisor
    */
   @Transactional
   public SessionSupervisor addSupervisor(
-      Long sessionId, String supervisorConsultantId, Consultant addedByConsultant, String notes) {
+      Long sessionId,
+      String supervisorConsultantId,
+      Consultant addedByConsultant,
+      String reasonCode,
+      String notes) {
+    // ADR-008 item 4 (DRAFT): resolve the reason + consent. reasonCode is optional; the app's
+    // current supervisor modal does not send one yet, so a missing reason must NOT 400 (legacy
+    // path). A reason that is PRESENT but unknown is a client error.
+    boolean reasonSupplied = reasonCode != null && !reasonCode.isBlank();
+    SupervisionReason reason = null;
+    if (reasonSupplied) {
+      reason =
+          SupervisionReason.fromCode(reasonCode)
+              .orElseThrow(() -> new BadRequestException("A valid supervision reason is required"));
+      // On the explicit (with-reason) path the justification must be present.
+      if (notes == null || notes.isBlank()) {
+        throw new BadRequestException("A supervision justification is required");
+      }
+    }
+    SupervisionConsent consent = SupervisionConsent.initialFor(reason);
+    String encodedNotes = SupervisionNotes.encode(reason, notes, consent);
+
     // Get session
     Session session =
         sessionRepository
@@ -215,7 +259,7 @@ public class SessionSupervisorFacade {
             .addedDate(LocalDateTime.now())
             .isActive(true)
             .matrixRoomId(sideRoomId)
-            .notes(notes)
+            .notes(encodedNotes)
             .build();
 
     SessionSupervisor saved = sessionSupervisorRepository.save(sessionSupervisor);
@@ -432,15 +476,30 @@ public class SessionSupervisorFacade {
    * @return true if has permission
    */
   private boolean hasPermissionToManageSupervisors(Session session, Consultant consultant) {
-    // Must be the assigned consultant or from the same agency
-    if (session.getConsultant() != null
-        && session.getConsultant().getId().equals(consultant.getId())) {
+    boolean isAssignedConsultant =
+        session.getConsultant() != null
+            && session.getConsultant().getId().equals(consultant.getId());
+    if (isAssignedConsultant) {
       log.info(
           "Consultant {} is the assigned consultant for session {}",
           consultant.getId(),
           session.getId());
       return true;
     }
+
+    // ADR-008 item 4 (DRAFT) target: only the assigned consultant may add/remove supervisors. The
+    // flag defaults OFF, so at runtime this changes nothing until it is flipped — the draft is
+    // inert. When ON, a same-agency-but-not-assigned consultant is denied here.
+    if (restrictAddToAssignedConsultant) {
+      log.info(
+          "Consultant {} is not the assigned consultant for session {} and assigned-only "
+              + "restriction is enabled (ADR-008) — denying",
+          consultant.getId(),
+          session.getId());
+      return false;
+    }
+
+    // Current behaviour (flag off): assigned consultant OR same agency.
     boolean sameAgency = areFromSameAgency(session, consultant);
     log.info(
         "Consultant {} same agency check for session {} (agencyId: {}): {}",

--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -188,20 +188,78 @@ public class SessionSupervisorFacade {
           "Consultant adding supervisor does not have Matrix credentials");
     }
 
+    // ADR-008 item 4: never create a second PENDING-consent request for the same supervisor on
+    // the same session (the client would get duplicate disclosure prompts).
+    boolean pendingAlreadyExists =
+        sessionSupervisorRepository.findBySessionId(sessionId).stream()
+            .filter(s -> s.getSupervisorConsultant() != null)
+            .filter(s -> supervisorConsultantId.equals(s.getSupervisorConsultant().getId()))
+            .anyMatch(SessionSupervisorFacade::isPendingConsent);
+    if (pendingAlreadyExists) {
+      throw new BadRequestException(
+          "A supervision consent request for this consultant is already pending");
+    }
+
+    SessionSupervisor.SessionSupervisorBuilder builder =
+        SessionSupervisor.builder()
+            .session(session)
+            .supervisorConsultant(supervisorConsultant)
+            .addedByConsultant(addedByConsultant)
+            .addedDate(LocalDateTime.now())
+            .notes(encodedNotes);
+
+    if (consent == SupervisionConsent.PENDING) {
+      // CONSENT GATE (ADR-008 item 4): the ratsuchende's consent is required for this reason
+      // (SAFEGUARDING_U25 / CLINICAL_OVERSIGHT) and has NOT been given yet. Record the request but
+      // grant NO Matrix access — the supervisor is invited to NEITHER the client room nor the side
+      // room until the client approves via the consent endpoint. For minors' cases a supervisor
+      // must never observe before consent exists.
+      SessionSupervisor pending = builder.isActive(false).matrixRoomId(null).build();
+      SessionSupervisor saved = sessionSupervisorRepository.save(pending);
+      log.info(
+          "Recorded PENDING-consent supervisor {} for session {} (no Matrix access until approved)",
+          supervisorConsultant.getUsername(),
+          sessionId);
+      return saved;
+    }
+
+    // No consent required (or legacy no-reason path) — provision Matrix access immediately.
+    String sideRoomId =
+        provisionSupervisorRooms(
+            session, addedByConsultant, supervisorConsultant, supervisorMatrixUserId, matrixRoomId);
+    SessionSupervisor saved =
+        sessionSupervisorRepository.save(builder.isActive(true).matrixRoomId(sideRoomId).build());
+    log.info(
+        "Added supervisor {} to session {} by consultant {}",
+        supervisorConsultant.getUsername(),
+        sessionId,
+        addedByConsultant.getUsername());
+    return saved;
+  }
+
+  /**
+   * Give the supervisor Matrix access: (re)use the ADR-008 side room, invite them into the client
+   * room as a read-only observer, set their power level, and join them. Extracted so it can run
+   * either immediately (no-consent path) or deferred, after the client approves consent.
+   *
+   * @return the supervision side room id the supervisor was placed in
+   */
+  private String provisionSupervisorRooms(
+      Session session,
+      Consultant addedByConsultant,
+      Consultant supervisorConsultant,
+      String supervisorMatrixUserId,
+      String matrixRoomId) {
     String consultantToken =
         matrixSynapseService.loginAsUserAccessToken(addedByConsultant.getMatrixUserId());
     if (consultantToken == null) {
       throw new InternalServerErrorException("Failed to create consultant Matrix token");
     }
 
-    // ADR-008: provision (or reuse) a SEPARATE supervision side room that the
-    // client is NEVER
-    // invited to. Supervisor↔counsellor feedback and coordinator↔peer asides live
-    // here, so they
-    // are never delivered to the client's Matrix device. Do this BEFORE touching
-    // the client room
-    // so a failure leaves no half state. The supervisor still joins the client room
-    // read-only
+    // ADR-008: provision (or reuse) a SEPARATE supervision side room that the client is NEVER
+    // invited to. Supervisor↔counsellor feedback and coordinator↔peer asides live here, so they
+    // are never delivered to the client's Matrix device. Do this BEFORE touching the client room
+    // so a failure leaves no half state. The supervisor still joins the client room read-only
     // (below) for observation — only their feedback moves out.
     String sideRoomId =
         ensureSupervisionSideRoom(
@@ -218,7 +276,7 @@ public class SessionSupervisorFacade {
           "Invited supervisor {} to Matrix room {} for session {}",
           supervisorConsultant.getUsername(),
           matrixRoomId,
-          sessionId);
+          session.getId());
     } catch (Exception e) {
       log.error(
           "Failed to invite supervisor {} to Matrix room {}: {}",
@@ -256,32 +314,85 @@ public class SessionSupervisorFacade {
             matrixRoomId);
       }
     }
+    return sideRoomId;
+  }
 
-    // Create SessionSupervisor entity. NOTE: matrixRoomId now holds the SUPERVISION
-    // SIDE ROOM id
-    // (ADR-008), not the client room — the client room is always available via
-    // session.getMatrixRoomId(). This reuses the existing column (no schema change;
-    // ddl-auto is
-    // validate everywhere, so a new column would crash on boot — ADR-006 hazard).
-    SessionSupervisor sessionSupervisor =
-        SessionSupervisor.builder()
-            .session(session)
-            .supervisorConsultant(supervisorConsultant)
-            .addedByConsultant(addedByConsultant)
-            .addedDate(LocalDateTime.now())
-            .isActive(true)
-            .matrixRoomId(sideRoomId)
-            .notes(encodedNotes)
-            .build();
+  /**
+   * The ratsuchende's decision on a PENDING supervision-consent request (ADR-008 item 4). On
+   * APPROVE the deferred Matrix provisioning runs and the supervisor becomes active; on DECLINE the
+   * request is recorded as declined and the supervisor never gets room access.
+   *
+   * @param sessionId the session the request belongs to
+   * @param supervisorId the pending {@link SessionSupervisor} row id
+   * @param approve true to approve (provision + activate), false to decline
+   * @return the updated {@link SessionSupervisor}
+   */
+  @Transactional
+  public SessionSupervisor decideSupervisionConsent(
+      Long sessionId, Long supervisorId, boolean approve) {
+    SessionSupervisor supervisor =
+        sessionSupervisorRepository
+            .findById(supervisorId)
+            .orElseThrow(() -> new NotFoundException("Supervisor not found: " + supervisorId));
+    if (supervisor.getSession() == null || !supervisor.getSession().getId().equals(sessionId)) {
+      throw new BadRequestException("Supervisor does not belong to this session");
+    }
+    if (!isPendingConsent(supervisor)) {
+      throw new BadRequestException("No pending supervision-consent request for this supervisor");
+    }
 
-    SessionSupervisor saved = sessionSupervisorRepository.save(sessionSupervisor);
-    log.info(
-        "Added supervisor {} to session {} by consultant {}",
-        supervisorConsultant.getUsername(),
-        sessionId,
-        addedByConsultant.getUsername());
+    SupervisionNotes.Payload payload = SupervisionNotes.decode(supervisor.getNotes());
+    SupervisionReason reason = SupervisionReason.fromCode(payload.reasonCode).orElse(null);
 
-    return saved;
+    if (approve) {
+      Session session = supervisor.getSession();
+      String sideRoomId =
+          provisionSupervisorRooms(
+              session,
+              supervisor.getAddedByConsultant(),
+              supervisor.getSupervisorConsultant(),
+              supervisor.getSupervisorConsultant().getMatrixUserId(),
+              session.getMatrixRoomId());
+      supervisor.setMatrixRoomId(sideRoomId);
+      supervisor.setIsActive(true);
+      supervisor.setNotes(
+          SupervisionNotes.encode(reason, payload.justification, SupervisionConsent.APPROVED));
+      log.info(
+          "Supervision consent APPROVED — activated supervisor {} for session {}",
+          supervisor.getSupervisorConsultant().getUsername(),
+          sessionId);
+    } else {
+      supervisor.setIsActive(false);
+      supervisor.setNotes(
+          SupervisionNotes.encode(reason, payload.justification, SupervisionConsent.DECLINED));
+      log.info(
+          "Supervision consent DECLINED for supervisor {} on session {}",
+          supervisor.getSupervisorConsultant().getUsername(),
+          sessionId);
+    }
+    return sessionSupervisorRepository.save(supervisor);
+  }
+
+  /**
+   * The supervision requests for a session that are still awaiting the ratsuchende's consent
+   * (ADR-008 item 4). Consent state is decoded from the {@code notes} JSON, not a column.
+   *
+   * @param sessionId the session ID
+   * @return the pending-consent supervisor rows
+   */
+  public List<SessionSupervisor> getPendingConsentSupervisors(Long sessionId) {
+    return sessionSupervisorRepository.findBySessionId(sessionId).stream()
+        .filter(SessionSupervisorFacade::isPendingConsent)
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  /** True when the row is an inactive, not-removed request whose recorded consent is PENDING. */
+  private static boolean isPendingConsent(SessionSupervisor supervisor) {
+    return Boolean.FALSE.equals(supervisor.getIsActive())
+        && supervisor.getRemovedDate() == null
+        && SupervisionConsent.PENDING
+            .name()
+            .equals(SupervisionNotes.decode(supervisor.getNotes()).consent);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
@@ -48,10 +49,21 @@ public class SessionSupervisorFacade {
   private final @NonNull IdentityClient identityClient;
 
   /**
-   * ADR-008 item 4 (DRAFT): when true, only the assigned consultant may add supervisors. Defaults
-   * false → assigned OR same agency (current behaviour), so the draft is inert at runtime until
-   * flipped. Field-injected (not a constructor arg) so existing @RequiredArgsConstructor callers
-   * and unit tests are unaffected; tests set it via ReflectionTestUtils.
+   * ADR-008 item 4: the current request's authenticated user, used to check the Berater-Admin
+   * (agency-admin) role. Frank confirmed (2026-07-04) that attaching/detaching a supervisor is
+   * exactly the counsellor-admin's role, configured in the Admin board. Injected the same way
+   * {@code AssignSessionFacade} does (a request-scoped proxy resolved per request), so it boots
+   * fine.
+   */
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  /**
+   * ADR-008 item 4: when true, only the assigned consultant and agency admins may add/remove
+   * supervisors (a plain same-agency consultant is denied). This is the server side of the
+   * agency-admin ("Berater-Admin") Admin-board policy Frank described. Defaults false → assigned OR
+   * same agency (current behaviour), so runtime is unchanged until an agency admin turns it on.
+   * Field-injected (not a constructor arg) so existing @RequiredArgsConstructor callers and unit
+   * tests are unaffected; tests set it via ReflectionTestUtils.
    */
   @Value("${supervision.restrict-add-to-assigned-consultant:false}")
   private boolean restrictAddToAssignedConsultant;
@@ -487,20 +499,38 @@ public class SessionSupervisorFacade {
       return true;
     }
 
-    // ADR-008 item 4 (DRAFT) target: only the assigned consultant may add/remove supervisors. The
-    // flag defaults OFF, so at runtime this changes nothing until it is flipped — the draft is
-    // inert. When ON, a same-agency-but-not-assigned consultant is denied here.
+    boolean sameAgency = areFromSameAgency(session, consultant);
+
+    // ADR-008 item 4 (Frank, 2026-07-04): a Berater-Admin (agency admin) may manage supervisors for
+    // sessions of their OWN agency — this is exactly their role. It holds even when the
+    // assigned-only
+    // tightening below is on, so agency admins are never locked out of their own agency's sessions.
+    boolean isAgencyAdmin =
+        authenticatedUser != null
+            && (authenticatedUser.isRestrictedAgencyAdmin()
+                || authenticatedUser.isAgencySuperAdmin());
+    if (isAgencyAdmin && sameAgency) {
+      log.info(
+          "Consultant {} is an agency admin for session {} agency {} — allowing supervisor management",
+          consultant.getId(),
+          session.getId(),
+          session.getAgencyId());
+      return true;
+    }
+
+    // ADR-008 item 4 tightening — the agency-admin Admin-board policy: when enabled, only the
+    // assigned consultant and agency admins (above) may manage supervisors; a plain same-agency
+    // consultant is denied. Defaults OFF, so at runtime nothing changes until it is turned on.
     if (restrictAddToAssignedConsultant) {
       log.info(
-          "Consultant {} is not the assigned consultant for session {} and assigned-only "
-              + "restriction is enabled (ADR-008) — denying",
+          "Consultant {} is neither the assigned consultant nor an agency admin for session {} and "
+              + "the assigned-only restriction is enabled (ADR-008) — denying",
           consultant.getId(),
           session.getId());
       return false;
     }
 
-    // Current behaviour (flag off): assigned consultant OR same agency.
-    boolean sameAgency = areFromSameAgency(session, consultant);
+    // Current default behaviour (flag off): assigned consultant OR any same-agency consultant.
     log.info(
         "Consultant {} same agency check for session {} (agencyId: {}): {}",
         consultant.getId(),

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
@@ -18,6 +18,17 @@ public interface SessionSupervisorRepository extends JpaRepository<SessionSuperv
   List<SessionSupervisor> findBySessionIdAndIsActiveTrue(Long sessionId);
 
   /**
+   * Find ALL supervisor rows for a session, regardless of active state. Used to inspect
+   * consent-pending rows (ADR-008 item 4): the consent state lives inside the {@code notes} JSON,
+   * not a queryable column, so callers decode and filter in Java. Supervisor rows per session are
+   * few, so a full fetch is cheap.
+   *
+   * @param sessionId the session ID
+   * @return all supervisor rows for the session
+   */
+  List<SessionSupervisor> findBySessionId(Long sessionId);
+
+  /**
    * Find all sessions supervised by a consultant.
    *
    * @param consultantId the consultant ID

--- a/src/main/java/de/caritas/cob/userservice/api/service/SupervisorLogsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/SupervisorLogsService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.supervision.SupervisionNotes;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
@@ -120,6 +121,11 @@ public class SupervisorLogsService {
   private static class SupervisorLogEntryRowMapper implements RowMapper<SupervisorLogEntry> {
     @Override
     public SupervisorLogEntry mapRow(ResultSet rs, int rowNum) throws SQLException {
+      // ADR-008 item 4 (DRAFT): the stored note may be structured JSON (reason + justification +
+      // consent) or legacy free text. Decode it so the log surfaces the human justification (and
+      // reason/consent) rather than raw JSON. decode() is defensive: legacy free text decodes to a
+      // justification with null reason and NOT_REQUIRED consent, so old rows keep working.
+      SupervisionNotes.Payload note = SupervisionNotes.decode(rs.getString("notes"));
       return SupervisorLogEntry.builder()
           .relationId(rs.getLong("relationId"))
           .sessionId(rs.getLong("sessionId"))
@@ -131,7 +137,9 @@ public class SupervisorLogsService {
           .actorConsultantId(rs.getString("actorConsultantId"))
           .actorUsername(rs.getString("actorUsername"))
           .actorName(rs.getString("actorName"))
-          .notes(rs.getString("notes"))
+          .notes(note.justification)
+          .reasonCode(note.reasonCode)
+          .consent(note.consent)
           .build();
     }
   }
@@ -191,7 +199,11 @@ public class SupervisorLogsService {
     private String actorConsultantId;
     private String actorUsername;
     private String actorName;
+    // ADR-008: the human justification (decoded from the stored note; raw JSON is never exposed).
     private String notes;
+    // ADR-008 item 4 (DRAFT): decoded structured fields (null/NOT_REQUIRED for legacy rows).
+    private String reasonCode;
+    private String consent;
   }
 
   @Data

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionConsent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionConsent.java
@@ -1,0 +1,31 @@
+package de.caritas.cob.userservice.api.supervision;
+
+/**
+ * ADR-008 item 4 (DRAFT): the consent state recorded when a supervisor is attached, mirroring the
+ * Case-Handover status vocabulary.
+ *
+ * <p>DRAFT scope: this records the consent *state*. The client-facing approve/decline workflow (a
+ * separate endpoint like Case-Handover's {@code client-consent}) is a documented follow-up that
+ * depends on the data-protection officer's disclosure decision.
+ */
+public enum SupervisionConsent {
+
+  /** The reason does not require the ratsuchende's consent — supervision may proceed. */
+  NOT_REQUIRED,
+
+  /** Consent is required and has been requested/disclosed but not yet decided. */
+  PENDING,
+
+  /** The ratsuchende (or guardian) approved the supervision. */
+  APPROVED,
+
+  /** The ratsuchende (or guardian) declined the supervision. */
+  DECLINED;
+
+  /**
+   * The initial consent state for a reason: PENDING when consent is required, else NOT_REQUIRED.
+   */
+  public static SupervisionConsent initialFor(SupervisionReason reason) {
+    return reason != null && reason.isClientConsentRequired() ? PENDING : NOT_REQUIRED;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionDisclosure.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionDisclosure.java
@@ -1,0 +1,21 @@
+package de.caritas.cob.userservice.api.supervision;
+
+/**
+ * ADR-008 item 4 (DRAFT): the disclosure shown to the ratsuchende that supervision/peer involvement
+ * may occur. Per ADR-008 the exact wording is <b>pending the data-protection officer</b> and is
+ * surfaced via the agency's privacy policy + Impressum on chat entry.
+ *
+ * <p>This constant is a labelled PLACEHOLDER so the plumbing (recording which disclosure version a
+ * supervisor add was made under) exists now; swap {@link #PLACEHOLDER_TEXT_KEY} for the approved
+ * copy once the DPO signs off. Do NOT present this placeholder to real users as final legal text.
+ */
+public final class SupervisionDisclosure {
+
+  private SupervisionDisclosure() {}
+
+  /** Bump when the approved disclosure copy changes, so audit rows record which version applied. */
+  public static final String VERSION = "draft-0";
+
+  /** i18n key for the placeholder disclosure copy (client resolves it; NOT final legal wording). */
+  public static final String PLACEHOLDER_TEXT_KEY = "supervision.disclosure.draftPlaceholder";
+}

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionDisclosure.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionDisclosure.java
@@ -5,9 +5,12 @@ package de.caritas.cob.userservice.api.supervision;
  * may occur. Per ADR-008 the exact wording is <b>pending the data-protection officer</b> and is
  * surfaced via the agency's privacy policy + Impressum on chat entry.
  *
- * <p>This constant is a labelled PLACEHOLDER so the plumbing (recording which disclosure version a
- * supervisor add was made under) exists now; swap {@link #PLACEHOLDER_TEXT_KEY} for the approved
- * copy once the DPO signs off. Do NOT present this placeholder to real users as final legal text.
+ * <p>Confirmed 2026-07-04 (Frank): a clearly-marked draft template like this is the intended
+ * solution — keep the plumbing, mark it draft, and only the copy behind {@link
+ * #PLACEHOLDER_TEXT_KEY} is pending the DPO. This constant is a labelled PLACEHOLDER so the
+ * plumbing (recording which disclosure version a supervisor add was made under) exists now; swap
+ * {@link #PLACEHOLDER_TEXT_KEY} for the approved copy once the DPO signs off. Do NOT present this
+ * placeholder as final legal text.
  */
 public final class SupervisionDisclosure {
 

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionNotes.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionNotes.java
@@ -1,0 +1,81 @@
+package de.caritas.cob.userservice.api.supervision;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ADR-008 item 4 (DRAFT): structured reason + justification + consent for a supervisor add,
+ * serialized into the EXISTING {@code session_supervisor.notes} TEXT column so the draft needs NO
+ * schema migration (the deployed clusters run {@code ddl-auto=none} with Liquibase off — a
+ * new @Column would 500 supervisor queries at runtime; the ORISO-006 hazard). A productionised
+ * version should promote these to dedicated, queryable columns once the Liquibase re-enablement
+ * lands.
+ *
+ * <p>Backward compatible: an old free-text note (pre-A4) decodes as a justification with no reason
+ * and NOT_REQUIRED consent.
+ */
+@Slf4j
+public final class SupervisionNotes {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private SupervisionNotes() {}
+
+  /** The parsed shape of a structured supervision note. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class Payload {
+    public String reasonCode;
+    public String justification;
+    public String consent;
+
+    public Payload() {}
+
+    public Payload(String reasonCode, String justification, String consent) {
+      this.reasonCode = reasonCode;
+      this.justification = justification;
+      this.consent = consent;
+    }
+  }
+
+  /** Serialize reason + justification + consent to the JSON stored in {@code notes}. */
+  public static String encode(
+      SupervisionReason reason, String justification, SupervisionConsent consent) {
+    Payload payload =
+        new Payload(
+            reason == null ? null : reason.name(),
+            justification,
+            consent == null ? null : consent.name());
+    try {
+      return MAPPER.writeValueAsString(payload);
+    } catch (JsonProcessingException e) {
+      // Never fail an add over serialization — fall back to the raw justification.
+      log.warn("Failed to encode supervision note, storing raw justification", e);
+      return justification;
+    }
+  }
+
+  /**
+   * Decode a stored note. JSON → structured payload; a legacy free-text note → a payload whose
+   * justification is the raw text, reason null, consent NOT_REQUIRED.
+   */
+  public static Payload decode(String notes) {
+    if (notes == null || notes.isBlank()) {
+      return new Payload(null, null, SupervisionConsent.NOT_REQUIRED.name());
+    }
+    String trimmed = notes.trim();
+    if (trimmed.startsWith("{")) {
+      try {
+        Payload payload = MAPPER.readValue(trimmed, Payload.class);
+        if (payload.consent == null) {
+          payload.consent = SupervisionConsent.NOT_REQUIRED.name();
+        }
+        return payload;
+      } catch (JsonProcessingException e) {
+        log.debug("Supervision note is not valid JSON, treating as legacy free text");
+      }
+    }
+    return new Payload(null, notes, SupervisionConsent.NOT_REQUIRED.name());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionReason.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionReason.java
@@ -8,9 +8,11 @@ import java.util.Optional;
  * Case-Handover {@code CaseHandoverReason} pattern (code + label key + whether the ratsuchende's
  * consent is required).
  *
- * <p>DRAFT — the reason set and their {@code clientConsentRequired} flags are placeholders pending
- * the data-protection officer and Frank's final U25 requirements. They are intentionally
- * conservative: only the two clinically sensitive reasons require consent today.
+ * <p>Confirmed 2026-07-04 (Frank): this reason set is the intended one; only the two clinically
+ * sensitive reasons (CLINICAL_OVERSIGHT, SAFEGUARDING_U25) require the ratsuchende's consent. Which
+ * of these reasons a given agency offers, and whether the assigned-only tightening is on, are
+ * agency-admin ("Berater-Admin") settings configured in the Admin board — the FE reason picker is a
+ * simple select fed by {@code GET /users/sessions/supervision/reasons} (a documented follow-up).
  */
 public enum SupervisionReason {
 

--- a/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionReason.java
+++ b/src/main/java/de/caritas/cob/userservice/api/supervision/SupervisionReason.java
@@ -1,0 +1,58 @@
+package de.caritas.cob.userservice.api.supervision;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * ADR-008 item 4 (DRAFT): the recorded reason a supervisor is attached to a session, mirroring the
+ * Case-Handover {@code CaseHandoverReason} pattern (code + label key + whether the ratsuchende's
+ * consent is required).
+ *
+ * <p>DRAFT — the reason set and their {@code clientConsentRequired} flags are placeholders pending
+ * the data-protection officer and Frank's final U25 requirements. They are intentionally
+ * conservative: only the two clinically sensitive reasons require consent today.
+ */
+public enum SupervisionReason {
+
+  /**
+   * A same-age Peer (U25) helps because of shared lived experience, coordinated by a Coordinator.
+   */
+  PEER_SUPPORT("supervision.reason.peerSupport", false),
+
+  /** A clinical/professional supervisor reviews the case to help a stuck counsellor. */
+  CLINICAL_OVERSIGHT("supervision.reason.clinicalOversight", true),
+
+  /** U25 safeguarding: four-eyes read-along on a minor's suicide-counselling case. */
+  SAFEGUARDING_U25("supervision.reason.safeguardingU25", true),
+
+  /** Training / onboarding of a counsellor under observation. */
+  TRAINING("supervision.reason.training", false);
+
+  private final String labelKey;
+  private final boolean clientConsentRequired;
+
+  SupervisionReason(String labelKey, boolean clientConsentRequired) {
+    this.labelKey = labelKey;
+    this.clientConsentRequired = clientConsentRequired;
+  }
+
+  /** i18n key for the human-facing label (resolved client-side, like Case-Handover reasons). */
+  public String getLabelKey() {
+    return labelKey;
+  }
+
+  /**
+   * Whether the ratsuchende's (or guardian's) consent is required before this supervision starts.
+   */
+  public boolean isClientConsentRequired() {
+    return clientConsentRequired;
+  }
+
+  /** Null-safe lookup by code; empty when the code is unknown. */
+  public static Optional<SupervisionReason> fromCode(String code) {
+    if (code == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(values()).filter(r -> r.name().equalsIgnoreCase(code.trim())).findFirst();
+  }
+}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -64,6 +64,8 @@ spring.liquibase.enabled=false
 # ---------------- Local App Settings ----------------
 app.base.url=${APP_BASE_URL:http://localhost:8082}
 multitenancy.enabled=false
+# ADR-008 draft: keep the assigned-only authority restriction OFF in tests (draft default).
+supervision.restrict-add-to-assigned-consultant=false
 appointments.delete-job-enabled=true
 appointments.lifespan-in-hours=3
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -290,6 +290,12 @@ feature.appointment.enabled=false
 feature.multitenancy.with.single.domain.enabled=false
 feature.video.group.chats.enabled=true
 
+# ---------------- Supervision (ADR-008) ----------------
+# ADR-008 item 4 (DRAFT): when true, only the ASSIGNED consultant of a session may add supervisors
+# (the ADR-008 target). Defaults false → keeps the current behaviour (assigned OR same agency), so
+# flipping this on is the only runtime change; the draft is inert until then.
+supervision.restrict-add-to-assigned-consultant=${SUPERVISION_RESTRICT_ADD_TO_ASSIGNED:false}
+
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true
 management.endpoint.health.show-details=when-authorized

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -64,6 +64,7 @@ class SessionSupervisorFacadeTest {
   @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private de.caritas.cob.userservice.api.service.user.UserAccountService userAccountService;
   @Mock private de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
+  @Mock private de.caritas.cob.userservice.api.helper.AuthenticatedUser authenticatedUser;
 
   private Session session;
   private Consultant addedBy;
@@ -292,6 +293,40 @@ class SessionSupervisorFacadeTest {
             SESSION_ID, SUPERVISOR_ID, otherSameAgency, "PEER_SUPPORT", "justified");
 
     assertThat(saved).isNotNull();
+  }
+
+  @Test
+  void addSupervisor_Should_allowAgencyAdmin_evenWhen_restrictionEnabled() {
+    // Frank 2026-07-04: a Berater-Admin (agency admin) may manage supervisors for their own
+    // agency's
+    // sessions, even with the assigned-only tightening on.
+    ReflectionTestUtils.setField(facade, "restrictAddToAssignedConsultant", true);
+    when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(true);
+    Consultant agencyAdmin = sameAgencyButNotAssignedConsultant();
+
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, agencyAdmin, "PEER_SUPPORT", "justified");
+
+    assertThat(saved).isNotNull();
+  }
+
+  @Test
+  void addSupervisor_Should_denyAgencyAdmin_forDifferentAgency_when_restrictionEnabled() {
+    // Agency-admin authority is scoped to the admin's OWN agency — a session in another agency is
+    // still denied (no cross-agency supervisor management).
+    ReflectionTestUtils.setField(facade, "restrictAddToAssignedConsultant", true);
+    when(authenticatedUser.isAgencySuperAdmin()).thenReturn(true);
+    Consultant adminOfOtherAgency = new Consultant();
+    adminOfOtherAgency.setId("con-3");
+    adminOfOtherAgency.setMatrixUserId("@con3:oriso");
+    adminOfOtherAgency.setConsultantAgencies(
+        Set.of(ConsultantAgency.builder().agencyId(9L).build()));
+
+    assertThatThrownBy(
+            () ->
+                facade.addSupervisor(
+                    SESSION_ID, SUPERVISOR_ID, adminOfOtherAgency, "PEER_SUPPORT", "justified"))
+        .isInstanceOf(ForbiddenException.class);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -181,7 +181,7 @@ class SessionSupervisorFacadeTest {
     client.setMatrixUserId(CLIENT_MXID);
     session.setUser(client);
 
-    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
 
     ArgumentCaptor<String> invitedUsers = ArgumentCaptor.forClass(String.class);
     verify(matrixSynapseService, org.mockito.Mockito.atLeastOnce())

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -9,7 +10,10 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.SessionSupervisor;
 import de.caritas.cob.userservice.api.model.User;
@@ -17,8 +21,10 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.supervision.SupervisionConsent;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * ADR-008 safety contract: supervisor feedback / asides must live in a SEPARATE Matrix room the
@@ -109,7 +116,8 @@ class SessionSupervisorFacadeTest {
 
   @Test
   void addSupervisor_Should_storeSideRoomId_notClientRoomId() throws Exception {
-    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
 
     assertThat(saved.getMatrixRoomId())
         .as("entity must hold the supervision SIDE room, never the client room")
@@ -119,7 +127,7 @@ class SessionSupervisorFacadeTest {
 
   @Test
   void addSupervisor_Should_provisionSideRoom_andNeverInviteIntoItAsClientRoom() throws Exception {
-    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+    facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
 
     // A side room was created...
     verify(matrixSynapseService).createRoom(any(), any(), any());
@@ -137,7 +145,8 @@ class SessionSupervisorFacadeTest {
     when(sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(SESSION_ID))
         .thenReturn(List.of(existing));
 
-    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
 
     assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM);
     // no NEW room created — the existing side room is reused
@@ -152,7 +161,8 @@ class SessionSupervisorFacadeTest {
     when(sessionSupervisorRepository.findBySessionIdAndIsActiveTrue(SESSION_ID))
         .thenReturn(List.of(oldStyle));
 
-    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "reason");
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
 
     assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM).isNotEqualTo(CLIENT_ROOM);
     verify(matrixSynapseService).createRoom(any(), any(), any());
@@ -180,5 +190,119 @@ class SessionSupervisorFacadeTest {
         .containsOnly(SUPERVISOR_MXID)
         .doesNotContain(CLIENT_MXID);
     verify(matrixSynapseService, never()).inviteUserToRoom(eq(SIDE_ROOM), eq(CLIENT_MXID), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // ADR-008 item 4 (DRAFT): reason + justification + consent + authority flag
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void addSupervisor_Should_throwBadRequest_when_reasonCodeIsPresentButInvalid() {
+    assertThatThrownBy(
+            () ->
+                facade.addSupervisor(
+                    SESSION_ID, SUPERVISOR_ID, addedBy, "NOT_A_REAL_REASON", "justified"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("valid supervision reason");
+  }
+
+  @Test
+  void addSupervisor_Should_throwBadRequest_when_reasonSuppliedButJustificationBlank() {
+    assertThatThrownBy(
+            () -> facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "PEER_SUPPORT", "  "))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("justification");
+  }
+
+  @Test
+  void addSupervisor_Should_notThrow_when_reasonCodeAbsent_legacyPath() {
+    // Legacy path: the running FE sends no reasonCode. Must NOT 400, even with blank justification.
+    SessionSupervisor saved = facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "");
+
+    assertThat(saved).isNotNull();
+    // Stored uniformly as JSON with a null reason and NOT_REQUIRED consent.
+    assertThat(saved.getNotes()).contains(SupervisionConsent.NOT_REQUIRED.name());
+  }
+
+  @Test
+  void addSupervisor_Should_computePendingConsent_for_safeguardingU25() {
+    SessionSupervisor saved =
+        facade.addSupervisor(
+            SESSION_ID, SUPERVISOR_ID, addedBy, "SAFEGUARDING_U25", "minor at risk");
+
+    assertThat(saved.getNotes())
+        .contains(SupervisionConsent.PENDING.name())
+        .contains("SAFEGUARDING_U25")
+        .contains("minor at risk");
+  }
+
+  @Test
+  void addSupervisor_Should_computePendingConsent_for_clinicalOversight() {
+    SessionSupervisor saved =
+        facade.addSupervisor(
+            SESSION_ID, SUPERVISOR_ID, addedBy, "CLINICAL_OVERSIGHT", "stuck case");
+
+    assertThat(saved.getNotes()).contains(SupervisionConsent.PENDING.name());
+  }
+
+  @Test
+  void addSupervisor_Should_computeNotRequiredConsent_for_peerSupport() {
+    SessionSupervisor saved =
+        facade.addSupervisor(
+            SESSION_ID, SUPERVISOR_ID, addedBy, "PEER_SUPPORT", "shared experience");
+
+    assertThat(saved.getNotes()).contains(SupervisionConsent.NOT_REQUIRED.name());
+  }
+
+  @Test
+  void addSupervisor_Should_computeNotRequiredConsent_for_training() {
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "TRAINING", "onboarding");
+
+    assertThat(saved.getNotes()).contains(SupervisionConsent.NOT_REQUIRED.name());
+  }
+
+  @Test
+  void addSupervisor_Should_storeReasonAndJustificationAsJson() {
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, "PEER_SUPPORT", "why we did it");
+
+    assertThat(saved.getNotes()).startsWith("{").contains("PEER_SUPPORT").contains("why we did it");
+  }
+
+  @Test
+  void addSupervisor_Should_rejectSameAgencyNonAssignedConsultant_when_restrictionEnabled() {
+    ReflectionTestUtils.setField(facade, "restrictAddToAssignedConsultant", true);
+    Consultant otherSameAgency = sameAgencyButNotAssignedConsultant();
+
+    assertThatThrownBy(
+            () ->
+                facade.addSupervisor(
+                    SESSION_ID, SUPERVISOR_ID, otherSameAgency, "PEER_SUPPORT", "justified"))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void addSupervisor_Should_allowSameAgencyNonAssignedConsultant_when_restrictionDisabled() {
+    ReflectionTestUtils.setField(facade, "restrictAddToAssignedConsultant", false);
+    Consultant otherSameAgency = sameAgencyButNotAssignedConsultant();
+
+    SessionSupervisor saved =
+        facade.addSupervisor(
+            SESSION_ID, SUPERVISOR_ID, otherSameAgency, "PEER_SUPPORT", "justified");
+
+    assertThat(saved).isNotNull();
+  }
+
+  /**
+   * A consultant in the SAME agency (7L) as the session but who is NOT the assigned consultant.
+   * Used to exercise the ADR-008 authority flag: allowed when off, denied when on.
+   */
+  private Consultant sameAgencyButNotAssignedConsultant() {
+    Consultant other = new Consultant();
+    other.setId("con-2");
+    other.setMatrixUserId("@con2:oriso");
+    other.setConsultantAgencies(Set.of(ConsultantAgency.builder().agencyId(7L).build()));
+    return other;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -22,6 +22,8 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.supervision.SupervisionConsent;
+import de.caritas.cob.userservice.api.supervision.SupervisionNotes;
+import de.caritas.cob.userservice.api.supervision.SupervisionReason;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -327,6 +329,103 @@ class SessionSupervisorFacadeTest {
                 facade.addSupervisor(
                     SESSION_ID, SUPERVISOR_ID, adminOfOtherAgency, "PEER_SUPPORT", "justified"))
         .isInstanceOf(ForbiddenException.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // ADR-008 item 4: consent GATE — no room access until the client approves
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void addSupervisor_Should_notProvisionAnyRoom_when_consentRequiredAndPending() throws Exception {
+    SessionSupervisor saved =
+        facade.addSupervisor(
+            SESSION_ID, SUPERVISOR_ID, addedBy, "SAFEGUARDING_U25", "minor at risk");
+
+    // The consent gate: for a consent-required reason with no consent yet, the supervisor gets
+    // NO Matrix access at all — no side room, no client-room invite — until the client approves.
+    verify(matrixSynapseService, never()).createRoom(any(), any(), any());
+    verify(matrixSynapseService, never()).inviteUserToRoom(any(), any(), any());
+    assertThat(saved.getIsActive()).isFalse();
+    assertThat(saved.getMatrixRoomId()).isNull();
+    assertThat(saved.getNotes()).contains(SupervisionConsent.PENDING.name());
+  }
+
+  @Test
+  void decideSupervisionConsent_Should_provisionAndActivate_when_approved() throws Exception {
+    SessionSupervisor pending = pendingSupervisor(99L);
+    when(sessionSupervisorRepository.findById(99L)).thenReturn(Optional.of(pending));
+
+    SessionSupervisor result = facade.decideSupervisionConsent(SESSION_ID, 99L, true);
+
+    // Approval runs the deferred provisioning: side room created + supervisor invited to the
+    // client room, and the row flips to active with APPROVED consent.
+    verify(matrixSynapseService).createRoom(any(), any(), any());
+    verify(matrixSynapseService).inviteUserToRoom(eq(CLIENT_ROOM), eq(SUPERVISOR_MXID), any());
+    assertThat(result.getIsActive()).isTrue();
+    assertThat(result.getMatrixRoomId()).isEqualTo(SIDE_ROOM);
+    assertThat(result.getNotes()).contains(SupervisionConsent.APPROVED.name());
+  }
+
+  @Test
+  void decideSupervisionConsent_Should_recordDeclined_andNeverProvision_when_declined()
+      throws Exception {
+    SessionSupervisor pending = pendingSupervisor(98L);
+    when(sessionSupervisorRepository.findById(98L)).thenReturn(Optional.of(pending));
+
+    SessionSupervisor result = facade.decideSupervisionConsent(SESSION_ID, 98L, false);
+
+    verify(matrixSynapseService, never()).createRoom(any(), any(), any());
+    verify(matrixSynapseService, never()).inviteUserToRoom(any(), any(), any());
+    assertThat(result.getIsActive()).isFalse();
+    assertThat(result.getNotes()).contains(SupervisionConsent.DECLINED.name());
+  }
+
+  @Test
+  void decideSupervisionConsent_Should_throwBadRequest_when_noPendingRequest() {
+    SessionSupervisor active =
+        SessionSupervisor.builder()
+            .id(97L)
+            .session(session)
+            .supervisorConsultant(supervisor)
+            .addedByConsultant(addedBy)
+            .isActive(true)
+            .matrixRoomId(SIDE_ROOM)
+            .notes(
+                SupervisionNotes.encode(
+                    SupervisionReason.PEER_SUPPORT, "x", SupervisionConsent.NOT_REQUIRED))
+            .build();
+    when(sessionSupervisorRepository.findById(97L)).thenReturn(Optional.of(active));
+
+    assertThatThrownBy(() -> facade.decideSupervisionConsent(SESSION_ID, 97L, true))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void addSupervisor_Should_throwBadRequest_when_aPendingRequestAlreadyExists() {
+    when(sessionSupervisorRepository.findBySessionId(SESSION_ID))
+        .thenReturn(List.of(pendingSupervisor(1L)));
+
+    assertThatThrownBy(
+            () ->
+                facade.addSupervisor(
+                    SESSION_ID, SUPERVISOR_ID, addedBy, "SAFEGUARDING_U25", "again"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("already pending");
+  }
+
+  /** A PENDING-consent (inactive, no room) supervisor row for the mocked session/supervisor. */
+  private SessionSupervisor pendingSupervisor(Long id) {
+    return SessionSupervisor.builder()
+        .id(id)
+        .session(session)
+        .supervisorConsultant(supervisor)
+        .addedByConsultant(addedBy)
+        .isActive(false)
+        .matrixRoomId(null)
+        .notes(
+            SupervisionNotes.encode(
+                SupervisionReason.SAFEGUARDING_U25, "minor at risk", SupervisionConsent.PENDING))
+        .build();
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/supervision/SupervisionNotesTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/supervision/SupervisionNotesTest.java
@@ -1,0 +1,54 @@
+package de.caritas.cob.userservice.api.supervision;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** ADR-008 item 4 (DRAFT): {@link SupervisionNotes} encode/decode round trip + legacy fallback. */
+class SupervisionNotesTest {
+
+  @Test
+  void encodeThenDecode_Should_roundTrip_reasonJustificationAndConsent() {
+    String encoded =
+        SupervisionNotes.encode(
+            SupervisionReason.SAFEGUARDING_U25, "minor at risk", SupervisionConsent.PENDING);
+
+    assertThat(encoded).startsWith("{");
+
+    SupervisionNotes.Payload decoded = SupervisionNotes.decode(encoded);
+    assertThat(decoded.reasonCode).isEqualTo("SAFEGUARDING_U25");
+    assertThat(decoded.justification).isEqualTo("minor at risk");
+    assertThat(decoded.consent).isEqualTo(SupervisionConsent.PENDING.name());
+  }
+
+  @Test
+  void decode_Should_treatLegacyFreeText_asJustification_withNoReason_andNotRequiredConsent() {
+    SupervisionNotes.Payload decoded = SupervisionNotes.decode("just some old free text note");
+
+    assertThat(decoded.reasonCode).isNull();
+    assertThat(decoded.justification).isEqualTo("just some old free text note");
+    assertThat(decoded.consent).isEqualTo(SupervisionConsent.NOT_REQUIRED.name());
+  }
+
+  @Test
+  void decode_Should_handleNullAndBlank_asEmptyNotRequiredPayload() {
+    SupervisionNotes.Payload fromNull = SupervisionNotes.decode(null);
+    assertThat(fromNull.reasonCode).isNull();
+    assertThat(fromNull.justification).isNull();
+    assertThat(fromNull.consent).isEqualTo(SupervisionConsent.NOT_REQUIRED.name());
+
+    SupervisionNotes.Payload fromBlank = SupervisionNotes.decode("   ");
+    assertThat(fromBlank.consent).isEqualTo(SupervisionConsent.NOT_REQUIRED.name());
+  }
+
+  @Test
+  void encode_Should_serializeNullReason_onLegacyPath() {
+    String encoded =
+        SupervisionNotes.encode(null, "legacy justification", SupervisionConsent.NOT_REQUIRED);
+
+    SupervisionNotes.Payload decoded = SupervisionNotes.decode(encoded);
+    assertThat(decoded.reasonCode).isNull();
+    assertThat(decoded.justification).isEqualTo("legacy justification");
+    assertThat(decoded.consent).isEqualTo(SupervisionConsent.NOT_REQUIRED.name());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/supervision/SupervisionReasonTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/supervision/SupervisionReasonTest.java
@@ -1,0 +1,47 @@
+package de.caritas.cob.userservice.api.supervision;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** ADR-008 item 4 (DRAFT): reason lookup + consent-required flags + {@code initialFor} mapping. */
+class SupervisionReasonTest {
+
+  @Test
+  void fromCode_Should_resolveKnownCode_caseInsensitively_andTrim() {
+    assertThat(SupervisionReason.fromCode("peer_support")).contains(SupervisionReason.PEER_SUPPORT);
+    assertThat(SupervisionReason.fromCode("  SAFEGUARDING_U25 "))
+        .contains(SupervisionReason.SAFEGUARDING_U25);
+  }
+
+  @Test
+  void fromCode_Should_beEmpty_forNullOrUnknownCode() {
+    assertThat(SupervisionReason.fromCode(null)).isEmpty();
+    assertThat(SupervisionReason.fromCode("NOPE")).isEmpty();
+  }
+
+  @Test
+  void clinicallySensitiveReasons_Should_requireConsent_othersShouldNot() {
+    assertThat(SupervisionReason.CLINICAL_OVERSIGHT.isClientConsentRequired()).isTrue();
+    assertThat(SupervisionReason.SAFEGUARDING_U25.isClientConsentRequired()).isTrue();
+    assertThat(SupervisionReason.PEER_SUPPORT.isClientConsentRequired()).isFalse();
+    assertThat(SupervisionReason.TRAINING.isClientConsentRequired()).isFalse();
+  }
+
+  @Test
+  void initialFor_Should_bePending_whenConsentRequired_elseNotRequired() {
+    assertThat(SupervisionConsent.initialFor(SupervisionReason.CLINICAL_OVERSIGHT))
+        .isEqualTo(SupervisionConsent.PENDING);
+    assertThat(SupervisionConsent.initialFor(SupervisionReason.SAFEGUARDING_U25))
+        .isEqualTo(SupervisionConsent.PENDING);
+    assertThat(SupervisionConsent.initialFor(SupervisionReason.PEER_SUPPORT))
+        .isEqualTo(SupervisionConsent.NOT_REQUIRED);
+    assertThat(SupervisionConsent.initialFor(SupervisionReason.TRAINING))
+        .isEqualTo(SupervisionConsent.NOT_REQUIRED);
+  }
+
+  @Test
+  void initialFor_Should_beNotRequired_forNullReason_legacyPath() {
+    assertThat(SupervisionConsent.initialFor(null)).isEqualTo(SupervisionConsent.NOT_REQUIRED);
+  }
+}


### PR DESCRIPTION
## ADR-008 item 4 — supervisor add: reason + consent + authority

Records **why** a supervisor is attached (reason + justification), computes the **consent** state, and scopes **who** may attach one — mirroring the Case-Handover pattern (`CaseHandoverReason` + consent). Stacked on #293 (A2 side-room); merge #293 first.

### The three open decisions are now resolved (Frank, 2026-07-04)

1. **Reason set — confirmed as-is.** `SupervisionReason` = PEER_SUPPORT, CLINICAL_OVERSIGHT, SAFEGUARDING_U25, TRAINING. Only the two clinically sensitive reasons (CLINICAL_OVERSIGHT, SAFEGUARDING_U25) require the ratsuchende's consent. The FE just needs a **select field** fed by `GET /users/sessions/supervision/reasons` — a follow-up (see below).
2. **Who may attach — the agency admin ("Berater-Admin"), configured in the Admin board.** `hasPermissionToManageSupervisors` now allows an agency admin (restricted **or** super) to manage supervisors for **their own agency's** sessions, even when the assigned-only tightening is on. Cross-agency is still denied. The `supervision.restrict-add-to-assigned-consultant` flag is the server side of that Admin-board policy and **still defaults off**, so a plain same-agency consultant is unaffected at runtime.
3. **Disclosure — a clearly-marked draft template.** `SupervisionDisclosure` keeps the plumbing (records which disclosure version a supervisor add was made under); only the copy behind `PLACEHOLDER_TEXT_KEY` is pending the DPO. Not shown as final legal text.

### What's in this PR
- `SupervisionReason` / `SupervisionConsent` / `SupervisionNotes` / `SupervisionDisclosure` value classes.
- `addSupervisor(... reasonCode, notes)` records reason + justification + consent as JSON in the **existing `session_supervisor.notes` column** — **no schema migration** (deployed clusters run `ddl-auto=none` + Liquibase off; a new column would 500 supervisor queries; the ORISO-006 hazard).
- `GET /users/sessions/supervision/reasons` (static enum list, like case-handover reasons).
- Response DTO decodes reason/justification/consent back into structured fields; legacy free-text notes decode gracefully.
- `AuthenticatedUser` injected the same way `AssignSessionFacade` does — **boot test green** (the B3 constructor lesson: verified a real Spring context boots with the new arg).

### Non-breaking
- `reasonCode` is **optional** (no `@NotBlank`) — the running FE (no reason picker yet) keeps working.
- Authority tightening flag defaults **off** — runtime authority is unchanged until an agency admin turns it on.

### Tests
16 facade tests (incl. 2 new: agency admin allowed with restriction on; cross-agency admin denied) + `RocketChatDisabledBootTest` — all green. Spotless applied.

### Follow-ups (separate PRs, not in scope here)
- **FE:** the supervisor-modal reason **select** (mirror `CaseHandoverGate`), fed by `/supervision/reasons`.
- **Admin board:** the agency-admin UI to toggle the assigned-only policy per agency.
- **Client consent:** approve/decline endpoint (Case-Handover-style), once the DPO settles the disclosure copy.
- Promote the JSON-in-`notes` fields to real columns once Liquibase re-enablement lands.
