### PR TITLE
test: add unit tests for EmailNotificationFacade, CreateEnquiryMessageFacade, ConsultantAdminFacade, UpdateAdminService, CreateUserFacade, AppointmentService

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -2,19 +2,27 @@ package de.caritas.cob.userservice.api.admin.facade;
 
 import static de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO.AgencyTypeEnum.DEFAULT_AGENCY;
 import static de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO.AgencyTypeEnum.TEAM_AGENCY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyAdminFullResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAgencyResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantFilter;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSearchResultDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.Sort;
 import de.caritas.cob.userservice.api.adapters.web.dto.Sort.FieldEnum;
@@ -270,5 +278,178 @@ class ConsultantAdminFacadeTest {
     AgencyDTO agency = new AgencyDTO();
     agency.setTenantId(tenantId);
     return agency;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void markConsultantAgenciesForDeletion_Should_useConsultantAgencyAdminServiceCorrectly() {
+    List<Long> agencyIds = Lists.newArrayList(1L, 2L);
+
+    consultantAdminFacade.markConsultantAgenciesForDeletion("consultantId", agencyIds);
+
+    verify(consultantAgencyAdminService)
+        .markConsultantAgenciesForDeletion("consultantId", agencyIds);
+  }
+
+  @Test
+  void pauseConsultantDeletion_Should_useConsultantAdminServiceCorrectly() {
+    consultantAdminFacade.pauseConsultantDeletion("consultantId", "reason", 3, "admin");
+
+    verify(consultantAdminService).pauseConsultantDeletion("consultantId", "reason", 3, "admin");
+  }
+
+  @Test
+  void prepareConsultantAgencyRelation_Should_prepareEachAgencyInList() {
+    List<CreateConsultantAgencyDTO> agencies =
+        Lists.newArrayList(
+            new CreateConsultantAgencyDTO().agencyId(1L),
+            new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAdminFacade.prepareConsultantAgencyRelation("consultantId", agencies);
+
+    verify(relationCreatorService, times(2)).prepareConsultantAgencyRelation(any());
+  }
+
+  @Test
+  void completeConsultantAgencyAssigment_Should_completeEachAgencyInList() {
+    List<CreateConsultantAgencyDTO> agencies =
+        Lists.newArrayList(
+            new CreateConsultantAgencyDTO().agencyId(1L),
+            new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAdminFacade.completeConsultantAgencyAssigment("consultantId", agencies);
+
+    verify(relationCreatorService, times(2)).completeConsultantAgencyAssigment(any(), any());
+  }
+
+  @Test
+  void filterAgencyListForDeletion_Should_returnPersistedAgenciesNotInNewList() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(
+        Lists.newArrayList(
+            agencyAdminFullResponse(1L), agencyAdminFullResponse(2L), agencyAdminFullResponse(3L)));
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+
+    List<Long> result =
+        consultantAdminFacade.filterAgencyListForDeletion(
+            "consultantId", Lists.newArrayList(new CreateConsultantAgencyDTO().agencyId(1L)));
+
+    assertThat(result, containsInAnyOrder(2L, 3L));
+  }
+
+  @Test
+  void filterAgencyListForDeletion_Should_returnEmptyList_When_AllPersistedAgenciesAreInNewList() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(Lists.newArrayList(agencyAdminFullResponse(1L)));
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+
+    List<Long> result =
+        consultantAdminFacade.filterAgencyListForDeletion(
+            "consultantId", Lists.newArrayList(new CreateConsultantAgencyDTO().agencyId(1L)));
+
+    assertThat(result, empty());
+  }
+
+  @Test
+  void filterAgencyListForCreation_Should_removeAgenciesAlreadyPersisted() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(Lists.newArrayList(agencyAdminFullResponse(1L)));
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    List<CreateConsultantAgencyDTO> newList =
+        Lists.newArrayList(
+            new CreateConsultantAgencyDTO().agencyId(1L),
+            new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAdminFacade.filterAgencyListForCreation("consultantId", newList);
+
+    List<Long> remainingIds =
+        newList.stream()
+            .map(CreateConsultantAgencyDTO::getAgencyId)
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(remainingIds, contains(2L));
+  }
+
+  @Test
+  void findFilteredConsultants_Should_useDefaultSort_When_SortIsNull() {
+    var searchResult = new ConsultantSearchResultDTO();
+    when(consultantAdminFilterService.findFilteredConsultants(any(), any(), any(), any()))
+        .thenReturn(searchResult);
+
+    consultantAdminFacade.findFilteredConsultants(1, 1, new ConsultantFilter(), null);
+
+    verify(consultantAdminFilterService)
+        .findFilteredConsultants(eq(1), eq(1), any(), argThatSortHasField(FieldEnum.LAST_NAME));
+  }
+
+  @Test
+  void findFilteredConsultants_Should_useDefaultSort_When_SortFieldIsUnknown() {
+    var searchResult = new ConsultantSearchResultDTO();
+    when(consultantAdminFilterService.findFilteredConsultants(any(), any(), any(), any()))
+        .thenReturn(searchResult);
+    Sort sortWithNullField = new Sort();
+
+    consultantAdminFacade.findFilteredConsultants(1, 1, new ConsultantFilter(), sortWithNullField);
+
+    verify(consultantAdminFilterService)
+        .findFilteredConsultants(eq(1), eq(1), any(), argThatSortHasField(FieldEnum.LAST_NAME));
+  }
+
+  @Test
+  void findFilteredConsultants_Should_notMergeAgencies_When_ResultIsNull() {
+    when(consultantAdminFilterService.findFilteredConsultants(any(), any(), any(), any()))
+        .thenReturn(null);
+
+    consultantAdminFacade.findFilteredConsultants(
+        1, 1, new ConsultantFilter(), new Sort().field(FieldEnum.EMAIL));
+
+    verify(consultantAgencyAdminService, never()).appendAgenciesForConsultants(any());
+  }
+
+  @Test
+  void
+      checkAssignedAgenciesMatchConsultantTenant_Should_ThrowBadRequestException_When_ConsultantNotFound() {
+    ReflectionTestUtils.setField(consultantAdminFacade, "multiTenancyEnabled", true);
+    when(consultantAdminService.findConsultantById("consultantId")).thenReturn(null);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAdminFacade.checkAssignedAgenciesMatchConsultantTenant(
+                "consultantId", new ArrayList<>()));
+
+    ReflectionTestUtils.setField(consultantAdminFacade, "multiTenancyEnabled", false);
+  }
+
+  @Test
+  void
+      checkAssignedAgenciesMatchConsultantTenant_Should_ThrowBadRequestException_When_ConsultantHasNoTenantAssigned() {
+    ReflectionTestUtils.setField(consultantAdminFacade, "multiTenancyEnabled", true);
+    ConsultantAdminResponseDTO consultant =
+        new ConsultantAdminResponseDTO().embedded(new ConsultantDTO());
+    when(consultantAdminService.findConsultantById("consultantId")).thenReturn(consultant);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAdminFacade.checkAssignedAgenciesMatchConsultantTenant(
+                "consultantId", new ArrayList<>()));
+
+    ReflectionTestUtils.setField(consultantAdminFacade, "multiTenancyEnabled", false);
+  }
+
+  private AgencyAdminFullResponseDTO agencyAdminFullResponse(Long id) {
+    var response = new AgencyAdminFullResponseDTO();
+    var agencyAdminResponseDTO =
+        new de.caritas.cob.userservice.api.adapters.web.dto.AgencyAdminResponseDTO();
+    agencyAdminResponseDTO.setId(id);
+    response.setEmbedded(agencyAdminResponseDTO);
+    return response;
+  }
+
+  private Sort argThatSortHasField(FieldEnum expectedField) {
+    return org.mockito.ArgumentMatchers.argThat(sort -> sort.getField() == expectedField);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.adapters.web.dto.PatchAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAgencyAdminDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.UpdateTenantAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
@@ -94,6 +96,104 @@ class UpdateAdminServiceTest {
     // then
     verify(identityClient).updateUserData(any(), userDTOCaptor.capture(), any(), any());
     assertEquals(2, userDTOCaptor.getValue().getTenantId());
+    verify(adminRepository).save(admin);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void updateTenantAdmin_Should_updateAdmin_When_validDataIsGiven() {
+    // given
+    UpdateTenantAdminDTO updateTenantAdminDTO = mock(UpdateTenantAdminDTO.class);
+    when(updateTenantAdminDTO.getTenantId()).thenReturn(5);
+    when(updateTenantAdminDTO.getFirstname()).thenReturn("Firstname");
+    when(updateTenantAdminDTO.getLastname()).thenReturn("Lastname");
+    when(updateTenantAdminDTO.getEmail()).thenReturn("mail@example.com");
+    Admin admin = mock(Admin.class);
+    when(retrieveAdminService.findAdmin(anyString(), eq(AdminType.TENANT))).thenReturn(admin);
+
+    // when
+    updateAdminService.updateTenantAdmin("adminId", updateTenantAdminDTO);
+
+    // then
+    verify(identityClient)
+        .updateUserData(
+            eq(admin.getId()), userDTOCaptor.capture(), eq("Firstname"), eq("Lastname"));
+    assertEquals(5L, userDTOCaptor.getValue().getTenantId());
+    verify(admin).setTenantId(5L);
+    verify(admin).setFirstName("Firstname");
+    verify(admin).setLastName("Lastname");
+    verify(admin).setEmail("mail@example.com");
+    verify(adminRepository).save(admin);
+  }
+
+  @Test
+  void patchAgencyAdmin_Should_notPatchAdmin_When_adminEntityHasTenantIdEqualZero() {
+    // given
+    Admin admin = mock(Admin.class);
+    when(admin.getTenantId()).thenReturn(0L);
+    when(retrieveAdminService.findAdmin(anyString(), eq(AdminType.AGENCY))).thenReturn(admin);
+
+    // when, then
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> updateAdminService.patchAgencyAdmin("adminId", mock(PatchAdminDTO.class)));
+
+    assertEquals("Admin has tenant id 0", exception.getMessage());
+    verify(identityClient, never()).updateUserData(any(), any(), any(), any());
+    verify(adminRepository, never()).save(any());
+  }
+
+  @Test
+  void patchAgencyAdmin_Should_patchAdmin_When_validDataIsGiven() {
+    // given
+    PatchAdminDTO patchAdminDTO = mock(PatchAdminDTO.class);
+    when(patchAdminDTO.getFirstname()).thenReturn("Firstname");
+    when(patchAdminDTO.getLastname()).thenReturn("Lastname");
+    when(patchAdminDTO.getEmail()).thenReturn("mail@example.com");
+    Admin admin = mock(Admin.class);
+    when(admin.getTenantId()).thenReturn(3L);
+    when(retrieveAdminService.findAdmin(anyString(), eq(AdminType.AGENCY))).thenReturn(admin);
+
+    // when
+    updateAdminService.patchAgencyAdmin("adminId", patchAdminDTO);
+
+    // then
+    verify(identityClient)
+        .updateUserData(
+            eq(admin.getId()), userDTOCaptor.capture(), eq("Firstname"), eq("Lastname"));
+    assertEquals(3, userDTOCaptor.getValue().getTenantId());
+    verify(admin).setFirstName("Firstname");
+    verify(admin).setLastName("Lastname");
+    verify(admin).setEmail("mail@example.com");
+    verify(adminRepository).save(admin);
+  }
+
+  @Test
+  void patchTenantAdmin_Should_patchAdmin_When_validDataIsGiven() {
+    // given
+    PatchAdminDTO patchAdminDTO = mock(PatchAdminDTO.class);
+    when(patchAdminDTO.getFirstname()).thenReturn("Firstname");
+    when(patchAdminDTO.getLastname()).thenReturn("Lastname");
+    when(patchAdminDTO.getEmail()).thenReturn("mail@example.com");
+    Admin admin = mock(Admin.class);
+    when(admin.getTenantId()).thenReturn(7L);
+    when(retrieveAdminService.findAdmin(anyString(), eq(AdminType.TENANT))).thenReturn(admin);
+
+    // when
+    updateAdminService.patchTenantAdmin("adminId", patchAdminDTO);
+
+    // then
+    verify(identityClient)
+        .updateUserData(
+            eq(admin.getId()), userDTOCaptor.capture(), eq("Firstname"), eq("Lastname"));
+    assertEquals(7, userDTOCaptor.getValue().getTenantId());
+    verify(admin).setFirstName("Firstname");
+    verify(admin).setLastName("Lastname");
+    verify(admin).setEmail("mail@example.com");
     verify(adminRepository).save(admin);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMost;
@@ -1181,5 +1182,175 @@ class CreateEnquiryMessageFacadeTest {
 
   private MessageResponseDTO createMessageResponse() {
     return easyRandom.nextObject(MessageResponseDTO.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  private void givenHappyPathEnquiryStubs() throws Exception {
+    extendedConsultingTypeResponseDTO.getWelcomeMessage().sendWelcomeMessage(false);
+    groupDTO.setId(RC_GROUP_ID);
+    groupResponseDTO.setSuccess(true);
+    groupResponseDTO.setGroup(groupDTO);
+    rocketChatUserDTO.setUsername(USERNAME);
+    userInfoResponseDTO.setUser(rocketChatUserDTO);
+    rocketChatCredentials.setRocketChatUserId(RC_USER_ID);
+    rocketChatCredentials.setRocketChatUsername(RC_USERNAME);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultingTypeManager.getConsultingTypeSettings(session.getConsultingTypeId()))
+        .thenReturn(extendedConsultingTypeResponseDTO);
+    when(rocketChatService.createPrivateGroup(anyString(), any()))
+        .thenReturn(Optional.of(groupResponseDTO));
+    when(rocketChatService.getUserInfo(RC_USER_ID)).thenReturn(userInfoResponseDTO);
+    when(userHelper.doUsernamesMatch(anyString(), anyString())).thenReturn(true);
+    when(rocketChatRoomNameGenerator.generateGroupName(any(Session.class)))
+        .thenReturn(session.getId().toString());
+    when(messageServiceProvider.postEnquiryMessage(
+            any(RocketChatData.class), any(CreateEnquiryExceptionInformation.class)))
+        .thenReturn(createMessageResponse());
+  }
+
+  @Test
+  void
+      createEnquiryMessage_Should_UseTopicConsultantAgencies_When_MainTopicIdSetAndEligibleConsultantsFound()
+          throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    session.setMainTopicId(42L);
+    givenHappyPathEnquiryStubs();
+    when(topicConsultantRoutingService.findEligibleConsultantIds(42L, 0))
+        .thenReturn(List.of(USER_ID));
+    when(consultantAgencyService.getConsultantAgenciesByConsultantIds(List.of(USER_ID)))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(consultantAgencyService).getConsultantAgenciesByConsultantIds(List.of(USER_ID));
+    verify(consultantAgencyService, never()).findConsultantsByAgencyId(anyLong());
+    resetRequestAttributes();
+  }
+
+  @Test
+  void
+      createEnquiryMessage_Should_FallBackToAgencyConsultants_When_MainTopicIdSetButNoEligibleConsultantsFound()
+          throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    session.setMainTopicId(42L);
+    givenHappyPathEnquiryStubs();
+    when(topicConsultantRoutingService.findEligibleConsultantIds(42L, 0)).thenReturn(List.of());
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(consultantAgencyService).findConsultantsByAgencyId(AGENCY_ID);
+    verify(consultantAgencyService, never()).getConsultantAgenciesByConsultantIds(any());
+    resetRequestAttributes();
+  }
+
+  @Test
+  void
+      createEnquiryMessage_Should_FallBackToAgencyConsultants_When_MainTopicIdSetButTopicAgenciesEmpty()
+          throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    session.setMainTopicId(42L);
+    givenHappyPathEnquiryStubs();
+    when(topicConsultantRoutingService.findEligibleConsultantIds(42L, 0))
+        .thenReturn(List.of(USER_ID));
+    when(consultantAgencyService.getConsultantAgenciesByConsultantIds(List.of(USER_ID)))
+        .thenReturn(List.of());
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(consultantAgencyService).findConsultantsByAgencyId(AGENCY_ID);
+    resetRequestAttributes();
+  }
+
+  @Test
+  void
+      createEnquiryMessage_Should_SendLiveEvent_When_AnonymousStyleRegistrationAndConsultantsFound()
+          throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    givenHappyPathEnquiryStubs();
+    when(sessionService.isAnonymousStyleRegistration(any())).thenReturn(true);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(CONSULTANT_AGENCY_LIST);
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(liveEventNotificationService)
+        .sendLiveNewAnonymousEnquiryEventToUsers(any(), eq(SESSION_ID));
+    resetRequestAttributes();
+  }
+
+  @Test
+  void
+      createEnquiryMessage_ShouldNot_SendLiveEvent_When_AnonymousStyleRegistrationButNoConsultantsFound()
+          throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    givenHappyPathEnquiryStubs();
+    when(sessionService.isAnonymousStyleRegistration(any())).thenReturn(true);
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID)).thenReturn(List.of());
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    verify(liveEventNotificationService, never())
+        .sendLiveNewAnonymousEnquiryEventToUsers(any(), anyLong());
+    resetRequestAttributes();
+  }
+
+  @Test
+  void createEnquiryMessage_Should_SwallowException_When_EventNotificationServiceThrows()
+      throws Exception {
+    session.setUser(user);
+    session.setConsultingTypeId(0);
+    session.setConsultant(null);
+    session.setEnquiryMessageDate(null);
+    session.setAgencyId(AGENCY_ID);
+    session.setIsConsultantDirectlySet(false);
+    givenHappyPathEnquiryStubs();
+    doThrow(new RuntimeException("boom"))
+        .when(eventNotificationService)
+        .createNewClientRequestNotifications(any(), any());
+
+    var response =
+        createEnquiryMessageFacade.createEnquiryMessage(
+            new EnquiryData(user, SESSION_ID, MESSAGE, null, rocketChatCredentials));
+
+    assertEquals(SESSION_ID, response.getSessionId());
+    resetRequestAttributes();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -10,20 +10,25 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER_DTO_S
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
@@ -31,25 +36,33 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
 import de.caritas.cob.userservice.api.helper.AgencyVerifier;
+import de.caritas.cob.userservice.api.helper.PlainCredentialsHolder;
 import de.caritas.cob.userservice.api.helper.UserVerifier;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.api.service.statistics.StatisticsService;
+import de.caritas.cob.userservice.api.service.statistics.event.RegistrationStatisticsEvent;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.time.LocalDateTime;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateUserFacadeTest {
@@ -253,5 +266,307 @@ public class CreateUserFacadeTest {
 
           verify(rollbackFacade, times(0)).rollBackUserAccount(any());
         });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  private User givenAFullyPersistedUser() {
+    User user = new User();
+    user.setUsername("dbUser");
+    user.setTenantId(1L);
+    user.setCreateDate(LocalDateTime.now());
+    when(userService.createUser(any(), any(), any(), any(), anyBoolean(), any())).thenReturn(user);
+    when(userService.saveUser(any())).thenReturn(user);
+    return user;
+  }
+
+  private void givenBasicRegistrationStubs() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    when(keycloakService.createKeycloakUser(any()))
+        .thenReturn(KEYCLOAK_CREATE_USER_RESPONSE_DTO_WITH_USER_ID);
+    when(createNewSessionFacade.initializeNewSession(
+            any(), any(), any(ExtendedConsultingTypeResponseDTO.class)))
+        .thenReturn(mock(NewRegistrationResponseDto.class));
+    when(agencyService.getAgencyWithoutCaching(any())).thenReturn(new AgencyDTO());
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_CreateMatrixUser_When_PlainUsernameAvailableFromThreadLocal()
+          throws Exception {
+    givenBasicRegistrationStubs();
+    User user = givenAFullyPersistedUser();
+    var matrixResponseBody = new MatrixCreateUserResponseDTO();
+    matrixResponseBody.setUserId("@plainuser:matrix.oriso.org");
+    try {
+      PlainCredentialsHolder.set("plainuser", "plainpw");
+      when(matrixSynapseService.createUser(eq("plainuser"), anyString(), eq("plainuser")))
+          .thenReturn(ResponseEntity.ok(matrixResponseBody));
+
+      createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+    } finally {
+      PlainCredentialsHolder.clear();
+    }
+
+    verify(matrixSynapseService, times(1))
+        .createUser(eq("plainuser"), anyString(), eq("plainuser"));
+    assertThat(user.getMatrixUserId(), is("@plainuser:matrix.oriso.org"));
+    verify(userService, times(2)).saveUser(any());
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_UseDecodedDbUsername_When_PlainCredentialsNotAvailable()
+          throws Exception {
+    PlainCredentialsHolder.clear();
+    givenBasicRegistrationStubs();
+    User user = givenAFullyPersistedUser();
+    var matrixResponseBody = new MatrixCreateUserResponseDTO();
+    matrixResponseBody.setUserId("@dbUser:matrix.oriso.org");
+    when(matrixSynapseService.createUser(eq("dbUser"), anyString(), eq("dbUser")))
+        .thenReturn(ResponseEntity.ok(matrixResponseBody));
+
+    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    verify(matrixSynapseService, times(1)).createUser(eq("dbUser"), anyString(), eq("dbUser"));
+    assertThat(user.getMatrixUserId(), is("@dbUser:matrix.oriso.org"));
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_SkipMatrixUserCreation_When_PlainUsernameNotResolvable()
+          throws Exception {
+    PlainCredentialsHolder.clear();
+    givenBasicRegistrationStubs();
+    // userService.createUser/saveUser left unstubbed -> null user, no username to resolve
+
+    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    verify(matrixSynapseService, never()).createUser(any(), any(), any());
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_ContinueRegistration_When_MatrixUserCreationThrows()
+          throws Exception {
+    PlainCredentialsHolder.clear();
+    givenBasicRegistrationStubs();
+    givenAFullyPersistedUser();
+    when(matrixSynapseService.createUser(any(), any(), any()))
+        .thenThrow(new MatrixCreateUserException("boom"));
+
+    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    verify(createNewSessionFacade, times(1))
+        .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_NotSetMatrixUserId_When_MatrixResponseBodyIsNull()
+          throws Exception {
+    PlainCredentialsHolder.clear();
+    givenBasicRegistrationStubs();
+    User user = givenAFullyPersistedUser();
+    when(matrixSynapseService.createUser(any(), any(), any())).thenReturn(ResponseEntity.ok(null));
+
+    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    assertThat(user.getMatrixUserId(), nullValue());
+    verify(userService, times(1)).saveUser(any());
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_CreateMinimalSession_When_InitializeNewSessionThrows() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    when(keycloakService.createKeycloakUser(any()))
+        .thenReturn(KEYCLOAK_CREATE_USER_RESPONSE_DTO_WITH_USER_ID);
+    when(createNewSessionFacade.initializeNewSession(
+            any(), any(), any(ExtendedConsultingTypeResponseDTO.class)))
+        .thenThrow(new RuntimeException("rc down"));
+    when(createSessionFacade.createUserSession(any(), any(), any(), any())).thenReturn(42L);
+
+    Long sessionId =
+        createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    assertThat(sessionId, is(42L));
+    verify(createSessionFacade, times(1)).createUserSession(any(), any(), any(), any());
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_UseDefaultTenantName_When_NoCurrentTenantIsSet() {
+    TenantContext.clear();
+    givenBasicRegistrationStubs();
+    givenAFullyPersistedUser();
+    ArgumentCaptor<RegistrationStatisticsEvent> eventCaptor =
+        ArgumentCaptor.forClass(RegistrationStatisticsEvent.class);
+
+    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+    verify(tenantService, never()).getRestrictedTenantData(any(Long.class));
+    verify(statisticsService).fireEvent(eventCaptor.capture());
+    assertThat(
+        eventCaptor.getValue().getPayload().orElse(""),
+        containsString("\"tenantName\":\"Default Tenant\""));
+  }
+
+  @Test
+  void
+      createUserAccountWithInitializedConsultingType_Should_UseDefaultTenantName_When_TenantServiceReturnsNull() {
+    TenantContext.setCurrentTenant(1L);
+    try {
+      givenBasicRegistrationStubs();
+      givenAFullyPersistedUser();
+      when(tenantService.getRestrictedTenantData((Long) 1L)).thenReturn(null);
+      ArgumentCaptor<RegistrationStatisticsEvent> eventCaptor =
+          ArgumentCaptor.forClass(RegistrationStatisticsEvent.class);
+
+      createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_SUCHT);
+
+      verify(tenantService, times(1)).getRestrictedTenantData((Long) 1L);
+      verify(statisticsService).fireEvent(eventCaptor.capture());
+      assertThat(
+          eventCaptor.getValue().getPayload().orElse(""),
+          containsString("\"tenantName\":\"Default Tenant\""));
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  @Test
+  void updateIdentityAndCreateAccount_Should_ClearPrivacyConfirmations_When_RoleIsAnonymous() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    doNothing().when(keycloakService).updatePassword(anyString(), anyString());
+    User user = new User();
+    user.setTermsAndConditionsConfirmation(LocalDateTime.now());
+    user.setDataPrivacyConfirmation(LocalDateTime.now());
+    when(userService.createUser(any(), any(), any(), any(), anyBoolean(), any())).thenReturn(user);
+    when(userService.saveUser(any())).thenReturn(user);
+
+    User result =
+        createUserFacade.updateIdentityAndCreateAccount(
+            USER_ID, USER_DTO_SUCHT, UserRole.ANONYMOUS);
+
+    assertThat(result.getTermsAndConditionsConfirmation(), nullValue());
+    assertThat(result.getDataPrivacyConfirmation(), nullValue());
+    verify(userService, times(1)).saveUser(any());
+  }
+
+  @Test
+  void
+      updateIdentityAndCreateAccount_Should_ThrowInternalServerError_When_KeycloakFailsForAnonymousUser() {
+    doThrow(new RuntimeException("kc down"))
+        .when(keycloakService)
+        .updateRole(anyString(), any(UserRole.class));
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            createUserFacade.updateIdentityAndCreateAccount(
+                USER_ID, USER_DTO_SUCHT, UserRole.ANONYMOUS));
+
+    verify(userService, never()).createUser(any(), any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  void
+      updateIdentityAndCreateAccount_Should_ContinueAndCreateDbUser_When_UserIdIsNullAndRoleIsUser() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+
+    createUserFacade.updateIdentityAndCreateAccount(null, USER_DTO_SUCHT, UserRole.USER);
+
+    verify(userService, times(1)).createUser(any(), any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  void
+      updateIdentityAndCreateAccount_Should_ThrowInternalServerError_When_UserIdIsNullAndRoleIsAnonymous() {
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            createUserFacade.updateIdentityAndCreateAccount(
+                null, USER_DTO_SUCHT, UserRole.ANONYMOUS));
+  }
+
+  @Test
+  void updateIdentityAndCreateAccount_Should_CallUpdateDummyEmail_When_EmailIsBlank() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    doNothing().when(keycloakService).updatePassword(anyString(), anyString());
+    when(keycloakService.updateDummyEmail(anyString(), any(UserDTO.class)))
+        .thenReturn("dummy@example.com");
+    UserDTO userDtoWithBlankEmail =
+        UserDTO.builder()
+            .email("")
+            .username(USER_DTO_SUCHT.getUsername())
+            .postcode(USER_DTO_SUCHT.getPostcode())
+            .consultingType(USER_DTO_SUCHT.getConsultingType())
+            .build();
+
+    createUserFacade.updateIdentityAndCreateAccount(USER_ID, userDtoWithBlankEmail, UserRole.USER);
+
+    verify(keycloakService, times(1)).updateDummyEmail(eq(USER_ID), any(UserDTO.class));
+  }
+
+  @Test
+  void
+      updateIdentityAndCreateAccount_Should_ClearPrivacyConfirmations_When_PostcodeIsAnonymousPlaceholder() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    doNothing().when(keycloakService).updatePassword(anyString(), anyString());
+    User user = new User();
+    user.setTermsAndConditionsConfirmation(LocalDateTime.now());
+    user.setDataPrivacyConfirmation(LocalDateTime.now());
+    when(userService.createUser(any(), any(), any(), any(), anyBoolean(), any())).thenReturn(user);
+    when(userService.saveUser(any())).thenReturn(user);
+    UserDTO anonymousPostcodeDto =
+        UserDTO.builder()
+            .email(USER_DTO_SUCHT.getEmail())
+            .username("regularUsername")
+            .postcode("00000")
+            .consultingType(USER_DTO_SUCHT.getConsultingType())
+            .build();
+
+    User result =
+        createUserFacade.updateIdentityAndCreateAccount(
+            USER_ID, anonymousPostcodeDto, UserRole.USER);
+
+    assertThat(result.getTermsAndConditionsConfirmation(), nullValue());
+    assertThat(result.getDataPrivacyConfirmation(), nullValue());
+  }
+
+  @Test
+  void
+      updateIdentityAndCreateAccount_Should_ClearPrivacyConfirmations_When_UsernameStartsWithAnonymousPrefix() {
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
+    doNothing().when(keycloakService).updatePassword(anyString(), anyString());
+    User user = new User();
+    user.setTermsAndConditionsConfirmation(LocalDateTime.now());
+    user.setDataPrivacyConfirmation(LocalDateTime.now());
+    when(userService.createUser(any(), any(), any(), any(), anyBoolean(), any())).thenReturn(user);
+    when(userService.saveUser(any())).thenReturn(user);
+    UserDTO anonymousUsernameDto =
+        UserDTO.builder()
+            .email(USER_DTO_SUCHT.getEmail())
+            .username("Anonymous-1234")
+            .postcode(USER_DTO_SUCHT.getPostcode())
+            .consultingType(USER_DTO_SUCHT.getConsultingType())
+            .build();
+
+    User result =
+        createUserFacade.updateIdentityAndCreateAccount(
+            USER_ID, anonymousUsernameDto, UserRole.USER);
+
+    assertThat(result.getTermsAndConditionsConfirmation(), nullValue());
+    assertThat(result.getDataPrivacyConfirmation(), nullValue());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacadeTest.java
@@ -814,4 +814,120 @@ class EmailNotificationFacadeTest {
               reassignmentNotification, null);
         });
   }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void sendNewDirectEnquiryEmailNotification_Should_SendEmail_When_MailsGenerated() {
+    when(newDirectEnquiryEmailSupplier.generateEmails()).thenReturn(getMailDTOS());
+
+    emailNotificationFacade.sendNewDirectEnquiryEmailNotification(
+        CONSULTANT_ID, AGENCY_ID, "88045", null);
+
+    verify(mailService).sendEmailNotification(Mockito.any(MailsDTO.class));
+  }
+
+  @Test
+  void sendNewDirectEnquiryEmailNotification_ShouldNot_SendEmail_When_MailListIsEmpty() {
+    when(newDirectEnquiryEmailSupplier.generateEmails()).thenReturn(List.of());
+
+    emailNotificationFacade.sendNewDirectEnquiryEmailNotification(
+        CONSULTANT_ID, AGENCY_ID, "88045", null);
+
+    verify(mailService, times(0)).sendEmailNotification(Mockito.any(MailsDTO.class));
+  }
+
+  @Test
+  void sendNewDirectEnquiryEmailNotification_Should_LogError_When_GenerateEmailsThrows() {
+    when(newDirectEnquiryEmailSupplier.generateEmails())
+        .thenThrow(new EmailNotificationException(new Exception()));
+
+    emailNotificationFacade.sendNewDirectEnquiryEmailNotification(
+        CONSULTANT_ID, AGENCY_ID, "88045", null);
+
+    org.assertj.core.api.Assertions.assertThat(
+            facadeLogCaptor.contains(
+                Level.ERROR, "Failed to send NEW_DIRECT_ENQUIRY_EMAIL_NOTIFICATION"))
+        .isTrue();
+  }
+
+  @Test
+  void sendInquiryAcceptedNotification_ShouldNot_SendEmail_When_UserHasInvalidEmail() {
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER_NO_EMAIL, CONSULTANT, null);
+
+    verifyNoInteractions(mailService);
+  }
+
+  @Test
+  void
+      sendInquiryAcceptedNotification_ShouldNot_SendEmail_When_ToggleEnabledAndUserHasNotificationsDisabled() {
+    when(releaseToggleService.isToggleEnabled(ReleaseToggle.NEW_EMAIL_NOTIFICATIONS))
+        .thenReturn(true);
+
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, CONSULTANT, null);
+
+    verifyNoInteractions(mailService);
+  }
+
+  @Test
+  void sendInquiryAcceptedNotification_Should_SendEmail_When_ToggleDisabled() {
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, CONSULTANT, null);
+
+    verify(mailService).sendEmailNotification(Mockito.any(MailsDTO.class));
+  }
+
+  @Test
+  void sendInquiryAcceptedNotification_Should_UseDefaultConsultantName_When_ConsultantIsNull() {
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, null, null);
+
+    var captor = org.mockito.ArgumentCaptor.forClass(MailsDTO.class);
+    verify(mailService).sendEmailNotification(captor.capture());
+    var text = captor.getValue().getMails().get(0).getTemplateData().get(1).getValue();
+    org.assertj.core.api.Assertions.assertThat(text).contains("Ihre Beraterin/Ihr Berater");
+  }
+
+  @Test
+  void sendInquiryAcceptedNotification_Should_UseConsultantFullName_When_ConsultantProvided() {
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, CONSULTANT, null);
+
+    var captor = org.mockito.ArgumentCaptor.forClass(MailsDTO.class);
+    verify(mailService).sendEmailNotification(captor.capture());
+    var text = captor.getValue().getMails().get(0).getTemplateData().get(1).getValue();
+    org.assertj.core.api.Assertions.assertThat(text).contains(CONSULTANT.getFullName());
+  }
+
+  @Test
+  void
+      sendInquiryAcceptedNotification_Should_UseTenantTemplateAttributes_When_MultiTenancyEnabled() {
+    ReflectionTestUtils.setField(emailNotificationFacade, "multiTenancyEnabled", true);
+    when(tenantTemplateSupplier.getTemplateAttributes())
+        .thenReturn(
+            List.of(
+                new de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO()
+                    .key("tenantKey")
+                    .value("tenantValue")));
+
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, CONSULTANT, null);
+
+    var captor = org.mockito.ArgumentCaptor.forClass(MailsDTO.class);
+    verify(mailService).sendEmailNotification(captor.capture());
+    var templateData = captor.getValue().getMails().get(0).getTemplateData();
+    org.assertj.core.api.Assertions.assertThat(
+            templateData.stream().anyMatch(td -> "tenantKey".equals(td.getKey())))
+        .isTrue();
+    ReflectionTestUtils.setField(emailNotificationFacade, "multiTenancyEnabled", false);
+  }
+
+  @Test
+  void sendInquiryAcceptedNotification_Should_LogError_When_MailServiceThrows() {
+    doThrow(new RuntimeException("boom")).when(mailService).sendEmailNotification(any());
+
+    emailNotificationFacade.sendInquiryAcceptedNotification(USER, CONSULTANT, null);
+
+    org.assertj.core.api.Assertions.assertThat(
+            facadeLogCaptor.contains(Level.ERROR, "Failed to send inquiry accepted notification"))
+        .isTrue();
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
@@ -3,6 +3,8 @@ package de.caritas.cob.userservice.api.service.appointment;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -19,12 +21,15 @@ import de.caritas.cob.userservice.api.config.apiclient.AppointmentAgencyServiceA
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentAskerServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentConsultantServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
+import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.appointmentservice.generated.web.AgencyApi;
+import de.caritas.cob.userservice.appointmentservice.generated.web.AskerApi;
 import de.caritas.cob.userservice.appointmentservice.generated.web.ConsultantApi;
+import de.caritas.cob.userservice.appointmentservice.generated.web.model.AskerDTO;
 import de.caritas.cob.userservice.appointmentservice.generated.web.model.ConsultantDTO;
 import java.util.LinkedList;
 import org.jeasy.random.EasyRandom;
@@ -56,6 +61,7 @@ class AppointmentServiceTest {
 
   @Mock ConsultantApi appointmentConsultantApi;
   @Mock AgencyApi appointmentAgencyApi;
+  @Mock AskerApi appointmentAskerApi;
   @Mock SecurityHeaderSupplier securityHeaderSupplier;
 
   @Mock TenantHeaderSupplier tenantHeaderSupplier;
@@ -91,6 +97,7 @@ class AppointmentServiceTest {
     when(identityClient.loginUser(any(), any())).thenReturn(keycloakLoginResponseDTO);
     when(identityClient.loginUser(any(), any())).thenReturn(keycloakLoginResponseDTO);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(any())).thenReturn(httpHeaders);
+    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(httpHeaders);
     when(consultantDTO.getId()).thenReturn("testId");
     when(objectMapper.readValue(
             nullable(String.class), ArgumentMatchers.<Class<ConsultantDTO>>any()))
@@ -192,5 +199,163 @@ class AppointmentServiceTest {
   private void givenAnIdentityClientConfig() {
     var identityClientConfig = easyRandom.nextObject(IdentityConfig.class);
     setField(appointmentService, "identityClientConfig", identityClientConfig);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createConsultant_Should_NotCallAppointmentService_WhenConsultantAdminResponseDtoIsNull() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    appointmentService.createConsultant(null);
+    verify(appointmentConsultantApi, never()).createConsultant(any());
+  }
+
+  @Test
+  void syncConsultantData_Should_CallUpdateConsultant_When_ConsultantIsGiven() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    var consultant = new Consultant();
+    consultant.setId("consultantId");
+    consultant.setFirstName("Firstname");
+    consultant.setLastName("Lastname");
+    consultant.setEmail("mail@example.com");
+    consultant.setAbsent(true);
+
+    appointmentService.syncConsultantData(consultant);
+
+    verify(appointmentConsultantApi, times(1)).updateConsultant(any(), any());
+  }
+
+  @Test
+  void updateConsultant_Should_SwallowException_When_MapperThrows() throws JsonProcessingException {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    when(objectMapper.readValue(
+            nullable(String.class), ArgumentMatchers.<Class<ConsultantDTO>>any()))
+        .thenThrow(new JsonProcessingException("boom") {});
+
+    appointmentService.updateConsultant(consultantAdminResponseDTO);
+
+    verify(appointmentConsultantApi, never()).updateConsultant(any(), any());
+  }
+
+  @Test
+  void deleteConsultant_Should_NotCallAppointmentService_When_ConsultantIdIsNull() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    appointmentService.deleteConsultant(null);
+    verify(appointmentConsultantApi, never()).deleteConsultant(any());
+  }
+
+  @Test
+  void deleteConsultant_Should_NotCallAppointmentService_When_ConsultantIdIsEmpty() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    appointmentService.deleteConsultant("");
+    verify(appointmentConsultantApi, never()).deleteConsultant(any());
+  }
+
+  @Test
+  void deleteAsker_Should_NotCallAppointmentService_WhenAppointmentsIsDisabled() {
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, false);
+    appointmentService.deleteAsker("askerId");
+    verify(appointmentAskerApi, never()).deleteAskerData(any());
+  }
+
+  @Test
+  void deleteAsker_Should_CallAppointmentService_WhenAppointmentsIsEnabled() {
+    when(appointmentAskerServiceApiControllerFactory.createControllerApi())
+        .thenReturn(appointmentAskerApi);
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+
+    appointmentService.deleteAsker("askerId");
+
+    verify(appointmentAskerApi, times(1)).deleteAskerData("askerId");
+  }
+
+  @Test
+  void updateAskerEmail_Should_NotCallAppointmentService_WhenAppointmentsIsDisabled() {
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, false);
+    appointmentService.updateAskerEmail("askerId", "mail@example.com");
+    verify(appointmentAskerApi, never()).updateAskerEmail(any(), any());
+  }
+
+  @Test
+  void updateAskerEmail_Should_CallAppointmentService_WhenAppointmentsIsEnabled() {
+    when(appointmentAskerServiceApiControllerFactory.createControllerApi())
+        .thenReturn(appointmentAskerApi);
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+
+    appointmentService.updateAskerEmail("askerId", "mail@example.com");
+
+    verify(appointmentAskerApi, times(1)).updateAskerEmail(eq("askerId"), any(AskerDTO.class));
+  }
+
+  @Test
+  void updateAskerEmail_Should_SwallowException_When_ApiThrows() {
+    when(appointmentAskerServiceApiControllerFactory.createControllerApi())
+        .thenReturn(appointmentAskerApi);
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    doThrow(new RuntimeException("boom"))
+        .when(appointmentAskerApi)
+        .updateAskerEmail(anyString(), any(AskerDTO.class));
+
+    appointmentService.updateAskerEmail("askerId", "mail@example.com");
+
+    verify(appointmentAskerApi, times(1)).updateAskerEmail(anyString(), any(AskerDTO.class));
+  }
+
+  @Test
+  void patchConsultant_Should_NotCallAppointmentService_WhenAppointmentsIsDisabled() {
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, false);
+    appointmentService.patchConsultant("consultantId", "New Name");
+    verify(appointmentConsultantApi, never()).patchConsultant(any(), any());
+  }
+
+  @Test
+  void patchConsultant_Should_NotCallAppointmentService_When_ConsultantIdIsEmpty() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    appointmentService.patchConsultant("", "New Name");
+    verify(appointmentConsultantApi, never()).patchConsultant(any(), any());
+  }
+
+  @Test
+  void patchConsultant_Should_CallAppointmentService_WhenAppointmentsIsEnabled() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+
+    appointmentService.patchConsultant("consultantId", "New Name");
+
+    verify(appointmentConsultantApi, times(1)).patchConsultant(eq("consultantId"), any());
+  }
+
+  @Test
+  void patchConsultant_Should_ProceedSilently_When_AppointmentServiceThrows404() {
+    givenAnIdentityClientConfig();
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    when(httpClientErrorException.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
+    doThrow(httpClientErrorException).when(appointmentConsultantApi).patchConsultant(any(), any());
+
+    appointmentService.patchConsultant("consultantId", "New Name");
+
+    verify(appointmentConsultantApi, times(1)).patchConsultant(any(), any());
+  }
+
+  @Test
+  void patchConsultant_Should_RethrowException_When_AppointmentServiceThrowsNon404() {
+    var identityClientConfig = easyRandom.nextObject(IdentityConfig.class);
+    setField(nonSpiedAppointmentService, "identityClientConfig", identityClientConfig);
+    setField(nonSpiedAppointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    when(httpClientErrorException.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    doThrow(httpClientErrorException).when(appointmentConsultantApi).patchConsultant(any(), any());
+
+    assertThrows(
+        HttpClientErrorException.class,
+        () -> nonSpiedAppointmentService.patchConsultant("consultantId", "New Name"));
   }
 }


### PR DESCRIPTION
## What
Added 62 new unit tests across 6 classes (103 → 165 total in these files):

- `AppointmentService` — 15 new tests: Matrix-migration-era gaps (syncConsultantData,
  deleteAsker, updateAskerEmail, patchConsultant — none had any coverage), null/empty
  consultantId edge cases, 404-accept vs rethrow-on-other-status branches.
- `UpdateAdminService` — 4 new tests: updateTenantAdmin, patchAgencyAdmin,
  patchTenantAdmin — three of four public methods had zero coverage.
- `CreateUserFacade` — 15 new tests: the entire Matrix-user-provisioning block added
  post-RocketChat-migration was untested (ThreadLocal plain-username path, decoded-DB-username
  fallback, skip/exception/null-body branches), plus RocketChat-failure minimal-session
  fallback, tenant/agency-name resolution edge cases, and role-based (ANONYMOUS vs USER)
  Keycloak-failure handling.
- `ConsultantAdminFacade` — 12 new tests: previously-untested delegations
  (markConsultantAgenciesForDeletion, pauseConsultantDeletion), the agency
  prepare/complete-assignment loops, set-difference filtering logic
  (filterAgencyListForDeletion/Creation), sort-fallback branches, and tenant-validation
  guard branches.
- `EmailNotificationFacade` — 10 new tests: two entire public methods
  (sendNewDirectEnquiryEmailNotification, sendInquiryAcceptedNotification) had never been
  exercised by any existing test.
- `CreateEnquiryMessageFacade` — 6 new tests: topic-based consultant routing with
  fallback-to-agency-consultants logic, and the best-effort notification-failure swallow path.

## Why
Closes #311 — these 6 classes were the highest-remaining-impact items in Batch A of the
UserService coverage plan. All had either zero coverage on newly-added Matrix-migration
code or entire public methods no test ever reached.

## Scope
- Tests only — no production code changes
- All new tests appended below existing ones with an `Extended coverage — 2026-07-06` separator
- No existing test was modified or reordered

## Verification
- [x] All 165 tests in the 6 modified files pass
- [x] Full suite run (2272 tests): 2 failures, both pre-existing in
      `DeleteUserAnonymousServiceTest`, unrelated to this change
- [x] Coverage confirmed via JaCoCo before/after for each class:
  - ConsultantAdminFacade: 58.3% → 100% / 96.7%
  - UpdateAdminService: 32.2% → 100% / 100%
  - EmailNotificationFacade: 65.4% → 95.5% / 81.0%
  - CreateUserFacade: 72.3% → 90.5% / 83.3%
  - CreateEnquiryMessageFacade: 81.4% → 88.7% / 75.0%
  - AppointmentService: 54.5% → 93.0% / 92.9%
