### PR TITLE
fix(case-handover): seed reason-policy table on dev; harden policy update

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -144,7 +144,9 @@ public class CaseHandoverService {
         caseHandoverReasonPolicyRepository.findAllByOrderByDisplayOrderAscCodeAsc().stream()
             .collect(
                 Collectors.toMap(
-                    CaseHandoverReasonPolicy::getCode, Function.identity(), (first, ignored) -> first));
+                    CaseHandoverReasonPolicy::getCode,
+                    Function.identity(),
+                    (first, ignored) -> first));
     LocalDateTime now = LocalDateTime.now();
     List<CaseHandoverReasonPolicy> policiesToSave =
         requestedReasons.stream()

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -137,9 +137,14 @@ public class CaseHandoverService {
       throw new BadRequestException("At least one handover reason policy is required");
     }
 
+    // Keep the first row per code: a plain toMap throws IllegalStateException (-> 500)
+    // if the table ever holds duplicate codes, e.g. after a hand-applied seed on an
+    // environment where the guarded 0057 changeset was skipped.
     Map<String, CaseHandoverReasonPolicy> existingPolicies =
         caseHandoverReasonPolicyRepository.findAllByOrderByDisplayOrderAscCodeAsc().stream()
-            .collect(Collectors.toMap(CaseHandoverReasonPolicy::getCode, Function.identity()));
+            .collect(
+                Collectors.toMap(
+                    CaseHandoverReasonPolicy::getCode, Function.identity(), (first, ignored) -> first));
     LocalDateTime now = LocalDateTime.now();
     List<CaseHandoverReasonPolicy> policiesToSave =
         requestedReasons.stream()

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -139,7 +139,10 @@ public class CaseHandoverService {
 
     // Keep the first row per code: a plain toMap throws IllegalStateException (-> 500)
     // if the table ever holds duplicate codes, e.g. after a hand-applied seed on an
-    // environment where the guarded 0057 changeset was skipped.
+    // environment where the guarded 0057 changeset was skipped. Note that code is the
+    // table's PRIMARY KEY in both the 0057 and 0059 schemas, so the DB already enforces
+    // uniqueness; no extra UNIQUE constraint is needed and this merge is defense-in-depth
+    // for rows created outside Liquibase (review note on #324).
     Map<String, CaseHandoverReasonPolicy> existingPolicies =
         caseHandoverReasonPolicyRepository.findAllByOrderByDisplayOrderAscCodeAsc().stream()
             .collect(

--- a/src/main/resources/db/changelog/changeset/0059_case_handover_reason_policy_repair/0059_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0059_case_handover_reason_policy_repair/0059_changeSet.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+  <!-- Heals the case-handover reason-policy table on environments where the
+       0057 changeset was MARK_RAN without running (its AND-precondition skipped
+       BOTH tables whenever case_handover_request already existed). Tagged
+       context="seed" so it runs on dev/seed environments; the SQL is idempotent
+       (CREATE IF NOT EXISTS + INSERT ... ON DUPLICATE KEY UPDATE), so it is a
+       no-op wherever the table is already present and seeded. -->
+  <changeSet id="0059_case_handover_reason_policy_repair" author="caritas" context="seed">
+    <sqlFile
+      path="db/changelog/changeset/0059_case_handover_reason_policy_repair/reason-policy-repair.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0059_case_handover_reason_policy_repair/reason-policy-repair.sql
+++ b/src/main/resources/db/changelog/changeset/0059_case_handover_reason_policy_repair/reason-policy-repair.sql
@@ -1,0 +1,82 @@
+-- Repair for the case-handover reason-policy table on environments where the
+-- 0057 changeset was MARK_RAN without executing its SQL. 0057 guarded BOTH the
+-- request table and the reason-policy table behind a single AND precondition, so
+-- on any environment where case_handover_request already existed (it was
+-- hand-applied on dev before 0057 ever ran) the precondition failed and the
+-- reason-policy CREATE + seed were skipped entirely. The table then stays empty,
+-- listReasonPolicies() falls back to the hardcoded defaults for GET, and the
+-- first PUT that tries to persist has no seeded rows to update.
+--
+-- This statement is idempotent and safe on every environment:
+--   * CREATE TABLE IF NOT EXISTS      -> no-op where the table already exists.
+--   * INSERT ... ON DUPLICATE KEY ... -> only inserts the default rows that are
+--     missing; existing rows (including admin edits) are left untouched.
+
+CREATE TABLE IF NOT EXISTS case_handover_reason_policy (
+  code VARCHAR(100) NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  client_consent_required TINYINT(1) NOT NULL DEFAULT 0,
+  access_allowed TINYINT(1) NOT NULL DEFAULT 1,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  display_order INT NOT NULL DEFAULT 100,
+  policy_authority VARCHAR(255) NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (code),
+  INDEX idx_case_handover_reason_enabled_order (enabled, display_order, code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+INSERT INTO case_handover_reason_policy (
+  code,
+  label,
+  client_consent_required,
+  access_allowed,
+  enabled,
+  display_order,
+  policy_authority
+) VALUES
+  (
+    'COUNSELLOR_ASKED_FOR_ADVICE',
+    'Counsellor asked for advice',
+    1,
+    1,
+    1,
+    10,
+    'platform-admin-default-case-handover-policy'
+  ),
+  (
+    'COUNSELLOR_ON_HOLIDAY',
+    'Counsellor is on holiday',
+    0,
+    1,
+    1,
+    20,
+    'platform-admin-default-case-handover-policy'
+  ),
+  (
+    'OTHER_EMERGENCY',
+    'Other emergency',
+    0,
+    1,
+    1,
+    30,
+    'platform-admin-default-case-handover-policy'
+  ),
+  (
+    'COUNSELLOR_IS_ILL',
+    'Counsellor is ill',
+    0,
+    1,
+    1,
+    40,
+    'platform-admin-default-case-handover-policy'
+  ),
+  (
+    'COUNSELLOR_LEFT',
+    'Counsellor does not work here anymore',
+    0,
+    1,
+    1,
+    50,
+    'platform-admin-default-case-handover-policy'
+  )
+ON DUPLICATE KEY UPDATE code = code;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -93,7 +93,9 @@
   <include
     file="db/changelog/changeset/0058_adr008_supervision_sideroom_migration/0058_changeSet.xml" />
 
-  <!-- Seed/demo data (context="seed"): currently none. Append future seed
-       changesets below this line and tag every changeset with context="seed". -->
+  <!-- Seed/demo data (context="seed"): append future seed changesets below this
+       line and tag every changeset with context="seed". -->
+  <include
+    file="db/changelog/changeset/0059_case_handover_reason_policy_repair/0059_changeSet.xml" />
 
 </databaseChangeLog>

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -351,7 +351,8 @@ class CaseHandoverServiceTest {
         .thenReturn(
             List.of(
                 reasonPolicy("COUNSELLOR_IS_ILL", "Counsellor is ill", false, true, true, 40),
-                reasonPolicy("COUNSELLOR_IS_ILL", "Counsellor is ill (dup)", true, true, true, 40)));
+                reasonPolicy(
+                    "COUNSELLOR_IS_ILL", "Counsellor is ill (dup)", true, true, true, 40)));
     when(caseHandoverReasonPolicyRepository.saveAll(any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -24,6 +24,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverReasonPolicyRepositor
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.CaseHandoverService.CaseHandoverReason;
 import de.caritas.cob.userservice.api.service.CaseHandoverService.CaseHandoverStatus;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
@@ -340,6 +341,38 @@ class CaseHandoverServiceTest {
         .auditOutcome("ACCESS_GRANTED")
         .tenantId(7L)
         .build();
+  }
+
+  @Test
+  void updateReasonPolicies_toleratesDuplicateStoredCodes_andPersists() {
+    // A hand-applied seed on an environment where 0057 was skipped can leave the
+    // table with duplicate codes; the update must not blow up with a 500.
+    when(caseHandoverReasonPolicyRepository.findAllByOrderByDisplayOrderAscCodeAsc())
+        .thenReturn(
+            List.of(
+                reasonPolicy("COUNSELLOR_IS_ILL", "Counsellor is ill", false, true, true, 40),
+                reasonPolicy("COUNSELLOR_IS_ILL", "Counsellor is ill (dup)", true, true, true, 40)));
+    when(caseHandoverReasonPolicyRepository.saveAll(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    CaseHandoverReason requested =
+        CaseHandoverReason.builder()
+            .code("COUNSELLOR_IS_ILL")
+            .label("Counsellor is ill")
+            .clientConsentRequired(true)
+            .accessAllowed(true)
+            .enabled(false)
+            .displayOrder(40)
+            .policyAuthority("platform-admin-default-case-handover-policy")
+            .build();
+
+    caseHandoverService.updateReasonPolicies(List.of(requested));
+
+    ArgumentCaptor<List<CaseHandoverReasonPolicy>> captor = ArgumentCaptor.forClass(List.class);
+    verify(caseHandoverReasonPolicyRepository).saveAll(captor.capture());
+    assertEquals(1, captor.getValue().size());
+    assertEquals("COUNSELLOR_IS_ILL", captor.getValue().get(0).getCode());
+    assertFalse(captor.getValue().get(0).getEnabled());
   }
 
   private CaseHandoverReasonPolicy reasonPolicy(


### PR DESCRIPTION
## Symptom (reported by @shazia-k, dev, 2026-07-07)

Under **Settings → Permissions → Case handover**, the toggles **Enabled** (module master) and the per-reason **client-consent** switches have no effect: the switch flips back right after clicking, no change persists.

## Diagnosis

Verified against the PreDev cluster: every `PUT /service/users/case-handover/reason-policies` returns **HTTP 500** (empty body, ~10 ms), while `GET` returns 200. The admin card applies an optimistic update and rolls back on error — hence "no effect after click". Both reported toggles go through this one endpoint.

The 500 is **environment state, not the request**:

- The request body is well-formed (screenshot from @shazia-k shows a complete 5-element payload) — a bad body would be **400**, not 500.
- A DB constraint violation maps to **409** in this service — not what we see.
- `spring.jpa.hibernate.ddl-auto=validate` passes at startup, so the dev table schema **matches** the entity (no missing/renamed column).
- Liquibase runs as the **application datasource user** (no separate liquibase user), so the app user **can write** — grants are not the issue.

Root cause: changeset **`0057`** guarded *both* `case_handover_request` *and* `case_handover_reason_policy` behind a single `AND` precondition with `onFail="MARK_RAN"`. On dev, `case_handover_request` had been **hand-applied** before `0057` ever ran (see the changeset's own comment), so the precondition failed and the reason-policy `CREATE` **and** seed were skipped wholesale. `GET` still returns 200 because `listReasonPolicies()` silently falls back to a hardcoded default list when the table is empty — masking the unseeded state until the first write.

## Changes

- **`0059` repair changeset** (`context="seed"`, idempotent): ensures `case_handover_reason_policy` exists and seeds the default reasons, **decoupled** from `case_handover_request`. `CREATE TABLE IF NOT EXISTS` + `INSERT ... ON DUPLICATE KEY UPDATE` → no-op where the table is already present/seeded, never clobbers admin edits.
- **`updateReasonPolicies` hardening**: collect existing policies with a merge function so duplicate stored codes can't raise `IllegalStateException` (→ 500).
- **Regression test** for the duplicate-code path.

## Verification (needs a dev redeploy)

The fix runs on the next userservice deploy to dev (liquibase applies `0059`). After deploy, please re-test in the admin: toggling **Enabled** / a client-consent switch should now `200` and persist across reload.

> Note on confidence: the write-path 500 is logged server-side as an internal error, but the dev pod only retains ~10 min of logs, so the exact stack trace of the earlier failures had already rolled off and could not be captured. The diagnosis above rules out the parse/constraint/schema/grant causes; the remaining cause consistent with all evidence is the unseeded table from the skipped `0057`. If post-deploy testing still shows a 500, grab the fresh stack trace (`kubectl -n caritas logs -f <userservice-pod>` while clicking once) and we adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)