### PR TITLE
test: add unit tests for api.service.matrix and api.adapters.matrix

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
@@ -29,6 +29,9 @@ class MatrixMediaClientTest {
   private static final String BASE_URL = "http://matrix.local";
   private static final String ACCESS_TOKEN = "access-token";
   private static final String ROOM_ID = "!room:matrix.local";
+  // MatrixUrlBuilder percent-encodes the room ID in the path (encode() before buildAndExpand()),
+  // so URL matchers expect the encoded form while uploadFile is still called with the raw ROOM_ID.
+  private static final String ENCODED_ROOM_ID = "%21room%3Amatrix.local";
 
   // encode().buildAndExpand() encodes Matrix IDs as opaque data: '!' → %21, ':' → %3A.
   // This differs from UriUtils.encodePathSegment which leaves RFC-3986 sub-delimiters unencoded.
@@ -274,7 +277,7 @@ class MatrixMediaClientTest {
             new ResponseEntity<>(
                 Map.of("content_uri", "mxc://matrix.local/bin-id"), HttpStatus.OK));
     when(restTemplate.exchange(
-            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            contains("/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),
             any(HttpEntity.class),
             eq(Map.class)))
@@ -285,7 +288,7 @@ class MatrixMediaClientTest {
     var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     verify(restTemplate)
         .exchange(
-            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            contains("/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/send/m.room.message/"),
             eq(HttpMethod.PUT),
             messageCaptor.capture(),
             eq(Map.class));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClientTest.java
@@ -264,6 +264,38 @@ class MatrixMediaClientTest {
   }
 
   @Test
+  void uploadFile_Should_UseFileMsgtype_When_ContentTypeIsNull() {
+    // Files without a MIME type must still be shared as generic Matrix file messages.
+    var file = new MockMultipartFile("file", "unknown.bin", null, "binary".getBytes());
+
+    when(restTemplate.postForEntity(
+            eq(BASE_URL + "/_matrix/media/r0/upload"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(
+            new ResponseEntity<>(
+                Map.of("content_uri", "mxc://matrix.local/bin-id"), HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(Map.of("event_id", "$event"), HttpStatus.OK));
+
+    matrixMediaClient.uploadFile(file, ROOM_ID, ACCESS_TOKEN);
+
+    var messageCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            contains("/_matrix/client/r0/rooms/" + ROOM_ID + "/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            messageCaptor.capture(),
+            eq(Map.class));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) messageCaptor.getValue().getBody();
+    assertThat(body).containsEntry("msgtype", "m.file");
+  }
+
+  @Test
   void uploadFile_Should_StillReturnSuccess_When_SendFileMessageFails() {
     var file = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -516,7 +516,7 @@ class MatrixRoomClientTest {
   void leaveRoom_success_returnsTrue() {
     // Leaving a room is best-effort; a 2xx from Synapse means the user is no longer a member.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/leave"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of()));
@@ -528,7 +528,7 @@ class MatrixRoomClientTest {
   void leaveRoom_forbidden_returnsTrueWhenUserAlreadyLeft() {
     // A 403 on leave means the desired end state (not in room) already holds.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/leave"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenThrow(
@@ -546,7 +546,7 @@ class MatrixRoomClientTest {
   void leaveRoom_notFound_returnsTrueWhenRoomIsGone() {
     // A 404 on leave is treated as success because the user cannot be in a missing room.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/leave"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenThrow(
@@ -564,7 +564,7 @@ class MatrixRoomClientTest {
   void leaveRoom_otherClientError_returnsFalse() {
     // Non-recoverable client errors must surface as a failed leave for callers to handle.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/leave"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenThrow(
@@ -582,7 +582,7 @@ class MatrixRoomClientTest {
   void leaveRoom_genericException_returnsFalse() {
     // Network failures during leave must not propagate as unchecked exceptions.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/leave"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenThrow(new RuntimeException("connection reset"));
@@ -594,7 +594,7 @@ class MatrixRoomClientTest {
   void joinRoom_genericException_returnsFalse() {
     // Unexpected join failures must degrade to false so membership flows can retry.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/join"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/join"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenThrow(new RuntimeException("connection reset"));
@@ -614,7 +614,7 @@ class MatrixRoomClientTest {
                 StandardCharsets.UTF_8))
         .when(restTemplate)
         .postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/unban"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/unban"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class));
 
@@ -627,7 +627,7 @@ class MatrixRoomClientTest {
     doThrow(new RuntimeException("synapse down"))
         .when(restTemplate)
         .postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/unban"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/unban"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class));
 
@@ -638,7 +638,7 @@ class MatrixRoomClientTest {
   void banUserFromRoom_nonSuccessResponse_returnsFalse() {
     // A non-2xx ban response without an exception must still be treated as failure.
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/ban"),
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/ban"),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(Map.class)))
         .thenReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of()));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -509,4 +509,140 @@ class MatrixRoomClientTest {
 
     assertThat(matrixRoomClient.unbanUserFromRoom(ROOM_ID, USER_ID, ACCESS_TOKEN)).isTrue();
   }
+
+  // ── leaveRoom ───────────────────────────────────────────────────────────────
+
+  @Test
+  void leaveRoom_success_returnsTrue() {
+    // Leaving a room is best-effort; a 2xx from Synapse means the user is no longer a member.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()));
+
+    assertThat(matrixRoomClient.leaveRoom(ROOM_ID, ACCESS_TOKEN)).isTrue();
+  }
+
+  @Test
+  void leaveRoom_forbidden_returnsTrueWhenUserAlreadyLeft() {
+    // A 403 on leave means the desired end state (not in room) already holds.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                null,
+                "{}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    assertThat(matrixRoomClient.leaveRoom(ROOM_ID, ACCESS_TOKEN)).isTrue();
+  }
+
+  @Test
+  void leaveRoom_notFound_returnsTrueWhenRoomIsGone() {
+    // A 404 on leave is treated as success because the user cannot be in a missing room.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                null,
+                "{}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    assertThat(matrixRoomClient.leaveRoom(ROOM_ID, ACCESS_TOKEN)).isTrue();
+  }
+
+  @Test
+  void leaveRoom_otherClientError_returnsFalse() {
+    // Non-recoverable client errors must surface as a failed leave for callers to handle.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                "Bad Request",
+                null,
+                "{}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    assertThat(matrixRoomClient.leaveRoom(ROOM_ID, ACCESS_TOKEN)).isFalse();
+  }
+
+  @Test
+  void leaveRoom_genericException_returnsFalse() {
+    // Network failures during leave must not propagate as unchecked exceptions.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/leave"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(new RuntimeException("connection reset"));
+
+    assertThat(matrixRoomClient.leaveRoom(ROOM_ID, ACCESS_TOKEN)).isFalse();
+  }
+
+  @Test
+  void joinRoom_genericException_returnsFalse() {
+    // Unexpected join failures must degrade to false so membership flows can retry.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/join"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenThrow(new RuntimeException("connection reset"));
+
+    assertThat(matrixRoomClient.joinRoom(ROOM_ID, ACCESS_TOKEN)).isFalse();
+  }
+
+  @Test
+  void unbanUserFromRoom_otherClientError_returnsFalse() {
+    // A genuine unban rejection (not "not banned") must be reported as failure.
+    doThrow(
+            HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                "Bad Request",
+                null,
+                "{\"error\":\"denied\"}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8))
+        .when(restTemplate)
+        .postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/unban"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class));
+
+    assertThat(matrixRoomClient.unbanUserFromRoom(ROOM_ID, USER_ID, ACCESS_TOKEN)).isFalse();
+  }
+
+  @Test
+  void unbanUserFromRoom_genericException_returnsFalse() {
+    // Unban is best-effort; transport errors must not bubble up to callers.
+    doThrow(new RuntimeException("synapse down"))
+        .when(restTemplate)
+        .postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/unban"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class));
+
+    assertThat(matrixRoomClient.unbanUserFromRoom(ROOM_ID, USER_ID, ACCESS_TOKEN)).isFalse();
+  }
+
+  @Test
+  void banUserFromRoom_nonSuccessResponse_returnsFalse() {
+    // A non-2xx ban response without an exception must still be treated as failure.
+    when(restTemplate.postForEntity(
+            eq(API_URL + "/_matrix/client/r0/rooms/" + ROOM_ID + "/ban"),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of()));
+
+    assertThat(matrixRoomClient.banUserFromRoom(ROOM_ID, USER_ID, ACCESS_TOKEN)).isFalse();
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -9,11 +10,17 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserRequestDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,6 +30,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriUtils;
@@ -39,12 +47,23 @@ class MatrixSynapseServiceTest {
   private static final String MATRIX_BASE_URL = "https://matrix.example";
   private static final String MATRIX_ADMIN_TOKEN = "admin-token";
   private static final String MATRIX_USER_TOKEN = "user-token";
+  private static final String REGISTER_URL =
+      "https://matrix.example.com/_synapse/admin/v1/register";
+  private static final String LOGIN_URL = "https://matrix.example.com/_matrix/client/r0/login";
+  private static final String REGISTRATION_SECRET = "caritas-registration-secret-2025";
 
-  @Mock private MatrixConfig matrixConfig;
+  private MatrixConfig matrixConfig;
   @Mock private RestTemplate restTemplate;
   @Mock private RestTemplate matrixLongPollRestTemplate;
   @Mock private MatrixRoomClient matrixRoomClient;
   @Mock private MatrixMediaClient matrixMediaClient;
+
+  @BeforeEach
+  void setUpMatrixConfig() {
+    matrixConfig = new MatrixConfig();
+    matrixConfig.setApiUrl("https://matrix.example.com");
+    matrixConfig.setRegistrationSharedSecret(REGISTRATION_SECRET);
+  }
 
   @Test
   void makeMatrixRequestShouldUseDedicatedLongPollRestTemplate() {
@@ -90,7 +109,7 @@ class MatrixSynapseServiceTest {
   void syncRoomShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
     var roomId = "!room:example.org";
-    when(matrixConfig.getApiUrl("/_matrix/client/r0/sync")).thenReturn(SYNC_URL);
+    matrixConfig.setApiUrl("https://matrix.example");
     var textMessage =
         Map.<String, Object>of(
             "type", "m.room.message", "content", Map.of("msgtype", "m.text", "body", "hello"));
@@ -129,9 +148,7 @@ class MatrixSynapseServiceTest {
   void getRoomMessagesShouldUseDedicatedLongPollRestTemplate() {
     var service = matrixSynapseService();
     var roomId = "!room:example.org";
-    when(matrixConfig.getApiUrl(any(String.class)))
-        .thenAnswer(
-            invocation -> "https://matrix.example" + invocation.getArgument(0, String.class));
+    matrixConfig.setApiUrl("https://matrix.example");
     when(matrixLongPollRestTemplate.exchange(
             any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("chunk", java.util.List.of())));
@@ -182,7 +199,8 @@ class MatrixSynapseServiceTest {
 
   @Test
   void deactivateUserShouldReturnFalseWhenAdminTokenMissing() {
-    when(matrixConfig.getAdminUsername()).thenReturn("");
+    matrixConfig.setAdminUsername("");
+    matrixConfig.setAdminPassword("");
 
     assertThat(matrixSynapseService().deactivateUser(MATRIX_USER_ID)).isFalse();
     verifyNoInteractions(restTemplate);
@@ -215,11 +233,8 @@ class MatrixSynapseServiceTest {
   }
 
   private void stubAdminLogin() {
-    when(matrixConfig.getAdminUsername()).thenReturn("admin");
-    when(matrixConfig.getAdminPassword()).thenReturn("admin-password");
-    when(matrixConfig.getApiUrl(any(String.class)))
-        .thenAnswer(
-            invocation -> "https://matrix.example.com" + invocation.getArgument(0, String.class));
+    matrixConfig.setAdminUsername("admin");
+    matrixConfig.setAdminPassword("admin-password");
     when(restTemplate.postForEntity(
             eq("https://matrix.example.com/_matrix/client/r0/login"),
             any(HttpEntity.class),
@@ -327,16 +342,19 @@ class MatrixSynapseServiceTest {
   }
 
   private void stubAdminLogin(URI expectedLoginAsUserUri) {
-    when(matrixConfig.getAdminUsername()).thenReturn("admin");
-    when(matrixConfig.getAdminPassword()).thenReturn("admin-password");
-    when(matrixConfig.getApiUrl(any(String.class)))
-        .thenAnswer(invocation -> MATRIX_BASE_URL + invocation.getArgument(0, String.class));
-    when(restTemplate.postForEntity(
-            eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"), any(HttpEntity.class), eq(Map.class)))
-        .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_ADMIN_TOKEN)));
+    stubAdminPasswordLoginOnly();
     when(restTemplate.postForEntity(
             eq(expectedLoginAsUserUri), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_USER_TOKEN)));
+  }
+
+  private void stubAdminPasswordLoginOnly() {
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    matrixConfig.setAdminUsername("admin");
+    matrixConfig.setAdminPassword("admin-password");
+    when(restTemplate.postForEntity(
+            eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_ADMIN_TOKEN)));
   }
 
   @Test
@@ -377,8 +395,7 @@ class MatrixSynapseServiceTest {
             eq(Map.class)))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", "stale-token")))
         .thenReturn(ResponseEntity.ok(Map.of("access_token", "fresh-token")));
-    when(matrixConfig.getApiUrl("/_matrix/client/r0/login"))
-        .thenReturn("https://matrix.example/_matrix/client/r0/login");
+    matrixConfig.setApiUrl("https://matrix.example");
 
     var stale = service.loginUser("alice", "secret");
     // Jump just past the 50-minute TTL so the cached entry is expired on the next read.
@@ -397,8 +414,7 @@ class MatrixSynapseServiceTest {
   }
 
   private void stubPasswordLogin(String accessToken) {
-    when(matrixConfig.getApiUrl("/_matrix/client/r0/login"))
-        .thenReturn("https://matrix.example/_matrix/client/r0/login");
+    matrixConfig.setApiUrl("https://matrix.example");
     when(restTemplate.postForEntity(
             eq("https://matrix.example/_matrix/client/r0/login"),
             any(HttpEntity.class),
@@ -423,5 +439,471 @@ class MatrixSynapseServiceTest {
         matrixLongPollRestTemplate,
         matrixRoomClient,
         matrixMediaClient);
+  }
+
+  // -------------------------------------------------------------------------
+  // createUser
+  // -------------------------------------------------------------------------
+
+  @Test
+  void createUser_success_buildsRegistrationRequestWithNonceAndMac() throws Exception {
+    // New platform users must be registered in Synapse with a signed nonce/MAC pair.
+    stubRegisterEndpoint();
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenReturn(ResponseEntity.ok("{\"nonce\":\"nonce-abc\"}"));
+    var responseBody = new MatrixCreateUserResponseDTO();
+    responseBody.setUserId("@newuser:matrix.example.com");
+    var createCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(
+            eq(REGISTER_URL), createCaptor.capture(), eq(MatrixCreateUserResponseDTO.class)))
+        .thenReturn(ResponseEntity.ok(responseBody));
+
+    var response = matrixSynapseService().createUser("newuser", "secret", "New User");
+
+    assertThat(response.getBody().getUserId()).isEqualTo("@newuser:matrix.example.com");
+    @SuppressWarnings("unchecked")
+    var body = (MatrixCreateUserRequestDTO) createCaptor.getValue().getBody();
+    assertThat(body.getUsername()).isEqualTo("newuser");
+    assertThat(body.getPassword()).isEqualTo("secret");
+    assertThat(body.getDisplayName()).isEqualTo("New User");
+    assertThat(body.isAdmin()).isFalse();
+    assertThat(body.getNonce()).isEqualTo("nonce-abc");
+    assertThat(body.getMac()).isNotBlank();
+    assertThat(createCaptor.getValue().getHeaders().getFirst("Authorization"))
+        .isEqualTo("Bearer " + REGISTRATION_SECRET);
+  }
+
+  @Test
+  void createUser_missingNonce_throwsMatrixCreateUserException() {
+    // Registration cannot proceed without a Synapse-issued nonce.
+    stubRegisterEndpoint();
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenReturn(ResponseEntity.ok("{\"status\":\"ok\"}"));
+
+    assertThatThrownBy(() -> matrixSynapseService().createUser("newuser", "secret", "New User"))
+        .isInstanceOf(MatrixCreateUserException.class)
+        .hasMessage("Could not create user (newuser) in Matrix");
+  }
+
+  @Test
+  void createUser_httpClientError_throwsMatrixCreateUserException() {
+    // Synapse rejection must surface as a typed registration failure for callers.
+    stubRegisterEndpoint();
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenReturn(ResponseEntity.ok("{\"nonce\":\"nonce-abc\"}"));
+    when(restTemplate.postForEntity(
+            eq(REGISTER_URL), any(HttpEntity.class), eq(MatrixCreateUserResponseDTO.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.CONFLICT,
+                "Conflict",
+                null,
+                "{\"error\":\"user exists\"}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> matrixSynapseService().createUser("newuser", "secret", "New User"))
+        .isInstanceOf(MatrixCreateUserException.class)
+        .hasMessageContaining("Could not create user (newuser) in Matrix");
+  }
+
+  @Test
+  void createUser_unexpectedError_throwsMatrixCreateUserException() {
+    // Network failures during registration must not leak as unchecked exceptions.
+    stubRegisterEndpoint();
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenThrow(new RuntimeException("connection reset"));
+
+    assertThatThrownBy(() -> matrixSynapseService().createUser("newuser", "secret", "New User"))
+        .isInstanceOf(MatrixCreateUserException.class)
+        .hasMessage("Could not create user (newuser) in Matrix");
+  }
+
+  // -------------------------------------------------------------------------
+  // getAdminToken / getAdminAccessToken
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getAdminToken_createsAdminUserWhenInitialLoginFails() {
+    // First deployment auto-provisions the technical admin account when login fails.
+    stubRegisterEndpoint();
+    matrixConfig.setAdminUsername("sysadmin");
+    matrixConfig.setAdminPassword("admin-pass");
+    when(restTemplate.postForEntity(eq(LOGIN_URL), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", ADMIN_TOKEN)));
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenReturn(ResponseEntity.ok("{\"nonce\":\"admin-nonce\"}"));
+    var adminCreateCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(
+            eq(REGISTER_URL), adminCreateCaptor.capture(), eq(MatrixCreateUserResponseDTO.class)))
+        .thenReturn(ResponseEntity.ok(new MatrixCreateUserResponseDTO()));
+
+    assertThat(matrixSynapseService().getAdminToken()).isEqualTo(ADMIN_TOKEN);
+
+    @SuppressWarnings("unchecked")
+    var adminBody = (MatrixCreateUserRequestDTO) adminCreateCaptor.getValue().getBody();
+    assertThat(adminBody.isAdmin()).isTrue();
+    assertThat(adminBody.getUsername()).isEqualTo("sysadmin");
+  }
+
+  @Test
+  void getAdminToken_reusesCachedTokenWithinFiftyMinuteWindow() {
+    // Repeated admin operations must not re-login on every call within the token TTL.
+    var clock = new AtomicLong(0L);
+    var service = matrixSynapseServiceWithClock(clock::get);
+    matrixConfig.setAdminUsername("admin");
+    matrixConfig.setAdminPassword("admin-password");
+    when(restTemplate.postForEntity(eq(LOGIN_URL), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", ADMIN_TOKEN)));
+
+    assertThat(service.getAdminToken()).isEqualTo(ADMIN_TOKEN);
+    clock.set(30 * 60 * 1000L);
+    assertThat(service.getAdminToken()).isEqualTo(ADMIN_TOKEN);
+
+    verify(restTemplate, times(1))
+        .postForEntity(eq(LOGIN_URL), any(HttpEntity.class), eq(Map.class));
+  }
+
+  @Test
+  void getAdminToken_returnsNullWhenCredentialsNotConfigured() {
+    // Missing admin credentials must disable privileged Synapse calls instead of failing hard.
+    matrixConfig.setAdminUsername(null);
+    matrixConfig.setAdminPassword(null);
+
+    assertThat(matrixSynapseService().getAdminToken()).isNull();
+    verifyNoInteractions(restTemplate);
+  }
+
+  // -------------------------------------------------------------------------
+  // loginAsUser / loginAsUserAccessToken
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginAsUser_blankMatrixUserId_returnsNullWithoutCallingSynapse() {
+    // Impersonation requires a valid Matrix user id; blank ids are rejected early.
+    assertThat(matrixSynapseService().loginAsUser("  ", 60_000L)).isNull();
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void loginAsUser_validForMs_includesValidityInRequestBody() {
+    // Short-lived browser tokens must tell Synapse when the impersonation expires.
+    var service = matrixSynapseService();
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminPasswordLoginOnly();
+    var bodyCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    long beforeCall = System.currentTimeMillis();
+
+    service.loginAsUser("@alice:example.org", 120_000L);
+
+    verify(restTemplate).postForEntity(eq(expectedUri), bodyCaptor.capture(), eq(Map.class));
+    @SuppressWarnings("unchecked")
+    var body = (Map<String, Object>) bodyCaptor.getValue().getBody();
+    assertThat(body).containsKey("valid_until_ms");
+    assertThat((Long) body.get("valid_until_ms"))
+        .isBetween(beforeCall + 120_000L, beforeCall + 120_000L + 5_000L);
+  }
+
+  @Test
+  void loginAsUser_httpClientError_returnsNull() {
+    // Impersonation failures must degrade gracefully for the messaging UI.
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminPasswordLoginOnly();
+    when(restTemplate.postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN,
+                "Forbidden",
+                null,
+                "{}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+    assertThat(matrixSynapseService().loginAsUser("@alice:example.org", 60_000L)).isNull();
+  }
+
+  @Test
+  void loginAsUserAccessToken_nullResponse_returnsNull() {
+    // Callers expect null when Synapse returns no impersonation payload.
+    matrixConfig.setAdminUsername(null);
+    matrixConfig.setAdminPassword(null);
+
+    assertThat(matrixSynapseService().loginAsUserAccessToken("@alice:example.org")).isNull();
+  }
+
+  @Test
+  void loginAsUserAccessToken_missingAccessToken_returnsNull() {
+    // A login-as-user response without access_token must not be treated as success.
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminPasswordLoginOnly();
+    when(restTemplate.postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("user_id", "@alice:example.org")));
+
+    assertThat(matrixSynapseService().loginAsUserAccessToken("@alice:example.org")).isNull();
+  }
+
+  // -------------------------------------------------------------------------
+  // updateUserDisplayName
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateUserDisplayName_success_returnsTrue() {
+    // Consultant display names shown in Matrix must be updatable via the admin API.
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains("/_synapse/admin/v2/users/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(ResponseEntity.ok(""));
+
+    assertThat(matrixSynapseService().updateUserDisplayName(MATRIX_USER_ID, "Seeker")).isTrue();
+  }
+
+  @Test
+  void updateUserDisplayName_noAdminToken_returnsFalse() {
+    // Display-name updates are skipped when privileged Synapse access is unavailable.
+    matrixConfig.setAdminUsername("");
+
+    assertThat(matrixSynapseService().updateUserDisplayName(MATRIX_USER_ID, "Seeker")).isFalse();
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void updateUserDisplayName_exception_returnsFalse() {
+    // Display-name sync is best-effort and must not break account flows.
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            any(String.class), eq(HttpMethod.PUT), any(HttpEntity.class), eq(String.class)))
+        .thenThrow(new RuntimeException("synapse down"));
+
+    assertThat(matrixSynapseService().updateUserDisplayName(MATRIX_USER_ID, "Seeker")).isFalse();
+  }
+
+  // -------------------------------------------------------------------------
+  // getRoomMembers
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getRoomMembers_noAdminToken_returnsEmptyOptional() {
+    // Room membership cannot be read without admin credentials.
+    matrixConfig.setAdminUsername("");
+
+    assertThat(matrixSynapseService().getRoomMembers(MATRIX_ROOM_ID)).isEmpty();
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void getRoomMembers_unexpectedResponseShape_returnsEmptyOptional() {
+    // Callers treat empty as "unknown" when Synapse returns an unexpected payload.
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains("/members"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("unexpected", List.of())));
+
+    assertThat(matrixSynapseService().getRoomMembers(MATRIX_ROOM_ID)).isEmpty();
+  }
+
+  @Test
+  void getRoomMembers_success_returnsMemberList() {
+    // Supervision and moderation flows need the authoritative room member list.
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains("/members"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(
+            ResponseEntity.ok(
+                Map.of(
+                    "members", List.of("@alice:matrix.example.com", "@bob:matrix.example.com"))));
+
+    var members = matrixSynapseService().getRoomMembers(MATRIX_ROOM_ID);
+
+    assertThat(members).contains(List.of("@alice:matrix.example.com", "@bob:matrix.example.com"));
+  }
+
+  @Test
+  void getRoomMembers_exception_returnsEmptyOptional() {
+    // Membership lookup is best-effort and must never throw to callers.
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new RuntimeException("synapse down"));
+
+    assertThat(matrixSynapseService().getRoomMembers(MATRIX_ROOM_ID)).isEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // sendMessage
+  // -------------------------------------------------------------------------
+
+  @Test
+  void sendMessage_success_returnsSynapseResponseBody() {
+    // Chat messages must be delivered to the session's Matrix room.
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    var synapseResponse = Map.<String, Object>of("event_id", "$event123");
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains("/send/m.room.message/"),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(synapseResponse));
+
+    var result = matrixSynapseService().sendMessage(MATRIX_ROOM_ID, "hello", ACCESS_TOKEN);
+
+    assertThat(result).isEqualTo(synapseResponse);
+  }
+
+  @Test
+  void sendMessage_exception_returnsErrorMap() {
+    // Send failures must return a structured error instead of propagating exceptions.
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    when(restTemplate.exchange(
+            any(String.class), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new RuntimeException("room not found"));
+
+    var result = matrixSynapseService().sendMessage(MATRIX_ROOM_ID, "hello", ACCESS_TOKEN);
+
+    assertThat(result).containsKey("error");
+    assertThat(result.get("error")).asString().contains("room not found");
+  }
+
+  // -------------------------------------------------------------------------
+  // findOnlineMatrixUserIds
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findOnlineMatrixUserIds_presenceDisabled_returnsEmptyOptional() {
+    // Availability routing falls back when Matrix presence is turned off in config.
+    matrixConfig.setPresenceEnabled(false);
+
+    assertThat(matrixSynapseService().findOnlineMatrixUserIds(List.of(MATRIX_USER_ID))).isEmpty();
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void findOnlineMatrixUserIds_noAdminToken_returnsEmptyOptional() {
+    // Presence cannot be polled without a privileged Synapse admin token.
+    matrixConfig.setPresenceEnabled(true);
+    matrixConfig.setAdminUsername("");
+
+    assertThat(matrixSynapseService().findOnlineMatrixUserIds(List.of(MATRIX_USER_ID))).isEmpty();
+  }
+
+  @Test
+  void findOnlineMatrixUserIds_emptyInput_returnsEmptySet() {
+    // An empty candidate list is a valid authoritative answer: nobody is online.
+    matrixConfig.setPresenceEnabled(true);
+    stubAdminLogin();
+
+    var result = matrixSynapseService().findOnlineMatrixUserIds(List.of());
+
+    assertThat(result).contains(Set.of());
+  }
+
+  @Test
+  void findOnlineMatrixUserIds_mixedPresence_returnsOnlyAvailableUsers() {
+    // Live-chat routing must include only consultants with an active Matrix client.
+    matrixConfig.setPresenceEnabled(true);
+    matrixConfig.setPresenceActiveThresholdMs(300_000L);
+    stubAdminLogin();
+    var onlineId = "@online:matrix.example.com";
+    var offlineId = "@offline:matrix.example.com";
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains(onlineId),
+            eq(HttpMethod.GET),
+            any(),
+            eq(Map.class)))
+        .thenReturn(
+            ResponseEntity.ok(
+                Map.of("presence", "online", "currently_active", true, "last_active_ago", 0)));
+    when(restTemplate.exchange(
+            org.mockito.ArgumentMatchers.contains(offlineId),
+            eq(HttpMethod.GET),
+            any(),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("presence", "offline")));
+
+    var result = matrixSynapseService().findOnlineMatrixUserIds(List.of(onlineId, offlineId));
+
+    assertThat(result).contains(Set.of(onlineId));
+  }
+
+  @Test
+  void findOnlineMatrixUserIds_allLookupsFail_returnsEmptyOptional() {
+    // When every presence lookup fails, callers must fall back to another availability signal.
+    matrixConfig.setPresenceEnabled(true);
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new RuntimeException("presence disabled on server"));
+
+    assertThat(
+            matrixSynapseService()
+                .findOnlineMatrixUserIds(List.of("@a:matrix.example.com", "@b:matrix.example.com")))
+        .isEmpty();
+  }
+
+  // -------------------------------------------------------------------------
+  // loginUserViaAdmin cache
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginUserViaAdmin_cacheHitWithinTtl_reusesImpersonationToken() {
+    // Repeated moderation actions should reuse the short-lived impersonation token.
+    var clock = new AtomicLong(0L);
+    var service = matrixSynapseServiceWithClock(clock::get);
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminLogin(expectedUri);
+
+    assertThat(service.loginUserViaAdmin("@alice:example.org")).isEqualTo(MATRIX_USER_TOKEN);
+    clock.set(10 * 60 * 1000L);
+    assertThat(service.loginUserViaAdmin("@alice:example.org")).isEqualTo(MATRIX_USER_TOKEN);
+
+    verify(restTemplate, times(1))
+        .postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class));
+  }
+
+  @Test
+  void loginUserViaAdmin_cacheExpiredAfterTtl_fetchesFreshToken() {
+    // Expired impersonation tokens must be refreshed so Synapse does not reject stale credentials.
+    var clock = new AtomicLong(0L);
+    var service = matrixSynapseServiceWithClock(clock::get);
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminPasswordLoginOnly();
+    when(restTemplate.postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "token-v1")))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "token-v2")));
+
+    assertThat(service.loginUserViaAdmin("@alice:example.org")).isEqualTo("token-v1");
+    clock.set(50 * 60 * 1000L + 1L);
+    assertThat(service.loginUserViaAdmin("@alice:example.org")).isEqualTo("token-v2");
+
+    verify(restTemplate, times(2))
+        .postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class));
+  }
+
+  @Test
+  void loginUserViaAdmin_noAccessTokenInResponse_returnsNull() {
+    // Impersonation without an access_token must be treated as failure.
+    var expectedUri =
+        URI.create(MATRIX_BASE_URL + "/_synapse/admin/v1/users/%40alice%3Aexample.org/login");
+    stubAdminPasswordLoginOnly();
+    when(restTemplate.postForEntity(eq(expectedUri), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("user_id", "@alice:example.org")));
+
+    assertThat(matrixSynapseService().loginUserViaAdmin("@alice:example.org")).isNull();
+  }
+
+  private void stubRegisterEndpoint() {
+    // apiUrl and registration secret are configured in setUpMatrixConfig()
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -448,7 +448,6 @@ class MatrixSynapseServiceTest {
   @Test
   void createUser_success_buildsRegistrationRequestWithNonceAndMac() throws Exception {
     // New platform users must be registered in Synapse with a signed nonce/MAC pair.
-    stubRegisterEndpoint();
     when(restTemplate.getForEntity(REGISTER_URL, String.class))
         .thenReturn(ResponseEntity.ok("{\"nonce\":\"nonce-abc\"}"));
     var responseBody = new MatrixCreateUserResponseDTO();
@@ -476,7 +475,6 @@ class MatrixSynapseServiceTest {
   @Test
   void createUser_missingNonce_throwsMatrixCreateUserException() {
     // Registration cannot proceed without a Synapse-issued nonce.
-    stubRegisterEndpoint();
     when(restTemplate.getForEntity(REGISTER_URL, String.class))
         .thenReturn(ResponseEntity.ok("{\"status\":\"ok\"}"));
 
@@ -488,7 +486,6 @@ class MatrixSynapseServiceTest {
   @Test
   void createUser_httpClientError_throwsMatrixCreateUserException() {
     // Synapse rejection must surface as a typed registration failure for callers.
-    stubRegisterEndpoint();
     when(restTemplate.getForEntity(REGISTER_URL, String.class))
         .thenReturn(ResponseEntity.ok("{\"nonce\":\"nonce-abc\"}"));
     when(restTemplate.postForEntity(
@@ -509,7 +506,6 @@ class MatrixSynapseServiceTest {
   @Test
   void createUser_unexpectedError_throwsMatrixCreateUserException() {
     // Network failures during registration must not leak as unchecked exceptions.
-    stubRegisterEndpoint();
     when(restTemplate.getForEntity(REGISTER_URL, String.class))
         .thenThrow(new RuntimeException("connection reset"));
 
@@ -525,7 +521,6 @@ class MatrixSynapseServiceTest {
   @Test
   void getAdminToken_createsAdminUserWhenInitialLoginFails() {
     // First deployment auto-provisions the technical admin account when login fails.
-    stubRegisterEndpoint();
     matrixConfig.setAdminUsername("sysadmin");
     matrixConfig.setAdminPassword("admin-pass");
     when(restTemplate.postForEntity(eq(LOGIN_URL), any(HttpEntity.class), eq(Map.class)))
@@ -815,8 +810,12 @@ class MatrixSynapseServiceTest {
     stubAdminLogin();
     var onlineId = "@online:matrix.example.com";
     var offlineId = "@offline:matrix.example.com";
+    // The user ID is percent-encoded in the presence URL path by MatrixUrlBuilder, so the URL
+    // matchers must look for the encoded form even though the client is called with the raw IDs.
+    var encodedOnlineId = "%40online%3Amatrix.example.com";
+    var encodedOfflineId = "%40offline%3Amatrix.example.com";
     when(restTemplate.exchange(
-            org.mockito.ArgumentMatchers.contains(onlineId),
+            org.mockito.ArgumentMatchers.contains(encodedOnlineId),
             eq(HttpMethod.GET),
             any(),
             eq(Map.class)))
@@ -824,7 +823,7 @@ class MatrixSynapseServiceTest {
             ResponseEntity.ok(
                 Map.of("presence", "online", "currently_active", true, "last_active_ago", 0)));
     when(restTemplate.exchange(
-            org.mockito.ArgumentMatchers.contains(offlineId),
+            org.mockito.ArgumentMatchers.contains(encodedOfflineId),
             eq(HttpMethod.GET),
             any(),
             eq(Map.class)))
@@ -901,9 +900,5 @@ class MatrixSynapseServiceTest {
         .thenReturn(ResponseEntity.ok(Map.of("user_id", "@alice:example.org")));
 
     assertThat(matrixSynapseService().loginUserViaAdmin("@alice:example.org")).isNull();
-  }
-
-  private void stubRegisterEndpoint() {
-    // apiUrl and registration secret are configured in setUpMatrixConfig()
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilderTest.java
@@ -124,4 +124,18 @@ class MatrixUrlBuilderTest {
     assertThat(url).doesNotContain("{");
     assertThat(url).doesNotContain("}");
   }
+
+  @Test
+  void buildUrl_ShouldSkipNullQueryParams() {
+    var queryParams = new java.util.LinkedHashMap<String, Object>();
+    queryParams.put("since", null);
+    queryParams.put("timeout", 0);
+
+    var url =
+        MatrixUrlBuilder.buildUrl(matrixConfig(), "/_matrix/client/r0/sync", Map.of(), queryParams);
+
+    // Null optional sync cursors must not produce empty query parameters in the URL.
+    assertThat(url).isEqualTo(BASE_URL + "/_matrix/client/r0/sync?timeout=0");
+    assertThat(url).doesNotContain("since");
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -19,11 +22,14 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class GroupChatMembershipServiceTest {
@@ -46,6 +52,22 @@ class GroupChatMembershipServiceTest {
   @Mock private Consultant consultant;
 
   @Mock private User user;
+
+  private Logger logger;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUpLogging() {
+    logger = (Logger) LoggerFactory.getLogger(GroupChatMembershipService.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDownLogging() {
+    logger.detachAppender(logAppender);
+  }
 
   private Chat.ChatBuilder chatBuilder() {
     return Chat.builder()
@@ -343,5 +365,65 @@ class GroupChatMembershipServiceTest {
     session.setGroupId("rcGroupId4711");
 
     assertNull(groupChatMembershipService.resolveMatrixRoomId(session));
+  }
+
+  // ── resolveMatrixRoomId(Chat) gaps ─────────────────────────────────────────
+
+  @Test
+  void resolveMatrixRoomId_Should_ReturnNull_When_ChatIsNull() {
+    // Callers may pass a null chat during teardown — room resolution must not NPE.
+    assertNull(groupChatMembershipService.resolveMatrixRoomId((Chat) null));
+  }
+
+  @Test
+  void resolveMatrixRoomId_Should_PreferMatrixRoomIdColumn_onChat() {
+    // Dedicated matrix_room_id column is authoritative over legacy group_id values.
+    var chat = chatBuilder().matrixRoomId(MATRIX_ROOM_ID).groupId("rcGroupId").build();
+    assertEquals(MATRIX_ROOM_ID, groupChatMembershipService.resolveMatrixRoomId(chat));
+  }
+
+  @Test
+  void resolveMatrixRoomId_Should_FallBackToGroupId_onChat_When_MatrixRoomIdNull() {
+    // Legacy chats may only store the Matrix room id in group_id — still resolvable.
+    var chat = chatBuilder().groupId(MATRIX_ROOM_ID).build();
+    assertEquals(MATRIX_ROOM_ID, groupChatMembershipService.resolveMatrixRoomId(chat));
+  }
+
+  @Test
+  void removeMemberFromRoom_Should_WarnAndNotThrow_When_LeaveRoomReturnsFalse() {
+    // A failed Matrix leave must not abort the chat-leave flow — warn and continue.
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID)).thenReturn("token");
+    when(matrixSynapseService.leaveRoom(MATRIX_ROOM_ID, "token")).thenReturn(false);
+
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+        () ->
+            groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
+
+    verify(matrixSynapseService).leaveRoom(MATRIX_ROOM_ID, "token");
+    assertTrue(
+        logAppender.list.stream()
+            .anyMatch(
+                e ->
+                    e.getLevel().toString().equals("WARN")
+                        && e.getFormattedMessage().contains("Could not remove member")));
+  }
+
+  @Test
+  void resolveHumanMembers_Should_IncludeConsultant_When_DisplayNameAndFullNameBlank() {
+    // Consultants without display metadata are still real members and must appear in member lists.
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(CONSULTANT_MATRIX_ID)));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultant));
+    when(consultant.getId()).thenReturn("consultant-id");
+    when(consultant.getUsername()).thenReturn("consultantUsername");
+    when(consultant.getDisplayName()).thenReturn("  ");
+    when(consultant.getFullName()).thenReturn(null);
+
+    var resolved = groupChatMembershipService.resolveHumanMembers(MATRIX_ROOM_ID);
+
+    assertEquals(1, resolved.size());
+    assertEquals("consultant-id", resolved.get(0).accountId());
+    assertTrue(resolved.get(0).consultant());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -1,22 +1,45 @@
 package de.caritas.cob.userservice.api.service.matrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -34,6 +57,23 @@ class MatrixEventListenerServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private ConsultantRepository consultantRepository;
   @Mock private SessionRepository sessionRepository;
+
+  private Logger logger;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUpLogging() {
+    logger = (Logger) LoggerFactory.getLogger(MatrixEventListenerService.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+    logger.setLevel(Level.DEBUG);
+  }
+
+  @AfterEach
+  void tearDownLogging() {
+    logger.detachAppender(logAppender);
+  }
 
   private MatrixEventListenerService newService() {
     return new MatrixEventListenerService(
@@ -109,5 +149,447 @@ class MatrixEventListenerServiceTest {
     boolean acquired = (boolean) ReflectionTestUtils.invokeMethod(service, "bootstrapAdminToken");
 
     assertThat(acquired).isFalse();
+  }
+
+  // ── classifyContent ────────────────────────────────────────────────────────
+
+  static Stream<Arguments> knownMsgTypes() {
+    return Stream.of(
+        Arguments.of("m.text", "TEXT"),
+        Arguments.of("m.image", "IMAGE"),
+        Arguments.of("m.file", "FILE"),
+        Arguments.of("m.audio", "AUDIO"),
+        Arguments.of("m.video", "VIDEO"),
+        Arguments.of("m.notice", "NOTICE"),
+        Arguments.of("m.emote", "EMOTE"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("knownMsgTypes")
+  void classifyContent_shouldMapKnownMsgTypesToContentClass(String msgtype, String expected) {
+    // Notification privacy metadata must classify Matrix message kinds for the UI layer.
+    var service = newService();
+    assertThat(invokeClassifyContent(service, msgtype)).isEqualTo(expected);
+  }
+
+  @Test
+  void classifyContent_shouldReturnUnknown_whenMsgtypeIsNull() {
+    // Events without a msgtype still need a safe fallback label for logging.
+    assertThat(invokeClassifyContent(newService(), null)).isEqualTo("UNKNOWN");
+  }
+
+  @Test
+  void classifyContent_shouldReturnUnknown_whenMsgtypeIsBlank() {
+    // Whitespace-only msgtypes must not be treated as a real content class.
+    assertThat(invokeClassifyContent(newService(), "   ")).isEqualTo("UNKNOWN");
+  }
+
+  @Test
+  void classifyContent_shouldReturnOther_whenMsgtypeIsUnrecognized() {
+    // Future Matrix msgtypes must bucket into OTHER until explicitly supported.
+    assertThat(invokeClassifyContent(newService(), "m.custom")).isEqualTo("OTHER");
+  }
+
+  // ── extractThreadRootId ────────────────────────────────────────────────────
+
+  @Test
+  void extractThreadRootId_shouldReturnNull_whenContentIsNull() {
+    // Non-thread messages must not fabricate a thread root id.
+    assertThat(invokeExtractThreadRootId(newService(), null)).isNull();
+  }
+
+  @Test
+  void extractThreadRootId_shouldReturnNull_whenRelatesToMissing() {
+    // Plain messages without m.relates_to are not thread replies.
+    assertThat(invokeExtractThreadRootId(newService(), Map.of("body", "hi"))).isNull();
+  }
+
+  @Test
+  void extractThreadRootId_shouldReturnNull_whenRelatesToIsNotAMap() {
+    // Malformed relates_to payloads must be ignored rather than crashing the sync loop.
+    assertThat(invokeExtractThreadRootId(newService(), Map.of("m.relates_to", "not-a-map")))
+        .isNull();
+  }
+
+  @Test
+  void extractThreadRootId_shouldReturnNull_whenRelTypeIsNotThread() {
+    // Only m.thread relations identify a thread root for reply notifications.
+    var content =
+        contentMap("m.relates_to", Map.of("rel_type", "m.reference", "event_id", "$root"));
+    assertThat(invokeExtractThreadRootId(newService(), content)).isNull();
+  }
+
+  @Test
+  void extractThreadRootId_shouldReturnEventId_whenValidThreadRelation() {
+    // Thread replies must carry the root event id so clients can open the correct thread.
+    var content =
+        contentMap("m.relates_to", Map.of("rel_type", "m.thread", "event_id", "$root-event"));
+    assertThat(invokeExtractThreadRootId(newService(), content)).isEqualTo("$root-event");
+  }
+
+  // ── extractMessageBody ───────────────────────────────────────────────────────
+
+  @Test
+  void extractMessageBody_shouldReturnBody_whenPresent() {
+    // Plain-text Matrix messages expose the user-visible text in the body field.
+    assertThat(invokeExtractMessageBody(newService(), Map.of("body", "hello"))).isEqualTo("hello");
+  }
+
+  @Test
+  void extractMessageBody_shouldReturnFormattedBody_whenBodyAbsent() {
+    // Rich-text fallbacks must still yield readable text for debug mirroring.
+    assertThat(invokeExtractMessageBody(newService(), Map.of("formatted_body", "<b>hello</b>")))
+        .isEqualTo("<b>hello</b>");
+  }
+
+  @Test
+  void extractMessageBody_shouldReturnThreadReplyMarker_whenOnlyRelatesToPresent() {
+    // Thread-only payloads still need a traceable placeholder for the Redis debug mirror.
+    var content = contentMap("m.relates_to", Map.of("event_id", "$parent"));
+    assertThat(invokeExtractMessageBody(newService(), content)).isEqualTo("thread-reply:$parent");
+  }
+
+  @Test
+  void extractMessageBody_shouldReturnNull_whenContentIsNull() {
+    // Empty events must not NPE the sync handler.
+    assertThat(invokeExtractMessageBody(newService(), null)).isNull();
+  }
+
+  // ── buildPrivacyEnvelope ─────────────────────────────────────────────────────
+
+  @Test
+  void buildPrivacyEnvelope_shouldFlagAttachment_whenMsgtypeIsImage() {
+    // Image messages must be flagged as attachments without logging the binary payload.
+    var envelope =
+        invokeBuildPrivacyEnvelope(
+            newService(),
+            Map.of("event_id", "$e1", "origin_server_ts", 1_700_000_000_000L),
+            "!room:matrix",
+            "@sender:matrix",
+            "m.image",
+            Map.of("body", "photo"));
+    assertThat(envelope.isHasAttachment()).isTrue();
+    assertThat(envelope.getContentClass()).isEqualTo("IMAGE");
+  }
+
+  @Test
+  void buildPrivacyEnvelope_shouldFlagAttachment_whenContentHasUrlKey() {
+    // Encrypted uploads reference media via url even when msgtype is non-standard.
+    var envelope =
+        invokeBuildPrivacyEnvelope(
+            newService(),
+            Map.of("event_id", "$e2"),
+            "!room:matrix",
+            "@sender:matrix",
+            "m.text",
+            Map.of("body", "see file", "url", "mxc://matrix/file"));
+    assertThat(envelope.isHasAttachment()).isTrue();
+  }
+
+  @Test
+  void buildPrivacyEnvelope_shouldFlagAttachment_whenContentHasFileKey() {
+    // File metadata objects also indicate an attachment for notification badges.
+    var envelope =
+        invokeBuildPrivacyEnvelope(
+            newService(),
+            Map.of("event_id", "$e3"),
+            "!room:matrix",
+            "@sender:matrix",
+            "m.text",
+            Map.of("body", "doc", "file", Map.of("mimetype", "application/pdf")));
+    assertThat(envelope.isHasAttachment()).isTrue();
+  }
+
+  @Test
+  void buildPrivacyEnvelope_shouldConvertNumericTimestamp() {
+    // Matrix server timestamps are numeric epoch millis used for notification ordering.
+    var envelope =
+        invokeBuildPrivacyEnvelope(
+            newService(),
+            Map.of("event_id", "$e4", "origin_server_ts", 1_234_567_890L),
+            "!room:matrix",
+            "@sender:matrix",
+            "m.text",
+            Map.of("body", "hi"));
+    assertThat(envelope.getTimestamp()).isEqualTo(1_234_567_890L);
+  }
+
+  @Test
+  void buildPrivacyEnvelope_shouldHandleNullEventId() {
+    // Partial events during sync must still produce a usable privacy envelope.
+    var envelope =
+        invokeBuildPrivacyEnvelope(
+            newService(),
+            new HashMap<String, Object>(),
+            "!room:matrix",
+            "@sender:matrix",
+            "m.text",
+            Map.of("body", "hi"));
+    assertThat(envelope.getMessageId()).isNull();
+    assertThat(envelope.getRoomId()).isEqualTo("!room:matrix");
+  }
+
+  // ── buildRecipientSet ────────────────────────────────────────────────────────
+
+  private static Session sessionWithParticipants(User user, Consultant consultant) {
+    var session = new Session();
+    session.setUser(user);
+    session.setConsultant(consultant);
+    return session;
+  }
+
+  @Test
+  void buildRecipientSet_shouldContainOnlyUser_whenConsultantMissing() {
+    // Ask-only sessions must still notify the advice seeker of new messages.
+    var user = new User();
+    user.setUserId("user-1");
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(user, null)))
+        .containsExactly("user-1");
+  }
+
+  @Test
+  void buildRecipientSet_shouldContainOnlyConsultant_whenUserMissing() {
+    // Consultant-only edge cases must still route notifications to the assigned consultant.
+    var consultant = new Consultant();
+    consultant.setId("consultant-1");
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(null, consultant)))
+        .containsExactly("consultant-1");
+  }
+
+  @Test
+  void buildRecipientSet_shouldContainBoth_whenUserAndConsultantPresent() {
+    // Standard counselling sessions notify both participants except the sender.
+    var user = new User();
+    user.setUserId("user-1");
+    var consultant = new Consultant();
+    consultant.setId("consultant-1");
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(user, consultant)))
+        .containsExactlyInAnyOrder("user-1", "consultant-1");
+  }
+
+  @Test
+  void buildRecipientSet_shouldIgnoreNullUser() {
+    // Detached session graphs must not NPE when the user association is missing.
+    var consultant = new Consultant();
+    consultant.setId("consultant-1");
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(null, consultant)))
+        .containsExactly("consultant-1");
+  }
+
+  @Test
+  void buildRecipientSet_shouldIgnoreNullConsultant() {
+    // Sessions awaiting assignment must still notify the asker.
+    var user = new User();
+    user.setUserId("user-1");
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(user, null)))
+        .containsExactly("user-1");
+  }
+
+  // ── registerRoom / unregisterRoom ───────────────────────────────────────────
+
+  @Test
+  void registerRoom_shouldPopulateBothMaps_whenRoomIdValid() {
+    // UI sync registration must index the room for session lookup and recipient fan-out.
+    var service = newService();
+    service.registerRoom(99L, "!room:matrix", Set.of("user-a", "user-b"));
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (Map<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    @SuppressWarnings("unchecked")
+    var roomToUsers =
+        (Map<String, Set<String>>) ReflectionTestUtils.getField(service, "roomToUsersMap");
+
+    assertThat(roomToSession).containsEntry("!room:matrix", 99L);
+    assertThat(roomToUsers).containsEntry("!room:matrix", Set.of("user-a", "user-b"));
+  }
+
+  @Test
+  void registerRoom_shouldBeNoOp_whenRoomIdBlank() {
+    // Invalid room ids must not pollute the in-memory registration indexes.
+    var service = newService();
+    service.registerRoom(1L, "", Set.of("user-a"));
+    service.registerRoom(2L, null, Set.of("user-b"));
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (Map<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    assertThat(roomToSession).isEmpty();
+  }
+
+  @Test
+  void unregisterRoom_shouldRemoveFromBothMaps() {
+    // Ended sessions must stop generating live events for that Matrix room.
+    var service = newService();
+    service.registerRoom(5L, "!room:matrix", Set.of("user-a"));
+    service.unregisterRoom("!room:matrix");
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (Map<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    @SuppressWarnings("unchecked")
+    var roomToUsers =
+        (Map<String, Set<String>>) ReflectionTestUtils.getField(service, "roomToUsersMap");
+
+    assertThat(roomToSession).doesNotContainKey("!room:matrix");
+    assertThat(roomToUsers).doesNotContainKey("!room:matrix");
+  }
+
+  @Test
+  void registerRoom_shouldRemainConsistent_underConcurrentRegistration() throws Exception {
+    // Multiple clients registering the same room must not corrupt the shared listener maps.
+    var service = newService();
+    var start = new CountDownLatch(1);
+    var done = new CountDownLatch(2);
+    var executor = Executors.newFixedThreadPool(2);
+
+    Runnable register =
+        () -> {
+          try {
+            start.await();
+            service.registerRoom(10L, "!room:concurrent", Set.of("user-x"));
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        };
+
+    executor.submit(register);
+    executor.submit(register);
+    start.countDown();
+    assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+    executor.shutdownNow();
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (ConcurrentHashMap<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    @SuppressWarnings("unchecked")
+    var roomToUsers =
+        (ConcurrentHashMap<String, Set<String>>)
+            ReflectionTestUtils.getField(service, "roomToUsersMap");
+
+    assertThat(roomToSession).containsEntry("!room:concurrent", 10L);
+    assertThat(roomToUsers).containsKey("!room:concurrent");
+    assertThat(roomToUsers.get("!room:concurrent")).contains("user-x");
+  }
+
+  @Test
+  void unregisterRoom_shouldLeaveMapsEmpty_underConcurrentUnregister() throws Exception {
+    // Concurrent unregister calls for the same room must not leave stale recipient entries.
+    var service = newService();
+    service.registerRoom(11L, "!room:gone", Set.of("user-y"));
+
+    var start = new CountDownLatch(1);
+    var done = new CountDownLatch(2);
+    var executor = Executors.newFixedThreadPool(2);
+
+    Runnable unregister =
+        () -> {
+          try {
+            start.await();
+            service.unregisterRoom("!room:gone");
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        };
+
+    executor.submit(unregister);
+    executor.submit(unregister);
+    start.countDown();
+    assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+    executor.shutdownNow();
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (Map<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    @SuppressWarnings("unchecked")
+    var roomToUsers =
+        (Map<String, Set<String>>) ReflectionTestUtils.getField(service, "roomToUsersMap");
+
+    assertThat(roomToSession).isEmpty();
+    assertThat(roomToUsers).isEmpty();
+  }
+
+  // ── safeContentLog ───────────────────────────────────────────────────────────
+
+  @Test
+  void safeContentLog_shouldNotThrow_whenEnvelopeIsNull() {
+    // Privacy logging must tolerate missing metadata during malformed sync events.
+    var service = newService();
+    assertThatCode(() -> invokeSafeContentLog(service, "matrix.message.received", null))
+        .doesNotThrowAnyException();
+    assertThat(logAppender.list)
+        .anyMatch(e -> e.getFormattedMessage().contains("matrix.message.received room=unknown"));
+  }
+
+  @Test
+  void safeContentLog_shouldLogEnvelopeFields_whenPopulated() {
+    // Operators need structured debug metadata without ever logging message plaintext.
+    var service = newService();
+    var envelope =
+        PrivacyEnvelope.builder()
+            .messageId("$evt")
+            .roomId("!room:matrix")
+            .senderId("@user:matrix")
+            .timestamp(99L)
+            .hasAttachment(true)
+            .contentClass("TEXT")
+            .build();
+
+    invokeSafeContentLog(service, "matrix.message.received", envelope);
+
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getFormattedMessage().contains("room=!room:matrix")
+                    && e.getFormattedMessage().contains("messageId=$evt")
+                    && e.getFormattedMessage().contains("contentClass=TEXT")
+                    && e.getFormattedMessage().contains("hasAttachment=true"));
+  }
+
+  private static Map<String, Object> contentMap(String key, Object value) {
+    Map<String, Object> content = new HashMap<>();
+    content.put(key, value);
+    return content;
+  }
+
+  private static String invokeClassifyContent(MatrixEventListenerService service, String msgtype) {
+    return (String) ReflectionTestUtils.invokeMethod(service, "classifyContent", msgtype);
+  }
+
+  private static String invokeExtractThreadRootId(
+      MatrixEventListenerService service, Map<String, Object> content) {
+    return (String) ReflectionTestUtils.invokeMethod(service, "extractThreadRootId", content);
+  }
+
+  private static String invokeExtractMessageBody(
+      MatrixEventListenerService service, Map<String, Object> content) {
+    return (String) ReflectionTestUtils.invokeMethod(service, "extractMessageBody", content);
+  }
+
+  private static PrivacyEnvelope invokeBuildPrivacyEnvelope(
+      MatrixEventListenerService service,
+      Map<String, Object> event,
+      String roomId,
+      String senderId,
+      String msgtype,
+      Map<String, Object> content) {
+    return (PrivacyEnvelope)
+        ReflectionTestUtils.invokeMethod(
+            service, "buildPrivacyEnvelope", event, roomId, senderId, msgtype, content);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Set<String> invokeBuildRecipientSet(
+      MatrixEventListenerService service, Session session) {
+    return (Set<String>) ReflectionTestUtils.invokeMethod(service, "buildRecipientSet", session);
+  }
+
+  private static void invokeSafeContentLog(
+      MatrixEventListenerService service, String marker, PrivacyEnvelope envelope) {
+    ReflectionTestUtils.invokeMethod(service, "safeContentLog", marker, envelope);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
@@ -1,0 +1,326 @@
+package de.caritas.cob.userservice.api.service.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixSessionSystemMessageServiceTest {
+
+  private static final Long SESSION_ID = 42L;
+  private static final Long AGENCY_ID = 7L;
+  private static final String MATRIX_ROOM_ID = "!room:matrix.oriso.org";
+  private static final String USER_MATRIX_ID = "@asker:matrix.oriso.org";
+  private static final String CONSULTANT_ID = "consultant-1";
+  private static final String CONSULTANT_MATRIX_ID = "@consultant:matrix.oriso.org";
+  private static final String ACCESS_TOKEN = "matrix-access-token";
+
+  @InjectMocks private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
+
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
+  @Mock private SessionService sessionService;
+  @Mock private ConsultantService consultantService;
+
+  private Logger logger;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUp() {
+    logger = (Logger) LoggerFactory.getLogger(MatrixSessionSystemMessageService.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(logAppender);
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldPostSystemNotificationJson_onHappyPathViaUserCredentials() {
+    // Participants must see a structured system message when the asker leaves, not silence.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker.username");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(eq(MATRIX_ROOM_ID), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    var bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService)
+        .sendMessage(eq(MATRIX_ROOM_ID), bodyCaptor.capture(), eq(ACCESS_TOKEN));
+    var body = bodyCaptor.getValue();
+    assertThat(body)
+        .startsWith(MatrixSessionSystemMessageService.SYSTEM_NOTIFICATION_PREFIX)
+        .contains("\"type\":\"" + MatrixSessionSystemMessageService.USER_LEFT_CHAT_TYPE + "\"")
+        .contains("\"username\":\"asker.username\"");
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldEscapeBackslashAndQuoteInUsername() {
+    // Usernames with JSON-special characters must not break the in-room notification payload.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "say\"hi\\");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), anyString()))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    var bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService).sendMessage(anyString(), bodyCaptor.capture(), anyString());
+    assertThat(bodyCaptor.getValue()).contains("\"username\":\"say\\\"hi\\\\\"");
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldUseAgencyPasswordLogin_withMatrixLocalpartExtracted() {
+    // Agency service accounts post as a localpart login when no human Matrix ID is on the session.
+    var session = sessionWithoutHumanMatrixIds();
+    var credentials = agencyCredentials("@agency-bot:matrix.oriso.org", "agency-secret");
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+    when(matrixSynapseService.loginUser("agency-bot", "agency-secret")).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(matrixSynapseService).loginUser("agency-bot", "agency-secret");
+    verify(matrixSynapseService).sendMessage(eq(MATRIX_ROOM_ID), anyString(), eq(ACCESS_TOKEN));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldUseBareAgencyLocalpart_whenMatrixUserIdHasNoSigil() {
+    // Bare localpart agency IDs must be passed through without forcing a @ prefix.
+    var session = sessionWithoutHumanMatrixIds();
+    var credentials = agencyCredentials("agency-bot", "agency-secret");
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+    when(matrixSynapseService.loginUser("agency-bot", "agency-secret")).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(matrixSynapseService).loginUser("agency-bot", "agency-secret");
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldUseConsultantMatrixId_afterReloadFromConsultantService() {
+    // Consultant credentials are refreshed from the DB so a stale session snapshot still works.
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    consultant.setMatrixUserId(CONSULTANT_MATRIX_ID);
+
+    var session = baseSession();
+    session.setUser(new User());
+    session.setConsultant(consultant);
+
+    when(consultantService.getConsultant(CONSULTANT_ID)).thenReturn(Optional.of(consultant));
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID))
+        .thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(consultantService).getConsultant(CONSULTANT_ID);
+    verify(matrixSynapseService).loginAsUserAccessToken(CONSULTANT_MATRIX_ID);
+    verify(matrixSynapseService).sendMessage(eq(MATRIX_ROOM_ID), anyString(), eq(ACCESS_TOKEN));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldDoNothing_whenSessionIsNull() {
+    // Finishing a session must never NPE when the caller passes a null reference.
+    matrixSessionSystemMessageService.postUserLeftChatMessage(null);
+
+    verifyNoInteractions(
+        matrixSynapseService, sessionService, consultantService, agencyMatrixCredentialClient);
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldDoNothing_whenSessionIdIsNull() {
+    // Sessions without a persisted id cannot be addressed in Matrix — skip quietly.
+    var session = new Session();
+    session.setMatrixRoomId(MATRIX_ROOM_ID);
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verifyNoInteractions(
+        matrixSynapseService, sessionService, consultantService, agencyMatrixCredentialClient);
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldReloadMatrixRoomIdFromSessionService_whenBlankOnSession() {
+    // Room id may only exist on the persisted session row, not the in-memory object.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker.username");
+    session.setMatrixRoomId(null);
+    var persisted = baseSession();
+    persisted.setMatrixRoomId(MATRIX_ROOM_ID);
+    persisted.setUser(session.getUser());
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(persisted));
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(sessionService).getSession(SESSION_ID);
+    verify(matrixSynapseService).sendMessage(eq(MATRIX_ROOM_ID), anyString(), eq(ACCESS_TOKEN));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldNotSendMessage_whenRoomIdStillBlankAfterReload() {
+    // Without a Matrix room there is nowhere to post — abort without calling Synapse.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker");
+    session.setMatrixRoomId("  ");
+    var persisted = baseSession();
+    persisted.setMatrixRoomId(null);
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(persisted));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(sessionService).getSession(SESSION_ID);
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldNotSendMessage_whenAgencyDtoMissingUserId() {
+    // Incomplete agency credentials cannot authenticate — message must not be attempted.
+    var session = sessionWithoutHumanMatrixIds();
+    var credentials = agencyCredentials(null, "agency-secret");
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(agencyMatrixCredentialClient).fetchMatrixCredentials(AGENCY_ID);
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+    assertThat(logAppender.list).noneMatch(e -> e.getLevel().toString().equals("WARN"));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldNotSendMessage_whenAgencyDtoMissingPassword() {
+    // Password-less agency credentials are filtered out before any Synapse login attempt.
+    var session = sessionWithoutHumanMatrixIds();
+    var credentials = agencyCredentials("@agency:matrix.oriso.org", "  ");
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+    verify(matrixSynapseService, never()).loginUser(anyString(), anyString());
+    assertThat(logAppender.list).noneMatch(e -> e.getLevel().toString().equals("WARN"));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldWarnAndSkipSend_whenAccessTokenUnavailable() {
+    // A missing token must not block session teardown — warn and continue.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(null);
+
+    assertThatCode(() -> matrixSessionSystemMessageService.postUserLeftChatMessage(session))
+        .doesNotThrowAnyException();
+
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("WARN")
+                    && e.getFormattedMessage().contains("token unavailable"));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldWarn_whenSendMessageReturnsErrorKey() {
+    // Synapse error responses must be surfaced without aborting the leave/delete flow.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("error", "M_FORBIDDEN"));
+
+    assertThatCode(() -> matrixSessionSystemMessageService.postUserLeftChatMessage(session))
+        .doesNotThrowAnyException();
+
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("WARN")
+                    && e.getFormattedMessage().contains("M_FORBIDDEN"));
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldPropagateException_whenSendMessageThrows() {
+    // Production code does not catch Synapse transport failures — document actual behaviour.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), anyString()))
+        .thenThrow(new RuntimeException("synapse down"));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> matrixSessionSystemMessageService.postUserLeftChatMessage(session));
+  }
+
+  private Session baseSession() {
+    var session = new Session();
+    session.setId(SESSION_ID);
+    session.setAgencyId(AGENCY_ID);
+    session.setMatrixRoomId(MATRIX_ROOM_ID);
+    return session;
+  }
+
+  private Session sessionWithUserMatrixId(String matrixUserId, String username) {
+    var user = new User();
+    user.setMatrixUserId(matrixUserId);
+    user.setUsername(username);
+    var session = baseSession();
+    session.setUser(user);
+    return session;
+  }
+
+  private Session sessionWithoutHumanMatrixIds() {
+    var session = baseSession();
+    session.setUser(new User());
+    session.setConsultant(new Consultant());
+    return session;
+  }
+
+  private AgencyMatrixCredentialsDTO agencyCredentials(String matrixUserId, String password) {
+    var dto = new AgencyMatrixCredentialsDTO();
+    dto.setMatrixUserId(matrixUserId);
+    dto.setMatrixPassword(password);
+    return dto;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
@@ -4,23 +4,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -38,6 +46,8 @@ class RedisMessageMirrorServiceTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private RedisMessageMirrorService service;
+  private Logger logger;
+  private ListAppender<ILoggingEvent> logAppender;
 
   @BeforeEach
   void setUp() {
@@ -46,6 +56,16 @@ class RedisMessageMirrorServiceTest {
     ReflectionTestUtils.setField(service, "ttlSeconds", 900L);
     ReflectionTestUtils.setField(service, "maxBodyLength", 500);
     ReflectionTestUtils.setField(service, "keyPrefix", "debug:msgmirror");
+
+    logger = (Logger) LoggerFactory.getLogger(RedisMessageMirrorService.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(logAppender);
   }
 
   @Test
@@ -112,6 +132,167 @@ class RedisMessageMirrorServiceTest {
 
     verify(redisTemplateProvider).getIfAvailable();
     verify(redisTemplate, never()).opsForValue();
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldReturnEarly_whenMessageBodyIsNull() {
+    // Empty timeline events must not create bogus Redis keys during debug mirroring.
+    ReflectionTestUtils.setField(service, "enabled", true);
+
+    service.mirrorOutgoingMessage(1L, "!room:example.org", SENDER_USERNAME, true, null, "$evt");
+
+    verifyNoInteractions(redisTemplateProvider);
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldReturnEarly_whenMessageBodyIsBlank() {
+    // Whitespace-only bodies carry no inspectable content and must be skipped.
+    ReflectionTestUtils.setField(service, "enabled", true);
+
+    service.mirrorOutgoingMessage(1L, "!room:example.org", SENDER_USERNAME, true, "   ", "$evt");
+
+    verifyNoInteractions(redisTemplateProvider);
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldNotTruncate_whenBodyLengthEqualsMax() throws Exception {
+    // Messages exactly at the limit must be hashed in full without off-by-one truncation.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    ReflectionTestUtils.setField(service, "maxBodyLength", 10);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    String body = "0123456789";
+
+    service.mirrorOutgoingMessage(1L, "!room:example.org", SENDER_USERNAME, true, body, "$evt");
+
+    ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).set(anyString(), payloadCaptor.capture(), any(Duration.class));
+    JsonNode payload = objectMapper.readTree(payloadCaptor.getValue());
+    assertThat(payload.get("messageLength").asInt()).isEqualTo(10);
+    assertThat(payload.get("messageHash").asText()).isEqualTo(sha256Prefix(body, 8));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldTruncate_whenBodyLengthExceedsMax() throws Exception {
+    // Oversized bodies must be capped so Redis payloads stay bounded in debug mode.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    ReflectionTestUtils.setField(service, "maxBodyLength", 10);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    String body = "01234567890";
+
+    service.mirrorOutgoingMessage(1L, "!room:example.org", SENDER_USERNAME, true, body, "$evt");
+
+    ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).set(anyString(), payloadCaptor.capture(), any(Duration.class));
+    JsonNode payload = objectMapper.readTree(payloadCaptor.getValue());
+    assertThat(payload.get("messageLength").asInt()).isEqualTo(10);
+    assertThat(payload.get("messageHash").asText())
+        .isEqualTo(sha256Prefix(body.substring(0, 10), 8));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldWarnAndNotThrow_whenRedisSetFails() {
+    // Redis outages during debug mirroring must not surface to counselling message delivery.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    doThrow(new RuntimeException("redis down"))
+        .when(valueOperations)
+        .set(anyString(), anyString(), any(Duration.class));
+
+    assertThatCode(
+            () ->
+                service.mirrorOutgoingMessage(
+                    1L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$evt"))
+        .doesNotThrowAnyException();
+
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("WARN")
+                    && e.getFormattedMessage().contains("Failed writing mirrored message"));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldUseTtl30Seconds_whenConfiguredTtlIs29() {
+    // TTL floor prevents keys expiring too quickly to be useful in Redis Commander.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    ReflectionTestUtils.setField(service, "ttlSeconds", 29L);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    service.mirrorOutgoingMessage(
+        1L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$evt");
+
+    ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(valueOperations).set(anyString(), anyString(), ttlCaptor.capture());
+    assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldUseTtl30Seconds_whenConfiguredTtlIsExactly30() {
+    // Boundary ttl of 30 seconds is the minimum allowed retention for debug mirrors.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    ReflectionTestUtils.setField(service, "ttlSeconds", 30L);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    service.mirrorOutgoingMessage(
+        1L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$evt");
+
+    ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(valueOperations).set(anyString(), anyString(), ttlCaptor.capture());
+    assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldUseConfiguredTtl_whenAboveMinimum() {
+    // Custom TTL above the floor must be honoured for longer debug inspection windows.
+    ReflectionTestUtils.setField(service, "enabled", true);
+    ReflectionTestUtils.setField(service, "ttlSeconds", 31L);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    service.mirrorOutgoingMessage(
+        1L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$evt");
+
+    ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(valueOperations).set(anyString(), anyString(), ttlCaptor.capture());
+    assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofSeconds(31));
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldLogSerializationWarning_whenObjectMapperFails()
+      throws Exception {
+    // Serialization errors must be visible to developers without aborting message handling.
+    ObjectMapper failingMapper = mock(ObjectMapper.class);
+    when(failingMapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("boom") {});
+    var failingService = new RedisMessageMirrorService(redisTemplateProvider, failingMapper);
+    ReflectionTestUtils.setField(failingService, "enabled", true);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+
+    Logger failingLogger = (Logger) LoggerFactory.getLogger(RedisMessageMirrorService.class);
+    ListAppender<ILoggingEvent> failingAppender = new ListAppender<>();
+    failingAppender.start();
+    failingLogger.addAppender(failingAppender);
+
+    try {
+      assertThatCode(
+              () ->
+                  failingService.mirrorOutgoingMessage(
+                      1L, "!room:example.org", SENDER_USERNAME, true, SENSITIVE_MESSAGE, "$evt"))
+          .doesNotThrowAnyException();
+
+      verify(redisTemplate, never()).opsForValue();
+      assertThat(failingAppender.list)
+          .anyMatch(
+              e ->
+                  e.getLevel().toString().equals("WARN")
+                      && e.getFormattedMessage().contains("Failed to serialize"));
+    } finally {
+      failingLogger.detachAppender(failingAppender);
+    }
   }
 
   private static String sha256Prefix(String input, int hexChars) throws NoSuchAlgorithmException {


### PR DESCRIPTION
#### [Issue #317](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/317)

## Context
Closes #317

Adds unit tests for two Matrix-related packages that were significantly 
below the 80% coverage target:

| Package | Before | Expected After |
|---|---|---|
| api.service.matrix | ~27% instruction, ~18% branch | ≥80% |
| api.adapters.matrix | ~56% instruction, ~32% branch | ≥80% |

## Changes

**api.service.matrix (95 tests)**
- `MatrixSessionSystemMessageService` — 14 tests (new file)
- `MatrixEventListenerService` — 36 new tests added (40 total)
- `GroupChatMembershipService` — 5 new tests added (29 total)
- `RedisMessageMirrorService` — 9 new tests added (12 total)

**api.adapters.matrix (98 tests)**
- `MatrixSynapseService` — 28 new tests added (48 total)
- `MatrixRoomClient` — 9 new tests added (33 total)
- `MatrixUrlBuilder` — 4 tests (new file)
- `MatrixMediaClient` — 1 new test added (13 total)

## Test coverage
- All 193 tests pass locally on JDK 21
- Run with: `mvn test -Dtest=MatrixSessionSystemMessageServiceTest,MatrixEventListenerServiceTest,GroupChatMembershipServiceTest,RedisMessageMirrorServiceTest,MatrixSynapseServiceTest,MatrixRoomClientTest,MatrixUrlBuilderTest,MatrixMediaClientTest`

## Excluded from scope
- DTO classes — Lombok POJOs, no logic
- `MatrixConfig` — trivial getter, low value
- Lifecycle methods (`initialize`, `shutdown`, `startMatrixSyncLoop`) — async thread pool, deferred to follow-up