### PR TITLE
fix: tolerate existing supervisor Matrix membership

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -270,22 +270,8 @@ public class SessionSupervisorFacade {
             consultantToken);
 
     // Invite supervisor to the CLIENT room as a read-only observer.
-    try {
-      matrixSynapseService.inviteUserToRoom(matrixRoomId, supervisorMatrixUserId, consultantToken);
-      log.info(
-          "Invited supervisor {} to Matrix room {} for session {}",
-          supervisorConsultant.getUsername(),
-          matrixRoomId,
-          session.getId());
-    } catch (Exception e) {
-      log.error(
-          "Failed to invite supervisor {} to Matrix room {}: {}",
-          supervisorConsultant.getUsername(),
-          matrixRoomId,
-          e.getMessage());
-      throw new InternalServerErrorException(
-          "Failed to invite supervisor to Matrix room: " + e.getMessage());
-    }
+    inviteSupervisorToClientRoom(
+        matrixRoomId, supervisorMatrixUserId, consultantToken, supervisorConsultant, session);
 
     // Set supervisor power level to 10 (read-only observer)
     boolean powerLevelSet =
@@ -562,6 +548,46 @@ public class SessionSupervisorFacade {
       throw new InternalServerErrorException("Failed to create user Matrix token");
     }
     matrixSynapseService.joinRoom(roomId, userToken);
+  }
+
+  private void inviteSupervisorToClientRoom(
+      String matrixRoomId,
+      String supervisorMatrixUserId,
+      String consultantToken,
+      Consultant supervisorConsultant,
+      Session session) {
+    try {
+      matrixSynapseService.inviteUserToRoom(matrixRoomId, supervisorMatrixUserId, consultantToken);
+      log.info(
+          "Invited supervisor {} to Matrix room {} for session {}",
+          supervisorConsultant.getUsername(),
+          matrixRoomId,
+          session.getId());
+    } catch (MatrixInviteUserException e) {
+      if (e.getMessage() != null && e.getMessage().contains("already in the room")) {
+        log.info(
+            "Supervisor {} already in Matrix room {} for session {}, continuing",
+            supervisorConsultant.getUsername(),
+            matrixRoomId,
+            session.getId());
+        return;
+      }
+      log.error(
+          "Failed to invite supervisor {} to Matrix room {}: {}",
+          supervisorConsultant.getUsername(),
+          matrixRoomId,
+          e.getMessage());
+      throw new InternalServerErrorException(
+          "Failed to invite supervisor to Matrix room: " + e.getMessage());
+    } catch (Exception e) {
+      log.error(
+          "Failed to invite supervisor {} to Matrix room {}: {}",
+          supervisorConsultant.getUsername(),
+          matrixRoomId,
+          e.getMessage());
+      throw new InternalServerErrorException(
+          "Failed to invite supervisor to Matrix room: " + e.getMessage());
+    }
   }
 
   /** Remove a user from a room if a room id is present; log but never fail the removal flow. */

--- a/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacadeTest.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
@@ -139,6 +140,22 @@ class SessionSupervisorFacadeTest {
     verify(matrixSynapseService, org.mockito.Mockito.atLeast(2))
         .inviteUserToRoom(rooms.capture(), eq(SUPERVISOR_MXID), any());
     assertThat(rooms.getAllValues()).contains(CLIENT_ROOM, SIDE_ROOM);
+  }
+
+  @Test
+  void addSupervisor_Should_continue_when_supervisorAlreadyInClientRoom() throws Exception {
+    when(matrixSynapseService.inviteUserToRoom(eq(CLIENT_ROOM), eq(SUPERVISOR_MXID), any()))
+        .thenThrow(
+            new MatrixInviteUserException(
+                "Could not invite user (@sup:oriso) to room (!clientroom:oriso) in Matrix: "
+                    + "{\"errcode\":\"M_FORBIDDEN\",\"error\":\"@sup:oriso is already in the room.\"}"));
+
+    SessionSupervisor saved =
+        facade.addSupervisor(SESSION_ID, SUPERVISOR_ID, addedBy, null, "reason");
+
+    assertThat(saved.getMatrixRoomId()).isEqualTo(SIDE_ROOM);
+    verify(matrixSynapseService).setUserPowerLevel(CLIENT_ROOM, SUPERVISOR_MXID, 10, "tok");
+    verify(sessionSupervisorRepository).save(any(SessionSupervisor.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- treat Matrix `already in the room` invite responses as idempotent when adding a supervisor to the client room
- keep the existing side-room idempotency behavior and continue with read-only power-level setup
- add a regression test for supervisor add when the supervisor is already a client-room member

## Validation
- `./mvnw -q -DskipTests -DskipITs -Dspotless.check.skip=true compile`
- `docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipTests -DskipITs spotless:check`
- `docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipITs -Dspotless.check.skip=true -Dtest=SessionSupervisorFacadeTest test`
- PreDev hot image `docker.io/storypapst/oriso-e2e:userservice-e2e-20260708-0200-v8` real App/API proof: add supervisor `201`, list active side-room row, delete `204`, final list empty. Evidence in `_e2e-artifacts/e2e-20260708-0200/supervision-proof.json`.