### PR TITLE
Hide inaccessible registered topic enquiries

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -418,6 +418,7 @@ public class SessionService {
         .findByMainTopicIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(
             topicIds, SessionStatus.NEW, RegistrationType.REGISTERED)
         .stream()
+        .filter(this::isAnonymousStyleRegistration)
         .filter(this::isVisibleRegisteredEnquiryForConsultant)
         .collect(Collectors.toList());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -1118,21 +1118,59 @@ class SessionServiceTest {
 
   @Test
   void
-      getRegisteredEnquiriesForConsultant_Should_IncludeTopicBasedSessions_When_ConsultantHasTopics() {
+      getRegisteredEnquiriesForConsultant_Should_IncludeAnonymousStyleTopicBasedSessions_When_ConsultantHasTopics() {
     Consultant consultant = mock(Consultant.class);
     when(consultant.getConsultantAgencies()).thenReturn(null);
     when(consultant.getId()).thenReturn(CONSULTANT_ID);
     when(consultantTopicRepository.findTopicIdsByConsultantId(CONSULTANT_ID))
         .thenReturn(List.of(42L));
+
+    Session topicBasedSession = easyRandom.nextObject(Session.class);
+    topicBasedSession.setPostcode("00000");
+    topicBasedSession.setMainTopicId(42L);
+    topicBasedSession.setRegistrationType(Session.RegistrationType.REGISTERED);
+    topicBasedSession.setStatus(SessionStatus.NEW);
+    topicBasedSession.setConsultant(null);
+    topicBasedSession.getUser().setDataPrivacyConfirmation(nowInUtc());
+
     when(sessionRepository
             .findByMainTopicIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(
                 any(), any(), any()))
-        .thenReturn(SESSION_LIST_WITH_CONSULTANT);
+        .thenReturn(List.of(topicBasedSession));
 
     List<ConsultantSessionResponseDTO> result =
         sessionService.getRegisteredEnquiriesForConsultant(consultant);
 
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void
+      getRegisteredEnquiriesForConsultant_Should_ExcludeRegularTopicOnlySessions_When_ConsultantHasNoSessionAgency() {
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getConsultantAgencies()).thenReturn(null);
+    when(consultant.getId()).thenReturn(CONSULTANT_ID);
+    when(consultantTopicRepository.findTopicIdsByConsultantId(CONSULTANT_ID))
+        .thenReturn(List.of(42L));
+
+    Session topicOnlySession = easyRandom.nextObject(Session.class);
+    topicOnlySession.setPostcode("10115");
+    topicOnlySession.setMainTopicId(42L);
+    topicOnlySession.setRegistrationType(Session.RegistrationType.REGISTERED);
+    topicOnlySession.setStatus(SessionStatus.NEW);
+    topicOnlySession.setConsultant(null);
+    topicOnlySession.getUser().setUsername("regular-registered-user");
+    topicOnlySession.getUser().setDataPrivacyConfirmation(nowInUtc());
+
+    when(sessionRepository
+            .findByMainTopicIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(
+                any(), any(), any()))
+        .thenReturn(List.of(topicOnlySession));
+
+    List<ConsultantSessionResponseDTO> result =
+        sessionService.getRegisteredEnquiriesForConsultant(consultant);
+
+    assertThat(result).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Restrict registered-enquiry topic expansion to anonymous-style/link-style registered sessions.
- Keep normal registered enquiries visible through agency membership only, matching the direct session permission check.
- Add regression coverage for the inaccessible topic-only session case.

## Problem

Closes OpenResilienceInitiative/ORISO-UserService#364.

Normal registered sessions from another agency were included in `/conversations/consultants/enquiries/registered` when they shared a consultant topic. The session detail route already denied those same sessions, so consultants saw list rows that could not be opened.

## Verification

- Red test: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -Dspotless.check.skip=true -Dtest=SessionServiceTest#getRegisteredEnquiriesForConsultant_Should_ExcludeRegularTopicOnlySessions_When_ConsultantHasNoSessionAgency test`
- Green targeted tests: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -Dspotless.check.skip=true -Dtest=SessionServiceTest#getRegisteredEnquiriesForConsultant_Should_ExcludeRegularTopicOnlySessions_When_ConsultantHasNoSessionAgency,SessionServiceTest#getRegisteredEnquiriesForConsultant_Should_IncludeAnonymousStyleTopicBasedSessions_When_ConsultantHasTopics,SessionServiceTest#getRegisteredEnquiriesForConsultant_Should_ExcludeAnonymousStyleSession_When_UserHasNoConsent test`
- Format: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw spotless:apply -DskipTests`
- Broader service test: `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw -Dspotless.check.skip=true -Dtest=SessionServiceTest test`

## Notes

Local Maven needs Java 21 for these tests. Java 25 fails in local tooling before JUnit because Spotless/Mockito/Jacoco dependencies do not support that classfile version in this repo setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined which topic-based registered enquiries are shown to consultants, excluding non-anonymous-style registrations that should not appear.
  * Improved topic-based enquiry handling so only the intended anonymous-style sessions are included.
* **Tests**
  * Updated coverage for topic-based registered enquiries to verify anonymous-style sessions are included.
  * Added a test to confirm regular topic-only sessions are excluded in the relevant consultant flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
