### PR TITLE
fix(userservice): propagate agency-assignment errors instead of swallowing them

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
@@ -203,24 +203,9 @@ public class UserAdminController implements UseradminApi {
   @Override
   public ResponseEntity<Void> setConsultantAgencies(
       String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
-    // MATRIX MIGRATION: Use simple creation for each agency instead of complex update logic
-    // This avoids the 403 error from filterAgencyListForDeletion
-    try {
-      for (CreateConsultantAgencyDTO agencyDTO : agencyList) {
-        try {
-          this.consultantAdminFacade.createNewConsultantAgency(consultantId, agencyDTO);
-        } catch (Exception e) {
-          // If agency already exists, continue
-          System.out.println("Agency assignment (might already exist): " + e.getMessage());
-        }
-      }
-      return ResponseEntity.ok().build();
-    } catch (Exception e) {
-      // Return 200 anyway to not block consultant creation
-      System.out.println(
-          "ERROR: Agency assignment failed for consultant " + consultantId + ": " + e.getMessage());
-      return ResponseEntity.ok().build();
-    }
+    this.consultantAdminFacade.checkPermissionsToAssignedAgencies(agencyList);
+    this.consultantAdminFacade.setConsultantAgencies(consultantId, agencyList);
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -94,7 +94,8 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       final BadRequestException ex, final WebRequest request) {
     log.warn(BAD_REQUEST, ex);
 
-    return handleExceptionInternal(ex, null, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    return handleExceptionInternal(
+        ex, messageBody(ex.getMessage()), new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   /**
@@ -230,6 +231,10 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
 
   private Map<String, String> reasonBody(String reason) {
     return Map.of("reason", reason);
+  }
+
+  private Map<String, String> messageBody(String message) {
+    return Map.of("message", Optional.ofNullable(message).orElse(HttpStatus.BAD_REQUEST.name()));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -170,6 +170,38 @@ public class ConsultantAdminFacade {
   }
 
   /**
+   * Sets the complete set of agency relations for a consultant: relations no longer present in the
+   * passed list are marked for deletion, missing relations are created, already-existing relations
+   * are left untouched (idempotency). Validation failures (e.g. topic/agency mismatch) are
+   * propagated to the caller instead of being swallowed, so the admin UI can surface them.
+   *
+   * @param consultantId the consultant to update
+   * @param agencyList the desired complete set of agency relations
+   */
+  public void setConsultantAgencies(
+      String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
+    var persistedAgencyIds =
+        consultantAgencyAdminService.findConsultantAgencies(consultantId).getEmbedded().stream()
+            .map(agencyAdminResponse -> agencyAdminResponse.getEmbedded().getId())
+            .collect(Collectors.toSet());
+    var desiredAgencyIds =
+        agencyList.stream().map(CreateConsultantAgencyDTO::getAgencyId).collect(Collectors.toSet());
+
+    var agencyIdsToDelete =
+        persistedAgencyIds.stream()
+            .filter(persistedAgencyId -> !desiredAgencyIds.contains(persistedAgencyId))
+            .collect(Collectors.toList());
+    if (!agencyIdsToDelete.isEmpty()) {
+      consultantAgencyAdminService.markConsultantAgenciesForDeletion(
+          consultantId, agencyIdsToDelete);
+    }
+
+    agencyList.stream()
+        .filter(agency -> !persistedAgencyIds.contains(agency.getAgencyId()))
+        .forEach(agency -> createNewConsultantAgency(consultantId, agency));
+  }
+
+  /**
    * Changes the consultant flag is_team_consultant and assignments for agency type changes.
    *
    * @param agencyId the id of the changed agency

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
@@ -82,6 +82,9 @@ public class ConsultantTopicAgencyCompatibilityValidator {
     assertAllSelectedAgenciesResolved(selectedAgencyIds, agencies);
     assertAgenciesBelongToTenant(agencies, tenantId);
 
+    // Offline agencies count towards topic coverage on purpose: a freshly created agency is
+    // offline until it has an assigned consultant, so filtering them out here would make it
+    // impossible to ever assign the first consultant to a new agency (bootstrap deadlock).
     var coveredTopicIds =
         agencies.stream()
             .map(AgencyDTO::getTopicIds)

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ import de.caritas.cob.userservice.api.admin.report.service.ViolationReportGenera
 import de.caritas.cob.userservice.api.admin.service.consultant.create.GrantConsultantIdentityService;
 import de.caritas.cob.userservice.api.admin.service.session.SessionAdminService;
 import de.caritas.cob.userservice.api.config.auth.RoleAuthorizationAuthorityMapper;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NoContentException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -280,23 +282,42 @@ class UserAdminControllerIT {
                 .content(objectMapper.writeValueAsString(agencies)))
         .andExpect(status().isOk());
 
-    verify(consultantAdminFacade, times(agencies.size()))
-        .createNewConsultantAgency(eq(consultantId), any());
+    verify(consultantAdminFacade).checkPermissionsToAssignedAgencies(anyList());
+    verify(consultantAdminFacade).setConsultantAgencies(eq(consultantId), anyList());
   }
 
   @Test
-  void setConsultantAgencies_Should_ReturnOkIfAgencyAssignmentFails() throws Exception {
+  void setConsultantAgencies_Should_PropagateBadRequest_When_AssignmentIsInvalid()
+      throws Exception {
     var consultantId = UUID.randomUUID().toString();
     var agencies = givenAgenciesToSet();
-    doThrow(new ForbiddenException(""))
+    doThrow(new BadRequestException("Consultant topic ids [10] are not covered by any agency"))
         .when(consultantAdminFacade)
-        .createNewConsultantAgency(eq(consultantId), any());
+        .setConsultantAgencies(eq(consultantId), anyList());
 
     mvc.perform(
             put("/useradmin/consultants/{consultantId}/agencies", consultantId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(agencies)))
-        .andExpect(status().isOk());
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void setConsultantAgencies_Should_PropagateForbidden_When_PermissionCheckFails()
+      throws Exception {
+    var consultantId = UUID.randomUUID().toString();
+    var agencies = givenAgenciesToSet();
+    doThrow(new ForbiddenException(""))
+        .when(consultantAdminFacade)
+        .checkPermissionsToAssignedAgencies(anyList());
+
+    mvc.perform(
+            put("/useradmin/consultants/{consultantId}/agencies", consultantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(agencies)))
+        .andExpect(status().isForbidden());
+
+    verify(consultantAdminFacade, never()).setConsultantAgencies(any(), anyList());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -37,9 +37,12 @@ class ApiResponseEntityExceptionHandlerTest {
 
   @Test
   void handleCustomBadRequest_badRequestException_returnsBadRequest() {
-    // Business reason: clients must receive 400 for semantic request errors.
+    // Business reason: clients must receive the semantic validation reason, not a silent failure.
     var response = handler.handleCustomBadRequest(new BadRequestException("bad"), request);
+
     assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("bad", body.get("message"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -8,7 +8,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -373,6 +375,62 @@ class ConsultantAdminFacadeTest {
   }
 
   @Test
+  void setConsultantAgencies_Should_createMissingAndDeleteRemovedAndSkipExisting() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(
+        Lists.newArrayList(agencyAdminFullResponse(1L), agencyAdminFullResponse(2L)));
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    // desired set: keep 1, drop 2, add 3
+    List<CreateConsultantAgencyDTO> desired =
+        Lists.newArrayList(
+            new CreateConsultantAgencyDTO().agencyId(1L),
+            new CreateConsultantAgencyDTO().agencyId(3L));
+
+    consultantAdminFacade.setConsultantAgencies("consultantId", desired);
+
+    verify(consultantAgencyAdminService)
+        .markConsultantAgenciesForDeletion("consultantId", Lists.newArrayList(2L));
+    verify(relationCreatorService)
+        .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(3L));
+    verify(relationCreatorService, never())
+        .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(1L));
+  }
+
+  @Test
+  void setConsultantAgencies_Should_notDelete_When_NothingRemoved() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(Lists.newArrayList(agencyAdminFullResponse(1L)));
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+
+    consultantAdminFacade.setConsultantAgencies(
+        "consultantId",
+        Lists.newArrayList(
+            new CreateConsultantAgencyDTO().agencyId(1L),
+            new CreateConsultantAgencyDTO().agencyId(2L)));
+
+    verify(consultantAgencyAdminService, never())
+        .markConsultantAgenciesForDeletion(any(), anyList());
+    verify(relationCreatorService)
+        .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(2L));
+  }
+
+  @Test
+  void setConsultantAgencies_Should_propagateValidationError() {
+    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
+    persisted.setEmbedded(Lists.newArrayList());
+    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    doThrow(new BadRequestException("topic not covered"))
+        .when(relationCreatorService)
+        .createNewConsultantAgency(eq("consultantId"), any());
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAdminFacade.setConsultantAgencies(
+                "consultantId", Lists.newArrayList(new CreateConsultantAgencyDTO().agencyId(9L))));
+  }
+
+  @Test
   void findFilteredConsultants_Should_useDefaultSort_When_SortIsNull() {
     var searchResult = new ConsultantSearchResultDTO();
     when(consultantAdminFilterService.findFilteredConsultants(any(), any(), any(), any()))
@@ -451,5 +509,10 @@ class ConsultantAdminFacadeTest {
 
   private Sort argThatSortHasField(FieldEnum expectedField) {
     return org.mockito.ArgumentMatchers.argThat(sort -> sort.getField() == expectedField);
+  }
+
+  private CreateConsultantAgencyDTO argThatAgencyId(Long expectedAgencyId) {
+    return org.mockito.ArgumentMatchers.argThat(
+        dto -> dto != null && expectedAgencyId.equals(dto.getAgencyId()));
   }
 }


### PR DESCRIPTION
## Problem

`UserAdminController.setConsultantAgencies` looped over the agency list, caught **every** exception with `System.out.println`, and always returned `200`. Validation failures from `ConsultantTopicAgencyCompatibilityValidator` (e.g. `Consultant topic ids [10] are not covered by selected/assigned agencies [272]`) were therefore silently swallowed — the admin UI believed the assignment succeeded while **nothing was persisted**. This blocked consultant→agency assignment during a Caritas demo on PreDev on 2026-07-08.

## Changes

- **Move orchestration into `ConsultantAdminFacade.setConsultantAgencies`** with proper PUT semantics matching the OpenAPI contract ("existing relations are deleted, passed relations added"):
  - relations no longer present in the request are marked for deletion,
  - missing relations are created,
  - already-assigned agencies are skipped (idempotent — this was the real reason the old code needed its "might already exist" catch).
- **Propagate `BadRequestException` / `ForbiddenException`** so the endpoint returns `400` / `403` with the validator message instead of a fake `200`.
- Run the restricted-agency permission check (`checkPermissionsToAssignedAgencies`) **before** mutating.
- **Offline-agency note:** documented in `ConsultantTopicAgencyCompatibilityValidator` why offline agencies still count towards topic coverage — a newly created agency is offline until it has an assigned consultant, so filtering them out would make it impossible to ever assign the first consultant (bootstrap deadlock). The `isActive` filter that caused this was already removed on `dev`; this only adds the explanatory comment.

## Tests

- `UserAdminControllerIT`: replaced the old "returns OK if assignment fails" test with cases asserting `400` on validation failure and `403` on permission failure (and that the mutation is skipped when the permission check fails).
- `ConsultantAdminFacadeTest`: new unit tests for create/delete/skip semantics and error propagation.
- `./mvnw test -Dtest=ConsultantAdminFacadeTest,UserAdminControllerIT` → green (33 + 37).

## Follow-ups (separate PRs)

- Admin UI: surface these `400`s and validate topic↔agency coverage client-side.
- A missing `AGENCY_ADMIN_SERVICE_API_URL` env var on the PreDev deployment made `GET .../agencies` return `500` (self-call) — patched on the cluster; the Helm chart already sets it, so this is deployment drift, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)