### PR TITLE
fix(userservice): don't fail consultant login when no agency is assigned

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProvider.java
@@ -9,7 +9,6 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailToggle;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailType;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
-import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -53,8 +52,13 @@ public class ConsultantDataProvider {
   @Transactional(readOnly = true)
   public UserDataResponseDTO retrieveData(Consultant consultant) {
     if (isEmpty(consultant.getConsultantAgencies())) {
-      throw new InternalServerErrorException(
-          String.format("No agency available for consultant %s", consultant.getId()));
+      // A consultant without an assigned agency must not break login: /users/data is the first
+      // call the app makes after authentication, so throwing here dropped the consultant on an
+      // error page and made the account look "unable to log in". Return the profile with an empty
+      // agency list instead — consistent with agencyDTOsOf() already degrading on agency errors.
+      log.warn(
+          "Consultant {} has no assigned agency; returning user data with an empty agency list.",
+          consultant.getId());
     }
 
     return userDataResponseDtoOf(consultant);

--- a/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/userdata/ConsultantDataProviderTest.java
@@ -15,7 +15,6 @@ import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
-import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -56,15 +55,18 @@ public class ConsultantDataProviderTest {
   @Mock private EmailNotificationMapper emailNotificationMapper;
 
   @Test
-  public void retrieveData_Should_ThrowInternalServerErrorException_When_NoAgenciesFound() {
-    assertThrows(
-        InternalServerErrorException.class,
-        () -> {
-          Consultant consultant = Mockito.mock(Consultant.class);
-          when(consultant.getConsultantAgencies()).thenReturn(new HashSet<>());
+  public void retrieveData_Should_ReturnMinimalProfile_When_NoAgenciesFound() {
+    Consultant consultant = easyRandom.nextObject(Consultant.class);
+    consultant.setConsultantAgencies(new HashSet<>());
+    when(agencyService.getAgencies(any())).thenReturn(List.of());
 
-          underTest.retrieveData(consultant);
-        });
+    var result = underTest.retrieveData(consultant);
+
+    assertNotNull(result);
+    assertEquals(consultant.getId(), result.getUserId());
+    assertTrue(result.getAgencies().isEmpty());
+    assertFalse(result.isHasAnonymousConversations());
+    Mockito.verifyNoInteractions(consultingTypeManager);
   }
 
   @Test


### PR DESCRIPTION
## Problem

Focused on the reported symptom: **a consultant cannot log into the app.** Authentication actually succeeds — the token is issued with the `consultant` role — but the very first call the app makes afterwards, `GET /users/data`, returned **500** and dropped the consultant on `error.404.html`, so the account looked unusable.

Root cause (verified on PreDev, correlationId in server logs):

```
InternalServerErrorException: No agency available for consultant ed6ff102-...
  at ConsultantDataProvider.retrieveData(ConsultantDataProvider.java:57)
```

`retrieveData` threw whenever the consultant had **no assigned agency**. On PreDev this hit every consultant whose agency assignment had silently failed (the swallowed-error bug fixed in #343), turning "no agency yet" into "can't log in at all".

## Change

Return the consultant profile with an **empty agency list** instead of throwing. This is consistent with the rest of the same provider, which already degrades gracefully — `agencyDTOsOf()` catches agency-service errors and returns an empty list rather than blocking login, with the comment *"Do not block login when agency-service cannot provide metadata"*. The lone hard `throw` on empty agencies contradicted that intent.

Downstream fields already handle empty agencies safely (`hasAnonymousConversations` → `false`, `hasArchive` reads the session repo).

## Tests

- `ConsultantDataProviderTest`: the former `..._Should_ThrowInternalServerErrorException_When_NoAgenciesFound` becomes `..._Should_ReturnMinimalProfile_When_NoAgenciesFound`, asserting an empty agency list and a populated profile.
- `./mvnw test -Dtest=ConsultantDataProviderTest` → 11/11 green.

## Context

The durable cure for consultants ending up agency-less is #343 (agency assignment no longer swallows validation errors) + ORISO-Admin #258 (surfaces them), both already merged to `dev`. This PR is the safety net so a consultant temporarily without an agency can still load the app instead of being locked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)