### PR TITLE
hotfix: apply 2FA role policy to email setup (fresh cut of #183)

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -1799,6 +1799,8 @@ paths:
           description: UNAUTHORIZED - no/invalid Keycloak token
         403:
           description: FORBIDDEN - no/invalid role/authorization or CSRF token
+        409:
+          description: CONFLICT - role from the request has no two factor auth enabled
         412:
           description: PRECONDITION FAILED - already set up
         429:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -1752,7 +1752,7 @@ paths:
     put:
       tags:
         - user-controller
-      summary: 'Starts 2FA activation process by email [authorities: consultant or user]'
+      summary: 'Starts 2FA activation process by email [authorities: OTP-enabled user roles]'
       operationId: startTwoFactorAuthByEmailSetup
       requestBody:
         content:
@@ -1769,6 +1769,8 @@ paths:
           description: UNAUTHORIZED - no/invalid Keycloak token
         403:
           description: FORBIDDEN - no/invalid role/authorization or CSRF token
+        409:
+          description: CONFLICT - role from the request has no two factor auth enabled
         412:
           description: PRECONDITION FAILED - another user owns this email
         500:
@@ -1779,7 +1781,7 @@ paths:
     post:
       tags:
         - user-controller
-      summary: 'Finishes 2FA activation process by email [authorities: consultant or user]'
+      summary: 'Finishes 2FA activation process by email [authorities: OTP-enabled user roles]'
       operationId: finishTwoFactorAuthByEmailSetup
       parameters:
         - name: tan
@@ -1809,7 +1811,7 @@ paths:
     put:
       tags:
         - user-controller
-      summary: 'Activates 2FA by mobile app [authorities: consultant or user]'
+      summary: 'Activates 2FA by mobile app [authorities: OTP-enabled user roles]'
       operationId: activateTwoFactorAuthByApp
       requestBody:
         content:
@@ -1836,7 +1838,7 @@ paths:
     delete:
       tags:
         - user-controller
-      summary: 'Deactivates 2FA by mobile app [authorities: consultant or user]'
+      summary: 'Deactivates 2FA by mobile app [authorities: OTP-enabled user roles]'
       operationId: deactivateTwoFactorAuthByApp
       responses:
         200:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
@@ -1,7 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
-import static org.apache.commons.lang3.BooleanUtils.isFalse;
-
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.OneTimePasswordDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
@@ -31,6 +29,8 @@ class UserTwoFactorAuthControllerDelegate {
   private final @NonNull UsernameTranscoder usernameTranscoder;
 
   ResponseEntity<Void> startTwoFactorAuthByEmailSetup(EmailDTO emailDTO) {
+    assertTwoFactorAuthAllowed();
+
     var username = usernameTranscoder.encodeUsername(authenticatedUser.getUsername());
     var email = emailDTO.getEmail().toLowerCase(Locale.ROOT);
 
@@ -49,6 +49,8 @@ class UserTwoFactorAuthControllerDelegate {
   }
 
   ResponseEntity<Void> finishTwoFactorAuthByEmailSetup(String tan) {
+    assertTwoFactorAuthAllowed();
+
     var username = usernameTranscoder.encodeUsername(authenticatedUser.getUsername());
     var validationResult = identityManager.validateOneTimePassword(username, tan);
 
@@ -68,22 +70,7 @@ class UserTwoFactorAuthControllerDelegate {
   }
 
   ResponseEntity<Void> activateTwoFactorAuthByApp(OneTimePasswordDTO oneTimePasswordDTO) {
-    if (authenticatedUser.isAdviceSeeker()
-        && isFalse(identityClientConfig.getOtpAllowedForUsers())) {
-      throw new ConflictException("2FA is disabled for user role");
-    }
-    if (authenticatedUser.isConsultant()
-        && isFalse(identityClientConfig.getOtpAllowedForConsultants())) {
-      throw new ConflictException("2FA is disabled for consultant role");
-    }
-    if (authenticatedUser.isSingleTenantAdmin()
-        && isFalse(identityClientConfig.getOtpAllowedForSingleTenantAdmins())) {
-      throw new ConflictException("2FA is disabled for single tenant admin role");
-    }
-    if (authenticatedUser.isTenantSuperAdmin()
-        && isFalse(identityClientConfig.getOtpAllowedForTenantSuperAdmins())) {
-      throw new ConflictException("2FA is disabled for tenant admin role");
-    }
+    assertTwoFactorAuthAllowed();
 
     var isValid =
         identityManager.setUpOneTimePassword(
@@ -99,5 +86,15 @@ class UserTwoFactorAuthControllerDelegate {
         usernameTranscoder.encodeUsername(authenticatedUser.getUsername()));
 
     return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  /**
+   * The OTP role policy must gate every 2FA setup path — app and email alike — so a role with 2FA
+   * disabled cannot sidestep the policy by choosing the email flow.
+   */
+  private void assertTwoFactorAuthAllowed() {
+    if (!identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())) {
+      throw new ConflictException("2FA is disabled for user role");
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
@@ -174,11 +174,14 @@ class UserController2faE2EIT {
   @WithMockUser(authorities = AuthorityValue.RESTRICTED_AGENCY_ADMIN)
   void startTwoFactorAuthByEmailSetupShouldRespondWithNoContent_If_Called_As_AgencyAdmin()
       throws Exception {
+    givenAValidRestrictedAgencyAdmin();
     startTwoFactorAuthorizationAndAssertResponseIsCorrect();
   }
 
   private void startTwoFactorAuthorizationAndAssertResponseIsCorrect() throws Exception {
-    givenAValidConsultant();
+    if (isNull(consultant)) {
+      givenAValidConsultant();
+    }
     givenAValidEmailDTO();
     givenKeycloakFoundNoEmailInUse();
     givenABearerToken();
@@ -203,6 +206,25 @@ class UserController2faE2EIT {
     var otpSetupDTO = otpSetupCaptor.getValue().getBody();
     assertNotNull(otpSetupDTO);
     assertEquals(emailDTO.getEmail().toLowerCase(), otpSetupDTO.getEmail());
+  }
+
+  @Test
+  @WithMockUser(authorities = AuthorityValue.CONSULTANT_DEFAULT)
+  void startTwoFactorAuthByEmailSetupShouldRespondWithConflictIfOtpIsDisabledForConsultant()
+      throws Exception {
+    givenAValidConsultant();
+    identityConfig.setOtpAllowedForConsultants(false);
+    givenAValidEmailDTO();
+
+    mockMvc
+        .perform(
+            put("/users/2fa/email")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emailDTO))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict());
   }
 
   @Test
@@ -653,6 +675,25 @@ class UserController2faE2EIT {
   }
 
   @Test
+  @WithMockUser(authorities = AuthorityValue.RESTRICTED_AGENCY_ADMIN)
+  void activateTwoFactorAuthByAppShouldRespondWithConflictIfRestrictedAgencyAdminOtpIsDisabled()
+      throws Exception {
+    givenAValidRestrictedAgencyAdmin();
+    identityConfig.setOtpAllowedForRestrictedAgencyAdmins(false);
+    givenACorrectlyFormattedOneTimePasswordDTO();
+
+    mockMvc
+        .perform(
+            put("/users/2fa/app")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(oneTimePasswordDTO))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
   @WithMockUser(authorities = AuthorityValue.CONSULTANT_DEFAULT)
   void deactivateTwoFactorAuthByAppShouldRespondWithOK() throws Exception {
     givenAValidConsultant();
@@ -942,6 +983,7 @@ class UserController2faE2EIT {
 
   private void givenAValidConsultant() {
     consultant = consultantRepository.findAll().iterator().next();
+    identityConfig.setOtpAllowedForConsultants(true);
     when(authenticatedUser.getUserId()).thenReturn(consultant.getId());
     when(authenticatedUser.isAdviceSeeker()).thenReturn(false);
     when(authenticatedUser.isConsultant()).thenReturn(true);
@@ -952,11 +994,25 @@ class UserController2faE2EIT {
 
   private void givenAValidUser() {
     user = userRepository.findAll().iterator().next();
+    identityConfig.setOtpAllowedForUsers(true);
     when(authenticatedUser.getUserId()).thenReturn(user.getUserId());
     when(authenticatedUser.isAdviceSeeker()).thenReturn(true);
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(authenticatedUser.getUsername()).thenReturn(user.getUsername());
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.USER.getValue()));
     when(authenticatedUser.getGrantedAuthorities()).thenReturn(Set.of("anotherAuthority"));
+  }
+
+  private void givenAValidRestrictedAgencyAdmin() {
+    consultant = consultantRepository.findAll().iterator().next();
+    identityConfig.setOtpAllowedForRestrictedAgencyAdmins(true);
+    when(authenticatedUser.getUserId()).thenReturn(consultant.getId());
+    when(authenticatedUser.isAdviceSeeker()).thenReturn(false);
+    when(authenticatedUser.isConsultant()).thenReturn(false);
+    when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(true);
+    when(authenticatedUser.getUsername()).thenReturn(consultant.getUsername());
+    when(authenticatedUser.getRoles())
+        .thenReturn(Set.of(UserRole.RESTRICTED_AGENCY_ADMIN.getValue()));
+    when(authenticatedUser.getGrantedAuthorities()).thenReturn(Set.of("restrictedAgencyAdmin"));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
@@ -373,6 +373,24 @@ class UserController2faE2EIT {
   }
 
   @Test
+  @WithMockUser(authorities = AuthorityValue.CONSULTANT_DEFAULT)
+  void finishTwoFactorAuthByEmailSetupShouldRespondWithConflictIfOtpIsDisabledForConsultant()
+      throws Exception {
+    givenAValidConsultant();
+    identityConfig.setOtpAllowedForConsultants(false);
+    givenABearerToken();
+    givenACorrectlyFormattedTan();
+
+    mockMvc
+        .perform(
+            post("/users/2fa/email/validate/{tan}", tan)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
   @WithMockUser(authorities = {AuthorityValue.USER_DEFAULT})
   void finishTwoFactorAuthByEmailSetupForAUserShouldRespondWithNoContent() throws Exception {
     givenAValidUser();

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
@@ -87,9 +87,9 @@ import org.springframework.web.client.RestTemplate;
 class UserController2faE2EIT {
 
   private static final EasyRandom easyRandom = new EasyRandom();
-  private static final String CSRF_HEADER = "csrfHeader";
+  private static final String CSRF_HEADER = "X-CSRF-Token";
   private static final String CSRF_VALUE = "test";
-  private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", CSRF_VALUE);
+  private static final Cookie CSRF_COOKIE = new Cookie("CSRF-TOKEN", CSRF_VALUE);
 
   @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -496,8 +496,8 @@ class UserControllerIT {
   @Test
   void activateTwoFactorAuthByApp_Should_NotActivateIfSingleTenantAdminButNotConfiguredToUse2Fa()
       throws Exception {
-    when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForSingleTenantAdmins()).thenReturn(false);
+    when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.SINGLE_TENANT_ADMIN.getValue()));
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -511,8 +511,8 @@ class UserControllerIT {
   @Test
   void activateTwoFactorAuthByApp_Should_NotActivateIfTenantSuperAdminButNotConfiguredToUse2Fa()
       throws Exception {
-    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForTenantSuperAdmins()).thenReturn(false);
+    when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -526,6 +526,8 @@ class UserControllerIT {
   @Test
   void activateTwoFactorAuthByApp_Should_Activate() throws Exception {
     when(authenticatedUser.getUsername()).thenReturn("username");
+    when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.CONSULTANT.getValue()));
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
     when(identityManager.setUpOneTimePassword(anyString(), anyString(), anyString()))
         .thenReturn(true);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -45,6 +46,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void startTwoFactorAuthByEmailSetupShouldCreateOtpForNormalizedEmail() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, "person@example.org"))
@@ -60,6 +62,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void startTwoFactorAuthByEmailSetupShouldThrowProjectExceptionWhenOtpSetupFails() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, "person@example.org"))
@@ -75,6 +78,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void startTwoFactorAuthByEmailSetupShouldReturnPreconditionFailedWhenEmailIsUnavailable() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, "person@example.org"))
@@ -88,6 +92,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldPatchUserWhenOtpWasCreated() {
+    allowOtpForCurrentRoles();
     var patchMap = Map.<String, Object>of("email", "person@example.org");
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
@@ -103,6 +108,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldReturnBadRequestWhenAttemptsRemain() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
@@ -116,6 +122,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldReturnPreconditionFailedWhenOtpAlreadyCreated() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
@@ -129,6 +136,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldReturnTooManyRequestsWhenAttemptsAreExhausted() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
@@ -141,9 +149,8 @@ class UserTwoFactorAuthControllerDelegateTest {
   }
 
   @Test
-  void activateTwoFactorAuthByAppShouldRejectAdviceSeekerWhenOtpIsDisabledForUsers() {
-    when(authenticatedUser.isAdviceSeeker()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForUsers()).thenReturn(false);
+  void activateTwoFactorAuthByAppShouldRejectRoleWithoutOtpPolicy() {
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -153,7 +160,31 @@ class UserTwoFactorAuthControllerDelegateTest {
   }
 
   @Test
+  void startTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+
+    assertThatThrownBy(
+            () -> delegate.startTwoFactorAuthByEmailSetup(new EmailDTO("person@example.org")))
+        .isInstanceOf(ConflictException.class)
+        .hasMessage("2FA is disabled for user role");
+
+    verifyNoInteractions(identityManager);
+  }
+
+  @Test
+  void finishTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.finishTwoFactorAuthByEmailSetup(OTP))
+        .isInstanceOf(ConflictException.class)
+        .hasMessage("2FA is disabled for user role");
+
+    verifyNoInteractions(identityManager);
+  }
+
+  @Test
   void activateTwoFactorAuthByAppShouldReturnOkWhenOtpIsAccepted() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.setUpOneTimePassword(ENCODED_USERNAME, OTP, SECRET)).thenReturn(true);
@@ -165,6 +196,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByAppShouldReturnBadRequestWhenOtpIsRejected() {
+    allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.setUpOneTimePassword(ENCODED_USERNAME, OTP, SECRET)).thenReturn(false);
@@ -187,5 +219,9 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   private OneTimePasswordDTO oneTimePassword() {
     return new OneTimePasswordDTO(SECRET, OTP);
+  }
+
+  private void allowOtpForCurrentRoles() {
+    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
   }
 }


### PR DESCRIPTION
Fresh cut of #183 from current dev, per owner request — the review feedback there is fully addressed (Shirloin's finish-path guard landed, rebased onto the 2FA delegate structure) but the stale review state still gates that PR.

- `UserTwoFactorAuthControllerDelegate.assertTwoFactorAuthAllowed()` (via existing `IdentityClientConfig.isOtpAllowed(roles)`) guards `startTwoFactorAuthByEmailSetup`, `finishTwoFactorAuthByEmailSetup`, and `activateTwoFactorAuthByApp` — a role with 2FA disabled can no longer sidestep the policy via the email flow.
- OpenAPI documents 409 on both email endpoints.
- Delegate unit tests for the unified policy + E2E conflict coverage for both email paths.

Supersedes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)