### PR TITLE
test: drop stale per-role 2FA delegate tests left behind by #323 (dev is red)

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -217,51 +217,6 @@ class UserTwoFactorAuthControllerDelegateTest {
     verify(identityManager).deleteOneTimePassword(ENCODED_USERNAME);
   }
 
-  @Test
-  void activateTwoFactorAuthByApp_consultantDisabled_throwsConflictException() {
-    // Consultants cannot enable app-based 2FA when OTP is disabled for their role.
-    when(authenticatedUser.isAdviceSeeker()).thenReturn(false);
-    when(authenticatedUser.isConsultant()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForConsultants()).thenReturn(false);
-
-    assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
-        .isInstanceOf(ConflictException.class)
-        .hasMessage("2FA is disabled for consultant role");
-
-    verifyNoInteractions(identityManager);
-  }
-
-  @Test
-  void activateTwoFactorAuthByApp_singleTenantAdminDisabled_throwsConflictException() {
-    // Single-tenant admins cannot enable app-based 2FA when OTP is disabled for their role.
-    when(authenticatedUser.isAdviceSeeker()).thenReturn(false);
-    when(authenticatedUser.isConsultant()).thenReturn(false);
-    when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForSingleTenantAdmins()).thenReturn(false);
-
-    assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
-        .isInstanceOf(ConflictException.class)
-        .hasMessage("2FA is disabled for single tenant admin role");
-
-    verifyNoInteractions(identityManager);
-  }
-
-  @Test
-  void activateTwoFactorAuthByApp_tenantSuperAdminDisabled_throwsConflictException() {
-    // Tenant super admins cannot enable app-based 2FA when OTP is disabled for their role.
-    when(authenticatedUser.isAdviceSeeker()).thenReturn(false);
-    when(authenticatedUser.isConsultant()).thenReturn(false);
-    when(authenticatedUser.isSingleTenantAdmin()).thenReturn(false);
-    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
-    when(identityClientConfig.getOtpAllowedForTenantSuperAdmins()).thenReturn(false);
-
-    assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
-        .isInstanceOf(ConflictException.class)
-        .hasMessage("2FA is disabled for tenant admin role");
-
-    verifyNoInteractions(identityManager);
-  }
-
   private OneTimePasswordDTO oneTimePassword() {
     return new OneTimePasswordDTO(SECRET, OTP);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -217,7 +217,6 @@ class UserTwoFactorAuthControllerDelegateTest {
     verify(identityManager).deleteOneTimePassword(ENCODED_USERNAME);
   }
 
-
   private OneTimePasswordDTO oneTimePassword() {
     return new OneTimePasswordDTO(SECRET, OTP);
   }


### PR DESCRIPTION
## Problem
Since the merge of #323 (20:42), **dev is red**: `UserTwoFactorAuthControllerDelegateTest` fails with 3× *Expecting message … "consultant role" but was "user role"* — visible on dev run [28897263071](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/28897263071) and on every PR since (e.g. #329).

## Cause
#323 unified the role policy into `IdentityClientConfig.isOtpAllowed(roles)` (message is now generic) and added the new `*ShouldRejectRoleWithoutOtpPolicy` tests for it — but three old per-role tests survived the rewrite. They stub the removed API (`getOtpAllowedForConsultants` etc.) and assert messages the code no longer produces.

## Fix
Deleted the 3 stale duplicates (−42 lines). Their behavior is covered by the new unified reject test.

## Verification
`./mvnw test -Dtest=UserTwoFactorAuthControllerDelegateTest` → **13/13 green**, spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
