### PR TITLE
fix(matrix-sync): require auth + session ownership for /matrix/sync/register (Finding A)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixSyncController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixSyncController.java
@@ -37,20 +37,26 @@ public class MatrixSyncController {
   @PostMapping("/register/{sessionId}")
   public ResponseEntity<?> registerRoomForSync(@PathVariable Long sessionId) {
 
+    // Authorize the authenticated caller against the session (asker owns it / consultant is
+    // assigned) BEFORE doing anything. Kept outside the try/catch so the ForbiddenException /
+    // NotFoundException propagate to the global exception handler (403/404) instead of being
+    // swallowed into a 500. Closes the unauthenticated IDOR that leaked room ids + participant
+    // counts and allowed anonymous state changes.
+    var session = sessionService.assertUserHasAccess(sessionId, authenticatedUser);
+
     try {
       log.info("📡 Registering Matrix room for session {}", sessionId);
 
-      var session = sessionService.getSession(sessionId);
-      if (session.isEmpty() || session.get().getMatrixRoomId() == null) {
-        log.error("Session {} not found or has no Matrix room", sessionId);
+      if (session.getMatrixRoomId() == null) {
+        log.error("Session {} has no Matrix room", sessionId);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(Map.of("error", "Session not found or has no Matrix room"));
       }
 
-      String matrixRoomId = session.get().getMatrixRoomId();
-      String userId = session.get().getUser().getUserId();
+      String matrixRoomId = session.getMatrixRoomId();
+      String userId = session.getUser().getUserId();
       String consultantId =
-          session.get().getConsultant() != null ? session.get().getConsultant().getId() : null;
+          session.getConsultant() != null ? session.getConsultant().getId() : null;
 
       // Build set of user IDs who should receive notifications
       Set<String> userIds = new HashSet<>();
@@ -87,13 +93,17 @@ public class MatrixSyncController {
   @DeleteMapping("/register/{sessionId}")
   public ResponseEntity<?> unregisterRoomFromSync(@PathVariable Long sessionId) {
 
+    // Authorize the caller against the session before unregistering, so an outsider cannot silently
+    // kill live-event notifications for another session (denial-of-function). Kept outside the
+    // try/catch so ForbiddenException / NotFoundException reach the global exception handler.
+    var session = sessionService.assertUserHasAccess(sessionId, authenticatedUser);
+
     try {
-      var session = sessionService.getSession(sessionId);
-      if (session.isEmpty() || session.get().getMatrixRoomId() == null) {
+      if (session.getMatrixRoomId() == null) {
         return ResponseEntity.ok(Map.of("success", true));
       }
 
-      String matrixRoomId = session.get().getMatrixRoomId();
+      String matrixRoomId = session.getMatrixRoomId();
       matrixEventListenerService.unregisterRoom(matrixRoomId);
 
       log.info("✅ Unregistered Matrix room {} for session {}", matrixRoomId, sessionId);

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -136,8 +136,6 @@ public class SecurityConfig {
                 .permitAll()
                 .requestMatchers("/users/sessions/askers")
                 .permitAll()
-                .requestMatchers("/matrix/sync/**", "/service/matrix/sync/**")
-                .permitAll()
                 .requestMatchers(
                     "/users/email",
                     "/users/mails/messages/new",
@@ -331,10 +329,7 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return web ->
-        web.ignoring()
-            .requestMatchers(
-                "/actuator/**", "/users/askers/new", "/matrix/sync/**", "/service/matrix/sync/**");
+    return web -> web.ignoring().requestMatchers("/actuator/**", "/users/askers/new");
   }
 
   @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -224,7 +224,6 @@ csrf.whitelist.configUris=/users/docs,\
   /actuator/loggers/**,\
   /actuator/loggers,\
   /webjars/**,\
-  /matrix/sync/**,\
   /users/sessions/room,\
   /users/sessions/room/**,\
   /users/invitelinks/,\

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixSyncControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixSyncControllerTest.java
@@ -1,0 +1,92 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.matrix.MatrixEventListenerService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixSyncControllerTest {
+
+  private static final Long SESSION_ID = 42L;
+  private static final String USER_ID = "user-id";
+  private static final String MATRIX_ROOM_ID = "!room:matrix";
+
+  @Mock private MatrixEventListenerService matrixEventListenerService;
+  @Mock private SessionService sessionService;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private MatrixSyncController controller;
+
+  @Test
+  void registerRoomForSync_ShouldThrowForbiddenBeforeRegistering_WhenSessionAccessIsDenied() {
+    when(sessionService.assertUserHasAccess(SESSION_ID, authenticatedUser))
+        .thenThrow(new ForbiddenException("No permission"));
+
+    assertThrows(ForbiddenException.class, () -> controller.registerRoomForSync(SESSION_ID));
+
+    // IDOR is closed: no room is registered and no Matrix room id / user count is leaked.
+    verifyNoInteractions(matrixEventListenerService);
+  }
+
+  @Test
+  void unregisterRoomFromSync_ShouldThrowForbiddenBeforeUnregistering_WhenSessionAccessIsDenied() {
+    when(sessionService.assertUserHasAccess(SESSION_ID, authenticatedUser))
+        .thenThrow(new ForbiddenException("No permission"));
+
+    assertThrows(ForbiddenException.class, () -> controller.unregisterRoomFromSync(SESSION_ID));
+
+    // Denial-of-function is closed: an outsider cannot unregister another session's room.
+    verifyNoInteractions(matrixEventListenerService);
+  }
+
+  @Test
+  void registerRoomForSync_ShouldRegisterRoom_WhenAuthorizedParticipant() {
+    when(sessionService.assertUserHasAccess(SESSION_ID, authenticatedUser))
+        .thenReturn(sessionWithMatrixRoom());
+
+    var response = controller.registerRoomForSync(SESSION_ID);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    verify(matrixEventListenerService).registerRoom(eq(SESSION_ID), eq(MATRIX_ROOM_ID), anySet());
+  }
+
+  private Session sessionWithMatrixRoom() {
+    return Session.builder()
+        .id(SESSION_ID)
+        .user(userWithMatrixId())
+        .consultingTypeId(0)
+        .registrationType(Session.RegistrationType.REGISTERED)
+        .postcode("12345")
+        .status(Session.SessionStatus.IN_PROGRESS)
+        .matrixRoomId(MATRIX_ROOM_ID)
+        .teamSession(false)
+        .build();
+  }
+
+  private User userWithMatrixId() {
+    return User.builder()
+        .userId(USER_ID)
+        .username("seeker")
+        .email("seeker@example.org")
+        .matrixUserId("@seeker:matrix")
+        .languageFormal(false)
+        .build();
+  }
+}


### PR DESCRIPTION
Fixes **Finding A** from the **Test Quality Audit 2026-07-04, item 5** — `MatrixSyncController` is fully unauthenticated.

## Verified exploit
`adapters/web/controller/MatrixSyncController.java` exposes `POST`/`DELETE /matrix/sync/register/{sessionId}` (and `/service/…` variants) with **three** overlapping open-access vectors and **no** ownership check:
1. `SecurityConfig` `permitAll()` for `/matrix/sync/**`, `/service/matrix/sync/**`.
2. `WebSecurityCustomizer.web.ignoring()` — bypasses the **entire** filter chain, including the `oauth2ResourceServer` JWT filter, so no token is ever decoded and the injected `AuthenticatedUser` stays unpopulated.
3. `csrf.whitelist.configUris` in `application.properties` lists `/matrix/sync/**`, and those `configUris` are themselves `permitAll()`'d in `SecurityConfig` (line ~98).

Result:
- **`POST /register/{sessionId}`** — looks up *any* sessionId and returns `{success, roomId, userCount}`: an **unauthenticated IDOR** that enumerates sessionIds to harvest Matrix room ids + participant counts, plus an anonymous state change (registers the room for live-event sync).
- **`DELETE /register/{sessionId}`** — an anonymous caller can unregister *any* session's room from sync → **denial-of-function** (kills live-event notifications for that session).

## Caller analysis (verify-first)
The endpoint has **ZERO callers anywhere today**:
- **ORISO-Frontend:** no code calls `matrix/sync/register`. Its `endpoints.ts` defines only `matrixAccessToken → /service/matrix/me/token`; the `'sync'` strings in the FE are matrix-js-sdk client sync-state listeners (the browser syncs directly with Synapse), not this backend endpoint.
- **ORISO-UserService internal:** `matrixEventListenerService.registerRoom/unregisterRoom` are called *only* from this controller — no `@Scheduled` job, no `RestTemplate`/`WebClient`, no Matrix appservice callback.
- **Sibling services:** no matches for `matrix/sync/register`.

It is orphaned code left from the Matrix migration. The `/service/` prefix is the ingress / inter-service path convention, **not** a privileged service-to-service channel — both path variants resolve to the same method with identical (missing) auth, so they are locked together.

## Fix (safe default, mirrors sibling `MatrixMessageController`)
`MatrixMessageController` (same `@RequestMapping({"/matrix","/service/matrix"})`, same `sessionId` path var) already authorizes every session endpoint with `sessionService.assertUserHasAccess(sessionId, authenticatedUser)`. This PR applies the same pattern:

**SecurityConfig / properties** — remove `/matrix/sync/**` + `/service/matrix/sync/**` from all three open-access vectors:
- the `permitAll()` rule,
- the `web.ignoring()` customizer,
- the `csrf.whitelist.configUris` list.

They now fall under the existing `"/matrix/**"`, `"/service/matrix/**"` matcher → `hasAnyAuthority(USER_DEFAULT, CONSULTANT_DEFAULT)`, so the JWT resource-server filter and `StatelessCsrfFilter` apply, exactly like the sibling Matrix message endpoints.

**Controller** — call `sessionService.assertUserHasAccess(sessionId, authenticatedUser)` at the top of both methods, **outside** the `try/catch`, so `ForbiddenException` (403) / `NotFoundException` (404) reach the global exception handler instead of being swallowed into a 500. This closes the IDOR: an authenticated caller can only touch a session they **own** (asker) or are **assigned to** (consultant/agency).

Because no caller exists today, **nothing legitimate breaks**. This is the safe default the audit calls for: authentication + session-ownership authorization.

Minor, acceptable behavior change: `DELETE` for a *genuinely missing* session now returns **404** (was an idempotent `200`). This stops anonymous session probing; the only intended caller (frontend on session close) always references a session it participates in.

## Test evidence (TDD, red → green)
New `MatrixSyncControllerTest` (JUnit5 + Mockito, matching `MatrixMessageControllerTest`):
- `registerRoomForSync_ShouldThrowForbiddenBeforeRegistering_WhenSessionAccessIsDenied` — **red** before fix ("Expected ForbiddenException … nothing was thrown"), green after; asserts `verifyNoInteractions(matrixEventListenerService)` (no leak).
- `unregisterRoomFromSync_ShouldThrowForbiddenBeforeUnregistering_WhenSessionAccessIsDenied` — same.
- `registerRoomForSync_ShouldRegisterRoom_WhenAuthorizedParticipant` — **red** before ("200 expected but 404"), green after; authorized participant still registers the room (200).

`Tests run: 3, Failures: 0`. Existing `MatrixMessageControllerTest` still green (4/4). Full module `test-compile` clean, `spotless:check` clean. JDK 21.

## Residual risk / callers to update
- No caller must change today (none exists).
- If a **future** frontend feature needs to drive room sync, it must call these endpoints as an authenticated user (asker/consultant on that session) with the CSRF token — the same contract as every other `/matrix/**` endpoint. Documented here so the contract is explicit.
- Alternatively, if this is genuinely dead code, a follow-up can delete the controller outright; this PR conservatively secures it rather than removing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)