### PR TITLE
test: fix context-load failures in 2 authorization ITs (schema not provisioned, not seed quoting)

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -121,7 +121,7 @@ import org.springframework.test.web.servlet.MockMvc;
       "spring.datasource.username=sa",
       "spring.datasource.password=sa",
       "spring.datasource.driver-class-name=org.h2.Driver",
-      "spring.jpa.hibernate.ddl-auto=none",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
       "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
       "keycloak.auth-server-url=https://auth.testing",
       "keycloak.realm=testing",

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserStatisticsControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserStatisticsControllerAuthorizationIT.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
       "spring.datasource.username=sa",
       "spring.datasource.password=sa",
       "spring.datasource.driver-class-name=org.h2.Driver",
-      "spring.jpa.hibernate.ddl-auto=none",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
       "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
       "keycloak.auth-server-url=https://auth.testing",
       "keycloak.realm=testing",


### PR DESCRIPTION
## Summary

Fixes the ApplicationContext **context-load** failures in the two UserService authorization ITs flagged by the CI burn-in readiness measurement (**Test Quality Audit 2026-07-04 — CI burn-in readiness, US-VERIFY-1**). Unblocks these ITs toward flipping the `verify` burn-in job to required.

**One-line change in each of two test files:** `spring.jpa.hibernate.ddl-auto=none` → `create-drop`. No production code, no `.github/`, no auth code, no seed SQL touched.

## Corrected root-cause diagnosis

The readiness ticket attributed ~170 failures to an **unquoted `INSERT INTO user`** reserved-word bug in `src/test/resources/database/UserServiceDatabase.sql`. On the **current `dev` branch that premise does not hold** — the branch is on **Spring Boot 4.0.1 / Hibernate 7.2 / H2 1.4.200** (the SB4 upgrade, commit `32aabdca`).

What actually happens:

1. `UserControllerAuthorizationIT` and `UserStatisticsControllerAuthorizationIT` set `spring.jpa.hibernate.ddl-auto=none` in their `@TestPropertySource`.
2. In the `testing` profile, Liquibase is disabled (`spring.liquibase.enabled=false`) and there is **no** `spring.sql.init.schema-locations`. With `ddl-auto=none`, **nothing creates the schema.**
3. The data seed (`spring.sql.init.data-locations=…/UserServiceDatabase.sql`) then fails at statement #9 with `org.h2.jdbc.JdbcSQLSyntaxErrorException: Tabelle "USER" nicht gefunden` → `dataSourceScriptDatabaseInitializer` bean fails → **whole ApplicationContext fails to load** → every test in the class errors.

Why the seed itself is **not** the bug on this branch (empirically verified against the exact H2 1.4.200 jar and a Hibernate 7.2 bootstrap):
- Hibernate 7.2 emits **`create table user`** *unquoted* for `@Table(name = "user")`; H2 1.4.200 folds the unquoted identifier to **`USER`**.
- The seed's bare `INSERT INTO user` also folds to `USER` → **matches**. Same for `session`.
- **50 of 52 ITs** (all using the profile default `ddl-auto=create-drop`) already **pass with the seed unchanged**, including tenant-aware ITs that additionally load `transformDataForTenants.sql`.
- Quoting the seed as `INSERT INTO "user"` would search for a *lowercase* `user` table and **break those 50 passing ITs** (proven: `Tabelle "user" nicht gefunden`).

So the seed is intentionally left untouched; only the schema-provisioning override in the 2 failing ITs is corrected to match the other 50.

## The fix

Give the 2 ITs the same schema provisioning as everyone else — `ddl-auto=create-drop` (the base `application-testing.properties` default). Hibernate creates the tables, the seed loads, the context starts.

## Before / after (JDK 21, `mvnw -o test -Dtest=…`)

| IT | before | after |
|---|---|---|
| `UserControllerAuthorizationIT` | 170 run / **170 context-load errors** | 170 run / **0 errors**, 72 pass, 98 unrelated auth-status assertion failures (401/403/…) |
| `UserStatisticsControllerAuthorizationIT` | 3 run / **3 context-load errors** | 3 run / **0 errors**, 1 pass, 2 unrelated auth-status assertion failures |

`grep` for any remaining SQL/schema error in the after-report: **0**. The context-load class of failure is fully eliminated. The remaining failures are pre-existing authorization-behavior assertions (HTTP 401 vs 403 vs 200) — a separate concern (relaxed-CSRF / Matrix-migration security divergence), out of scope here.

Sanity-checked create-drop ITs still green with the seed unchanged: `SessionAdminServiceIT` (12/12), `ConsultantAdminFilterServiceTenantAwareIT` (15/15), `UserServiceApplicationIT` (1/1).

## Impact

Removes the single largest bucket of `verify` context-load errors (these 2 ITs alone accounted for ~173), unblocking the burn-in toward flip-to-required. `spotless:apply` clean; no collision — none of the 23 open UserService PRs (#183–#307) touch these two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)