### PR TITLE
fix: delete sessions within transaction

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/archive/SessionDeleteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/archive/SessionDeleteService.java
@@ -17,6 +17,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +32,7 @@ public class SessionDeleteService {
 
   private final @NonNull MatrixSessionSystemMessageService matrixSessionSystemMessageService;
 
+  @Transactional
   public void deleteSession(Long sessionId) {
     log.info("Deleting session with id {}", sessionId);
 


### PR DESCRIPTION
## Summary
- run session deletion inside a transaction so the user sessions collection can be evaluated during cascade cleanup
- fixes live delete-session 500 caused by LazyInitializationException in SessionDeleteService

## Verification
- docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipITs -Dspotless.check.skip=true -Dtest=SessionDeleteServiceTest test
- docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipTests -DskipITs spotless:check
- PreDev hot image userservice-e2e-20260708-0200-v10: DELETE /service/users/sessions/103115 returned 200 and DB session count became 0

Artifact: /Users/frankgerhardt/ORISO/_e2e-artifacts/e2e-20260708-0200/deletion-cascade-proof.json