### PR TITLE
fix: allow service conversation endpoints

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -100,7 +100,9 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/users/askers/new",
                     "/conversations/askers/anonymous/new",
+                    "/service/conversations/askers/anonymous/new",
                     "/conversations/anonymous/availability",
+                    "/service/conversations/anonymous/availability",
                     "/users/consultants/{consultantId:" + UUID_PATTERN + "}",
                     "/users/consultants/languages",
                     "/users/magic-link/request",
@@ -121,6 +123,9 @@ public class SecurityConfig {
                         HttpMethod.POST, ".*/users/magic-link/(request|consume)$"))
                 .permitAll()
                 .requestMatchers(HttpMethod.GET, "/conversations/anonymous/{sessionId:[0-9]+}")
+                .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT)
+                .requestMatchers(
+                    HttpMethod.GET, "/service/conversations/anonymous/{sessionId:[0-9]+}")
                 .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT)
                 .requestMatchers("/users/notifications")
                 .hasAnyAuthority(NOTIFICATIONS_TECHNICAL)
@@ -207,7 +212,9 @@ public class SecurityConfig {
                     "/users/sessions/consultants",
                     "/users/sessions/teams",
                     "/conversations/askers/anonymous/{sessionId:[0-9]+}/accept",
+                    "/service/conversations/askers/anonymous/{sessionId:[0-9]+}/accept",
                     "/conversations/consultants/**",
+                    "/service/conversations/consultants/**",
                     "/users/case-handover/reasons",
                     "/service/users/case-handover/reasons",
                     "/users/case-handover/candidates",


### PR DESCRIPTION
## Summary\n- add gateway-prefixed /service/conversations aliases to UserService security matchers\n- allows live-chat availability, queue, accept, and anonymous details endpoints through the same auth buckets as their controller paths\n\n## Validation\n- ./mvnw -q -DskipTests -DskipITs -Dspotless.check.skip=true compile\n- docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipTests -DskipITs spotless:check\n- PreDev hot image docker.io/storypapst/oriso-e2e:userservice-e2e-20260708-0200-v9\n- live Admin Links proof: invite link created, /service/conversations/consultants/availability returned 204, anonymous queue showed session 103114, accept returned 200\n- supervision proof still passed on v9\n