### PR TITLE
fix: handle empty agency lookup without throwing

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -343,7 +343,13 @@ public class ConsultantAdminFacade {
       List<CreateConsultantAgencyDTO> agencyList, Long consultantTenantId) {
     agencyList.stream()
         .map(a -> agencyService.getAgency(a.getAgencyId()))
-        .map(a -> a.getTenantId())
+        .map(
+            agency -> {
+              if (agency == null) {
+                throw new BadRequestException("Agency not found");
+              }
+              return agency.getTenantId();
+            })
         .filter(agencyTenantId -> !agencyTenantId.equals(consultantTenantId))
         .findAny()
         .ifPresent(

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
@@ -38,7 +38,7 @@ public class AgencyService {
    * @param agencyId {@link AgencyDTO#getId()}
    * @return AgencyDTO {@link AgencyDTO}
    */
-  @Cacheable(value = CacheManagerConfig.AGENCY_CACHE, key = "#agencyId")
+  @Cacheable(value = CacheManagerConfig.AGENCY_CACHE, key = "#agencyId", unless = "#result == null")
   public AgencyDTO getAgency(Long agencyId) {
     return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).stream()
         .findFirst()

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
@@ -40,7 +40,9 @@ public class AgencyService {
    */
   @Cacheable(value = CacheManagerConfig.AGENCY_CACHE, key = "#agencyId")
   public AgencyDTO getAgency(Long agencyId) {
-    return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).iterator().next();
+    return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).stream()
+        .findFirst()
+        .orElse(null);
   }
 
   /**
@@ -51,7 +53,9 @@ public class AgencyService {
    * @return AgencyDTO {@link AgencyDTO}
    */
   public AgencyDTO getAgencyWithoutCaching(Long agencyId) {
-    return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).iterator().next();
+    return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).stream()
+        .findFirst()
+        .orElse(null);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolver.java
@@ -113,6 +113,9 @@ public class MultitenancyWithSingleDomainTenantResolver implements TenantResolve
   }
 
   private void validateResolvedAgencyContainsTenant(AgencyDTO agency) {
+    if (agency == null) {
+      throw new BadRequestException("Cannot resolve tenant, as the agency could not be found!");
+    }
     if (agency.getTenantId() == null) {
       throw new BadRequestException(
           "Cannot resolve tenant, as the resolved agency has null tenantId!");

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
@@ -85,6 +85,32 @@ class AgencyServiceTest {
   }
 
   @Test
+  void getAgencyWithoutCaching_Should_returnNull_When_agencyNotFound() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(List.of());
+
+    AgencyDTO result = agencyService.getAgencyWithoutCaching(1L);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void getAgency_Should_returnNull_When_agencyNotFound() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(List.of());
+
+    AgencyDTO result = agencyService.getAgency(1L);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
   void getAgenciesNotCached_Should_returnEmptyList_When_emptyIdsProvided() {
     List<AgencyDTO> result = agencyService.getAgenciesNotCached(List.of());
     assertThat(result).isEmpty();

--- a/src/test/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolverTest.java
@@ -139,6 +139,20 @@ class MultitenancyWithSingleDomainTenantResolverTest {
         () -> multitenancyWithSingleDomainTenantResolver.resolve(request));
   }
 
+  @Test
+  void
+      resolve_Should_ThrowBadRequestException_When_AgencyIdProvidedInHeader_ButAgencyNotFound() {
+    // given
+    ReflectionTestUtils.setField(
+        multitenancyWithSingleDomainTenantResolver, "multitenancyWithSingleDomain", true);
+    when(headersResolver.findHeaderValue("agencyId")).thenReturn(Optional.of(1L));
+    when(agencyService.getAgency(1L)).thenReturn(null);
+    // when, then
+    assertThrows(
+        BadRequestException.class,
+        () -> multitenancyWithSingleDomainTenantResolver.resolve(request));
+  }
+
   private void resetRequestAttributes() {
     RequestContextHolder.setRequestAttributes(null);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/tenant/MultitenancyWithSingleDomainTenantResolverTest.java
@@ -140,8 +140,7 @@ class MultitenancyWithSingleDomainTenantResolverTest {
   }
 
   @Test
-  void
-      resolve_Should_ThrowBadRequestException_When_AgencyIdProvidedInHeader_ButAgencyNotFound() {
+  void resolve_Should_ThrowBadRequestException_When_AgencyIdProvidedInHeader_ButAgencyNotFound() {
     // given
     ReflectionTestUtils.setField(
         multitenancyWithSingleDomainTenantResolver, "multitenancyWithSingleDomain", true);


### PR DESCRIPTION
## Summary
- `getAgency()` / `getAgencyWithoutCaching()` return `null` on empty API response
- Unit tests for missing agency

## Why
Companion to OpenResilienceInitiative/ORISO-AgencyService#4 — no `.iterator().next()` on empty list.

## Test plan
- [ ] `AgencyServiceTest` passes on CI

Related to OpenResilienceInitiative/ORISO-AgencyService#4

