### PR TITLE
refactor: extract user support controller delegate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -1,7 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
-import static org.apache.commons.lang3.BooleanUtils.isTrue;
-
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AbsenceDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
@@ -38,25 +36,15 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionListResponseDTO;
-import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
-import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.service.AskerImportService;
-import de.caritas.cob.userservice.api.service.ConsultantImportService;
-import de.caritas.cob.userservice.api.service.SessionDataService;
-import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
-import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
-import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UsersApi;
 import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -76,20 +64,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UsersApi {
 
   private final @NotNull UserAccountService userAccountProvider;
-  private final @NotNull SessionService sessionService;
-  private final @NotNull AuthenticatedUser authenticatedUser;
-  private final @NotNull ConsultantImportService consultantImportService;
-  private final @NotNull EmailNotificationFacade emailNotificationFacade;
-  private final @NotNull AskerImportService askerImportService;
   private final @NotNull UserChatControllerDelegate userChatControllerDelegate;
   private final @NotNull UserSessionControllerDelegate userSessionControllerDelegate;
   private final @NotNull UserAccountControllerDelegate userAccountControllerDelegate;
   private final @NotNull UserTwoFactorAuthControllerDelegate userTwoFactorAuthControllerDelegate;
   private final @NotNull UserRegistrationControllerDelegate userRegistrationControllerDelegate;
   private final @NotNull UserConsultantControllerDelegate userConsultantControllerDelegate;
-  private final @NotNull SessionDataService sessionDataService;
-
-  private final @NonNull EventNotificationService eventNotificationService;
+  private final @NotNull UserSupportControllerDelegate userSupportControllerDelegate;
 
   @Override
   public ResponseEntity<Void> userExists(String username) {
@@ -325,10 +306,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> importConsultants() {
-
-    consultantImportService.startImport();
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.importConsultants();
   }
 
   /**
@@ -338,10 +316,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> importAskers() {
-
-    askerImportService.startImport();
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.importAskers();
   }
 
   /**
@@ -351,10 +326,7 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<Void> importAskersWithoutSession() {
-
-    askerImportService.startImportForAskersWithoutSession();
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.importAskersWithoutSession();
   }
 
   /**
@@ -368,16 +340,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<Void> sendNewMessageNotification(
       @RequestBody NewMessageNotificationDTO newMessageNotificationDTO) {
-
-    emailNotificationFacade.sendNewMessageNotification(
-        newMessageNotificationDTO.getRcGroupId(),
-        authenticatedUser.getRoles(),
-        authenticatedUser.getUserId(),
-        TenantContext.getCurrentTenantData());
-    eventNotificationService.createMessageNotificationFromRoom(
-        newMessageNotificationDTO.getRcGroupId(), authenticatedUser.getUserId(), null, false);
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.sendNewMessageNotification(newMessageNotificationDTO);
   }
 
   /**
@@ -391,16 +354,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<Void> sendReassignmentNotification(
       @RequestBody ReassignmentNotificationDTO reassignmentNotificationDTO) {
-
-    if (isTrue(reassignmentNotificationDTO.getIsConfirmed())) {
-      emailNotificationFacade.sendReassignConfirmationNotification(
-          reassignmentNotificationDTO, TenantContext.getCurrentTenantData());
-    } else {
-      emailNotificationFacade.sendReassignRequestNotification(
-          reassignmentNotificationDTO.getRcGroupId(), TenantContext.getCurrentTenantData());
-    }
-
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.sendReassignmentNotification(reassignmentNotificationDTO);
   }
 
   /**
@@ -671,8 +625,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<Void> updateSessionData(
       @PathVariable Long sessionId, SessionDataDTO sessionDataDTO) {
-    this.sessionDataService.saveSessionData(sessionId, sessionDataDTO);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return userSupportControllerDelegate.updateSessionData(sessionId, sessionDataDTO);
   }
 
   /**
@@ -742,7 +695,6 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<RocketChatGroupIdDTO> getRocketChatGroupId(
       String consultantId, String askerId) {
-    String groupId = sessionService.findGroupIdByConsultantAndUser(consultantId, askerId);
-    return new ResponseEntity<>(new RocketChatGroupIdDTO().groupId(groupId), HttpStatus.OK);
+    return userSupportControllerDelegate.getRocketChatGroupId(consultantId, askerId);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSupportControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSupportControllerDelegate.java
@@ -1,0 +1,85 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.NewMessageNotificationDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ReassignmentNotificationDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.RocketChatGroupIdDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDataDTO;
+import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.AskerImportService;
+import de.caritas.cob.userservice.api.service.ConsultantImportService;
+import de.caritas.cob.userservice.api.service.SessionDataService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class UserSupportControllerDelegate {
+
+  private final @NonNull SessionService sessionService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull ConsultantImportService consultantImportService;
+  private final @NonNull EmailNotificationFacade emailNotificationFacade;
+  private final @NonNull AskerImportService askerImportService;
+  private final @NonNull SessionDataService sessionDataService;
+  private final @NonNull EventNotificationService eventNotificationService;
+
+  ResponseEntity<Void> importConsultants() {
+    consultantImportService.startImport();
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> importAskers() {
+    askerImportService.startImport();
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> importAskersWithoutSession() {
+    askerImportService.startImportForAskersWithoutSession();
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> sendNewMessageNotification(
+      NewMessageNotificationDTO newMessageNotificationDTO) {
+    emailNotificationFacade.sendNewMessageNotification(
+        newMessageNotificationDTO.getRcGroupId(),
+        authenticatedUser.getRoles(),
+        authenticatedUser.getUserId(),
+        TenantContext.getCurrentTenantData());
+    eventNotificationService.createMessageNotificationFromRoom(
+        newMessageNotificationDTO.getRcGroupId(), authenticatedUser.getUserId(), null, false);
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> sendReassignmentNotification(
+      ReassignmentNotificationDTO reassignmentNotificationDTO) {
+    if (isTrue(reassignmentNotificationDTO.getIsConfirmed())) {
+      emailNotificationFacade.sendReassignConfirmationNotification(
+          reassignmentNotificationDTO, TenantContext.getCurrentTenantData());
+    } else {
+      emailNotificationFacade.sendReassignRequestNotification(
+          reassignmentNotificationDTO.getRcGroupId(), TenantContext.getCurrentTenantData());
+    }
+
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<Void> updateSessionData(Long sessionId, SessionDataDTO sessionDataDTO) {
+    sessionDataService.saveSessionData(sessionId, sessionDataDTO);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  ResponseEntity<RocketChatGroupIdDTO> getRocketChatGroupId(String consultantId, String askerId) {
+    String groupId = sessionService.findGroupIdByConsultantAndUser(consultantId, askerId);
+    return new ResponseEntity<>(new RocketChatGroupIdDTO().groupId(groupId), HttpStatus.OK);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -96,6 +96,7 @@ import org.springframework.test.web.servlet.MockMvc;
   UserTwoFactorAuthControllerDelegate.class,
   UserRegistrationControllerDelegate.class,
   UserConsultantControllerDelegate.class,
+  UserSupportControllerDelegate.class,
   ApiResponseEntityExceptionHandler.class,
   EncodeUsernameJsonDeserializer.class,
   UrlDecodePasswordJsonDeserializer.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSupportControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSupportControllerDelegateTest.java
@@ -1,0 +1,150 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.NewMessageNotificationDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ReassignmentNotificationDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDataDTO;
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.AskerImportService;
+import de.caritas.cob.userservice.api.service.ConsultantImportService;
+import de.caritas.cob.userservice.api.service.SessionDataService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.tenant.TenantData;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class UserSupportControllerDelegateTest {
+
+  private static final String RC_GROUP_ID = "rc-group-id";
+  private static final String USER_ID = "user-id";
+  private static final String CONSULTANT_ID = "consultant-id";
+  private static final String ASKER_ID = "asker-id";
+  private static final UUID CONSULTANT_UUID =
+      UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Mock private SessionService sessionService;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private ConsultantImportService consultantImportService;
+  @Mock private EmailNotificationFacade emailNotificationFacade;
+  @Mock private AskerImportService askerImportService;
+  @Mock private SessionDataService sessionDataService;
+  @Mock private EventNotificationService eventNotificationService;
+
+  @InjectMocks private UserSupportControllerDelegate delegate;
+
+  @Test
+  void importConsultantsShouldStartImportAndReturnOk() {
+    var response = delegate.importConsultants();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(consultantImportService).startImport();
+  }
+
+  @Test
+  void importAskersShouldStartImportAndReturnOk() {
+    var response = delegate.importAskers();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(askerImportService).startImport();
+  }
+
+  @Test
+  void importAskersWithoutSessionShouldStartImportAndReturnOk() {
+    var response = delegate.importAskersWithoutSession();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(askerImportService).startImportForAskersWithoutSession();
+  }
+
+  @Test
+  void sendNewMessageNotificationShouldSendEmailAndCreateEvent() {
+    var roles = Set.of(UserRole.USER.getValue());
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+
+    var response = delegate.sendNewMessageNotification(new NewMessageNotificationDTO(RC_GROUP_ID));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(emailNotificationFacade).sendNewMessageNotification(RC_GROUP_ID, roles, USER_ID, null);
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(RC_GROUP_ID, USER_ID, null, false);
+  }
+
+  @Test
+  void sendReassignmentNotificationShouldSendConfirmationWhenConfirmed() {
+    var reassignmentNotification =
+        new ReassignmentNotificationDTO(RC_GROUP_ID, CONSULTANT_UUID)
+            .fromConsultantName("Consultant")
+            .isConfirmed(true);
+
+    var response = delegate.sendReassignmentNotification(reassignmentNotification);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(emailNotificationFacade)
+        .sendReassignConfirmationNotification(reassignmentNotification, null);
+    verify(emailNotificationFacade, never())
+        .sendReassignRequestNotification(any(), any(TenantData.class));
+  }
+
+  @Test
+  void sendReassignmentNotificationShouldSendRequestWhenNotConfirmed() {
+    var reassignmentNotification =
+        new ReassignmentNotificationDTO(RC_GROUP_ID, CONSULTANT_UUID).isConfirmed(false);
+
+    var response = delegate.sendReassignmentNotification(reassignmentNotification);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(emailNotificationFacade).sendReassignRequestNotification(RC_GROUP_ID, null);
+    verify(emailNotificationFacade, never())
+        .sendReassignConfirmationNotification(any(), any(TenantData.class));
+  }
+
+  @Test
+  void sendReassignmentNotificationShouldSendRequestWhenConfirmationIsNull() {
+    var reassignmentNotification = new ReassignmentNotificationDTO(RC_GROUP_ID, CONSULTANT_UUID);
+
+    var response = delegate.sendReassignmentNotification(reassignmentNotification);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(emailNotificationFacade).sendReassignRequestNotification(RC_GROUP_ID, null);
+    verify(emailNotificationFacade, never())
+        .sendReassignConfirmationNotification(any(), any(TenantData.class));
+  }
+
+  @Test
+  void updateSessionDataShouldSaveDataAndReturnOk() {
+    var sessionData = new SessionDataDTO().age("17").state("8");
+
+    var response = delegate.updateSessionData(1L, sessionData);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(sessionDataService).saveSessionData(1L, sessionData);
+  }
+
+  @Test
+  void getRocketChatGroupIdShouldReturnGroupId() {
+    when(sessionService.findGroupIdByConsultantAndUser(CONSULTANT_ID, ASKER_ID))
+        .thenReturn(RC_GROUP_ID);
+
+    var response = delegate.getRocketChatGroupId(CONSULTANT_ID, ASKER_ID);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getGroupId()).isEqualTo(RC_GROUP_ID);
+  }
+}


### PR DESCRIPTION
Summary
Extract support/ops endpoints from UserController into UserSupportControllerDelegate.
Keep UserController as a thin delegator for:
importConsultants
importAskers
importAskersWithoutSession
sendNewMessageNotification
sendReassignmentNotification
updateSessionData
getRocketChatGroupId
Add focused delegate unit tests and wire UserSupportControllerDelegate into UserControllerIT.
Why
Continues the UserController refactor (#92): moves import, notification, session-data, and lookup flows out of the controller so support/ops logic is isolated and easier to test.

What is tested
UserSupportControllerDelegate

Import flows: consultants, askers, askers without session
sendNewMessageNotification: email facade + event notification
sendReassignmentNotification: confirmed, not confirmed, and isConfirmed = null
updateSessionData: delegates to SessionDataService
getRocketChatGroupId: returns mapped DTO from SessionService
Verification
UserSupportControllerDelegateTest passed
UserControllerIT passed
spotless:check passed (Java 21)