### PR TITLE
Fix agency admin search projection alias collision

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepository.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.model.AdminAgency;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,9 @@ public interface AdminAgencyRepository extends CrudRepository<AdminAgency, Long>
   @Transactional
   void deleteByAdminId(String adminId);
 
-  @SuppressWarnings("all")
+  @Query(
+      "SELECT adminAgency.id AS id, adminAgency.agencyId AS agencyId, adminAgency.admin.id AS adminId "
+          + "FROM AdminAgency adminAgency "
+          + "WHERE adminAgency.admin.id IN :adminIds")
   List<AdminAgencyBase> findByAdminIdIn(Set<String> adminIds);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/AdminAgencyRepositoryIT.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.caritas.cob.userservice.api.config.JpaAuditingConfiguration;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.AdminAgency;
+import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
@@ -63,6 +65,19 @@ class AdminAgencyRepositoryIT {
     adminAgency = adminAgencyRepository.save(adminAgency);
 
     assertTrue(adminAgency.getCreateDate().isBefore(adminAgency.getUpdateDate()));
+  }
+
+  @Test
+  void findByAdminIdInShouldReturnProjectionWithAdminId() {
+    givenPersistedAdminWIthAgency();
+
+    var adminAgencies = adminAgencyRepository.findByAdminIdIn(Set.of(admin.getId()));
+
+    assertEquals(1, adminAgencies.size());
+    AdminAgencyBase projection = adminAgencies.get(0);
+    assertEquals(adminAgency.getId(), projection.getId());
+    assertEquals(adminAgency.getAgencyId(), projection.getAgencyId());
+    assertEquals(admin.getId(), projection.getAdminId());
   }
 
   private void givenPersistedAdminWIthAgency() {


### PR DESCRIPTION
## Problem

`GET /useradmin/agencyadmins/search` returns 500 after the Spring Boot/Hibernate upgrade. PreDev logs show `BadJpqlGrammarException` / `AliasCollisionException: Duplicate alias 'id'` from `AdminAgencyRepository.findByAdminIdIn(...)`.

This keeps the Admin agency-admin table empty even after agency-admin creation and agency assignment succeed.

Closes #337.

## Solution

Replace the derived projection query with an explicit JPQL projection that assigns unique aliases for:

- `AdminAgency.id`
- `AdminAgency.agencyId`
- `AdminAgency.admin.id`

Add a DataJpa regression test proving the projection returns the relation id, agency id, and admin id.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q spotless:check`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q -Dspotless.check.skip=true -Dtest=AdminAgencyRepositoryIT,AgencyAdminUserServiceTest test`
- `git diff --check`

## Notes

Local Java 25 is not usable for this repository's current test stack: Spotless/google-java-format and Mockito/ByteBuddy fail before the relevant tests run. Java 21 works locally and matches the current test tooling better.
