### PR TITLE
fix: prevent double URL-encoding of Matrix room IDs in Synapse calls

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixMediaClient.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -77,7 +76,7 @@ public class MatrixMediaClient {
   }
 
   public byte[] downloadFile(String serverName, String mediaId, String accessToken) {
-    String url =
+    var url =
         MatrixUrlBuilder.buildUrl(
             matrixConfig,
             ENDPOINT_MEDIA_DOWNLOAD,
@@ -90,8 +89,7 @@ public class MatrixMediaClient {
 
     ResponseEntity<byte[]> response;
     try {
-      response =
-          restTemplate.exchange(URI.create(url), HttpMethod.GET, requestEntity, byte[].class);
+      response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, byte[].class);
     } catch (RuntimeException e) {
       log.error("❌ Failed to download file from Matrix", e);
       throw new RuntimeException("Failed to download file: " + e.getMessage(), e);
@@ -150,7 +148,7 @@ public class MatrixMediaClient {
       log.info("📨 Sending file message to Matrix room: {} (type: {})", roomId, msgtype);
 
       @SuppressWarnings("rawtypes")
-      var response = restTemplate.exchange(URI.create(url), HttpMethod.PUT, request, Map.class);
+      var response = restTemplate.exchange(url, HttpMethod.PUT, request, Map.class);
 
       log.info("✅ File message sent successfully");
     } catch (Exception ex) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -104,8 +104,7 @@ public class MatrixRoomClient {
       var url = buildUrl(ENDPOINT_INVITE_USER, Map.of("roomId", roomId));
       log.info("Inviting Matrix user: {} to room: {} at URL: {}", userId, roomId, url);
 
-      var response =
-          restTemplate.postForEntity(URI.create(url), request, MatrixInviteUserResponseDTO.class);
+      var response = restTemplate.postForEntity(url, request, MatrixInviteUserResponseDTO.class);
 
       log.info("Successfully invited Matrix user: {} to room: {}", userId, roomId);
 
@@ -142,7 +141,7 @@ public class MatrixRoomClient {
       var url = buildUrl(ENDPOINT_JOIN_ROOM, Map.of("roomId", roomId));
       log.info("Accepting room invitation (joining room): {} at URL: {}", roomId, url);
 
-      var response = restTemplate.postForEntity(URI.create(url), request, Map.class);
+      var response = restTemplate.postForEntity(url, request, Map.class);
 
       if (response.getStatusCode().is2xxSuccessful()) {
         log.info("Successfully joined Matrix room: {}", roomId);
@@ -190,7 +189,7 @@ public class MatrixRoomClient {
       var url = buildUrl(ENDPOINT_LEAVE_ROOM, Map.of("roomId", roomId));
       log.info("Leaving Matrix room: {} at URL: {}", roomId, url);
 
-      var response = restTemplate.postForEntity(URI.create(url), request, Map.class);
+      var response = restTemplate.postForEntity(url, request, Map.class);
 
       if (response.getStatusCode().is2xxSuccessful()) {
         log.info("Successfully left Matrix room: {}", roomId);
@@ -243,7 +242,7 @@ public class MatrixRoomClient {
       var url = buildUrl(ENDPOINT_BAN_ROOM, Map.of("roomId", roomId));
       log.info("Banning Matrix user {} from room {}", userId, roomId);
 
-      var response = restTemplate.postForEntity(URI.create(url), request, Map.class);
+      var response = restTemplate.postForEntity(url, request, Map.class);
       if (response.getStatusCode().is2xxSuccessful()) {
         log.info("Successfully banned Matrix user {} from room {}", userId, roomId);
         return true;
@@ -294,7 +293,7 @@ public class MatrixRoomClient {
       var url = buildUrl(ENDPOINT_UNBAN_ROOM, Map.of("roomId", roomId));
       log.info("Unbanning Matrix user {} from room {}", userId, roomId);
 
-      var response = restTemplate.postForEntity(URI.create(url), request, Map.class);
+      var response = restTemplate.postForEntity(url, request, Map.class);
       if (response.getStatusCode().is2xxSuccessful()) {
         log.info("Successfully unbanned Matrix user {} from room {}", userId, roomId);
         return true;
@@ -334,13 +333,13 @@ public class MatrixRoomClient {
   public boolean setUserPowerLevel(
       String roomId, String userId, int powerLevel, String accessToken) {
     try {
-      String url = buildUrl(ENDPOINT_POWER_LEVELS, Map.of("roomId", roomId));
+      var url = buildUrl(ENDPOINT_POWER_LEVELS, Map.of("roomId", roomId));
 
       HttpHeaders headers = getClientHttpHeaders(accessToken);
       HttpEntity<Void> getRequest = new HttpEntity<>(headers);
 
       ResponseEntity<Map> currentResponse =
-          restTemplate.exchange(URI.create(url), HttpMethod.GET, getRequest, Map.class);
+          restTemplate.exchange(url, HttpMethod.GET, getRequest, Map.class);
 
       if (currentResponse.getBody() == null) {
         log.error("Failed to get current power levels for room {}", roomId);
@@ -357,7 +356,7 @@ public class MatrixRoomClient {
       powerLevels.put("users", updatedUsers);
 
       HttpEntity<Map<String, Object>> updateRequest = new HttpEntity<>(powerLevels, headers);
-      restTemplate.put(URI.create(url), updateRequest);
+      restTemplate.put(url, updateRequest);
 
       log.info("Set power level {} for user {} in room {}", powerLevel, userId, roomId);
       return true;
@@ -378,7 +377,7 @@ public class MatrixRoomClient {
 
   public boolean removeUserFromRoom(String roomId, String userId, String accessToken) {
     try {
-      String url = buildUrl(ENDPOINT_MEMBERSHIP, Map.of("roomId", roomId, "userId", userId));
+      var url = buildUrl(ENDPOINT_MEMBERSHIP, Map.of("roomId", roomId, "userId", userId));
 
       Map<String, Object> membershipEvent = new HashMap<>();
       membershipEvent.put("membership", "leave");
@@ -386,7 +385,7 @@ public class MatrixRoomClient {
       HttpHeaders headers = getClientHttpHeaders(accessToken);
       HttpEntity<Map<String, Object>> request = new HttpEntity<>(membershipEvent, headers);
 
-      restTemplate.put(URI.create(url), request);
+      restTemplate.put(url, request);
 
       log.info("Removed user {} from room {}", userId, roomId);
       return true;
@@ -421,11 +420,11 @@ public class MatrixRoomClient {
     return new HashMap<>();
   }
 
-  private String buildUrl(String endpoint) {
+  private URI buildUrl(String endpoint) {
     return MatrixUrlBuilder.buildUrl(matrixConfig, endpoint);
   }
 
-  private String buildUrl(String endpoint, Map<String, ?> uriVariables) {
+  private URI buildUrl(String endpoint, Map<String, ?> uriVariables) {
     return MatrixUrlBuilder.buildUrl(matrixConfig, endpoint, uriVariables);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -455,7 +455,7 @@ public class MatrixSynapseService {
       }
 
       // Update display name using Synapse ADMIN v2 API
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
 
@@ -470,7 +470,7 @@ public class MatrixSynapseService {
 
       ResponseEntity<String> response =
           restTemplate.exchange(
-              URI.create(url), org.springframework.http.HttpMethod.PUT, request, String.class);
+              url, org.springframework.http.HttpMethod.PUT, request, String.class);
 
       log.info(
           "Successfully updated Matrix display name for user: {} to: {}",
@@ -499,7 +499,7 @@ public class MatrixSynapseService {
         return false;
       }
 
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_DEACTIVATE_USER, java.util.Map.of("userId", matrixUserId));
 
@@ -514,7 +514,7 @@ public class MatrixSynapseService {
 
       ResponseEntity<String> response =
           restTemplate.exchange(
-              URI.create(url), org.springframework.http.HttpMethod.POST, request, String.class);
+              url, org.springframework.http.HttpMethod.POST, request, String.class);
 
       log.info("Successfully deactivated Matrix user: {}", matrixUserId);
       return response.getStatusCode().is2xxSuccessful();
@@ -539,7 +539,7 @@ public class MatrixSynapseService {
         return false;
       }
 
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_PURGE_ROOM, java.util.Map.of("roomId", matrixRoomId));
 
@@ -554,7 +554,7 @@ public class MatrixSynapseService {
 
       ResponseEntity<String> response =
           restTemplate.exchange(
-              URI.create(url), org.springframework.http.HttpMethod.DELETE, request, String.class);
+              url, org.springframework.http.HttpMethod.DELETE, request, String.class);
 
       log.info("Successfully purged Matrix room: {}", matrixRoomId);
       return response.getStatusCode().is2xxSuccessful();
@@ -783,7 +783,7 @@ public class MatrixSynapseService {
     }
 
     try {
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_ROOM_MEMBERS, java.util.Map.of("roomId", matrixRoomId));
 
@@ -792,10 +792,7 @@ public class MatrixSynapseService {
 
       ResponseEntity<java.util.Map> response =
           restTemplate.exchange(
-              URI.create(url),
-              org.springframework.http.HttpMethod.GET,
-              request,
-              java.util.Map.class);
+              url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
 
       var body = response.getBody();
       if (body == null || !(body.get("members") instanceof java.util.List<?> members)) {
@@ -842,10 +839,7 @@ public class MatrixSynapseService {
 
       var response =
           restTemplate.exchange(
-              URI.create(url),
-              org.springframework.http.HttpMethod.PUT,
-              request,
-              java.util.Map.class);
+              url, org.springframework.http.HttpMethod.PUT, request, java.util.Map.class);
 
       return response.getBody();
     } catch (Exception ex) {
@@ -880,10 +874,7 @@ public class MatrixSynapseService {
 
       var response =
           matrixLongPollRestTemplate.exchange(
-              URI.create(url),
-              org.springframework.http.HttpMethod.GET,
-              request,
-              java.util.Map.class);
+              url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
 
       if (response.getBody() != null && response.getBody().containsKey("chunk")) {
         @SuppressWarnings("unchecked")
@@ -933,7 +924,7 @@ public class MatrixSynapseService {
       }
       queryParams.put("filter", filter);
 
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(matrixConfig, ENDPOINT_SYNC, java.util.Map.of(), queryParams);
 
       log.info("Syncing Matrix room: {} for user: {} (timeout: {}ms)", roomId, username, timeout);
@@ -1249,7 +1240,10 @@ public class MatrixSynapseService {
 
       var response =
           restTemplate.exchange(
-              url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
+              URI.create(url),
+              org.springframework.http.HttpMethod.GET,
+              request,
+              java.util.Map.class);
 
       if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
         @SuppressWarnings("unchecked")
@@ -1379,7 +1373,7 @@ public class MatrixSynapseService {
     }
 
     try {
-      String url =
+      var url =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_PRESENCE, java.util.Map.of("userId", matrixUserId));
       HttpEntity<Void> request = new HttpEntity<>(getClientHttpHeaders(adminToken));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilder.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -10,15 +11,15 @@ final class MatrixUrlBuilder {
 
   private MatrixUrlBuilder() {}
 
-  static String buildUrl(MatrixConfig matrixConfig, String endpoint) {
+  static URI buildUrl(MatrixConfig matrixConfig, String endpoint) {
     return buildUrl(matrixConfig, endpoint, Map.of(), Map.of());
   }
 
-  static String buildUrl(MatrixConfig matrixConfig, String endpoint, Map<String, ?> uriVariables) {
+  static URI buildUrl(MatrixConfig matrixConfig, String endpoint, Map<String, ?> uriVariables) {
     return buildUrl(matrixConfig, endpoint, uriVariables, Map.of());
   }
 
-  static String buildUrl(
+  static URI buildUrl(
       MatrixConfig matrixConfig,
       String endpoint,
       Map<String, ?> uriVariables,
@@ -44,7 +45,8 @@ final class MatrixUrlBuilder {
           }
         });
     // Components are already encoded (path via .encode(), query values via encodeQueryParam), so
-    // build with encoded=true and do not expand again.
-    return builder.build(true).toUriString();
+    // build with encoded=true and do not expand again. Return a URI (not a String) so RestTemplate
+    // does not apply a second round of percent-encoding to path segments.
+    return builder.build(true).toUri();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -68,7 +68,7 @@ class MatrixRoomClientTest {
     var responseBody = new MatrixCreateRoomResponseDTO();
     responseBody.setRoomId(ROOM_ID);
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/createRoom"),
+            eq(uri(API_URL + "/_matrix/client/r0/createRoom")),
             createRoomRequestCaptor.capture(),
             eq(MatrixCreateRoomResponseDTO.class)))
         .thenReturn(ResponseEntity.ok(responseBody));
@@ -88,7 +88,7 @@ class MatrixRoomClientTest {
   @Test
   void createRoom_ShouldThrowMatrixCreateRoomException_WhenMatrixRejectsRequest() {
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/createRoom"),
+            eq(uri(API_URL + "/_matrix/client/r0/createRoom")),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(MatrixCreateRoomResponseDTO.class)))
         .thenThrow(
@@ -108,7 +108,7 @@ class MatrixRoomClientTest {
   @Test
   void createRoom_ShouldThrowMatrixCreateRoomException_WhenUnexpectedErrorOccurs() {
     when(restTemplate.postForEntity(
-            eq(API_URL + "/_matrix/client/r0/createRoom"),
+            eq(uri(API_URL + "/_matrix/client/r0/createRoom")),
             org.mockito.ArgumentMatchers.any(HttpEntity.class),
             eq(MatrixCreateRoomResponseDTO.class)))
         .thenThrow(new RuntimeException("connection failed"));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -119,20 +119,20 @@ class MatrixSynapseServiceTest {
     var rooms = Map.<String, Object>of("join", join);
     var responseBody = Map.<String, Object>of("next_batch", "s_token_42", "rooms", rooms);
     when(matrixLongPollRestTemplate.exchange(
-            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+            any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
         .thenReturn(ResponseEntity.ok(responseBody));
-    var urlCaptor = ArgumentCaptor.forClass(String.class);
+    var urlCaptor = ArgumentCaptor.forClass(URI.class);
 
     var result = service.syncRoom(roomId, ACCESS_TOKEN, "alice", 30000);
 
     verify(matrixLongPollRestTemplate)
         .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
-    assertThat(urlCaptor.getValue()).startsWith(SYNC_URL + "?");
-    assertThat(urlCaptor.getValue()).contains("timeout=30000");
+    assertThat(urlCaptor.getValue().toString()).startsWith(SYNC_URL + "?");
+    assertThat(urlCaptor.getValue().toString()).contains("timeout=30000");
     // The JSON filter is URL-encoded (its braces survive as %7B/%7D) and the room id is present.
-    assertThat(urlCaptor.getValue()).contains("filter=");
-    assertThat(urlCaptor.getValue()).contains("timeline");
-    assertThat(urlCaptor.getValue())
+    assertThat(urlCaptor.getValue().toString()).contains("filter=");
+    assertThat(urlCaptor.getValue().toString()).contains("timeline");
+    assertThat(urlCaptor.getValue().toString())
         .contains(UriUtils.encodeQueryParam(roomId, StandardCharsets.UTF_8));
     // The parsed result reflects the body: the next_batch token and the single text message.
     assertThat(result).isNotNull();
@@ -823,7 +823,7 @@ class MatrixSynapseServiceTest {
     var encodedOnlineId = "%40online%3Amatrix.example.com";
     var encodedOfflineId = "%40offline%3Amatrix.example.com";
     when(restTemplate.exchange(
-            org.mockito.ArgumentMatchers.<String>argThat(
+            org.mockito.ArgumentMatchers.<URI>argThat(
                 uri -> uri != null && uri.toString().contains(encodedOnlineId)),
             eq(HttpMethod.GET),
             any(),
@@ -832,7 +832,7 @@ class MatrixSynapseServiceTest {
             ResponseEntity.ok(
                 Map.of("presence", "online", "currently_active", true, "last_active_ago", 0)));
     when(restTemplate.exchange(
-            org.mockito.ArgumentMatchers.<String>argThat(
+            org.mockito.ArgumentMatchers.<URI>argThat(
                 uri -> uri != null && uri.toString().contains(encodedOfflineId)),
             eq(HttpMethod.GET),
             any(),

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixUrlBuilderTest.java
@@ -44,7 +44,8 @@ class MatrixUrlBuilderTest {
             "/_matrix/client/r0/rooms/{roomId}/messages",
             Map.of("roomId", "!room:example.org"));
 
-    assertThat(url).isEqualTo(BASE_URL + "/_matrix/client/r0/rooms/%21room%3Aexample.org/messages");
+    assertThat(url.toString())
+        .isEqualTo(BASE_URL + "/_matrix/client/r0/rooms/%21room%3Aexample.org/messages");
   }
 
   @Test
@@ -55,7 +56,7 @@ class MatrixUrlBuilderTest {
             "/_matrix/client/r0/presence/{userId}/status",
             Map.of("userId", "@user:example.org"));
 
-    assertThat(url)
+    assertThat(url.toString())
         .isEqualTo(BASE_URL + "/_matrix/client/r0/presence/%40user%3Aexample.org/status");
   }
 
@@ -67,7 +68,7 @@ class MatrixUrlBuilderTest {
             "/_matrix/client/r0/rooms/{roomId}/state/m.room.member/{userId}",
             Map.of("roomId", "!room:example.org", "userId", "@user:example.org"));
 
-    assertThat(url)
+    assertThat(url.toString())
         .isEqualTo(
             BASE_URL
                 + "/_matrix/client/r0/rooms/%21room%3Aexample.org"
@@ -83,10 +84,10 @@ class MatrixUrlBuilderTest {
             Map.of("roomId", "!room:example.org"),
             Map.of("dir", "b", "limit", 100));
 
-    assertThat(url)
+    assertThat(url.toString())
         .startsWith(BASE_URL + "/_matrix/client/r0/rooms/%21room%3Aexample.org/messages?");
-    assertThat(url).contains("dir=b");
-    assertThat(url).contains("limit=100");
+    assertThat(url.toString()).contains("dir=b");
+    assertThat(url.toString()).contains("limit=100");
   }
 
   // ── JSON filter in query params must not throw ────────────────────────────
@@ -118,11 +119,11 @@ class MatrixUrlBuilderTest {
         MatrixUrlBuilder.buildUrl(
             matrixConfig(), "/_matrix/client/r0/sync", Map.of(), Map.of("filter", jsonFilter));
 
-    assertThat(url).contains("filter=");
+    assertThat(url.toString()).contains("filter=");
     // Braces must be percent-encoded in the query string.
-    assertThat(url).contains("%7B"); // { → %7B
-    assertThat(url).doesNotContain("{");
-    assertThat(url).doesNotContain("}");
+    assertThat(url.toString()).contains("%7B"); // { → %7B
+    assertThat(url.toString()).doesNotContain("{");
+    assertThat(url.toString()).doesNotContain("}");
   }
 
   @Test
@@ -135,7 +136,7 @@ class MatrixUrlBuilderTest {
         MatrixUrlBuilder.buildUrl(matrixConfig(), "/_matrix/client/r0/sync", Map.of(), queryParams);
 
     // Null optional sync cursors must not produce empty query parameters in the URL.
-    assertThat(url).isEqualTo(BASE_URL + "/_matrix/client/r0/sync?timeout=0");
-    assertThat(url).doesNotContain("since");
+    assertThat(url.toString()).isEqualTo(BASE_URL + "/_matrix/client/r0/sync?timeout=0");
+    assertThat(url.toString()).doesNotContain("since");
   }
 }


### PR DESCRIPTION
Return URI from MatrixUrlBuilder so RestTemplate does not re-encode path segments that already contain percent-encoded room and user IDs. This fixes accept-enquiry failures where invite/join/power-level requests hit Synapse with %2521/%253A and the session assignment was rolled back with 500.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

