### PR TITLE
test: Matrix-only enquiry room-provisioning coverage (C2) + scheduler ITs to Matrix mode

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
@@ -1,0 +1,225 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
+import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * End-to-end Matrix-only (RC-off) coverage of the enquiry room-provisioning chain through {@link
+ * CreateEnquiryMessageFacade}, driving a REAL {@link AgencyPreAssignmentRoomService} (rather than a
+ * mock) so the full orchestration actually runs:
+ *
+ * <pre>
+ *   createEnquiryMessage (rocket-chat.enabled=false, session has no Matrix room)
+ *     -> ensureMatrixRoomForEnquiry
+ *        -> AgencyPreAssignmentRoomService.ensureHoldingRoom
+ *           -> Matrix room created, enquiry user invited + joined (membership)
+ *           -> session.matrixRoomId persisted
+ *     -> Matrix enquiry message sent
+ *     -> session persisted (status NEW, groupId = matrix room id)
+ * </pre>
+ *
+ * and asserts {@code verifyNoInteractions(rocketChatService)} for the whole flow.
+ *
+ * <p>This is the enquiry-facade end-to-end path that PR #300 explicitly deferred ("enquiry-facade
+ * coverage stays at the adapter-contract level rather than driving CreateEnquiryMessageFacade
+ * end-to-end"). The prior {@code CreateEnquiryMessageFacadeTest} Matrix cases all pre-seed {@code
+ * session.matrixRoomId} and mock the room service, so the create/invite/membership/persist chain
+ * was never exercised via the facade. Test Quality Audit 2026-07-04 — RC teardown phase 2 + C2.
+ */
+@ExtendWith(MockitoExtension.class)
+class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
+
+  private static final Long SESSION_ID = 1234L;
+  private static final Long AGENCY_ID = 55L;
+  private static final String MESSAGE = "Hello, I need help.";
+  private static final String USER_ID = "user-abc";
+  private static final String USER_MATRIX_ID = "@asker:oriso.org";
+  private static final String AGENCY_MATRIX_ID = "@agency-svc:oriso.org";
+  private static final String AGENCY_MATRIX_LOCALPART = "agency-svc";
+  private static final String AGENCY_MATRIX_PASSWORD = "s3cret";
+  private static final String AGENCY_TOKEN = "agency-token";
+  private static final String USER_TOKEN = "user-token";
+  private static final String NEW_ROOM_ID = "!provisioned:oriso.org";
+  private static final String MATRIX_EVENT_ID = "$event-1";
+
+  @InjectMocks private CreateEnquiryMessageFacade createEnquiryMessageFacade;
+
+  @Mock private SessionService sessionService;
+  @Mock private RocketChatService rocketChatService;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private ConsultantAgencyService consultantAgencyService;
+  @Mock private ConsultingTypeManager consultingTypeManager;
+  @Mock private TopicConsultantRoutingService topicConsultantRoutingService;
+
+  @Mock
+  private de.caritas.cob.userservice.api.facade.EmailNotificationFacade emailNotificationFacade;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.message.MessageServiceProvider
+      messageServiceProvider;
+
+  @Mock private de.caritas.cob.userservice.api.helper.UserHelper userHelper;
+  @Mock private de.caritas.cob.userservice.api.service.user.UserService userService;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService
+      liveEventNotificationService;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.notification.EventNotificationService
+      eventNotificationService;
+
+  // Satisfies @InjectMocks construction (facade uses @NonNull constructor injection); the real
+  // service is swapped in via setField in @BeforeEach so the orchestration actually runs.
+  @Mock private AgencyPreAssignmentRoomService injectedRoomServicePlaceholder;
+
+  // Room-provisioning collaborators of the REAL AgencyPreAssignmentRoomService.
+  @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
+
+  private Session session;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    // RC-off: the Matrix path is always taken.
+    setField(createEnquiryMessageFacade, "rocketChatEnabled", false);
+
+    // Wire a REAL room-provisioning service around the mocked Matrix collaborators so the
+    // create/invite/join/persist orchestration actually executes when the facade calls it.
+    var realRoomService =
+        new AgencyPreAssignmentRoomService(
+            matrixCredentialClient, matrixSynapseService, sessionService);
+    setField(createEnquiryMessageFacade, "agencyPreAssignmentRoomService", realRoomService);
+
+    user = new User();
+    user.setUserId(USER_ID);
+    user.setMatrixUserId(USER_MATRIX_ID);
+
+    session = new Session();
+    session.setId(SESSION_ID);
+    session.setAgencyId(AGENCY_ID);
+    session.setRegistrationType(RegistrationType.REGISTERED);
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setIsConsultantDirectlySet(false);
+    session.setMatrixRoomId(null); // no room yet -> provisioning must run
+
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(Mockito.mock(HttpServletRequest.class)));
+  }
+
+  private AgencyMatrixCredentialsDTO validCredentials() {
+    var creds = new AgencyMatrixCredentialsDTO();
+    creds.setMatrixUserId(AGENCY_MATRIX_ID);
+    creds.setMatrixPassword(AGENCY_MATRIX_PASSWORD);
+    return creds;
+  }
+
+  @Test
+  @DisplayName(
+      "RC-off enquiry with no existing room provisions Matrix room end-to-end and never touches"
+          + " Rocket.Chat")
+  void createEnquiryMessage_provisionsMatrixRoomEndToEnd_andNeverCallsRocketChat()
+      throws Exception {
+    var consultant = new Consultant();
+    consultant.setId("consultant-1");
+    var consultantAgency = new ConsultantAgency();
+    consultantAgency.setConsultant(consultant);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(List.of(consultantAgency));
+
+    // Room-provisioning collaborators (real AgencyPreAssignmentRoomService drives these).
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+    var createBody = new MatrixCreateRoomResponseDTO();
+    createBody.setRoomId(NEW_ROOM_ID);
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenReturn(ResponseEntity.ok(createBody));
+    when(matrixSynapseService.inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN))
+        .thenReturn(ResponseEntity.ok(new MatrixInviteUserResponseDTO()));
+
+    // Enquiry-message post + membership use the user's own token.
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(matrixSynapseService.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
+    when(matrixSynapseService.sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN))
+        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+
+    var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(
+                user, SESSION_ID, MESSAGE, null, RocketChatCredentials.builder().build()));
+
+    // Room provisioned: create -> invite -> membership.
+    verify(matrixSynapseService).createRoom(anyString(), anyString(), eq(AGENCY_TOKEN));
+    verify(matrixSynapseService).inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+    verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, USER_TOKEN);
+
+    // Enquiry message posted to the provisioned room.
+    verify(matrixSynapseService).sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN);
+
+    // Session persisted with the provisioned room id (once by the room service, once by the
+    // facade).
+    verify(sessionService, Mockito.atLeastOnce()).saveSession(session);
+    assertEquals(NEW_ROOM_ID, session.getMatrixRoomId());
+    assertEquals(NEW_ROOM_ID, session.getGroupId());
+    assertEquals(SessionStatus.NEW, session.getStatus());
+
+    // Response reflects the provisioned Matrix room + event.
+    assertEquals(NEW_ROOM_ID, response.getRcGroupId());
+    assertEquals(SESSION_ID, response.getSessionId());
+    assertEquals(MATRIX_EVENT_ID, response.getT());
+
+    // The whole enquiry flow never touched Rocket.Chat.
+    verifyNoInteractions(rocketChatService);
+
+    RequestContextHolder.resetRequestAttributes();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
@@ -1,0 +1,250 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Matrix-only integration coverage for the agency pre-assignment (holding) room provisioning path —
+ * the room-creation / invite / membership orchestration that runs when an enquiry is created with
+ * {@code rocket-chat.enabled=false} and the session does not yet have a Matrix room.
+ *
+ * <p>This class-under-test had ZERO test coverage. It is the enquiry-time room provisioner reached
+ * via {@code CreateEnquiryMessageFacade.ensureMatrixRoomForEnquiry(...)}. These tests assert the
+ * production orchestration deterministically (Mockito, no live Synapse): the agency service account
+ * logs in, a room is created, the enquiry user is invited AND joins (membership), and the room id
+ * is persisted on the session. No Rocket.Chat interaction is possible here — the service does not
+ * depend on RocketChatService at all, which is itself the RC-off contract for this slice.
+ *
+ * <p>Complements PR #300 (which proved branch selection at the chat/adapter level and explicitly
+ * deferred driving the enquiry room-provisioning path end-to-end). Test Quality Audit 2026-07-04 —
+ * RC teardown phase 2 + C2.
+ */
+@ExtendWith(MockitoExtension.class)
+class AgencyPreAssignmentRoomServiceTest {
+
+  private static final Long AGENCY_ID = 4711L;
+  private static final Long SESSION_ID = 99L;
+  private static final String USER_MATRIX_ID = "@asker:oriso.org";
+  private static final String AGENCY_MATRIX_ID = "@agency-svc:oriso.org";
+  private static final String AGENCY_MATRIX_LOCALPART = "agency-svc";
+  private static final String AGENCY_MATRIX_PASSWORD = "s3cret";
+  private static final String AGENCY_TOKEN = "agency-access-token";
+  private static final String USER_TOKEN = "user-access-token";
+  private static final String NEW_ROOM_ID = "!newRoom:oriso.org";
+
+  @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private SessionService sessionService;
+
+  @InjectMocks private AgencyPreAssignmentRoomService underTest;
+
+  private Session session;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User();
+    user.setUserId("user-1");
+    user.setMatrixUserId(USER_MATRIX_ID);
+
+    session = new Session();
+    session.setId(SESSION_ID);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(null);
+  }
+
+  private AgencyMatrixCredentialsDTO validCredentials() {
+    var creds = new AgencyMatrixCredentialsDTO();
+    creds.setMatrixUserId(AGENCY_MATRIX_ID);
+    creds.setMatrixPassword(AGENCY_MATRIX_PASSWORD);
+    return creds;
+  }
+
+  private void stubHappyPathUntilRoomCreation() throws MatrixCreateRoomException {
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+    var body = new MatrixCreateRoomResponseDTO();
+    body.setRoomId(NEW_ROOM_ID);
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenReturn(ResponseEntity.ok(body));
+  }
+
+  @Test
+  @DisplayName(
+      "ensureHoldingRoom provisions the room end-to-end: create -> invite -> join -> persist")
+  void ensureHoldingRoom_provisionsRoomInviteMembershipAndPersists() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    when(matrixSynapseService.inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN))
+        .thenReturn(ResponseEntity.ok(new MatrixInviteUserResponseDTO()));
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(matrixSynapseService.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    // agency service account authenticated with the local part of its matrix id
+    verify(matrixSynapseService).loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD);
+
+    // room created with the agency token
+    ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> aliasCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService)
+        .createRoom(nameCaptor.capture(), aliasCaptor.capture(), eq(AGENCY_TOKEN));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        nameCaptor.getValue().contains(String.valueOf(SESSION_ID)));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        aliasCaptor.getValue().startsWith("agency_hold_" + SESSION_ID));
+
+    // user invited to the new room and membership established via join
+    verify(matrixSynapseService).inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+    verify(matrixSynapseService).loginAsUserAccessToken(USER_MATRIX_ID);
+    verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, USER_TOKEN);
+
+    // room id persisted on the session
+    verify(sessionService).saveSession(session);
+    assertEquals(NEW_ROOM_ID, session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom is a no-op when the session already has a Matrix room")
+  void ensureHoldingRoom_noOp_whenRoomAlreadyPresent() {
+    session.setMatrixRoomId("!existing:oriso.org");
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(matrixCredentialClient, matrixSynapseService, sessionService);
+    assertEquals("!existing:oriso.org", session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom skips provisioning when the session has no agency")
+  void ensureHoldingRoom_skips_whenNoAgency() {
+    session.setAgencyId(null);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(matrixCredentialClient, matrixSynapseService, sessionService);
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom skips provisioning when the enquiry user has no Matrix id")
+  void ensureHoldingRoom_skips_whenUserHasNoMatrixId() {
+    user.setMatrixUserId("  ");
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(matrixCredentialClient, matrixSynapseService, sessionService);
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom skips provisioning when the agency has no Matrix service account")
+  void ensureHoldingRoom_skips_whenNoAgencyCredentials() {
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(matrixSynapseService, sessionService);
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom aborts before login when agency credentials are incomplete")
+  void ensureHoldingRoom_aborts_whenCredentialsIncomplete() {
+    var creds = new AgencyMatrixCredentialsDTO();
+    creds.setMatrixUserId(AGENCY_MATRIX_ID);
+    creds.setMatrixPassword("  ");
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.of(creds));
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(matrixSynapseService, sessionService);
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom does not persist a room when the agency login fails")
+  void ensureHoldingRoom_doesNotPersist_whenAgencyLoginFails() {
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn("  ");
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionService, never()).saveSession(any());
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom does not persist a room when create returns an empty body")
+  void ensureHoldingRoom_doesNotPersist_whenCreateRoomReturnsEmptyBody() throws Exception {
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+    var emptyBody = new MatrixCreateRoomResponseDTO();
+    emptyBody.setRoomId("  ");
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenReturn(ResponseEntity.ok(emptyBody));
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(matrixSynapseService, never()).inviteUserToRoom(anyString(), anyString(), anyString());
+    verify(sessionService, never()).saveSession(any());
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom swallows a MatrixCreateRoomException without persisting")
+  void ensureHoldingRoom_swallowsCreateRoomException() throws Exception {
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenThrow(new MatrixCreateRoomException("boom"));
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionService, never()).saveSession(any());
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom is null-safe for null session or user")
+  void ensureHoldingRoom_nullSafe() {
+    underTest.ensureHoldingRoom(null, user);
+    underTest.ensureHoldingRoom(session, null);
+
+    verifyNoInteractions(matrixCredentialClient, matrixSynapseService, sessionService);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateAnonymousUserSchedulerIT.java
@@ -30,7 +30,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
+// RC teardown phase 2: this scheduler IT never exercises Rocket.Chat (it only imports
+// RocketChatTestConfig for context and never calls it), so it runs in the production Matrix-only
+// mode (rocket-chat.enabled=false → DisabledRocketChatService is the active bean).
+@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=false"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({KeycloakTestConfig.class, RocketChatTestConfig.class, ApiControllerTestConfig.class})
 class DeactivateAnonymousUserSchedulerIT {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
@@ -32,7 +32,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
-@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=true"})
+// RC teardown phase 2: this scheduler IT never exercises Rocket.Chat (it only imports
+// RocketChatTestConfig for context and never calls it), so it runs in the production Matrix-only
+// mode (rocket-chat.enabled=false → DisabledRocketChatService is the active bean).
+@TestPropertySource(properties = {"spring.profiles.active=testing", "rocket-chat.enabled=false"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @Import({
   KeycloakTestConfig.class,


### PR DESCRIPTION
## What & why

Closes the **C2** gap from the **Test Quality Audit 2026-07-04 — RC teardown phase 2 + C2**: the Matrix-only (`rocket-chat.enabled=false`) enquiry **room-provisioning** path — *enquiry → Matrix room creation → invite → membership → persist* — had **no integration coverage**. This PR adds that coverage and picks up exactly where **PR #300** stopped.

**Coordination with #300 (no overlap):** #300 added `DisabledRocketChatServiceContractTest` + `CreateChatFacadeRocketChatDisabledTest` and *explicitly deferred* driving the enquiry facade end-to-end ("enquiry-facade coverage stays at the adapter-contract level rather than driving `CreateEnquiryMessageFacade` end-to-end… A focused `verifyNoInteractions(rocketChatService)` on the enquiry facade's Matrix branch is the one easy extension if wanted"). This PR is that extension. Different files, complementary scope.

## New coverage

### 1. `AgencyPreAssignmentRoomServiceTest` — 10 tests (NEW; class had ZERO coverage)
`AgencyPreAssignmentRoomService` is the enquiry-time room provisioner reached via `CreateEnquiryMessageFacade.ensureMatrixRoomForEnquiry(...)`. Deterministic Mockito (no live Synapse). Asserts the full orchestration:
- agency service-account login (local part of its Matrix id) → `createRoom` → `inviteUserToRoom` → user `loginAsUserAccessToken` + `joinRoom` (**membership**) → `session.matrixRoomId` set + `sessionService.saveSession` (**persist**)
- guard branches: room already present, no agency, user without Matrix id, missing / incomplete agency credentials, agency-login failure, empty create-room body, `MatrixCreateRoomException` swallowed, null-safety.

### 2. `CreateEnquiryMessageFacadeMatrixRoomProvisioningTest` — 1 test (NEW; end-to-end)
Drives `CreateEnquiryMessageFacade.createEnquiryMessage(...)` with **RC off** and a session that has **no Matrix room yet**, wiring a **real** `AgencyPreAssignmentRoomService` around a mocked `MatrixSynapseService`/`AgencyMatrixCredentialClient` so the create/invite/join/persist chain actually runs through the facade. Asserts: room provisioned (create+invite+join), enquiry message posted to it, session persisted (status `NEW`, `groupId` = room id), response carries the Matrix room + event, and **`verifyNoInteractions(rocketChatService)`** for the whole flow.

Why this is genuinely new: the existing `CreateEnquiryMessageFacadeTest` Matrix cases all **pre-seed `session.matrixRoomId`** and **mock** the room service, so the actual provisioning chain was never exercised via the facade.

## Scheduler ITs → Matrix mode (2 files, 1 line each)

`DeleteUserAnonymousSchedulerIT` and `DeactivateAnonymousUserSchedulerIT` were pinned `rocket-chat.enabled=true` but **never exercise Rocket.Chat** (they import `RocketChatTestConfig` for context and never call it — no RC mocks, no RC assertions). Flipped to `rocket-chat.enabled=false` so they run in the production Matrix-only config.

⚠️ **Honesty note:** these two `*IT` classes could **not be validated locally** — both fail in `@BeforeEach setup()` with `javax.ws.rs.NotFoundException: HTTP 404` from `createAnonymousEnquiry(...)` hitting an un-stubbed service endpoint in a bare local checkout. **This is PRE-EXISTING** and reproduces identically on unmodified `origin/dev` with `rocket-chat.enabled=true`, so it is unrelated to this change (which is inert w.r.t. the 404). They run in the failsafe `integration-test` phase (`testFailureIgnore`), not the surefire CI gate. Isolated in its own commit so it can be dropped independently if preferred.

## The 61 RC-pinned controller E2E ITs — DEFERRED with a plan (NOT deleted, NOT faked-green)

`UserControllerSessionE2EIT` (line 142, `@SpringBootTest(properties = "rocket-chat.enabled=true")`, **26 tests**) and `UserControllerChatE2EIT` (line 119, same pin, **35 tests**) are the only deep session/chat ITs and are hard-pinned to RC. They depend on `RocketChatTestConfig` (which is `@ConditionalOnProperty(rocket-chat.enabled=true)`) and assert RC-specific side effects (`RocketChatTestConfig.addTechnicalUserToGroup(...) called`, `rcGroupId`, muted-user room state, group deletion, etc.). Flipping to `false` de-registers that config and makes every RC assertion invalid, so **wholesale conversion is a large, high-risk rewrite unsuitable for a test-only PR**. Converting even the "RC-incidental" ones still requires removing `RocketChatTestConfig`-based setup and re-verifying each.

**Deferred conversion plan (per group — what each asserts today → Matrix equivalent on `MatrixSynapseService`):**

| Group | # | Asserts today (RC) | Matrix equivalent |
|-------|---|--------------------|-------------------|
| `createEnquiryMessage*` (Session IT) | 3 | RC group create + message post | `createRoom` + `sendMessage` (see new tests in this PR — reuse the harness) |
| `getSessionsFor*Consultant/User*` (Session IT) | 10 | RC room subscriptions / message queries drive session-list enrichment | Matrix room-state / last-message enrichment via the Matrix session-list provider |
| `assignSession*` (Session IT) | 2 | RC tech-user group membership add | `inviteUserToRoom` / membership on assign |
| `removeFromSession*` (Session IT) | 3 | RC user removal from group | Matrix room leave / kick |
| `createChatV1/V2` (Chat IT) | 2 | RC group creation | `createRoomAsMatrixUser` |
| `banFromChat*` (Chat IT) | 7 | RC mute-user-in-room | Matrix power-level / ban |
| `getChat*` (Chat IT) | 4 | RC room info → banned/muted users | Matrix room member state |
| `leaveChat*` (Chat IT) | 4 | RC group deletion + Mongo member queries | Matrix room leave + member count (Matrix-native) |
| `updateE2eInChats*` (Chat IT) | 6 | RC subscriptions fetch + E2E key post | Matrix E2EE key distribution (only if/when SDK crypto is enabled — see ADR-004/005) |
| `stopChat*` (Chat IT) | 4 | RC group deletion | Matrix room shutdown (cf. `fix/group-stop-matrix-lifecycle`) |
| RC-incidental (both ITs) | 16 | just need app context; mock empty RC responses | remove `RocketChatTestConfig` setup, flip to `false`, re-verify |

Recommended follow-up: a dedicated ticket to migrate these two IT classes to a shared Matrix test harness (the `MatrixSynapseService` mock pattern established here), one controller at a time. Several groups (`leaveChat`, `stopChat`, member queries) already have production Matrix equivalents landing in sibling PRs (#295/#296/#297), so their ITs should be converted alongside those.

## Verification

- Full **surefire suite** (JDK 21, `release 21`, the CI gate) → **BUILD SUCCESS, 0 failures, 0 errors**.
- New tests green together with the existing `CreateEnquiryMessageFacadeTest` (40 total in that group).
- No unnecessary-stubbing warnings on the end-to-end test → confirms the real production path drives every mock.

Test-only; no `src/main`, no schema, no `.github/` changes. No file overlap with #300 or PR #306 (the sibling deletions PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)