### PR TITLE
test: add unit tests for ConsultantDTO, ConsultantSessionDTO, ConsultantDtoMapper, KeycloakService, RocketChatAsyncHelper, AuthenticatedUser

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1429,4 +1429,210 @@ public class KeycloakServiceTest {
 
     verify(userResourceForUpdate.roles().realmLevel()).add(singletonList(roleRepresentation));
   }
+
+  // ---------------------------------------------------------------------------
+  // Extended branch coverage — 2026-07-07 (isPasswordPolicyViolation / isPasswordPolicyMessage)
+  // ---------------------------------------------------------------------------
+
+  private void givenResetPasswordThrows(Exception exception) {
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    doThrow(exception).when(userResource).resetPassword(any());
+  }
+
+  @Test
+  public void
+      updatePassword_Should_throwCustomValidationHttpStatusException_When_MessageMentionsPasswordPolicy() {
+    givenResetPasswordThrows(new RuntimeException("password policy violation"));
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_throwCustomValidationHttpStatusException_When_MessageMentionsPasswordInvalid() {
+    givenResetPasswordThrows(new RuntimeException("password is invalid"));
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_throwCustomValidationHttpStatusException_When_MessageMentionsPasswordNotMet() {
+    givenResetPasswordThrows(new RuntimeException("password requirements not met"));
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_throwCustomValidationHttpStatusException_When_MessageMentionsPasswordDoesNotMatch() {
+    givenResetPasswordThrows(new RuntimeException("password does not match pattern"));
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_ThrowCustomValidationHttpStatusException_When_CauseIsPolicyViolation() {
+    var cause = new RuntimeException("password policy violation");
+    givenResetPasswordThrows(new RuntimeException("wrapper", cause));
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_ThrowCustomValidationHttpStatusException_When_RestClientResponseExceptionHasPolicyBody() {
+    var restException = mock(RestClientResponseException.class);
+    when(restException.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(restException.getResponseBodyAsString()).thenReturn("password policy violated");
+    when(restException.getMessage()).thenReturn("400 Bad Request");
+    givenResetPasswordThrows(restException);
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_RethrowOriginalException_When_RestClientResponseExceptionHasNonPolicyBody() {
+    var restException = mock(RestClientResponseException.class);
+    when(restException.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(restException.getResponseBodyAsString()).thenReturn("some other error");
+    when(restException.getMessage()).thenReturn("some other error");
+    givenResetPasswordThrows(restException);
+
+    assertThrows(
+        RestClientResponseException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_RethrowOriginalException_When_RestClientResponseExceptionHasNonBadRequestStatus() {
+    var restException = mock(RestClientResponseException.class);
+    when(restException.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+    when(restException.getMessage()).thenReturn("server error");
+    givenResetPasswordThrows(restException);
+
+    assertThrows(
+        RestClientResponseException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void updatePassword_Should_RethrowOriginalException_When_MessageIsNull() {
+    givenResetPasswordThrows(new RuntimeException((String) null));
+
+    assertThrows(RuntimeException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void updatePassword_Should_RethrowOriginalException_When_MessageIsBlank() {
+    givenResetPasswordThrows(new RuntimeException("   "));
+
+    assertThrows(RuntimeException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      updatePassword_Should_RethrowOriginalException_When_MessageMentionsPasswordButNoPolicyKeyword() {
+    givenResetPasswordThrows(new RuntimeException("password field is required"));
+
+    assertThrows(RuntimeException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void updatePassword_Should_RethrowOriginalException_When_UnrelatedError() {
+    givenResetPasswordThrows(new RuntimeException("connection refused"));
+
+    assertThrows(RuntimeException.class, () -> keycloakService.updatePassword("userId", "weak"));
+  }
+
+  @Test
+  public void
+      createKeycloakUser_Should_LeaveTenantIdAttributeUnset_When_TenantIdAndCurrentTenantAreNull() {
+    setField(keycloakService, "multiTenancyEnabled", true);
+    TenantContext.clear();
+    UserDTO userDTO = new EasyRandom().nextObject(UserDTO.class);
+    userDTO.setTenantId(null);
+    UsersResource usersResource = mock(UsersResource.class);
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(HttpStatus.CREATED.value());
+    when(usersResource.create(any())).thenReturn(response);
+    givenAUserResourceForCreatedUser(usersResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    givenPostCreateAttributeUpdate(usersResource, response, USER_ID);
+
+    var keycloakUser = keycloakService.createKeycloakUser(userDTO);
+
+    assertThat(keycloakUser.getStatus(), is(HttpStatus.CREATED));
+    setField(keycloakService, "multiTenancyEnabled", false);
+  }
+
+  @Test
+  public void changeEmailAddress_username_Should_UpdateEmail_When_EmailDiffers() {
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    when(userRepresentation.getEmail()).thenReturn("old@example.com");
+    when(userRepresentation.getId()).thenReturn(USER_ID);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(USERNAME)).thenReturn(List.of(userRepresentation));
+    UserResource userResource = mock(UserResource.class);
+    when(usersResource.get(USER_ID)).thenReturn(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.changeEmailAddress(USERNAME, "New@Example.com");
+
+    verify(userRepresentation).setEmail("new@example.com");
+    verify(userResource).update(userRepresentation);
+  }
+
+  @Test
+  public void changeEmailAddress_username_Should_NotUpdateEmail_When_EmailIsUnchanged() {
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    when(userRepresentation.getEmail()).thenReturn("same@example.com");
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(USERNAME)).thenReturn(List.of(userRepresentation));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.changeEmailAddress(USERNAME, "same@example.com");
+
+    verify(userRepresentation, org.mockito.Mockito.never()).setEmail(anyString());
+    verify(usersResource, org.mockito.Mockito.never()).get(anyString());
+  }
+
+  @Test
+  public void setUpOtpCredential_Should_ReturnFalse_When_KeycloakReturnsUnauthorized() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.UNAUTHORIZED);
+    when(keycloakClient.putForEntity(any(), any(), any(), any())).thenThrow(exception);
+
+    boolean result = keycloakService.setUpOtpCredential(USERNAME, "123456", "secret");
+
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void setUpOtpCredential_Should_RethrowException_When_StatusIsNotUnauthorized() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(keycloakClient.putForEntity(any(), any(), any(), any())).thenThrow(exception);
+
+    assertThrows(
+        org.springframework.web.client.HttpClientErrorException.class,
+        () -> keycloakService.setUpOtpCredential(USERNAME, "123456", "secret"));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1139,4 +1139,294 @@ public class KeycloakServiceTest {
 
     return userError;
   }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void verifyIgnoringOtp_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
+    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(exception.getResponseBodyAsString()).thenReturn("Missing totp");
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(exception);
+
+    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  public void verifyIgnoringOtp_Should_ReturnFalse_When_OtherBadRequest() {
+    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(exception.getResponseBodyAsString()).thenReturn("Invalid credentials");
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(exception);
+
+    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+
+    assertThat(result, is(false));
+  }
+
+  @Test
+  public void verifyIgnoringOtp_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
+    var loginResponse = mock(KeycloakLoginResponseDTO.class);
+    when(loginResponse.getRefreshToken()).thenReturn(REFRESH_TOKEN);
+    ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
+        new ResponseEntity<>(loginResponse, HttpStatus.OK);
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(responseEntity);
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    ResponseEntity<Void> logoutResponse = new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class))).thenReturn(logoutResponse);
+
+    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+
+    assertThat(result, is(true));
+    verify(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
+  }
+
+  @Test
+  public void verifyIgnoringOtp_Should_ReturnTrueWithoutLogout_When_NoRefreshToken() {
+    var loginResponse = mock(KeycloakLoginResponseDTO.class);
+    when(loginResponse.getRefreshToken()).thenReturn(null);
+    ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
+        new ResponseEntity<>(loginResponse, HttpStatus.OK);
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(responseEntity);
+
+    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+
+    assertThat(result, is(true));
+    verify(restTemplate, org.mockito.Mockito.never())
+        .postForEntity(anyString(), any(), eq(Void.class));
+  }
+
+  @Test
+  public void initiateEmailVerification_Should_ReturnEmptyOptional_When_RequestSucceeds() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    when(keycloakClient.putForEntity(any(), any(), any(), any()))
+        .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+    var result = keycloakService.initiateEmailVerification(USERNAME, "mail@example.com");
+
+    assertThat(result.isPresent(), is(false));
+  }
+
+  @Test
+  public void initiateEmailVerification_Should_ReturnMessage_When_KeycloakRejects() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    when(keycloakClient.putForEntity(any(), any(), any(), any()))
+        .thenThrow(new RestClientException("Keycloak said no"));
+
+    var result = keycloakService.initiateEmailVerification(USERNAME, "mail@example.com");
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get().contains("Keycloak said no"), is(true));
+  }
+
+  @Test
+  public void finishEmailVerification_Should_ReturnMappedSuccess_When_RequestSucceeds() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    ResponseEntity<de.caritas.cob.userservice.api.model.SuccessWithEmail> responseEntity =
+        new ResponseEntity<>(
+            new de.caritas.cob.userservice.api.model.SuccessWithEmail(), HttpStatus.OK);
+    when(keycloakClient.postForEntity(
+            any(), any(), any(), eq(de.caritas.cob.userservice.api.model.SuccessWithEmail.class)))
+        .thenReturn(responseEntity);
+    var expected = new HashMap<String, String>();
+    expected.put("status", "ok");
+    when(keycloakMapper.mapOf(responseEntity)).thenReturn(expected);
+
+    var result = keycloakService.finishEmailVerification(USERNAME, "123456");
+
+    assertThat(result, is(expected));
+  }
+
+  @Test
+  public void finishEmailVerification_Should_ReturnMappedError_When_KeycloakRejects() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    when(keycloakClient.postForEntity(any(), any(), any(), any())).thenThrow(exception);
+    var expected = new HashMap<String, String>();
+    expected.put("status", "error");
+    when(keycloakMapper.mapOf(exception)).thenReturn(expected);
+
+    var result = keycloakService.finishEmailVerification(USERNAME, "123456");
+
+    assertThat(result, is(expected));
+  }
+
+  @Test
+  public void findUserByEmail_Should_ReturnMappedUser_When_MatchFound() {
+    var email = "mail@example.com";
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    when(userRepresentation.getEmail()).thenReturn(email);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(email, 0, Integer.MAX_VALUE))
+        .thenReturn(singletonList(userRepresentation));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+    var expected = new HashMap<String, String>();
+    expected.put("email", email);
+    when(keycloakMapper.mapOf(userRepresentation)).thenReturn(expected);
+
+    var result = keycloakService.findUserByEmail(email);
+
+    assertThat(result, is(expected));
+  }
+
+  @Test
+  public void findUserByEmail_Should_ReturnEmptyMap_When_NoMatchFound() {
+    var email = "mail@example.com";
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(email, 0, Integer.MAX_VALUE)).thenReturn(List.of());
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    var result = keycloakService.findUserByEmail(email);
+
+    assertThat(result.isEmpty(), is(true));
+  }
+
+  private UserResource givenUserResourceWithRealmRoles(String... roleNames) {
+    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
+    var roleRepresentations =
+        java.util.Arrays.stream(roleNames)
+            .map(
+                name -> {
+                  RoleRepresentation role = mock(RoleRepresentation.class);
+                  when(role.getName()).thenReturn(name);
+                  return role;
+                })
+            .collect(java.util.stream.Collectors.toList());
+    when(roleScopeResource.listAll()).thenReturn(roleRepresentations);
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+    UserResource userResource = mock(UserResource.class);
+    when(userResource.roles()).thenReturn(roleMappingResource);
+    return userResource;
+  }
+
+  @Test
+  public void userHasRole_Should_ReturnTrue_When_UserHasRole() {
+    UserResource userResource = givenUserResourceWithRealmRoles("user");
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    assertThat(keycloakService.userHasRole(USER_ID, "user"), is(true));
+  }
+
+  @Test
+  public void userHasRole_Should_ReturnFalse_When_UserDoesNotHaveRole() {
+    UserResource userResource = givenUserResourceWithRealmRoles("consultant");
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    assertThat(keycloakService.userHasRole(USER_ID, "user"), is(false));
+  }
+
+  @Test
+  public void userHasRole_Should_ThrowKeycloakException_When_LookupFails() {
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(any())).thenThrow(new RuntimeException("boom"));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    assertThrows(KeycloakException.class, () -> keycloakService.userHasRole(USER_ID, "user"));
+  }
+
+  @Test
+  public void getRealmRoles_Should_ReturnRoleNames_When_LookupSucceeds() {
+    UserResource userResource = givenUserResourceWithRealmRoles("user", "consultant");
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    List<String> roles = keycloakService.getRealmRoles(USER_ID);
+
+    assertThat(roles, is(Lists.newArrayList("user", "consultant")));
+  }
+
+  @Test
+  public void getRealmRoles_Should_ThrowKeycloakException_When_LookupFails() {
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(any())).thenThrow(new RuntimeException("boom"));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    assertThrows(KeycloakException.class, () -> keycloakService.getRealmRoles(USER_ID));
+  }
+
+  @Test
+  public void findByUsername_Should_DelegateToUsersResourceSearch() {
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(USERNAME)).thenReturn(singletonList(userRepresentation));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    List<UserRepresentation> result = keycloakService.findByUsername(USERNAME);
+
+    assertThat(result, is(singletonList(userRepresentation)));
+  }
+
+  @Test
+  public void deleteUser_Should_RemoveUser_When_UserExists() {
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.deleteUser(USER_ID);
+
+    verify(userResource).remove();
+  }
+
+  @Test
+  public void deleteUser_Should_LogWarnAndSwallow_When_UserNotFound() {
+    UsersResource usersResource = mock(UsersResource.class);
+    UserResource userResource = mock(UserResource.class);
+    org.mockito.Mockito.doThrow(new javax.ws.rs.NotFoundException()).when(userResource).remove();
+    when(usersResource.get(any())).thenReturn(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.deleteUser(USER_ID);
+
+    assertThat(
+        logCaptor.contains(Level.WARN, "not found in Keycloak, skipping deletion"), is(true));
+  }
+
+  @Test
+  public void ensureRole_Should_SkipUpdate_When_UserAlreadyHasRole() {
+    UserResource userResource = givenUserResourceWithRealmRoles("consultant");
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.ensureRole(USER_ID, "consultant");
+
+    verify(usersResource, times(1)).get(USER_ID);
+  }
+
+  @Test
+  public void ensureRole_Should_UpdateRole_When_UserDoesNotHaveRole() {
+    // ensureRole's own userHasRole pre-check goes through keycloakClient.getUsersResource() —
+    // report no roles so the check fails and updateRole proceeds.
+    UserResource userResourceForCheck = givenUserResourceWithRealmRoles();
+    UsersResource usersResourceForCheck = givenUsersResourceWithAnyUserId(userResourceForCheck);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResourceForCheck);
+
+    // updateRole goes through keycloakClient.getRealmResource().users() — report the role as
+    // already assigned so the post-add verification loop succeeds immediately.
+    var realmResource = mock(RealmResource.class);
+    var rolesResource = mock(RolesResource.class);
+    var roleResource = mock(RoleResource.class);
+    var roleRepresentation = new RoleRepresentation();
+    when(roleResource.toRepresentation()).thenReturn(roleRepresentation);
+    when(rolesResource.get("consultant")).thenReturn(roleResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+    UserResource userResourceForUpdate = givenUserResourceWithRealmRoles("consultant");
+    UsersResource usersResourceForUpdate = givenUsersResourceWithAnyUserId(userResourceForUpdate);
+    when(realmResource.users()).thenReturn(usersResourceForUpdate);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    keycloakService.ensureRole(USER_ID, "consultant");
+
+    verify(userResourceForUpdate.roles().realmLevel()).add(singletonList(roleRepresentation));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1382,7 +1382,9 @@ public class KeycloakServiceTest {
   public void deleteUser_Should_LogWarnAndSwallow_When_UserNotFound() {
     UsersResource usersResource = mock(UsersResource.class);
     UserResource userResource = mock(UserResource.class);
-    org.mockito.Mockito.doThrow(new javax.ws.rs.NotFoundException()).when(userResource).remove();
+    org.mockito.Mockito.doThrow(mock(jakarta.ws.rs.NotFoundException.class))
+        .when(userResource)
+        .remove();
     when(usersResource.get(any())).thenReturn(userResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantDTOTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantDTOTest.java
@@ -1,0 +1,188 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConsultantDTOTest {
+
+  private ConsultantDTO givenAFullyPopulatedConsultantDTO() {
+    return new ConsultantDTO()
+        .id("id")
+        .username("username")
+        .firstname("firstname")
+        .lastname("lastname")
+        .email("mail@example.com")
+        .formalLanguage(true)
+        .teamConsultant(true)
+        .absent(false)
+        .absenceMessage("absent message")
+        .createDate("2026-01-01")
+        .updateDate("2026-01-02")
+        .deleteDate(null)
+        .status("CREATED")
+        .agencies(List.of(new AgencyAdminResponseDTO().id(1L)))
+        .isGroupchatConsultant(true)
+        .isSupervisor(false)
+        .tenantId(1)
+        .tenantName("tenant")
+        .displayName("Display Name")
+        .publicName("Public Name")
+        .roleInOrg("role")
+        .vacated(false)
+        .adminRights(true)
+        .topics(List.of(new ConsultantTopicDTO().id(2L)));
+  }
+
+  @Test
+  void builderChain_Should_RoundTripAllFields() {
+    var dto = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(dto.getId()).isEqualTo("id");
+    assertThat(dto.getUsername()).isEqualTo("username");
+    assertThat(dto.getFirstname()).isEqualTo("firstname");
+    assertThat(dto.getLastname()).isEqualTo("lastname");
+    assertThat(dto.getEmail()).isEqualTo("mail@example.com");
+    assertThat(dto.getFormalLanguage()).isTrue();
+    assertThat(dto.getTeamConsultant()).isTrue();
+    assertThat(dto.getAbsent()).isFalse();
+    assertThat(dto.getAbsenceMessage()).isEqualTo("absent message");
+    assertThat(dto.getCreateDate()).isEqualTo("2026-01-01");
+    assertThat(dto.getUpdateDate()).isEqualTo("2026-01-02");
+    assertThat(dto.getDeleteDate()).isNull();
+    assertThat(dto.getStatus()).isEqualTo("CREATED");
+    assertThat(dto.getAgencies()).hasSize(1);
+    assertThat(dto.getIsGroupchatConsultant()).isTrue();
+    assertThat(dto.getIsSupervisor()).isFalse();
+    assertThat(dto.getTenantId()).isEqualTo(1);
+    assertThat(dto.getTenantName()).isEqualTo("tenant");
+    assertThat(dto.getDisplayName()).isEqualTo("Display Name");
+    assertThat(dto.getPublicName()).isEqualTo("Public Name");
+    assertThat(dto.getRoleInOrg()).isEqualTo("role");
+    assertThat(dto.getVacated()).isFalse();
+    assertThat(dto.getAdminRights()).isTrue();
+    assertThat(dto.getTopics()).hasSize(1);
+  }
+
+  @Test
+  void setters_Should_RoundTripAllFields() {
+    var dto = new ConsultantDTO();
+    dto.setId("id");
+    dto.setUsername("username");
+    dto.setFirstname("firstname");
+    dto.setLastname("lastname");
+    dto.setEmail("mail@example.com");
+    dto.setFormalLanguage(true);
+    dto.setTeamConsultant(true);
+    dto.setAbsent(false);
+    dto.setAbsenceMessage("absent message");
+    dto.setCreateDate("2026-01-01");
+    dto.setUpdateDate("2026-01-02");
+    dto.setDeleteDate("2026-01-03");
+    dto.setStatus("CREATED");
+    dto.setAgencies(List.of(new AgencyAdminResponseDTO().id(1L)));
+    dto.setIsGroupchatConsultant(true);
+    dto.setIsSupervisor(false);
+    dto.setTenantId(1);
+    dto.setTenantName("tenant");
+    dto.setDisplayName("Display Name");
+    dto.setPublicName("Public Name");
+    dto.setRoleInOrg("role");
+    dto.setVacated(false);
+    dto.setAdminRights(true);
+    dto.setTopics(List.of(new ConsultantTopicDTO().id(2L)));
+
+    assertThat(dto.getId()).isEqualTo("id");
+    assertThat(dto.getDeleteDate()).isEqualTo("2026-01-03");
+    assertThat(dto.getAgencies()).hasSize(1);
+    assertThat(dto.getTopics()).hasSize(1);
+  }
+
+  @Test
+  void addAgenciesItem_Should_InitializeList_When_AgenciesIsNull() {
+    var dto = new ConsultantDTO();
+    dto.setAgencies(null);
+
+    dto.addAgenciesItem(new AgencyAdminResponseDTO().id(1L));
+
+    assertThat(dto.getAgencies()).hasSize(1);
+  }
+
+  @Test
+  void addAgenciesItem_Should_AppendToExistingList_When_AgenciesAlreadyInitialized() {
+    var dto = new ConsultantDTO();
+
+    dto.addAgenciesItem(new AgencyAdminResponseDTO().id(1L));
+    dto.addAgenciesItem(new AgencyAdminResponseDTO().id(2L));
+
+    assertThat(dto.getAgencies()).hasSize(2);
+  }
+
+  @Test
+  void addTopicsItem_Should_InitializeList_When_TopicsIsNull() {
+    var dto = new ConsultantDTO();
+    dto.setTopics(null);
+
+    dto.addTopicsItem(new ConsultantTopicDTO().id(1L));
+
+    assertThat(dto.getTopics()).hasSize(1);
+  }
+
+  @Test
+  void addTopicsItem_Should_AppendToExistingList_When_TopicsAlreadyInitialized() {
+    var dto = new ConsultantDTO();
+
+    dto.addTopicsItem(new ConsultantTopicDTO().id(1L));
+    dto.addTopicsItem(new ConsultantTopicDTO().id(2L));
+
+    assertThat(dto.getTopics()).hasSize(2);
+  }
+
+  @Test
+  void equals_Should_ReturnTrue_When_SameInstance() {
+    var dto = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(dto.equals(dto)).isTrue();
+  }
+
+  @Test
+  void equals_Should_ReturnTrue_When_AllFieldsMatch() {
+    var dto1 = givenAFullyPopulatedConsultantDTO();
+    var dto2 = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(dto1).isEqualTo(dto2);
+    assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode());
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_AFieldDiffers() {
+    var dto1 = givenAFullyPopulatedConsultantDTO();
+    var dto2 = givenAFullyPopulatedConsultantDTO().username("differentUsername");
+
+    assertThat(dto1).isNotEqualTo(dto2);
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_ComparedToNull() {
+    var dto = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(dto.equals(null)).isFalse();
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_ComparedToDifferentClass() {
+    var dto = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(dto.equals("not a ConsultantDTO")).isFalse();
+  }
+
+  @Test
+  void toString_Should_ContainFieldValues() {
+    var dto = givenAFullyPopulatedConsultantDTO();
+
+    var result = dto.toString();
+
+    assertThat(result).contains("username").contains("Display Name");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantDTOTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantDTOTest.java
@@ -185,4 +185,34 @@ class ConsultantDTOTest {
 
     assertThat(result).contains("username").contains("Display Name");
   }
+
+  @Test
+  void equals_Should_ReturnFalse_When_AnyIndividualFieldDiffers() {
+    var base = givenAFullyPopulatedConsultantDTO();
+
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().id("otherId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().firstname("otherFirstname"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().lastname("otherLastname"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().email("other@example.com"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().formalLanguage(false));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().teamConsultant(false));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().absent(true));
+    assertThat(base)
+        .isNotEqualTo(givenAFullyPopulatedConsultantDTO().absenceMessage("other message"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().createDate("2027-01-01"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().updateDate("2027-01-02"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().deleteDate("2027-01-03"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().status("DELETED"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().agencies(List.of()));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().isGroupchatConsultant(false));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().isSupervisor(true));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().tenantId(2));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().tenantName("otherTenant"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().displayName("Other Display"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().publicName("Other Public"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().roleInOrg("other role"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().vacated(true));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().adminRights(false));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedConsultantDTO().topics(List.of()));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantSessionDTOTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantSessionDTOTest.java
@@ -1,0 +1,149 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConsultantSessionDTOTest {
+
+  private ConsultantSessionDTO givenAFullyPopulatedDto() {
+    return new ConsultantSessionDTO()
+        .id(1L)
+        .agencyId(2L)
+        .consultingType(3)
+        .status(4)
+        .postcode("88045")
+        .groupId("groupId")
+        .consultantId("consultantId")
+        .consultantRcId("consultantRcId")
+        .askerId("askerId")
+        .askerRcId("askerRcId")
+        .askerUserName("askerUserName")
+        .isTeamSession(true)
+        .age(30)
+        .gender("gender")
+        .counsellingRelation("relation")
+        .mainTopic(new SessionTopicDTO().id(5L))
+        .topics(List.of(new SessionTopicDTO().id(6L)))
+        .referer("referer");
+  }
+
+  @Test
+  void builderChain_Should_RoundTripAllFields() {
+    var dto = givenAFullyPopulatedDto();
+
+    assertThat(dto.getId()).isEqualTo(1L);
+    assertThat(dto.getAgencyId()).isEqualTo(2L);
+    assertThat(dto.getConsultingType()).isEqualTo(3);
+    assertThat(dto.getStatus()).isEqualTo(4);
+    assertThat(dto.getPostcode()).isEqualTo("88045");
+    assertThat(dto.getGroupId()).isEqualTo("groupId");
+    assertThat(dto.getConsultantId()).isEqualTo("consultantId");
+    assertThat(dto.getConsultantRcId()).isEqualTo("consultantRcId");
+    assertThat(dto.getAskerId()).isEqualTo("askerId");
+    assertThat(dto.getAskerRcId()).isEqualTo("askerRcId");
+    assertThat(dto.getAskerUserName()).isEqualTo("askerUserName");
+    assertThat(dto.getIsTeamSession()).isTrue();
+    assertThat(dto.getAge()).isEqualTo(30);
+    assertThat(dto.getGender()).isEqualTo("gender");
+    assertThat(dto.getCounsellingRelation()).isEqualTo("relation");
+    assertThat(dto.getMainTopic().getId()).isEqualTo(5L);
+    assertThat(dto.getTopics()).hasSize(1);
+    assertThat(dto.getReferer()).isEqualTo("referer");
+  }
+
+  @Test
+  void setters_Should_RoundTripAllFields() {
+    var dto = new ConsultantSessionDTO();
+    dto.setId(1L);
+    dto.setAgencyId(2L);
+    dto.setConsultingType(3);
+    dto.setStatus(4);
+    dto.setPostcode("88045");
+    dto.setGroupId("groupId");
+    dto.setConsultantId("consultantId");
+    dto.setConsultantRcId("consultantRcId");
+    dto.setAskerId("askerId");
+    dto.setAskerRcId("askerRcId");
+    dto.setAskerUserName("askerUserName");
+    dto.setIsTeamSession(true);
+    dto.setAge(30);
+    dto.setGender("gender");
+    dto.setCounsellingRelation("relation");
+    dto.setMainTopic(new SessionTopicDTO().id(5L));
+    dto.setTopics(List.of(new SessionTopicDTO().id(6L)));
+    dto.setReferer("referer");
+
+    assertThat(dto.getId()).isEqualTo(1L);
+    assertThat(dto.getMainTopic().getId()).isEqualTo(5L);
+    assertThat(dto.getTopics()).hasSize(1);
+  }
+
+  @Test
+  void addTopicsItem_Should_InitializeList_When_TopicsIsNull() {
+    var dto = new ConsultantSessionDTO();
+    dto.setTopics(null);
+
+    dto.addTopicsItem(new SessionTopicDTO().id(1L));
+
+    assertThat(dto.getTopics()).hasSize(1);
+  }
+
+  @Test
+  void addTopicsItem_Should_AppendToExistingList_When_TopicsAlreadyInitialized() {
+    var dto = new ConsultantSessionDTO();
+
+    dto.addTopicsItem(new SessionTopicDTO().id(1L));
+    dto.addTopicsItem(new SessionTopicDTO().id(2L));
+
+    assertThat(dto.getTopics()).hasSize(2);
+  }
+
+  @Test
+  void equals_Should_ReturnTrue_When_SameInstance() {
+    var dto = givenAFullyPopulatedDto();
+
+    assertThat(dto.equals(dto)).isTrue();
+  }
+
+  @Test
+  void equals_Should_ReturnTrue_When_AllFieldsMatch() {
+    var dto1 = givenAFullyPopulatedDto();
+    var dto2 = givenAFullyPopulatedDto();
+
+    assertThat(dto1).isEqualTo(dto2);
+    assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode());
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_AFieldDiffers() {
+    var dto1 = givenAFullyPopulatedDto();
+    var dto2 = givenAFullyPopulatedDto().postcode("00000");
+
+    assertThat(dto1).isNotEqualTo(dto2);
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_ComparedToNull() {
+    var dto = givenAFullyPopulatedDto();
+
+    assertThat(dto.equals(null)).isFalse();
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_ComparedToDifferentClass() {
+    var dto = givenAFullyPopulatedDto();
+
+    assertThat(dto.equals("not a ConsultantSessionDTO")).isFalse();
+  }
+
+  @Test
+  void toString_Should_ContainFieldValues() {
+    var dto = givenAFullyPopulatedDto();
+
+    var result = dto.toString();
+
+    assertThat(result).contains("askerUserName").contains("relation");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantSessionDTOTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/dto/ConsultantSessionDTOTest.java
@@ -146,4 +146,38 @@ class ConsultantSessionDTOTest {
 
     assertThat(result).contains("askerUserName").contains("relation");
   }
+
+  @Test
+  void toString_Should_HandleNullField() {
+    var dto = givenAFullyPopulatedDto().referer(null);
+
+    var result = dto.toString();
+
+    assertThat(result).contains("null");
+  }
+
+  @Test
+  void equals_Should_ReturnFalse_When_AnyIndividualFieldDiffers() {
+    var base = givenAFullyPopulatedDto();
+
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().id(99L));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().agencyId(99L));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().consultingType(99));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().status(99));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().postcode("00000"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().groupId("otherGroupId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().consultantId("otherConsultantId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().consultantRcId("otherRcId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().askerId("otherAskerId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().askerRcId("otherAskerRcId"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().askerUserName("otherAskerUserName"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().isTeamSession(false));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().age(99));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().gender("otherGender"));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().counsellingRelation("otherRelation"));
+    assertThat(base)
+        .isNotEqualTo(givenAFullyPopulatedDto().mainTopic(new SessionTopicDTO().id(99L)));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().topics(List.of()));
+    assertThat(base).isNotEqualTo(givenAFullyPopulatedDto().referer("otherReferer"));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -1,23 +1,52 @@
 package de.caritas.cob.userservice.api.adapters.web.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.HalLink.MethodEnum;
+import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
+import de.caritas.cob.userservice.topicservice.generated.web.model.TopicDTO;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @ExtendWith(MockitoExtension.class)
 class ConsultantDtoMapperTest {
 
   @Mock private IdentityClient identityClient;
+  @Mock private ConsultantTopicRepository consultantTopicRepository;
+  @Mock private TopicService topicService;
+
+  @BeforeEach
+  void setupRequestContext() {
+    var request = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
 
   @Test
   void consultantDtoOf_Should_MapMasterTableFields() {
@@ -59,5 +88,320 @@ class ConsultantDtoMapperTest {
     consultantMap.put("tenantName", "Tenant");
     consultantMap.put("agencies", new ArrayList<Map<String, Object>>());
     return consultantMap;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  private ConsultantDtoMapper givenAMapper() {
+    ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
+    ReflectionTestUtils.setField(
+        consultantDtoMapper, "consultantTopicRepository", consultantTopicRepository);
+    ReflectionTestUtils.setField(consultantDtoMapper, "topicService", topicService);
+    return consultantDtoMapper;
+  }
+
+  @Test
+  void consultantDtoOf_Should_MapCounsellorRole_When_NotSupervisor() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    Map<String, Object> map = consultantMap();
+    map.put("isSupervisor", false);
+    map.put("deletedAt", null);
+
+    var consultant = consultantDtoMapper.consultantDtoOf(map);
+
+    assertThat(consultant.getRoleInOrg()).isEqualTo("Counsellor");
+    assertThat(consultant.getAdminRights()).isFalse();
+    assertThat(consultant.getIsSupervisor()).isFalse();
+    assertThat(consultant.getVacated()).isFalse();
+  }
+
+  @Test
+  void consultantDtoOf_Should_LeaveTenantIdNull_When_TenantIdIsNull() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    Map<String, Object> map = consultantMap();
+    map.put("tenantId", null);
+
+    var consultant = consultantDtoMapper.consultantDtoOf(map);
+
+    assertThat(consultant.getTenantId()).isNull();
+  }
+
+  @Test
+  void consultantDtoOf_Should_SetGroupchatConsultantFalse_When_IdentityClientThrows() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString()))
+        .thenThrow(new RuntimeException("keycloak user missing"));
+
+    var consultant = consultantDtoMapper.consultantDtoOf(consultantMap());
+
+    assertThat(consultant.getIsGroupchatConsultant()).isFalse();
+  }
+
+  @Test
+  void consultantDtoOf_Should_MapAgencies_When_AgenciesPresent() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    Map<String, Object> map = consultantMap();
+    Map<String, Object> agencyMap = new HashMap<>();
+    agencyMap.put("id", 1L);
+    agencyMap.put("name", "Agency Name");
+    agencyMap.put("postcode", "88045");
+    agencyMap.put("city", "City");
+    agencyMap.put("description", "description");
+    agencyMap.put("isTeamAgency", true);
+    agencyMap.put("isOffline", false);
+    agencyMap.put("consultingType", 1);
+    ArrayList<Map<String, Object>> agencies = new ArrayList<>();
+    agencies.add(agencyMap);
+    map.put("agencies", agencies);
+
+    var consultant = consultantDtoMapper.consultantDtoOf(map);
+
+    assertThat(consultant.getAgencies()).hasSize(1);
+    assertThat(consultant.getAgencies().get(0).getName()).isEqualTo("Agency Name");
+    assertThat(consultant.getAgencies().get(0).getTeamAgency()).isTrue();
+  }
+
+  @Test
+  void updateAdminConsultantOf_Should_MapAllFieldsAndLowercaseEmail() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    var updateConsultantDTO =
+        new UpdateConsultantDTO()
+            .email("Mail@Example.COM")
+            .firstname("Firstname")
+            .lastname("Lastname")
+            .languages(List.of(LanguageCode.DE))
+            .dataPrivacyConfirmation(true)
+            .termsAndConditionsConfirmation(true);
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .rocketChatId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .languageFormal(true)
+            .absent(true)
+            .absenceMessage("absence message")
+            .build();
+
+    var result = consultantDtoMapper.updateAdminConsultantOf(updateConsultantDTO, consultant);
+
+    assertThat(result.getEmail()).isEqualTo("mail@example.com");
+    assertThat(result.getFirstname()).isEqualTo("Firstname");
+    assertThat(result.getLastname()).isEqualTo("Lastname");
+    assertThat(result.getFormalLanguage()).isTrue();
+    assertThat(result.getAbsent()).isTrue();
+    assertThat(result.getAbsenceMessage()).isEqualTo("absence message");
+    assertThat(result.getLanguages()).containsExactly("de");
+    assertThat(result.getDataPrivacyConfirmation()).isTrue();
+    assertThat(result.getTermsAndConditionsConfirmation()).isTrue();
+  }
+
+  @Test
+  void updateAdminConsultantOf_Should_LeaveEmailNull_When_EmailIsNull() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    var updateConsultantDTO = new UpdateConsultantDTO().firstname("Firstname").lastname("Lastname");
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .rocketChatId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .build();
+
+    var result = consultantDtoMapper.updateAdminConsultantOf(updateConsultantDTO, consultant);
+
+    assertThat(result.getEmail()).isNull();
+  }
+
+  @Test
+  void consultantResponseDtoOf_Should_MapNames_When_MapNamesIsTrue() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .rocketChatId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .supervisor(true)
+            .build();
+    var agencies = List.of(new AgencyDTO().id(1L).name("Agency"));
+
+    var result = consultantDtoMapper.consultantResponseDtoOf(consultant, agencies, true);
+
+    assertThat(result.getConsultantId()).isEqualTo("consultantId");
+    assertThat(result.getFirstName()).isEqualTo("Firstname");
+    assertThat(result.getLastName()).isEqualTo("Lastname");
+    assertThat(result.getIsSupervisor()).isTrue();
+    assertThat(result.getAgencies()).hasSize(1);
+  }
+
+  @Test
+  void consultantResponseDtoOf_Should_NotMapNames_When_MapNamesIsFalse() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .rocketChatId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .supervisor(false)
+            .build();
+
+    var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
+
+    assertThat(result.getFirstName()).isNull();
+    assertThat(result.getLastName()).isNull();
+    assertThat(result.getIsSupervisor()).isFalse();
+  }
+
+  @Test
+  void consultantLinkOf_Should_BuildGetLink_When_MethodIsDefault() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.consultantLinkOf("consultantId", MethodEnum.GET);
+
+    assertThat(link.getHref()).contains("consultantId");
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.GET);
+  }
+
+  @Test
+  void consultantLinkOf_Should_BuildPutLink_When_MethodIsPut() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.consultantLinkOf("consultantId", MethodEnum.PUT);
+
+    assertThat(link.getHref()).contains("consultantId");
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.PUT);
+  }
+
+  @Test
+  void consultantLinkOf_Should_BuildDeleteLink_When_MethodIsDelete() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.consultantLinkOf("consultantId", MethodEnum.DELETE);
+
+    assertThat(link.getHref()).contains("consultantId");
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.DELETE);
+  }
+
+  @Test
+  void consultantAgencyLinkOf_Should_BuildPostLink_When_MethodIsPost() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.consultantAgencyLinkOf("consultantId", MethodEnum.POST);
+
+    assertThat(link.getHref()).contains("consultantId");
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.POST);
+  }
+
+  @Test
+  void consultantAgencyLinkOf_Should_BuildGetLink_When_MethodIsGet() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.consultantAgencyLinkOf("consultantId", MethodEnum.GET);
+
+    assertThat(link.getHref()).contains("consultantId");
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.GET);
+  }
+
+  @Test
+  void consultantLinksOf_Should_BuildAllFiveLinks() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    Map<String, Object> map = new HashMap<>();
+    map.put("id", "consultantId");
+
+    var links = consultantDtoMapper.consultantLinksOf(map);
+
+    assertThat(links.getSelf().getHref()).contains("consultantId");
+    assertThat(links.getUpdate().getMethod()).isEqualTo(MethodEnum.PUT);
+    assertThat(links.getDelete().getMethod()).isEqualTo(MethodEnum.DELETE);
+    assertThat(links.getAgencies().getMethod()).isEqualTo(MethodEnum.GET);
+    assertThat(links.getAddAgency().getMethod()).isEqualTo(MethodEnum.POST);
+  }
+
+  @Test
+  void pageLinkOf_Should_BuildSelfLink() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+
+    var link = consultantDtoMapper.pageLinkOf("query", 1, 20, "LAST_NAME", "ASC");
+
+    assertThat(link.getMethod()).isEqualTo(MethodEnum.GET);
+    assertThat(link.getHref()).contains("query");
+  }
+
+  private Map<String, Object> givenAResultMap(boolean isFirstPage, boolean isLastPage) {
+    Map<String, Object> resultMap = new HashMap<>();
+    List<Map<String, Object>> consultantMaps = new ArrayList<>();
+    consultantMaps.add(consultantMap());
+    resultMap.put("consultants", consultantMaps);
+    resultMap.put("totalElements", 1);
+    resultMap.put("isFirstPage", isFirstPage);
+    resultMap.put("isLastPage", isLastPage);
+    return resultMap;
+  }
+
+  @Test
+  void consultantSearchResultOf_Should_SkipTopicLookup_When_NoTopicIdsFoundForAnyConsultant() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(List.of());
+
+    var result =
+        consultantDtoMapper.consultantSearchResultOf(
+            givenAResultMap(true, true), "query", 0, 20, "LAST_NAME", "ASC");
+
+    assertThat(result.getTotal()).isEqualTo(1);
+    assertThat(result.getEmbedded()).hasSize(1);
+    assertThat(result.getEmbedded().get(0).getEmbedded().getTopics()).isEmpty();
+    assertThat(result.getLinks().getPrevious()).isNull();
+    assertThat(result.getLinks().getNext()).isNull();
+  }
+
+  @Test
+  void consultantSearchResultOf_Should_EnrichTopics_When_TopicIdsFoundForConsultant() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    List<Object[]> rows = java.util.Collections.singletonList(new Object[] {"consultant-id", 42L});
+    when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(rows);
+    var topicDto = new TopicDTO();
+    topicDto.setId(42L);
+    topicDto.setName("Topic Name");
+    when(topicService.getAllTopicsMap()).thenReturn(Map.of(42L, topicDto));
+
+    var result =
+        consultantDtoMapper.consultantSearchResultOf(
+            givenAResultMap(true, true), "query", 0, 20, "LAST_NAME", "ASC");
+
+    var topics = result.getEmbedded().get(0).getEmbedded().getTopics();
+    assertThat(topics).hasSize(1);
+    assertThat(topics.get(0).getName()).isEqualTo("Topic Name");
+  }
+
+  @Test
+  void consultantSearchResultOf_Should_AddPreviousAndNextLinks_When_NotFirstOrLastPage() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(List.of());
+
+    var result =
+        consultantDtoMapper.consultantSearchResultOf(
+            givenAResultMap(false, false), "query", 1, 20, "LAST_NAME", "ASC");
+
+    assertThat(result.getLinks().getPrevious()).isNotNull();
+    assertThat(result.getLinks().getNext()).isNotNull();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelperTest.java
@@ -1,0 +1,204 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.facade.RocketChatFacade;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.ConsultantAgencyStatus;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.helper.MailService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RocketChatAsyncHelperTest {
+
+  @InjectMocks private RocketChatAsyncHelper rocketChatAsyncHelper;
+
+  @Mock private RocketChatFacade rocketChatFacade;
+  @Mock private SessionRepository sessionRepository;
+  @Mock private IdentityClient identityClient;
+  @Mock private ConsultingTypeManager consultingTypeManager;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private ConsultantAgencyRepository consultantAgencyRepository;
+  @Mock private MailService mailService;
+
+  private Consultant givenConsultant(String matrixUserId) {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultantId");
+    consultant.setUsername("consultantUsername");
+    consultant.setMatrixUserId(matrixUserId);
+    return consultant;
+  }
+
+  private AgencyDTO givenAgency(boolean teamAgency) {
+    AgencyDTO agency = new AgencyDTO();
+    agency.setId(1L);
+    agency.setTeamAgency(teamAgency);
+    return agency;
+  }
+
+  private ConsultantAgency givenInProgressConsultantAgency() {
+    ConsultantAgency consultantAgency = new ConsultantAgency();
+    consultantAgency.setStatus(ConsultantAgencyStatus.IN_PROGRESS);
+    return consultantAgency;
+  }
+
+  @Test
+  void
+      addConsultantToSessions_Should_SetConsultantCreated_When_NoRelevantSessionsAndNoOtherInProgressRelations() {
+    ReflectionTestUtils.setField(rocketChatAsyncHelper, "applicationBaseUrl", "http://base.url");
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(false);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(1L, SessionStatus.NEW))
+        .thenReturn(List.of());
+    ConsultantAgency consultantAgency = givenInProgressConsultantAgency();
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            "consultantId", 1L, ConsultantAgencyStatus.IN_PROGRESS))
+        .thenReturn(consultantAgency);
+    when(consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(
+            "consultantId", ConsultantAgencyStatus.IN_PROGRESS))
+        .thenReturn(List.of());
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    assertThat(consultantAgency.getStatus()).isEqualTo(ConsultantAgencyStatus.CREATED);
+    verify(consultantAgencyRepository).save(consultantAgency);
+    assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.CREATED);
+    verify(consultantRepository).save(consultant);
+  }
+
+  @Test
+  void addConsultantToSessions_Should_IncludeTeamSessions_When_AgencyIsTeamAgency() {
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(true);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(1L, SessionStatus.NEW))
+        .thenReturn(List.of());
+    when(sessionRepository.findByAgencyIdAndStatusAndTeamSessionIsTrue(
+            1L, SessionStatus.IN_PROGRESS))
+        .thenReturn(List.of());
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            any(), any(), any()))
+        .thenReturn(givenInProgressConsultantAgency());
+    when(consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(any(), any()))
+        .thenReturn(List.of());
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    verify(sessionRepository)
+        .findByAgencyIdAndStatusAndTeamSessionIsTrue(1L, SessionStatus.IN_PROGRESS);
+  }
+
+  @Test
+  void
+      addConsultantToSessions_Should_SetErrorStatusAndSendMail_When_ExceptionThrownAndConsultantHasNoMatrixId() {
+    ReflectionTestUtils.setField(rocketChatAsyncHelper, "applicationBaseUrl", "http://base.url");
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(false);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(any(), any()))
+        .thenThrow(new RuntimeException("db down"));
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.ERROR);
+    verify(consultantRepository).save(consultant);
+    verify(mailService).sendErrorEmailNotification(any());
+  }
+
+  @Test
+  void
+      addConsultantToSessions_Should_ContinueAndFinalizeStatus_When_ExceptionThrownButConsultantHasMatrixId() {
+    Consultant consultant = givenConsultant("@matrixUser:matrix.oriso.org");
+    AgencyDTO agency = givenAgency(false);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(any(), any()))
+        .thenThrow(new RuntimeException("rc down"));
+    ConsultantAgency consultantAgency = givenInProgressConsultantAgency();
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            any(), any(), any()))
+        .thenReturn(consultantAgency);
+    when(consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(any(), any()))
+        .thenReturn(List.of());
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    verify(mailService, never()).sendErrorEmailNotification(any());
+    assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.CREATED);
+    verify(consultantAgencyRepository, times(1)).save(consultantAgency);
+  }
+
+  @Test
+  void addConsultantToSessions_Should_SkipStatusFinalization_When_NoInProgressRelationVisible() {
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(false);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(any(), any()))
+        .thenReturn(List.of());
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            any(), any(), any()))
+        .thenReturn(null);
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    verify(consultantAgencyRepository, never()).save(any());
+    verify(consultantRepository, never()).save(any());
+  }
+
+  @Test
+  void
+      addConsultantToSessions_Should_NotSetConsultantCreated_When_OtherInProgressRelationsStillExist() {
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(false);
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(any(), any()))
+        .thenReturn(List.of());
+    ConsultantAgency consultantAgency = givenInProgressConsultantAgency();
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            any(), any(), any()))
+        .thenReturn(consultantAgency);
+    when(consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(any(), any()))
+        .thenReturn(List.of(givenInProgressConsultantAgency()));
+
+    rocketChatAsyncHelper.addConsultantToSessions(consultant, agency, msg -> {}, 1L);
+
+    verify(consultantAgencyRepository).save(consultantAgency);
+    verify(consultantRepository, never()).save(any());
+  }
+
+  @Test
+  void finalizeConsultantAgencyRelation_Should_UpdateConsultantStatus_When_RelationIsInProgress() {
+    Consultant consultant = givenConsultant(null);
+    AgencyDTO agency = givenAgency(false);
+    ConsultantAgency consultantAgency = givenInProgressConsultantAgency();
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
+            "consultantId", 1L, ConsultantAgencyStatus.IN_PROGRESS))
+        .thenReturn(consultantAgency);
+    when(consultantAgencyRepository.findByConsultantIdAndStatusAndDeleteDateIsNull(
+            "consultantId", ConsultantAgencyStatus.IN_PROGRESS))
+        .thenReturn(List.of());
+
+    rocketChatAsyncHelper.finalizeConsultantAgencyRelation(consultant, agency);
+
+    assertThat(consultantAgency.getStatus()).isEqualTo(ConsultantAgencyStatus.CREATED);
+    assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.CREATED);
+    verify(consultantRepository).save(consultant);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/helper/AuthenticatedUserTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/AuthenticatedUserTest.java
@@ -1,8 +1,10 @@
 package de.caritas.cob.userservice.api.helper;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,5 +57,166 @@ public class AuthenticatedUserTest {
           AuthenticatedUser authenticatedUser = new AuthenticatedUser();
           authenticatedUser.setAccessToken(null);
         });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Extended coverage — 2026-07-06
+  // ---------------------------------------------------------------------------
+
+  private AuthenticatedUser givenAuthenticatedUserWithRoles(String... roles) {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+    authenticatedUser.setUserId("userId");
+    authenticatedUser.setUsername("username");
+    authenticatedUser.setAccessToken("token");
+    authenticatedUser.setRoles(new HashSet<>(java.util.Arrays.asList(roles)));
+    return authenticatedUser;
+  }
+
+  @Test
+  public void isRestrictedAgencyAdmin_Should_ReturnFalse_When_RolesIsNull() {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+    assertThat(authenticatedUser.isRestrictedAgencyAdmin()).isFalse();
+  }
+
+  @Test
+  public void isRestrictedAgencyAdmin_Should_ReturnFalse_When_RolesIsEmpty() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles();
+    assertThat(authenticatedUser.isRestrictedAgencyAdmin()).isFalse();
+  }
+
+  @Test
+  public void isRestrictedAgencyAdmin_Should_ReturnTrue_When_RolesContainRestrictedAgencyAdmin() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("restricted-agency-admin");
+    assertThat(authenticatedUser.isRestrictedAgencyAdmin()).isTrue();
+  }
+
+  @Test
+  public void isAgencySuperAdmin_Should_ReturnFalse_When_RolesDoNotContainAgencyAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isAgencySuperAdmin()).isFalse();
+  }
+
+  @Test
+  public void isAgencySuperAdmin_Should_ReturnTrue_When_RolesContainAgencyAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("agency-admin");
+    assertThat(authenticatedUser.isAgencySuperAdmin()).isTrue();
+  }
+
+  @Test
+  public void hasRestrictedAgencyPriviliges_Should_ReturnTrue_When_RestrictedAndNotSuperAdmin() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("restricted-agency-admin");
+    assertThat(authenticatedUser.hasRestrictedAgencyPriviliges()).isTrue();
+  }
+
+  @Test
+  public void hasRestrictedAgencyPriviliges_Should_ReturnFalse_When_RestrictedAndAlsoSuperAdmin() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("restricted-agency-admin", "agency-admin");
+    assertThat(authenticatedUser.hasRestrictedAgencyPriviliges()).isFalse();
+  }
+
+  @Test
+  public void hasRestrictedAgencyPriviliges_Should_ReturnFalse_When_NotRestricted() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("agency-admin");
+    assertThat(authenticatedUser.hasRestrictedAgencyPriviliges()).isFalse();
+  }
+
+  @Test
+  public void isAdviceSeeker_Should_ReturnTrue_When_RolesContainUser() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isAdviceSeeker()).isTrue();
+  }
+
+  @Test
+  public void isAdviceSeeker_Should_ReturnFalse_When_RolesDoNotContainUser() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("consultant");
+    assertThat(authenticatedUser.isAdviceSeeker()).isFalse();
+  }
+
+  @Test
+  public void isConsultant_Should_ReturnTrue_When_RolesContainConsultant() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("consultant");
+    assertThat(authenticatedUser.isConsultant()).isTrue();
+  }
+
+  @Test
+  public void isConsultant_Should_ReturnFalse_When_RolesDoNotContainConsultant() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isConsultant()).isFalse();
+  }
+
+  @Test
+  public void isSingleTenantAdmin_Should_ReturnTrue_When_RolesContainSingleTenantAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("single-tenant-admin");
+    assertThat(authenticatedUser.isSingleTenantAdmin()).isTrue();
+  }
+
+  @Test
+  public void isSingleTenantAdmin_Should_ReturnFalse_When_RolesDoNotContainSingleTenantAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isSingleTenantAdmin()).isFalse();
+  }
+
+  @Test
+  public void isTenantSuperAdmin_Should_ReturnTrue_When_RolesContainTenantAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("tenant-admin");
+    assertThat(authenticatedUser.isTenantSuperAdmin()).isTrue();
+  }
+
+  @Test
+  public void isTenantSuperAdmin_Should_ReturnFalse_When_RolesDoNotContainTenantAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isTenantSuperAdmin()).isFalse();
+  }
+
+  @Test
+  public void isAnonymous_Should_ReturnTrue_When_RolesContainAnonymous() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("anonymous");
+    assertThat(authenticatedUser.isAnonymous()).isTrue();
+  }
+
+  @Test
+  public void isAnonymous_Should_ReturnFalse_When_RolesDoNotContainAnonymous() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("user");
+    assertThat(authenticatedUser.isAnonymous()).isFalse();
+  }
+
+  @Test
+  public void isPlatformAdmin_Should_ReturnTrue_When_TenantIdIsZeroAndAgencyAndTenantSuperAdmin() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("agency-admin", "tenant-admin");
+    authenticatedUser.setTenantId(0L);
+    assertThat(authenticatedUser.isPlatformAdmin()).isTrue();
+  }
+
+  @Test
+  public void isPlatformAdmin_Should_ReturnFalse_When_TenantIdIsNotZero() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("agency-admin", "tenant-admin");
+    authenticatedUser.setTenantId(1L);
+    assertThat(authenticatedUser.isPlatformAdmin()).isFalse();
+  }
+
+  @Test
+  public void isPlatformAdmin_Should_ReturnFalse_When_TenantIdIsNull() {
+    AuthenticatedUser authenticatedUser =
+        givenAuthenticatedUserWithRoles("agency-admin", "tenant-admin");
+    assertThat(authenticatedUser.isPlatformAdmin()).isFalse();
+  }
+
+  @Test
+  public void isPlatformAdmin_Should_ReturnFalse_When_NotAgencySuperAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("tenant-admin");
+    authenticatedUser.setTenantId(0L);
+    assertThat(authenticatedUser.isPlatformAdmin()).isFalse();
+  }
+
+  @Test
+  public void isPlatformAdmin_Should_ReturnFalse_When_NotTenantSuperAdmin() {
+    AuthenticatedUser authenticatedUser = givenAuthenticatedUserWithRoles("agency-admin");
+    authenticatedUser.setTenantId(0L);
+    assertThat(authenticatedUser.isPlatformAdmin()).isFalse();
   }
 }


### PR DESCRIPTION
## What
Added 110 new unit tests across 6 classes (56 → 166 total in these files):

- `AuthenticatedUser` — 23 new tests: none of the 9 role-check convenience methods
  (isRestrictedAgencyAdmin, isAgencySuperAdmin, hasRestrictedAgencyPriviliges,
  isAdviceSeeker, isConsultant, isSingleTenantAdmin, isTenantSuperAdmin, isPlatformAdmin,
  isAnonymous) had any prior coverage.
- `RocketChatAsyncHelper` — 7 new tests (new file): zero prior coverage on the
  Rocket.Chat group-assignment orchestration, including the Matrix-consultant-aware
  error handling (RocketChat failures are non-blocking for Matrix consultants) and the
  consultant/consultant_agency status finalization branches.
- `KeycloakService` — 37 new tests: 9 entirely untested public methods
  (verifyIgnoringOtp, initiateEmailVerification, finishEmailVerification, findUserByEmail,
  ensureRole, deleteUser, userHasRole, getRealmRoles, findByUsername) out of 35 total,
  plus a full branch pass on `isPasswordPolicyViolation`/`isPasswordPolicyMessage`
  (cause-chain traversal, RestClientResponseException body matching, all 4 string-match
  branches), the previously-untested `changeEmailAddress(username, email)` overload,
  `setUpOtpCredential`'s 401-vs-rethrow exception branches, and `resolveTenantId`'s
  null-fallback path. Branch coverage: 59.0% → 82.6%.
- `ConsultantDTO` / `ConsultantSessionDTO` — 13 / 12 new tests (new files): generated
  OpenAPI DTOs with zero coverage — builder round-trip, null-list-init branches on
  addXItem helpers, and a full per-field pass on the generated equals()'s `&&` chain
  (each field's short-circuit-false branch only fires when that specific field differs
  while all others match). Both now at 100% instruction / 100% branch.
- `ConsultantDtoMapper` — 18 new tests: covers the remaining field-mapping branches on
  consultantDtoOf/updateAdminConsultantOf/consultantResponseDtoOf, plus the HATEOAS
  link-building methods (consultantLinksOf, consultantLinkOf, consultantAgencyLinkOf,
  pageLinkOf) and consultantSearchResultOf's topic-enrichment and pagination-link
  branches, using a MockHttpServletRequest + RequestContextHolder to satisfy Spring
  HATEOAS's linkTo/methodOn without a full MVC test context. 99.5% instr / 84.6% branch.

## Why
Closes #320 — these 6 classes were the next highest-remaining-impact items across
Batch B (DTOs) and Batch C (medium services) of the UserService coverage plan.
KeycloakService, ConsultantDTO, and ConsultantSessionDTO were revisited in a follow-up
commit specifically to push branch coverage above 80% on top of the initial pass.

## Scope
- Tests only — no production code changes
- All new tests appended below existing ones with an `Extended coverage` separator
  (3 new files created from scratch for classes with no prior test file)
- No existing test was modified or reordered

## Verification
- [x] All 166 tests in the 6 modified files pass
- [x] Full suite run 4x total: 0 failures except one pre-existing, unrelated flaky test
      (`DeleteUserAnonymousServiceTest`, not touched by this PR)
- [x] Coverage confirmed via JaCoCo before/after for each class:
  - AuthenticatedUser: 19% → 100% instr / 84.2% branch
  - RocketChatAsyncHelper: 2% → 98.9% instr / 100% branch
  - KeycloakService: 72.9%/59.0% → 94.4% instr / 82.6% branch
  - ConsultantDTO: 23% → 100% instr / 100% branch
  - ConsultantSessionDTO: 23% → 100% instr / 100% branch
  - ConsultantDtoMapper: 30% → 99.5% instr / 84.6% branch
