### PR TITLE
ci: non-blocking oasdiff API contract diff on PRs

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -46,3 +46,39 @@ jobs:
       uses: ./.github/actions/maven-verify-burnin
       with:
         java_version: '21'
+
+  # Non-blocking OpenAPI contract diff: flags breaking changes to this service's
+  # own vendored specs (api/*.yaml) between the PR base and head. Informational
+  # for now; flip to blocking once the process around intentional breaking
+  # changes (version bump / consumer sign-off) is agreed.
+  api-contract-diff:
+    name: api-contract-diff (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v6
+
+    - name: Checkout base branch
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.base_ref }}
+        path: .base
+
+    - name: Diff own OpenAPI specs against base (oasdiff breaking)
+      shell: bash
+      run: |
+        shopt -s nullglob
+        status=0
+        for spec in api/*.yaml api/*.yml; do
+          if [ -f ".base/$spec" ]; then
+            echo "::group::oasdiff breaking $spec"
+            docker run --rm -v "$PWD:/work:ro" tufin/oasdiff:latest \
+              breaking "/work/.base/$spec" "/work/$spec" --fail-on WARN || status=1
+            echo "::endgroup::"
+          else
+            echo "Skipping $spec (new on this branch, nothing to diff against)"
+          fi
+        done
+        exit $status


### PR DESCRIPTION
## What

Adds a non-blocking `api-contract-diff` job to `ci-pull-request.yml`: it checks out the PR base branch into a subdirectory and runs the `tufin/oasdiff` docker image (`breaking`, `--fail-on WARN`) over every vendored own-API spec (`api/userservice.yaml`, `api/useradminservice.yaml`, `api/conversationservice.yaml`, `api/appointmentservice.yaml`, `api/userstatisticsservice.yaml`) against the PR head. `continue-on-error: true` keeps it informational until the team agrees on a process for intentional breaking changes — same pattern as AgencyService #106, TenantService #67, ConsultingTypeService #51.

## Verification

Local run with the docker image: identical specs → exit 0 (`No changes detected`); diffing two different specs → exit 1 with `[api-path-removed-without-deprecation]` errors, so both the pass and fail paths work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)