### PR TITLE
Expose BadRequest messages in PR 343

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -94,7 +94,8 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       final BadRequestException ex, final WebRequest request) {
     log.warn(BAD_REQUEST, ex);
 
-    return handleExceptionInternal(ex, null, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    return handleExceptionInternal(
+        ex, messageBody(ex.getMessage()), new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   /**
@@ -230,6 +231,10 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
 
   private Map<String, String> reasonBody(String reason) {
     return Map.of("reason", reason);
+  }
+
+  private Map<String, String> messageBody(String message) {
+    return Map.of("message", Optional.ofNullable(message).orElse(HttpStatus.BAD_REQUEST.name()));
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -37,9 +37,12 @@ class ApiResponseEntityExceptionHandlerTest {
 
   @Test
   void handleCustomBadRequest_badRequestException_returnsBadRequest() {
-    // Business reason: clients must receive 400 for semantic request errors.
+    // Business reason: clients must receive the semantic validation reason, not a silent failure.
     var response = handler.handleCustomBadRequest(new BadRequestException("bad"), request);
+
     assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("bad", body.get("message"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up for #343.

PR #343 is the better main fix for consultant agency assignment because it keeps the set semantics in `ConsultantAdminFacade`. This small follow-up keeps the missing response contract from #342: semantic `BadRequestException` failures now return a stable `{ "message": "..." }` body so Admin can surface the backend validation text.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q -Dspotless.check.skip=true -Dtest=ApiResponseEntityExceptionHandlerTest,UserAdminControllerIT,ConsultantAdminFacadeTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -q spotless:check`
- `git diff --check`