### PR TITLE
ci: run integration tests as a non-blocking burn-in job (verify)

### DIFF
--- a/.github/actions/maven-verify-burnin/action.yml
+++ b/.github/actions/maven-verify-burnin/action.yml
@@ -1,0 +1,92 @@
+name: Reusable Maven integration-test burn-in
+
+# Burn-in action (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+# Runs the full `verify` lifecycle so the surefire `integration-tests` execution
+# (bound to the integration-test phase, includes **/*IT.*) actually runs. These
+# integration tests have never run in CI before, so this action is wired into a
+# NON-BLOCKING (continue-on-error) job. It must NOT be a required check until the
+# ITs are green. `mvnw` is run with `-fae` so IT failures are visible in the job
+# summary and reports without aborting the report-collection step below.
+
+inputs:
+  java_version:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Set up JDK and Maven
+    uses: actions/setup-java@v5
+    with:
+      java-version: ${{ inputs.java_version }}
+      distribution: 'temurin'
+      cache: maven
+
+  - name: Run Maven verify (unit + integration tests, burn-in)
+    shell: bash
+    # -fae (fail-at-end) lets every module/execution run so the report set is
+    # complete; the actual pass/fail signal comes from the report gate below,
+    # which this burn-in job tolerates (continue-on-error at the job level).
+    run: ./mvnw -B -fae verify
+
+  - name: Assert test reports were produced (zero-report guard)
+    if: ${{ always() }}
+    shell: bash
+    # Guards against a future silent-skip: a green build that produced ZERO test
+    # reports must be treated as a failure, not a pass. Surefire writes both the
+    # unit (**/*Test) and integration (**/*IT) executions into surefire-reports;
+    # failsafe-reports is globbed too in case a module adopts failsafe later.
+    run: |
+      shopt -s nullglob globstar
+      reports=( **/target/surefire-reports/TEST-*.xml **/target/failsafe-reports/TEST-*.xml )
+      count=${#reports[@]}
+      echo "Found ${count} test report file(s)."
+      if [ "${count}" -eq 0 ]; then
+        echo "::error::Zero test reports were produced — tests were silently skipped or never ran."
+        exit 1
+      fi
+
+  - name: Summarise integration-test results (burn-in)
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      python3 - <<'PY'
+      from pathlib import Path
+      import xml.etree.ElementTree as ET
+
+      total_tests = total_failures = total_errors = total_skipped = 0
+      failing = []
+      for report in Path(".").glob("**/target/surefire-reports/TEST-*.xml"):
+          try:
+              root = ET.parse(report).getroot()
+          except ET.ParseError:
+              continue
+          tests = int(root.attrib.get("tests", 0))
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          skipped = int(root.attrib.get("skipped", 0))
+          total_tests += tests
+          total_failures += failures
+          total_errors += errors
+          total_skipped += skipped
+          if failures or errors:
+              failing.append((report, failures, errors))
+
+      print(f"Integration-test burn-in: tests={total_tests} "
+            f"failures={total_failures} errors={total_errors} skipped={total_skipped}")
+      if failing:
+          print("Reports with failures/errors (expected during burn-in):")
+          for report, failures, errors in sorted(failing):
+              print(f"- {report}: failures={failures}, errors={errors}")
+      PY
+
+  - name: Upload test reports
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: integration-test-reports-${{ inputs.java_version }}
+      path: |
+        **/target/surefire-reports/*.xml
+        **/target/failsafe-reports/*.xml
+      if-no-files-found: warn
+      retention-days: 7

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -19,3 +19,20 @@ jobs:
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify` so the integration-test phase (~69 *IT classes) runs on
+  # feature branches too. continue-on-error keeps it non-blocking during burn-in.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,3 +34,22 @@ jobs:
         push_to_ghcr: true
         image_name: oriso-userservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify` on dev/main so integration-test results stay visible after
+  # merge. Deliberately independent of the publish job: a red burn-in must NOT block
+  # image publishing while the ITs are being stabilised. continue-on-error enforces
+  # that. Flip to a required gate once burn-in is consistently green.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -27,3 +27,22 @@ jobs:
         push_to_ghcr: false
         image_name: oriso-userservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify`, which reaches the surefire `integration-tests` execution
+  # (integration-test phase, **/*IT.*) — ~69 IT classes that have never run in CI.
+  # continue-on-error keeps this OFF the required-checks path until the ITs are
+  # green; flip to a required check once burn-in is consistently passing.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'


### PR DESCRIPTION
## What changed

CI for UserService ran only `./mvnw -B test`, which stops before Maven's `integration-test` phase. The surefire `integration-tests` execution (bound to `integration-test`, includes `**/*IT.*`) therefore **never ran** — ~69 IT classes (incl. every `*TenantAwareIT`) were dormant.

This PR adds a **separate, non-blocking** integration-test job to all three workflows and hardens against silent test-skips.

**Maven invocation — before → after (per job):**

| Job | Before | After |
| --- | --- | --- |
| unit-test gate (`maven-build`, **blocking**) | `./mvnw -B test` + surefire-failure guard, then `./mvnw -B package -DskipTests` | *unchanged* |
| `integration-tests` (**new, non-blocking burn-in**) | — | `./mvnw -B -fae verify` + zero-report guard |

Files:
- **New** `.github/actions/maven-verify-burnin/action.yml` — runs `verify`, then a zero-report guard, an IT summary, and uploads reports as an artifact.
- `.github/workflows/ci-pull-request.yml`, `ci-feature-branch.yml`, `ci-main.yml` — add the `integration-tests (non-blocking, burn-in)` job.
- The existing `maven-build` action (blocking unit gate) is **untouched** — it already runs the test-failure guard on `dev`.

## Burn-in, not big-bang (rationale)

These ITs have **never run in CI**. Rather than flip `verify` on as a required gate and risk blocking every merge on newly-surfaced red tests, the new job is a **separate job with `continue-on-error: true`**, clearly named `integration-tests (non-blocking, burn-in)`. Results become visible in every PR and on `dev`/`main` without gating merges. **The existing unit-test gate stays blocking.**

**Action item:** once the burn-in job is consistently green, flip it to a required status check (remove `continue-on-error`, add to branch protection).

## Zero-report guard

The burn-in action fails the job if **zero** test report XMLs were produced:

```bash
reports=( **/target/surefire-reports/TEST-*.xml **/target/failsafe-reports/TEST-*.xml )
[ "${#reports[@]}" -eq 0 ] && exit 1
```

This guards against a future silent test-skip (a green build with zero reports currently passes). `verify` runs with `-fae` (fail-at-end) so the report set is complete even when some ITs fail.

## Expected-red ITs + services needed

Infra analysis (per repo, this audit): the ITs use **embedded H2 + Spring `@MockitoBean` mocks** — Keycloak, Rocket.Chat, Matrix/Synapse, LiveKit, Agency, ConsultingType and Tenant are all mocked or disabled (`rocket-chat.enabled=false`). **No external services / Testcontainers / WireMock are required on the runner.** `DatabaseChangelogDriftIT` self-skips unless `LIQUIBASE_IT_DB_URL` is set, and it plus `LiquibaseHibernateIT` are already excluded from the IT execution in the POM.

So no runner services are needed. However this repo has historically masked test failures with `testFailureIgnore=true` and the IT phase has never actually executed in CI, so **some of the ~69 ITs may be genuinely red on first run** — which is exactly why this is a non-blocking burn-in. Any ITs that later prove to need real infra will feed the audit roadmap Part 2 (Testcontainers) rather than being stood up here.

## Relationship to Hassan's PR #277

PR #277 (`chore(ci): clarify UserService validation workflows`) targets **`main`** and its changes (workflow/job renames, the surefire-failure guard in `maven-build`, PR-vs-publish Docker split) are **already present on `dev`**. This PR composes **additively** on top of that state: it does not modify `maven-build` or the Docker action, only adds a new `integration-tests` job + a new `maven-verify-burnin` action. No conflict with #277.

---

Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
