### PR TITLE
fix: resolve Hibernate 6 AliasCollisionException in AdminAgencyReposi…

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepository.java
@@ -4,7 +4,9 @@ import de.caritas.cob.userservice.api.model.AdminAgency;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface AdminAgencyRepository extends CrudRepository<AdminAgency, Long> {
@@ -19,6 +21,11 @@ public interface AdminAgencyRepository extends CrudRepository<AdminAgency, Long>
   @Transactional
   void deleteByAdminId(String adminId);
 
-  @SuppressWarnings("all")
-  List<AdminAgencyBase> findByAdminIdIn(Set<String> adminIds);
+  // Explicit projection query with distinct aliases. The derived query would map both getId()
+  // (AdminAgency.id) and getAdminId() (the joined admin.id) to the alias "id", which Hibernate 6
+  // rejects with an AliasCollisionException.
+  @Query(
+      "SELECT a.id AS id, a.agencyId AS agencyId, ad.id AS adminId "
+          + "FROM AdminAgency a LEFT JOIN a.admin ad WHERE ad.id IN :adminIds")
+  List<AdminAgencyBase> findByAdminIdIn(@Param("adminIds") Set<String> adminIds);
 }


### PR DESCRIPTION
…tory

Replace the derived findByAdminIdIn projection with an explicit @Query using distinct aliases so agency admin search no longer 500s after the Spring Boot 4 upgrade.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

