### PR TITLE
fix(userservice): stop logging plaintext passwords

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -1202,6 +1202,7 @@ components:
           maxLength: 255
         password:
           type: string
+          format: password
           example: "SecurePass123!"
           description: "Password for the consultant"
           minLength: 8

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -3023,10 +3023,12 @@ components:
       properties:
         secret:
           type: string
+          format: password
           minLength: 32
           maxLength: 32
         otp:
           type: string
+          format: password
           minLength: 6
           maxLength: 6
 
@@ -3046,6 +3048,7 @@ components:
           default: false
         secret:
           type: string
+          format: password
         qrCode:
           type: string
         type:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2766,9 +2766,11 @@ components:
       properties:
         oldPassword:
           type: string
+          format: password
           example: oldpass@w0rd
         newPassword:
           type: string
+          format: password
           example: newpass@w0rd
 
     ChatDTO:
@@ -2993,6 +2995,7 @@ components:
       properties:
         password:
           type: string
+          format: password
           example: p@ssw0rd
 
     RocketChatGroupIdDTO:

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,6 +4,9 @@ logging.level.root=INFO
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+# Keep RestTemplate at INFO: its DEBUG body logging prints outbound request
+# payloads (e.g. Matrix service-account passwords) in clear text.
+logging.level.org.springframework.web.client.RestTemplate=INFO
 
 # ---------------- Keycloak ----------------
 keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL:}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,6 +4,9 @@ logging.level.root=INFO
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+# Keep RestTemplate at INFO: its DEBUG body logging prints outbound request
+# payloads (e.g. Matrix service-account passwords) in clear text.
+logging.level.org.springframework.web.client.RestTemplate=INFO
 
 # ---------------- Keycloak ----------------
 keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL:}

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -4,6 +4,9 @@ logging.level.root=INFO
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+# Keep RestTemplate at INFO: its DEBUG body logging prints outbound request
+# payloads (e.g. Matrix service-account passwords) in clear text.
+logging.level.org.springframework.web.client.RestTemplate=INFO
 
 # ---------------- Keycloak ----------------
 keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL:}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -4,6 +4,9 @@ logging.level.root=INFO
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+# Keep RestTemplate at INFO: its DEBUG body logging prints outbound request
+# payloads (e.g. Matrix service-account passwords) in clear text.
+logging.level.org.springframework.web.client.RestTemplate=INFO
 
 # ---------------- Keycloak ----------------
 keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL:http://localhost:8080/auth}


### PR DESCRIPTION
## Problem

DEBUG-level request logging (`org.springframework.web`) printed clear-text passwords in pod logs. Verified on PreDev on 2026-07-08, e.g.:

```
Read ... CreateConsultantDTO { username: bera_08jul2026, password: Bera_08jul2026, ... }
Writing [{password=..., type=m.login.password, user=agency-266-service}]
```

Two independent sources:

1. **DTO `toString()`** — `RequestResponseBodyMethodProcessor` logs the parsed request body via `toString()`. `CreateAdminDTO` already masked its password (it declares `format: password`, so the OpenAPI generator emits `"*"`), but `CreateConsultantDTO`, `PasswordDTO` (`oldPassword`/`newPassword`) and `DeleteUserAccountDTO` did not.
2. **RestTemplate body logging** — outbound request bodies are logged at DEBUG, including Matrix service-account passwords. These are raw `Map`s, not DTOs, so field masking cannot help.

## Changes

- Add `format: password` to the unmasked password fields in `api/useradminservice.yaml` (`CreateConsultantDTO`) and `api/userservice.yaml` (`PasswordDTO.oldPassword`, `PasswordDTO.newPassword`, `DeleteUserAccountDTO.password`). The generator then renders them as `*` in `toString()` — verified against the generated sources.
- Pin `org.springframework.web.client.RestTemplate` to `INFO` in every profile that raises `org.springframework.web` to `DEBUG` (`dev`, `prod`, `staging`, `testing`), so outbound request bodies are no longer dumped.

## Not a functional change

`format: password` is a documentation/annotation hint only — the request/response wire format is unchanged. No handler or client code is touched.

## Reviewer action

Dev passwords already captured in existing pod logs should be **rotated** — leaving that to @Storypapst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)