### PR TITLE
test: fix flaky DeleteUserAnonymousServiceTest

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousServiceTest.java
@@ -160,7 +160,7 @@ class DeleteUserAnonymousServiceTest {
 
   private static List<LocalDateTime> createOverdueUpdateDates() {
     LocalDateTime now = LocalDateTime.now();
-    LocalDateTime oneDeletionPeriodAgo = now.minusMinutes(DELETION_PERIOD_MINUTES);
+    LocalDateTime oneDeletionPeriodAgo = now.minusMinutes(DELETION_PERIOD_MINUTES).minusSeconds(1);
     LocalDateTime timeLongInThePast = oneDeletionPeriodAgo.minusMinutes(10);
 
     return List.of(oneDeletionPeriodAgo, timeLongInThePast);
@@ -180,6 +180,7 @@ class DeleteUserAnonymousServiceTest {
 
     this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
 
+    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
     verify(this.workflowErrorMailService, times(1)).buildAndSendErrorMail(List.of(error));
     verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
   }


### PR DESCRIPTION
## Summary

This PR fixes a flaky unit test in `DeleteUserAnonymousServiceTest`.

The test was using an update date exactly at the deletion period boundary. Since the production code checks the timestamp using `isBefore()`, the test could intermittently fail depending on execution timing.

## Changes

- Updated overdue test data to use a timestamp before the deletion threshold.
- Updated the shared overdue date helper to consistently generate timestamps outside the deletion period.
- Ensured the test remains deterministic and no longer depends on execution timing.

## Verification

- ✅ `mvn clean compile`
- ✅ `mvn test`
- ✅ All tests passed (`2881 tests, 0 failures, 0 errors`)