### PR TITLE
fix: restrict direct topic session access

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -742,6 +742,7 @@ public class SessionService {
    */
   private boolean isAllowedToAdviseByTopic(Consultant consultant, Session session) {
     return isTeamSessionOrNew(session)
+        && isAnonymousStyleRegistration(session)
         && nonNull(session.getMainTopicId())
         && consultantTopicRepository
             .findTopicIdsByConsultantId(consultant.getId())

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -831,6 +831,31 @@ class SessionServiceTest {
   }
 
   @Test
+  void getSessionsByIds_should_not_find_registered_other_agency_session_by_topic_only() {
+    Session registeredSession = easyRandom.nextObject(Session.class);
+    registeredSession.setId(SESSION_ID);
+    registeredSession.setAgencyId(275L);
+    registeredSession.setConsultant(null);
+    registeredSession.setMainTopicId(42L);
+    registeredSession.setPostcode(POSTCODE);
+    registeredSession.setRegistrationType(REGISTERED);
+    registeredSession.setStatus(SessionStatus.NEW);
+
+    ConsultantAgency agency = new ConsultantAgency();
+    agency.setAgencyId(4711L);
+    var consultant = createConsultantWithAgencies(agency);
+
+    when(sessionRepository.findAllById(singleton(SESSION_ID)))
+        .thenReturn(singletonList(registeredSession));
+
+    var sessionResponse =
+        sessionService.getSessionsByIds(
+            consultant, singleton(SESSION_ID), singleton(UserRole.CONSULTANT.getValue()));
+
+    assertThat(sessionResponse).isEmpty();
+  }
+
+  @Test
   void getSessionsByUserAndGroupIds_should_find_session_for_anonymous_user_of_session() {
     Session anonymousEnquiry =
         createAnonymousNewEnquiryWithConsultingType(AGENCY_DTO_SUCHT.getConsultingType());


### PR DESCRIPTION
## Summary
- require anonymous-style invite/live-chat markers before topic-only consultant access can bypass agency membership
- keep normal registered sessions protected by agency assignment on direct room lookup
- add regression coverage for direct session-id lookup with matching topic but wrong agency

## Verification
- docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipITs -Dspotless.check.skip=true -Dtest=SessionServiceTest#getSessionsByIds_should_not_find_registered_other_agency_session_by_topic_only test
- docker run --rm -v /Users/frankgerhardt/ORISO/ORISO-UserService:/workspace -v /Users/frankgerhardt/.m2:/root/.m2 -w /workspace eclipse-temurin:21 ./mvnw -q -DskipTests -DskipITs spotless:check
- PreDev hot image userservice-e2e-20260708-0200-v11: agency-241 consultant direct lookup of agency-275 session 103108 returned 204; handover status 403; candidate search empty

Artifact: /Users/frankgerhardt/ORISO/_e2e-artifacts/e2e-20260708-0200/negative-agency-isolation-proof.json