### PR TITLE
Extract Keycloak auth/session ops into KeycloakAuthClient.

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
@@ -1,0 +1,175 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static java.util.Objects.nonNull;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import jakarta.ws.rs.BadRequestException;
+import java.util.Collections;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Keycloak OpenID Connect / session operations extracted from {@link KeycloakService} (issue #91
+ * Keycloak refactor, PR1 auth slice). Keeps login/logout/OTP-verify/session close behind a focused
+ * collaborator so {@link KeycloakService} can stay the {@code IdentityClient} facade.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KeycloakAuthClient {
+
+  private static final String KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+  private static final String KEYCLOAK_GRANT_TYPE_PASSWORD = "password";
+  private static final String BODY_KEY_CLIENT_ID = "client_id";
+  private static final String BODY_KEY_GRANT_TYPE = "grant_type";
+  private static final String BODY_KEY_PASSWORD = "password";
+  private static final String BODY_KEY_USERNAME = "username";
+  private static final String ENDPOINT_OPENID_CONNECT_LOGIN = "/token";
+  private static final String ENDPOINT_OPENID_CONNECT_LOGOUT = "/logout";
+
+  private final @NonNull RestTemplate restTemplate;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull KeycloakClient keycloakClient;
+
+  private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
+
+  @Value("${keycloak.config.app-client-id}")
+  private String keycloakClientId;
+
+  /**
+   * Performs a Keycloak login and returns the Keycloak {@link KeycloakLoginResponseDTO} on success.
+   *
+   * @param userName the username
+   * @param password the password
+   * @return {@link KeycloakLoginResponseDTO}
+   */
+  public KeycloakLoginResponseDTO loginUser(final String userName, final String password) {
+    // Keycloak stores decoded usernames; callers often pass the encoded form from MariaDB.
+    var entity = loginRequest(usernameTranscoder.decodeUsername(userName), password);
+    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
+
+    try {
+      return restTemplate.postForEntity(url, entity, KeycloakLoginResponseDTO.class).getBody();
+
+    } catch (RestClientResponseException exception) {
+      throw new BadRequestException(
+          String.format(
+              "Could not log in user %s into Keycloak: %s", userName, exception.getMessage()),
+          exception);
+    }
+  }
+
+  public boolean verifyIgnoringOtp(String username, String password) {
+    var entity = loginRequest(username, password);
+    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
+
+    ResponseEntity<KeycloakLoginResponseDTO> loginResponse;
+    try {
+      loginResponse = restTemplate.postForEntity(url, entity, KeycloakLoginResponseDTO.class);
+    } catch (HttpClientErrorException exception) {
+      return exception.getStatusCode().equals(HttpStatus.BAD_REQUEST)
+          && exception.getResponseBodyAsString().contains("Missing totp"); // but password correct
+    }
+
+    var responsePayload = loginResponse.getBody();
+    if (nonNull(responsePayload) && nonNull(responsePayload.getRefreshToken())) {
+      logoutUser(responsePayload.getRefreshToken());
+    }
+
+    return true;
+  }
+
+  /**
+   * Performs a Keycloak logout. This only destroys the Keycloak session, the (offline) access token
+   * will still be valid until expiration date/time ends.
+   *
+   * @param refreshToken the refreshToken
+   * @return true if logout was successful
+   */
+  public boolean logoutUser(final String refreshToken) {
+    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
+    map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
+    map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN);
+    map.add(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, refreshToken);
+
+    var httpHeaders = new HttpHeaders();
+    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    httpHeaders.add("Authorization", "Bearer " + authenticatedUser.getAccessToken());
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, httpHeaders);
+
+    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGOUT);
+    try {
+      var response = restTemplate.postForEntity(url, request, Void.class);
+      return wasLogoutSuccessful(response);
+    } catch (Exception ex) {
+      log.error("Keycloak error: Could not log out user", ex);
+
+      return false;
+    }
+  }
+
+  /**
+   * Closes the provided session.
+   *
+   * @param sessionId Keycloak session ID
+   */
+  public void closeSession(String sessionId) {
+    keycloakClient.getRealmResource().deleteSession(sessionId, false);
+  }
+
+  private HttpEntity<MultiValueMap<String, String>> loginRequest(String userName, String password) {
+    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
+    map.add(BODY_KEY_USERNAME, userName);
+    map.add(BODY_KEY_PASSWORD, password);
+    map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
+    map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_PASSWORD);
+
+    var httpHeaders = new HttpHeaders();
+    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    return new HttpEntity<>(map, httpHeaders);
+  }
+
+  private boolean wasLogoutSuccessful(ResponseEntity<Void> responseEntity) {
+    if (!responseEntity.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
+      log.error("Keycloak error: Could not log out user");
+
+      return false;
+    }
+    return true;
+  }
+
+  static final class SensitiveKeycloakFormData extends LinkedMultiValueMap<String, String> {
+
+    private static final String REDACTED = "[REDACTED]";
+
+    @Override
+    public String toString() {
+      var sanitized = new LinkedMultiValueMap<>(this);
+      if (sanitized.containsKey(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN)) {
+        sanitized.put(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, Collections.singletonList(REDACTED));
+      }
+      if (sanitized.containsKey(BODY_KEY_PASSWORD)) {
+        sanitized.put(BODY_KEY_PASSWORD, Collections.singletonList(REDACTED));
+      }
+      return sanitized.toString();
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
@@ -156,7 +156,7 @@ public class KeycloakAuthClient {
     return true;
   }
 
-  static final class SensitiveKeycloakFormData extends LinkedMultiValueMap<String, String> {
+  private static final class SensitiveKeycloakFormData extends LinkedMultiValueMap<String, String> {
 
     private static final String REDACTED = "[REDACTED]";
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -48,19 +48,12 @@ import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 
 /** Service for Keycloak REST API calls. */
 @Service
@@ -68,14 +61,6 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class KeycloakService implements IdentityClient {
 
-  private static final String KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
-  private static final String KEYCLOAK_GRANT_TYPE_PASSWORD = "password";
-  private static final String BODY_KEY_CLIENT_ID = "client_id";
-  private static final String BODY_KEY_GRANT_TYPE = "grant_type";
-  private static final String BODY_KEY_PASSWORD = "password";
-  private static final String BODY_KEY_USERNAME = "username";
-  private static final String ENDPOINT_OPENID_CONNECT_LOGIN = "/token";
-  private static final String ENDPOINT_OPENID_CONNECT_LOGOUT = "/logout";
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
   private static final String ENDPOINT_OTP_TEARDOWN = "/delete-otp/{username}";
@@ -87,18 +72,15 @@ public class KeycloakService implements IdentityClient {
   private static final String USERNAME_ATTRIBUTE = "username";
   private static final String LEGACY_USERNAME_ATTRIBUTE = "userName";
 
-  private final @NonNull RestTemplate restTemplate;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAccountInputValidator userAccountInputValidator;
   private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull KeycloakClient keycloakClient;
   private final @NonNull KeycloakMapper keycloakMapper;
   private final @NonNull UserHelper userHelper;
+  private final @NonNull KeycloakAuthClient keycloakAuthClient;
 
   private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
-
-  @Value("${keycloak.config.app-client-id}")
-  private String keycloakClientId;
 
   @Value("${api.error.keycloakError}")
   private String keycloakError;
@@ -154,53 +136,12 @@ public class KeycloakService implements IdentityClient {
    * @return {@link KeycloakLoginResponseDTO}
    */
   public KeycloakLoginResponseDTO loginUser(final String userName, final String password) {
-    // Keycloak stores decoded usernames; callers often pass the encoded form from MariaDB.
-    var entity = loginRequest(usernameTranscoder.decodeUsername(userName), password);
-    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
-
-    try {
-      return restTemplate.postForEntity(url, entity, KeycloakLoginResponseDTO.class).getBody();
-
-    } catch (RestClientResponseException exception) {
-      throw new BadRequestException(
-          String.format(
-              "Could not log in user %s into Keycloak: %s", userName, exception.getMessage()),
-          exception);
-    }
-  }
-
-  private HttpEntity<MultiValueMap<String, String>> loginRequest(String userName, String password) {
-    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
-    map.add(BODY_KEY_USERNAME, userName);
-    map.add(BODY_KEY_PASSWORD, password);
-    map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
-    map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_PASSWORD);
-
-    var httpHeaders = new HttpHeaders();
-    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-    return new HttpEntity<>(map, httpHeaders);
+    return keycloakAuthClient.loginUser(userName, password);
   }
 
   @Override
   public boolean verifyIgnoringOtp(String username, String password) {
-    var entity = loginRequest(username, password);
-    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
-
-    ResponseEntity<KeycloakLoginResponseDTO> loginResponse;
-    try {
-      loginResponse = restTemplate.postForEntity(url, entity, KeycloakLoginResponseDTO.class);
-    } catch (HttpClientErrorException exception) {
-      return exception.getStatusCode().equals(HttpStatus.BAD_REQUEST)
-          && exception.getResponseBodyAsString().contains("Missing totp"); // but password correct
-    }
-
-    var responsePayload = loginResponse.getBody();
-    if (nonNull(responsePayload) && nonNull(responsePayload.getRefreshToken())) {
-      logoutUser(responsePayload.getRefreshToken());
-    }
-
-    return true;
+    return keycloakAuthClient.verifyIgnoringOtp(username, password);
   }
 
   /**
@@ -211,51 +152,7 @@ public class KeycloakService implements IdentityClient {
    * @return true if logout was successful
    */
   public boolean logoutUser(final String refreshToken) {
-    MultiValueMap<String, String> map = new SensitiveKeycloakFormData();
-    map.add(BODY_KEY_CLIENT_ID, keycloakClientId);
-    map.add(BODY_KEY_GRANT_TYPE, KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN);
-    map.add(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, refreshToken);
-
-    var httpHeaders = new HttpHeaders();
-    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-    httpHeaders.add("Authorization", "Bearer " + authenticatedUser.getAccessToken());
-    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, httpHeaders);
-
-    var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGOUT);
-    try {
-      var response = restTemplate.postForEntity(url, request, Void.class);
-      return wasLogoutSuccessful(response);
-    } catch (Exception ex) {
-      log.error("Keycloak error: Could not log out user", ex);
-
-      return false;
-    }
-  }
-
-  private boolean wasLogoutSuccessful(ResponseEntity<Void> responseEntity) {
-    if (!responseEntity.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
-      log.error("Keycloak error: Could not log out user");
-
-      return false;
-    }
-    return true;
-  }
-
-  private static final class SensitiveKeycloakFormData extends LinkedMultiValueMap<String, String> {
-
-    private static final String REDACTED = "[REDACTED]";
-
-    @Override
-    public String toString() {
-      var sanitized = new LinkedMultiValueMap<>(this);
-      if (sanitized.containsKey(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN)) {
-        sanitized.put(KEYCLOAK_GRANT_TYPE_REFRESH_TOKEN, Collections.singletonList(REDACTED));
-      }
-      if (sanitized.containsKey(BODY_KEY_PASSWORD)) {
-        sanitized.put(BODY_KEY_PASSWORD, Collections.singletonList(REDACTED));
-      }
-      return sanitized.toString();
-    }
+    return keycloakAuthClient.logoutUser(refreshToken);
   }
 
   /**
@@ -928,7 +825,7 @@ public class KeycloakService implements IdentityClient {
    * @param sessionId Keycloak session ID
    */
   public void closeSession(String sessionId) {
-    keycloakClient.getRealmResource().deleteSession(sessionId, false);
+    keycloakAuthClient.closeSession(sessionId);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
@@ -1,0 +1,184 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import ch.qos.logback.classic.Level;
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.testutils.LogbackCaptor;
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KeycloakAuthClientTest {
+
+  private static final String USERNAME = "testuser";
+  private static final String PASSWORD = "oldP@66w0rd!";
+  private static final String REFRESH_TOKEN = "s09djf0w9ejf09wsejf09wjef";
+
+  @InjectMocks private KeycloakAuthClient keycloakAuthClient;
+
+  @Mock private RestTemplate restTemplate;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private KeycloakClient keycloakClient;
+
+  private LogbackCaptor logCaptor;
+
+  @BeforeEach
+  void setUp() {
+    when(identityClientConfig.getOpenIdConnectUrl(anyString()))
+        .thenReturn("https://keycloak/token-or-logout");
+    setField(keycloakAuthClient, "keycloakClientId", "app");
+    logCaptor = LogbackCaptor.forClass(KeycloakAuthClient.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logCaptor.detach();
+  }
+
+  @Test
+  void loginUser_Should_ReturnResponseBody_When_KeycloakLoginSucceeds() {
+    var loginResponse = new KeycloakLoginResponseDTO();
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
+
+    assertThat(keycloakAuthClient.loginUser(USERNAME, PASSWORD), is(loginResponse));
+  }
+
+  @Test
+  void loginUser_Should_ThrowBadRequest_When_KeycloakLoginFails() {
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(new RestClientResponseException("error", 500, "text", null, null, null));
+
+    assertThrows(BadRequestException.class, () -> keycloakAuthClient.loginUser(USERNAME, PASSWORD));
+  }
+
+  @Test
+  void verifyIgnoringOtp_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
+    var exception = mock(HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(exception.getResponseBodyAsString()).thenReturn("Missing totp");
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(exception);
+
+    assertTrue(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD));
+  }
+
+  @Test
+  void verifyIgnoringOtp_Should_ReturnFalse_When_OtherBadRequest() {
+    var exception = mock(HttpClientErrorException.class);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+    when(exception.getResponseBodyAsString()).thenReturn("Invalid credentials");
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(exception);
+
+    assertThat(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD), is(false));
+  }
+
+  @Test
+  void verifyIgnoringOtp_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
+    var loginResponse = mock(KeycloakLoginResponseDTO.class);
+    when(loginResponse.getRefreshToken()).thenReturn(REFRESH_TOKEN);
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+    assertTrue(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD));
+
+    verify(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
+  }
+
+  @Test
+  void verifyIgnoringOtp_Should_ReturnTrueWithoutLogout_When_ResponseBodyIsNull() {
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.OK).body(null));
+
+    assertTrue(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD));
+
+    verify(restTemplate, never()).postForEntity(anyString(), any(), eq(Void.class));
+  }
+
+  @Test
+  void verifyIgnoringOtp_Should_ReturnTrueWithoutLogout_When_RefreshTokenIsNull() {
+    var loginResponse = mock(KeycloakLoginResponseDTO.class);
+    when(loginResponse.getRefreshToken()).thenReturn(null);
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
+
+    assertTrue(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD));
+
+    verify(restTemplate, never()).postForEntity(anyString(), any(), eq(Void.class));
+  }
+
+  @Test
+  void logoutUser_Should_ReturnTrue_When_KeycloakReturnsNoContent() {
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+    assertTrue(keycloakAuthClient.logoutUser(REFRESH_TOKEN));
+  }
+
+  @Test
+  void logoutUser_Should_ReturnFalseAndLogError_When_KeycloakReturnsUnexpectedStatus() {
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
+
+    assertThat(keycloakAuthClient.logoutUser(REFRESH_TOKEN), is(false));
+    assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
+  }
+
+  @Test
+  void logoutUser_Should_ReturnFalseAndLogError_When_KeycloakLogoutThrowsException() {
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
+        .thenThrow(new RestClientException("keycloak unavailable"));
+
+    assertThat(keycloakAuthClient.logoutUser(REFRESH_TOKEN), is(false));
+    assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
+  }
+
+  @Test
+  void closeSession_Should_DeleteSession() {
+    var realmResource = mock(RealmResource.class);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    keycloakAuthClient.closeSession("sessionId");
+
+    verify(realmResource, times(1)).deleteSession(eq("sessionId"), eq(false));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
@@ -53,23 +53,26 @@ class KeycloakServiceLoggingTest {
 
   @BeforeEach
   void setUp() {
+    var keycloakAuthClient =
+        new KeycloakAuthClient(
+            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+    setField(keycloakAuthClient, "keycloakClientId", "app");
     keycloakService =
         new KeycloakService(
-            restTemplate,
             authenticatedUser,
             userAccountInputValidator,
             identityClientConfig,
             keycloakClient,
             keycloakMapper,
-            userHelper);
-    setField(keycloakService, "keycloakClientId", "app");
+            userHelper,
+            keycloakAuthClient);
 
     lenient().when(authenticatedUser.getAccessToken()).thenReturn("access-token");
     lenient()
         .when(identityClientConfig.getOpenIdConnectUrl(anyString()))
         .thenReturn("https://keycloak/logout");
 
-    logger = (Logger) LoggerFactory.getLogger(KeycloakService.class);
+    logger = (Logger) LoggerFactory.getLogger(KeycloakAuthClient.class);
     listAppender = new ListAppender<>();
     listAppender.start();
     logger.addAppender(listAppender);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -98,6 +98,9 @@ public class KeycloakServiceTest {
   @SuppressWarnings("unused")
   private KeycloakMapper keycloakMapper;
 
+  /** Satisfies {@link InjectMocks}; replaced with a real client in {@link #setup()}. */
+  @Mock private KeycloakAuthClient keycloakAuthClient;
+
   @Mock private UsernameTranscoder usernameTranscoder;
   @Mock private UserHelper userHelper;
 
@@ -106,15 +109,21 @@ public class KeycloakServiceTest {
   EasyRandom easyRandom = new EasyRandom();
 
   private LogbackCaptor logCaptor;
+  private LogbackCaptor authLogCaptor;
 
   @BeforeEach
   public void setup() throws NoSuchFieldException, SecurityException {
     givenAKeycloakLoginUrl();
     givenAKeycloakLogoutUrl();
-    setField(keycloakService, "keycloakClientId", "app");
+    var realAuthClient =
+        new KeycloakAuthClient(
+            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+    setField(realAuthClient, "keycloakClientId", "app");
+    setField(keycloakService, "keycloakAuthClient", realAuthClient);
     setField(keycloakService, "usernameTranscoder", usernameTranscoder);
     setField(keycloakService, "multiTenancyEnabled", false);
     logCaptor = LogbackCaptor.forClass(KeycloakService.class);
+    authLogCaptor = LogbackCaptor.forClass(KeycloakAuthClient.class);
     when(usernameTranscoder.decodeUsername(any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
   }
@@ -122,6 +131,7 @@ public class KeycloakServiceTest {
   @AfterEach
   public void tearDown() {
     logCaptor.detach();
+    authLogCaptor.detach();
   }
 
   @Test
@@ -192,7 +202,7 @@ public class KeycloakServiceTest {
     boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
 
     assertFalse(response);
-    assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
+    assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
   }
 
   @Test
@@ -204,7 +214,7 @@ public class KeycloakServiceTest {
     boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
 
     assertFalse(response);
-    assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
+    assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.testConfig;
 
 import com.google.common.collect.Maps;
+import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakAuthClient;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakClient;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakMapper;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
@@ -35,14 +36,18 @@ public class KeycloakTestConfig {
       KeycloakMapper keycloakMapper,
       UserHelper userHelper) {
 
+    var keycloakAuthClient =
+        new KeycloakAuthClient(
+            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+
     return new KeycloakService(
-        restTemplate,
         authenticatedUser,
         userAccountInputValidator,
         identityClientConfig,
         keycloakClient,
         keycloakMapper,
-        userHelper) {
+        userHelper,
+        keycloakAuthClient) {
       @Override
       public boolean changePassword(String userId, String password) {
         return super.changePassword(userId, password);


### PR DESCRIPTION
## Summary
First slice of the Keycloak refactor (#91).

Pulls login, logout, OTP-ignorant password verify, and session close out of `KeycloakService` into a dedicated `KeycloakAuthClient`, so the auth/session surface stays readable and reviewable on its own.

`KeycloakService` remains the `IdentityClient` facade and simply delegates — no API or behavior change.

## Test plan
- [x] `KeycloakServiceTest` + `KeycloakServiceLoggingTest`
- [ ] CI green