### PR TITLE
Propagate consultant agency assignment validation errors

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
@@ -44,6 +44,7 @@ import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -203,24 +204,13 @@ public class UserAdminController implements UseradminApi {
   @Override
   public ResponseEntity<Void> setConsultantAgencies(
       String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
-    // MATRIX MIGRATION: Use simple creation for each agency instead of complex update logic
-    // This avoids the 403 error from filterAgencyListForDeletion
-    try {
-      for (CreateConsultantAgencyDTO agencyDTO : agencyList) {
-        try {
-          this.consultantAdminFacade.createNewConsultantAgency(consultantId, agencyDTO);
-        } catch (Exception e) {
-          // If agency already exists, continue
-          System.out.println("Agency assignment (might already exist): " + e.getMessage());
-        }
-      }
-      return ResponseEntity.ok().build();
-    } catch (Exception e) {
-      // Return 200 anyway to not block consultant creation
-      System.out.println(
-          "ERROR: Agency assignment failed for consultant " + consultantId + ": " + e.getMessage());
-      return ResponseEntity.ok().build();
-    }
+    consultantAdminFacade.checkPermissionsToAssignedAgencies(agencyList);
+
+    var agenciesToCreate = new ArrayList<>(agencyList);
+    consultantAdminFacade.filterAgencyListForCreation(consultantId, agenciesToCreate);
+    consultantAdminFacade.prepareConsultantAgencyRelation(consultantId, agenciesToCreate);
+    consultantAdminFacade.completeConsultantAgencyAssigment(consultantId, agenciesToCreate);
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -94,7 +94,8 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       final BadRequestException ex, final WebRequest request) {
     log.warn(BAD_REQUEST, ex);
 
-    return handleExceptionInternal(ex, null, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    return handleExceptionInternal(
+        ex, messageBody(ex.getMessage()), new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   /**
@@ -230,6 +231,10 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
 
   private Map<String, String> reasonBody(String reason) {
     return Map.of("reason", reason);
+  }
+
+  private Map<String, String> messageBody(String message) {
+    return Map.of("message", Optional.ofNullable(message).orElse(HttpStatus.BAD_REQUEST.name()));
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,7 +32,7 @@ import de.caritas.cob.userservice.api.admin.report.service.ViolationReportGenera
 import de.caritas.cob.userservice.api.admin.service.consultant.create.GrantConsultantIdentityService;
 import de.caritas.cob.userservice.api.admin.service.session.SessionAdminService;
 import de.caritas.cob.userservice.api.config.auth.RoleAuthorizationAuthorityMapper;
-import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NoContentException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
@@ -280,23 +281,32 @@ class UserAdminControllerIT {
                 .content(objectMapper.writeValueAsString(agencies)))
         .andExpect(status().isOk());
 
-    verify(consultantAdminFacade, times(agencies.size()))
-        .createNewConsultantAgency(eq(consultantId), any());
+    verify(consultantAdminFacade).checkPermissionsToAssignedAgencies(agencies);
+    verify(consultantAdminFacade).filterAgencyListForCreation(eq(consultantId), anyList());
+    verify(consultantAdminFacade).prepareConsultantAgencyRelation(eq(consultantId), anyList());
+    verify(consultantAdminFacade).completeConsultantAgencyAssigment(eq(consultantId), anyList());
   }
 
   @Test
-  void setConsultantAgencies_Should_ReturnOkIfAgencyAssignmentFails() throws Exception {
+  void setConsultantAgencies_Should_ReturnBadRequestWithMessage_WhenValidationFails()
+      throws Exception {
     var consultantId = UUID.randomUUID().toString();
     var agencies = givenAgenciesToSet();
-    doThrow(new ForbiddenException(""))
+    var validationMessage =
+        "Consultant topic ids [10] are not covered by selected/assigned agencies [272]";
+    doThrow(new BadRequestException(validationMessage))
         .when(consultantAdminFacade)
-        .createNewConsultantAgency(eq(consultantId), any());
+        .prepareConsultantAgencyRelation(eq(consultantId), anyList());
 
     mvc.perform(
             put("/useradmin/consultants/{consultantId}/agencies", consultantId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(agencies)))
-        .andExpect(status().isOk());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(validationMessage));
+
+    verify(consultantAdminFacade, never())
+        .completeConsultantAgencyAssigment(anyString(), anyList());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -37,9 +37,12 @@ class ApiResponseEntityExceptionHandlerTest {
 
   @Test
   void handleCustomBadRequest_badRequestException_returnsBadRequest() {
-    // Business reason: clients must receive 400 for semantic request errors.
+    // Business reason: clients must receive the semantic validation reason, not a silent failure.
     var response = handler.handleCustomBadRequest(new BadRequestException("bad"), request);
+
     assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("bad", body.get("message"));
   }
 
   @Test


### PR DESCRIPTION
## Problem

`UserAdminController.setConsultantAgencies` swallowed every assignment exception and still returned HTTP 200. That made the Admin UI report successful consultant-agency assignment even when `ConsultantTopicAgencyCompatibilityValidator` rejected the request.

Fixes #341.

## Solution

- Remove the broad catch/`System.out.println` path from `setConsultantAgencies`.
- Check permissions, copy the request list, filter already persisted agency relations, then run the existing prepare/complete assignment flow.
- Let `BadRequestException` propagate as HTTP 400.
- Return the `BadRequestException` message as `{"message":"..."}` so the Admin UI can display the backend validation reason.

## Notes

This keeps already assigned agencies idempotent by filtering them before creation. It intentionally does not restore the full OpenAPI replace/delete semantics because the previous delete path is documented in the controller as causing a 403 during Matrix migration.

The existing validator tests already document the bootstrap decision that offline agencies count for topic coverage, so newly created offline agencies can receive their first consultant.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q spotless:check`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q -Dspotless.check.skip=true -Dtest=UserAdminControllerIT,ApiResponseEntityExceptionHandlerTest,ConsultantAdminFacadeTest,ConsultantTopicAgencyCompatibilityValidatorTest test`
- `git diff --check`

## Review

Do not merge automatically. Frank reviews this PR before merge/deploy.