### PR TITLE
test: increase unit test coverage for consultant create, matrix, and agency services

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapterTest.java
@@ -1,0 +1,63 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CreateConsultantDTOCreationInputAdapterTest {
+
+  private static final String USERNAME = "consultantUser";
+  private static final String PASSWORD = "SecurePass1!";
+
+  @Test
+  void getters_Should_returnExpectedValues_When_dtoFieldsAreSet() {
+    CreateConsultantDTO dto = new CreateConsultantDTO();
+    dto.setUsername(USERNAME);
+    dto.setFirstname("First");
+    dto.setLastname("Last");
+    dto.setEmail("consultant@example.com");
+    dto.setPassword(PASSWORD);
+    dto.setAbsent(true);
+    dto.setAbsenceMessage("Away");
+    dto.setFormalLanguage(true);
+    dto.setTenantId(3L);
+    dto.setTopicIds(List.of(10L, 20L));
+
+    ConsultantCreationInput input = new CreateConsultantDTOCreationInputAdapter(dto);
+
+    assertThat(input.getIdOld(), nullValue());
+    assertThat(input.getUserName(), is(USERNAME));
+    assertThat(input.getEncodedUsername(), is(new UsernameTranscoder().encodeUsername(USERNAME)));
+    assertThat(input.getFirstName(), is("First"));
+    assertThat(input.getLastName(), is("Last"));
+    assertThat(input.getEmail(), is("consultant@example.com"));
+    assertThat(input.getPassword(), is(PASSWORD));
+    assertThat(input.isAbsent(), is(true));
+    assertThat(input.getAbsenceMessage(), is("Away"));
+    assertThat(input.isTeamConsultant(), is(false));
+    assertThat(input.isLanguageFormal(), is(true));
+    assertThat(input.getTenantId(), is(3L));
+    assertThat(input.getTopicIds(), is(List.of(10L, 20L)));
+    assertThat(input.getCreateDate(), notNullValue());
+    assertThat(input.getUpdateDate(), notNullValue());
+  }
+
+  @Test
+  void booleanFlags_Should_defaultToFalse_When_dtoFlagsAreNull() {
+    CreateConsultantDTO dto = new CreateConsultantDTO();
+    dto.setUsername(USERNAME);
+    dto.setAbsent(null);
+    dto.setFormalLanguage(null);
+
+    ConsultantCreationInput input = new CreateConsultantDTOCreationInputAdapter(dto);
+
+    assertThat(input.isAbsent(), is(false));
+    assertThat(input.isLanguageFormal(), is(false));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
@@ -1,0 +1,419 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create;
+
+import static de.caritas.cob.userservice.api.config.auth.UserRole.CONSULTANT;
+import static de.caritas.cob.userservice.api.config.auth.UserRole.GROUP_CHAT_CONSULTANT;
+import static de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason.NUMBER_OF_LICENSES_EXCEEDED;
+import static de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason.PASSWORD_NOT_VALID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantAdminService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.exception.httpresponses.DistributedTransactionException;
+import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatAddUserToGroupException;
+import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.helper.PlainCredentialsHolder;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.Licensing;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Set;
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CreateConsultantSagaTest {
+
+  private static final String KEYCLOAK_USER_ID = "keycloak-user-id";
+  private static final String ROCKET_CHAT_USER_ID = "rocket-chat-user-id";
+  private static final String VALID_USERNAME = "validUsername";
+  private static final String VALID_EMAIL = "valid@emailaddress.de";
+  private static final String VALID_PASSWORD = "ValidPass1!";
+
+  @InjectMocks private CreateConsultantSaga createConsultantSaga;
+
+  @Mock private IdentityClient identityClient;
+  @Mock private RocketChatService rocketChatService;
+  @Mock private ConsultantService consultantService;
+  @Mock private UserHelper userHelper;
+
+  @Mock
+  private de.caritas.cob.userservice.api.admin.service.consultant.validation
+          .UserAccountInputValidator
+      userAccountInputValidator;
+
+  @Mock private TenantAdminService tenantAdminService;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private RollbackFacade rollbackFacade;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private AppointmentService appointmentService;
+  @Mock private SessionService sessionService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(createConsultantSaga, "appointmentFeatureEnabled", false);
+    ReflectionTestUtils.setField(createConsultantSaga, "multiTenancyEnabled", false);
+    PlainCredentialsHolder.clear();
+    TenantContext.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    PlainCredentialsHolder.clear();
+    TenantContext.clear();
+  }
+
+  @Test
+  void createNewConsultant_Should_returnResponse_When_happyPath() throws Exception {
+    stubHappyPath();
+
+    var response = createConsultantSaga.createNewConsultant(validCreateConsultantDto());
+
+    assertThat(response, notNullValue());
+    assertThat(response.getEmbedded(), notNullValue());
+    assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
+    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
+    verify(appointmentService, never()).createConsultant(any());
+  }
+
+  @Test
+  void createNewConsultant_Should_callAppointmentService_When_featureEnabled() throws Exception {
+    ReflectionTestUtils.setField(createConsultantSaga, "appointmentFeatureEnabled", true);
+    stubHappyPath();
+
+    createConsultantSaga.createNewConsultant(validCreateConsultantDto());
+
+    verify(appointmentService).createConsultant(any());
+  }
+
+  @Test
+  void createNewConsultant_Should_rollback_When_appointmentServiceFails() throws Exception {
+    ReflectionTestUtils.setField(createConsultantSaga, "appointmentFeatureEnabled", true);
+    stubHappyPath();
+    when(authenticatedUser.getUserId()).thenReturn("admin-id");
+    when(authenticatedUser.getRoles()).thenReturn(Set.of("admin"));
+    doThrow(new RuntimeException("appointment down"))
+        .when(appointmentService)
+        .createConsultant(any());
+
+    var ex =
+        assertThrows(
+            DistributedTransactionException.class,
+            () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
+
+    assertThat(
+        ex.getCustomHttpHeaders().get("X-Reason").get(0),
+        is(
+            "DISTRIBUTED_TRANSACTION_FAILED_ON_STEP_CREATE_ACCOUNT_IN_CALCOM_OR_APPOINTMENTSERVICE"));
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+  }
+
+  @Test
+  void createNewConsultant_Should_throwBadRequest_When_passwordMissing() {
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setPassword(null);
+    stubKeycloakUserCreation();
+
+    assertThrows(BadRequestException.class, () -> createConsultantSaga.createNewConsultant(dto));
+  }
+
+  @Test
+  void createNewConsultant_Should_throwCustomValidation_When_passwordUpdateFails() {
+    stubKeycloakUserCreation();
+    doThrow(new CustomValidationHttpStatusException(PASSWORD_NOT_VALID, HttpStatus.BAD_REQUEST))
+        .when(identityClient)
+        .updatePassword(anyString(), anyString());
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
+
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+    verify(identityClient, never()).updateRole(anyString(), anyString());
+  }
+
+  @Test
+  void createNewConsultant_Should_throwDistributedTransaction_When_roleUpdateFails()
+      throws Exception {
+    stubKeycloakUserCreation();
+    doThrow(new RuntimeException("role update failed"))
+        .when(identityClient)
+        .updateRole(anyString(), anyString());
+
+    assertThrows(
+        DistributedTransactionException.class,
+        () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
+
+    verify(rocketChatService, never()).getUserID(anyString(), anyString(), anyBoolean());
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+  }
+
+  @Test
+  void createNewConsultant_Should_throwDistributedTransaction_When_saveConsultantFails()
+      throws Exception {
+    stubKeycloakUserCreation();
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenReturn(ROCKET_CHAT_USER_ID);
+    doThrow(new RuntimeException("db down")).when(consultantService).saveConsultant(any());
+
+    assertThrows(
+        DistributedTransactionException.class,
+        () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
+
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+  }
+
+  @Test
+  void createNewConsultant_Should_useDummyRocketChatId_When_rocketChatCreationFails()
+      throws Exception {
+    stubKeycloakUserCreation();
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenThrow(new RuntimeException("rocket chat down"));
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var response = createConsultantSaga.createNewConsultant(validCreateConsultantDto());
+
+    assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
+    ArgumentCaptor<Consultant> consultantCaptor = ArgumentCaptor.forClass(Consultant.class);
+    verify(consultantService).saveConsultant(consultantCaptor.capture());
+    assertThat(consultantCaptor.getValue().getRocketChatId(), is("dummy-rc"));
+  }
+
+  @Test
+  void createNewConsultant_Should_addGroupChatRole_When_flagEnabled() throws Exception {
+    stubHappyPath();
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setIsGroupchatConsultant(true);
+
+    createConsultantSaga.createNewConsultant(dto);
+
+    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
+    verify(identityClient).updateRole(KEYCLOAK_USER_ID, GROUP_CHAT_CONSULTANT.getValue());
+  }
+
+  @Test
+  void createNewConsultant_Should_throwBadRequest_When_importRecordHasNoPassword() {
+    ImportRecord importRecord = validImportRecord();
+    stubKeycloakUserCreation();
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            createConsultantSaga.createNewConsultant(
+                importRecord, CollectionHelper.asSet(CONSULTANT.getValue())));
+  }
+
+  @Test
+  void createNewConsultant_Should_assignSessions_When_enquiriesExist() throws Exception {
+    stubHappyPath();
+    when(sessionService.getRegisteredEnquiriesForConsultant(any()))
+        .thenReturn(
+            Lists.newArrayList(
+                new ConsultantSessionResponseDTO().session(new SessionDTO().groupId("group-1"))));
+    when(sessionService.getArchivedSessionsForConsultant(any()))
+        .thenReturn(
+            Lists.newArrayList(
+                new ConsultantSessionResponseDTO().session(new SessionDTO().groupId("group-2"))));
+
+    createConsultantSaga.createNewConsultant(validCreateConsultantDto());
+
+    verify(rocketChatService).addUserToGroup(ROCKET_CHAT_USER_ID, "group-1");
+    verify(rocketChatService).addUserToGroup(ROCKET_CHAT_USER_ID, "group-2");
+  }
+
+  @Test
+  void createNewConsultant_Should_continue_When_addUserToGroupFails() throws Exception {
+    stubHappyPath();
+    when(sessionService.getRegisteredEnquiriesForConsultant(any()))
+        .thenReturn(
+            Lists.newArrayList(
+                new ConsultantSessionResponseDTO().session(new SessionDTO().groupId("group-1"))));
+    when(sessionService.getArchivedSessionsForConsultant(any())).thenReturn(Lists.newArrayList());
+    doThrow(new RocketChatAddUserToGroupException("add failed"))
+        .when(rocketChatService)
+        .addUserToGroup(anyString(), anyString());
+
+    var response = createConsultantSaga.createNewConsultant(validCreateConsultantDto());
+
+    assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
+  }
+
+  @Test
+  void rollbackCreateNewConsultant_Should_delegateToRollbackFacade() {
+    Consultant consultant = new Consultant();
+    consultant.setId(KEYCLOAK_USER_ID);
+
+    createConsultantSaga.rollbackCreateNewConsultant(consultant);
+
+    verify(rollbackFacade).rollbackConsultantAccount(consultant);
+  }
+
+  @Test
+  void createNewConsultant_Should_throwLicensesExceeded_When_multiTenancyEnabledAndLimitReached() {
+    ReflectionTestUtils.setField(createConsultantSaga, "multiTenancyEnabled", true);
+    TenantContext.setCurrentTenant(1L);
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTenantId(1L);
+    var tenant = new TenantDTO().licensing(new Licensing().allowedNumberOfUsers(1));
+    when(tenantAdminService.getTenantById(1L)).thenReturn(tenant);
+    when(consultantService.getNumberOfActiveConsultants(1L)).thenReturn(1L);
+
+    var ex =
+        assertThrows(
+            CustomValidationHttpStatusException.class,
+            () -> createConsultantSaga.createNewConsultant(dto));
+
+    assertThat(
+        ex.getCustomHttpHeaders().get("X-Reason").get(0), is(NUMBER_OF_LICENSES_EXCEEDED.name()));
+    verify(identityClient, never()).createKeycloakUser(any(), anyString(), anyString());
+  }
+
+  @Test
+  void createNewConsultant_Should_throwBadRequest_When_superadminCreatesWithoutTenantId() {
+    ReflectionTestUtils.setField(createConsultantSaga, "multiTenancyEnabled", true);
+    TenantContext.setCurrentTenant(0L);
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTenantId(null);
+
+    assertThrows(BadRequestException.class, () -> createConsultantSaga.createNewConsultant(dto));
+  }
+
+  @Test
+  void createNewConsultant_Should_throwBadRequest_When_tenantIdDoesNotMatchContext() {
+    ReflectionTestUtils.setField(createConsultantSaga, "multiTenancyEnabled", true);
+    TenantContext.setCurrentTenant(2L);
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTenantId(99L);
+
+    assertThrows(BadRequestException.class, () -> createConsultantSaga.createNewConsultant(dto));
+  }
+
+  @Test
+  void createNewConsultant_Should_resolveTenantIdFromAccessToken_When_contextMissing()
+      throws Exception {
+    ReflectionTestUtils.setField(createConsultantSaga, "multiTenancyEnabled", true);
+    when(authenticatedUser.getAccessToken()).thenReturn(jwtWithTenantId(5L));
+    var tenant = new TenantDTO().licensing(new Licensing().allowedNumberOfUsers(10));
+    when(tenantAdminService.getTenantById(5L)).thenReturn(tenant);
+    when(consultantService.getNumberOfActiveConsultants(5L)).thenReturn(0L);
+    stubHappyPath();
+
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTenantId(null);
+
+    createConsultantSaga.createNewConsultant(dto);
+
+    assertThat(dto.getTenantId(), is(5L));
+  }
+
+  @Test
+  void createNewConsultant_Should_throwDistributedTransaction_When_passwordUpdateThrowsGeneric()
+      throws Exception {
+    stubKeycloakUserCreation();
+    doThrow(new RuntimeException("keycloak down"))
+        .when(identityClient)
+        .updatePassword(anyString(), anyString());
+
+    var ex =
+        assertThrows(
+            DistributedTransactionException.class,
+            () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
+
+    assertThat(
+        ex.getCustomHttpHeaders().get("X-Reason").get(0),
+        is("DISTRIBUTED_TRANSACTION_FAILED_ON_STEP_UPDATE_USER_PASSWORD_IN_KEYCLOAK"));
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+  }
+
+  private void stubHappyPath() throws Exception {
+    stubKeycloakUserCreation();
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenReturn(ROCKET_CHAT_USER_ID);
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(sessionService.getRegisteredEnquiriesForConsultant(any()))
+        .thenReturn(Lists.newArrayList());
+    when(sessionService.getArchivedSessionsForConsultant(any())).thenReturn(Lists.newArrayList());
+  }
+
+  private void stubKeycloakUserCreation() {
+    when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              PlainCredentialsHolder.set(VALID_USERNAME, null);
+              KeycloakCreateUserResponseDTO response = new KeycloakCreateUserResponseDTO();
+              response.setUserId(KEYCLOAK_USER_ID);
+              return response;
+            });
+  }
+
+  private CreateConsultantDTO validCreateConsultantDto() {
+    CreateConsultantDTO dto = new CreateConsultantDTO();
+    dto.setUsername(VALID_USERNAME);
+    dto.setEmail(VALID_EMAIL);
+    dto.setPassword(VALID_PASSWORD);
+    dto.setFirstname("First");
+    dto.setLastname("Last");
+    dto.setIsGroupchatConsultant(false);
+    return dto;
+  }
+
+  private ImportRecord validImportRecord() {
+    ImportRecord importRecord = new ImportRecord();
+    importRecord.setUsername(VALID_USERNAME);
+    importRecord.setUsernameEncoded("encoded-" + VALID_USERNAME);
+    importRecord.setEmail(VALID_EMAIL);
+    importRecord.setFirstName("First");
+    importRecord.setLastName("Last");
+    return importRecord;
+  }
+
+  private String jwtWithTenantId(long tenantId) {
+    String header =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString("{\"alg\":\"none\"}".getBytes(StandardCharsets.UTF_8));
+    String payload =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(
+                String.format("{\"tenantId\":%d}", tenantId).getBytes(StandardCharsets.UTF_8));
+    return header + "." + payload + ".signature";
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
@@ -294,4 +294,125 @@ class GrantConsultantIdentityServiceTest {
 
     verify(identityClient).removeRoleIfPresent(ADMIN_ID, CONSULTANT.getValue());
   }
+
+  @Test
+  void skipAgencyAssignment_When_agencyIdsNull() throws Exception {
+    dto.setAgencyIds(null);
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(validAdmin()));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    stubHappyMatrix();
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
+
+    verify(consultantAgencyRelationCreatorService, never())
+        .createNewConsultantAgency(anyString(), any());
+  }
+
+  @Test
+  void createRocketChatUser_When_adminHasNoRcUserId() throws Exception {
+    Admin admin = validAdmin();
+    admin.setRcUserId(null);
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(admin));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    stubHappyMatrix();
+    when(userHelper.getRandomPassword()).thenReturn("randomPw");
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenReturn("new-rc-id");
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
+
+    verify(rocketChatService).getUserID(anyString(), anyString(), anyBoolean());
+    ArgumentCaptor<Consultant> consultantCaptor = ArgumentCaptor.forClass(Consultant.class);
+    verify(consultantService).saveConsultant(consultantCaptor.capture());
+    assertThat(consultantCaptor.getValue().getRocketChatId(), is("new-rc-id"));
+  }
+
+  @Test
+  void useDummyRocketChatId_When_rocketChatCreationFails() throws Exception {
+    Admin admin = validAdmin();
+    admin.setRcUserId(null);
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(admin));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    stubHappyMatrix();
+    when(userHelper.getRandomPassword()).thenReturn("randomPw");
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenThrow(new RuntimeException("rocket chat down"));
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
+
+    ArgumentCaptor<Consultant> consultantCaptor = ArgumentCaptor.forClass(Consultant.class);
+    verify(consultantService).saveConsultant(consultantCaptor.capture());
+    assertThat(consultantCaptor.getValue().getRocketChatId(), is("dummy-rc"));
+  }
+
+  @Test
+  void continueWithoutMatrixUserId_When_matrixResponseMissingUserId() throws Exception {
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(validAdmin()));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    when(userHelper.getRandomPassword()).thenReturn("randomPw");
+    when(matrixSynapseService.createUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.ok(new MatrixCreateUserResponseDTO()));
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
+
+    ArgumentCaptor<Consultant> consultantCaptor = ArgumentCaptor.forClass(Consultant.class);
+    verify(consultantService).saveConsultant(consultantCaptor.capture());
+    assertThat(consultantCaptor.getValue().getMatrixUserId(), nullValue());
+  }
+
+  @Test
+  void rollbackGroupChatRole_When_consultantSaveFailsAndGroupChatEnabled() throws Exception {
+    dto.setGroupchatConsultant(true);
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(validAdmin()));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    stubHappyMatrix();
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenThrow(new RuntimeException("db down"));
+
+    assertThrows(
+        DistributedTransactionException.class,
+        () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
+
+    verify(identityClient).removeRoleIfPresent(ADMIN_ID, CONSULTANT.getValue());
+    verify(identityClient).removeRoleIfPresent(ADMIN_ID, GROUP_CHAT_CONSULTANT.getValue());
+  }
+
+  @Test
+  void rollbackGroupChatRole_When_agencyAssignmentFailsAndGroupChatEnabled() throws Exception {
+    dto.setGroupchatConsultant(true);
+    when(adminRepository.findById(ADMIN_ID)).thenReturn(Optional.of(validAdmin()));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(ADMIN_ID)).thenReturn(Optional.empty());
+    when(consultantRepository.findByUsernameAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.empty());
+    stubHappyMatrix();
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    doThrow(new BadRequestException("invalid agency assignment"))
+        .when(consultantAgencyRelationCreatorService)
+        .createNewConsultantAgency(eq(ADMIN_ID), any());
+
+    assertThrows(
+        BadRequestException.class,
+        () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
+
+    verify(identityClient).removeRoleIfPresent(ADMIN_ID, GROUP_CHAT_CONSULTANT.getValue());
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/ImportRecordCreationInputAdapterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/ImportRecordCreationInputAdapterTest.java
@@ -1,0 +1,46 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
+import org.junit.jupiter.api.Test;
+
+class ImportRecordCreationInputAdapterTest {
+
+  @Test
+  void getters_Should_returnExpectedValues_When_importRecordFieldsAreSet() {
+    ImportRecord importRecord = new ImportRecord();
+    importRecord.setIdOld(42L);
+    importRecord.setUsername("plainUsername");
+    importRecord.setUsernameEncoded("encodedUsername");
+    importRecord.setFirstName("Import");
+    importRecord.setLastName("Record");
+    importRecord.setEmail("import@example.com");
+    importRecord.setAbsent(true);
+    importRecord.setAbsenceMessage("On leave");
+    importRecord.setTeamConsultant(true);
+    importRecord.setFormalLanguage(true);
+    importRecord.setTenantId(7L);
+
+    ConsultantCreationInput input = new ImportRecordCreationInputAdapter(importRecord);
+
+    assertThat(input.getIdOld(), is(42L));
+    assertThat(input.getUserName(), is("plainUsername"));
+    assertThat(input.getEncodedUsername(), is("encodedUsername"));
+    assertThat(input.getFirstName(), is("Import"));
+    assertThat(input.getLastName(), is("Record"));
+    assertThat(input.getEmail(), is("import@example.com"));
+    assertThat(input.getPassword(), nullValue());
+    assertThat(input.isAbsent(), is(true));
+    assertThat(input.getAbsenceMessage(), is("On leave"));
+    assertThat(input.isTeamConsultant(), is(true));
+    assertThat(input.isLanguageFormal(), is(true));
+    assertThat(input.getTenantId(), is(7L));
+    assertThat(input.getTopicIds(), nullValue());
+    assertThat(input.getCreateDate(), notNullValue());
+    assertThat(input.getUpdateDate(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.CollectionHelper.asSet;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.ConsultantTopicAgencyCompatibilityValidator;
@@ -21,11 +21,19 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.RolesDTO;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -47,7 +55,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Mock private AgencyService agencyService;
 
-  @Mock private KeycloakService keycloakService;
+  @Mock private IdentityClient identityClient;
 
   @Mock private RocketChatAsyncHelper rocketChatAsyncHelper;
 
@@ -55,6 +63,11 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Mock
   private ConsultantTopicAgencyCompatibilityValidator consultantTopicAgencyCompatibilityValidator;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
 
   @Test
   public void
@@ -133,5 +146,181 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     verify(rocketChatAsyncHelper, never()).addConsultantToSessions(any(), any(), any(), any());
     assertThat(consultant.getStatus()).isEqualTo(ConsultantStatus.IN_PROGRESS);
     verify(consultantRepository).save(consultant);
+  }
+
+  @Test
+  public void createNewConsultantAgency_Should_throwBadRequest_When_consultantDoesNotExist() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull("missing")).thenReturn(Optional.empty());
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAgencyRelationCreatorService.createNewConsultantAgency(
+                "missing", new CreateConsultantAgencyDTO().agencyId(2L)));
+
+    verify(consultantAgencyService, never()).saveConsultantAgency(any());
+  }
+
+  @Test
+  public void createNewConsultantAgency_Should_throwBadRequest_When_agencyDoesNotExist() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.of(new Consultant()));
+    when(agencyService.getAgencyWithoutCaching(99L)).thenReturn(null);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAgencyRelationCreatorService.createNewConsultantAgency(
+                "consultant Id", new CreateConsultantAgencyDTO().agencyId(99L)));
+  }
+
+  @Test
+  public void
+      createNewConsultantAgency_Should_throwBadRequest_When_assignedAgenciesHaveDifferentConsultingType() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(1L);
+    consultant.setConsultantAgencies(Set.of(ConsultantAgency.builder().agencyId(3L).build()));
+
+    AgencyDTO existingAgency = new AgencyDTO().consultingType(1).id(3L);
+    AgencyDTO newAgency = new AgencyDTO().consultingType(2).id(2L);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(newAgency);
+    when(agencyService.getAgencyWithoutCaching(3L)).thenReturn(existingAgency);
+    when(consultingTypeManager.isConsultantBoundedToAgency(2)).thenReturn(true);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAgencyRelationCreatorService.createNewConsultantAgency(
+                "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L)));
+  }
+
+  @Test
+  public void createConsultantAgencyRelations_Should_throwBadRequest_When_consultantHasNoRole() {
+    when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(false);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAgencyRelationCreatorService.createConsultantAgencyRelations(
+                "consultant Id", Set.of(1L), asSet("consultant"), LogService::logInfo));
+
+    verify(consultantAgencyService, never()).saveConsultantAgency(any());
+  }
+
+  @Test
+  public void createConsultantAgencyRelations_Should_createRelations_When_rolesArePresent() {
+    AgencyDTO agencyDTO = new AgencyDTO().consultingType(1).id(1L);
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(1L);
+
+    when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(true);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(1L)).thenReturn(agencyDTO);
+    when(consultingTypeManager.getConsultingTypeSettings(1))
+        .thenReturn(easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class));
+
+    consultantAgencyRelationCreatorService.createConsultantAgencyRelations(
+        "consultant Id", Set.of(1L), asSet("consultant"), LogService::logInfo);
+
+    verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
+  }
+
+  @Test
+  public void completeConsultantAgencyAssigment_Should_useAsyncRocketChat_When_rocketChatEnabled() {
+    ReflectionTestUtils.setField(consultantAgencyRelationCreatorService, "rocketChatEnabled", true);
+    TenantContext.setCurrentTenant(4L);
+
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(false);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+        input, LogService::logInfo);
+
+    verify(rocketChatAsyncHelper)
+        .addConsultantToSessions(eq(consultant), eq(agencyDTO), any(), eq(4L));
+    verify(rocketChatAsyncHelper, never()).finalizeConsultantAgencyRelation(any(), any());
+  }
+
+  @Test
+  public void
+      completeConsultantAgencyAssigment_Should_markTeamConsultant_When_teamAgencyAssigned() {
+    ReflectionTestUtils.setField(
+        consultantAgencyRelationCreatorService, "rocketChatEnabled", false);
+
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setStatus(ConsultantStatus.CREATED);
+    consultant.setTeamConsultant(false);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(true);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+        input, LogService::logInfo);
+
+    assertThat(consultant.isTeamConsultant()).isTrue();
+    verify(consultantRepository, org.mockito.Mockito.atLeastOnce()).save(consultant);
+  }
+
+  @Test
+  public void createNewConsultantAgency_Should_assignKeycloakRoles_When_roleSetConfigured() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(1L);
+    AgencyDTO agencyDTO = new AgencyDTO().consultingType(0).id(15L);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(givenConsultingTypeWithRoles("main", List.of("consultant-role")));
+
+    CreateConsultantAgencyDTO createConsultantAgencyDTO =
+        new CreateConsultantAgencyDTO().roleSetKey("main").agencyId(15L);
+
+    consultantAgencyRelationCreatorService.createNewConsultantAgency(
+        "consultant Id", createConsultantAgencyDTO);
+
+    verify(identityClient).ensureRole("consultant Id", "consultant-role");
+    verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
+  }
+
+  private ExtendedConsultingTypeResponseDTO givenConsultingTypeWithRoles(
+      String roleSetName, List<String> roles) {
+    var roleSets = new LinkedHashMap<String, List<String>>();
+    roleSets.put(roleSetName, roles);
+
+    var roleConsultant =
+        new de.caritas.cob.userservice.api.manager.consultingtype.roles.Consultant();
+    roleConsultant.setRoleSets(roleSets);
+
+    var rolesDTO = new RolesDTO();
+    rolesDTO.setConsultant(roleConsultant);
+
+    var consultingTypeResponse = easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class);
+    consultingTypeResponse.setRoles(rolesDTO);
+    return consultingTypeResponse;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/CreateConsultantAgencyDTOInputAdapterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/CreateConsultantAgencyDTOInputAdapterTest.java
@@ -1,0 +1,28 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import org.junit.jupiter.api.Test;
+
+class CreateConsultantAgencyDTOInputAdapterTest {
+
+  @Test
+  void getters_Should_returnExpectedValues_When_dtoFieldsAreSet() {
+    CreateConsultantAgencyDTO dto =
+        new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("main");
+
+    ConsultantAgencyCreationInput input =
+        new CreateConsultantAgencyDTOInputAdapter("consultant-1", dto);
+
+    assertThat(input.getConsultantId(), is("consultant-1"));
+    assertThat(input.getAgencyId(), is(15L));
+    assertThat(input.getRoleSetNames(), contains("main"));
+    assertThat(input.getAdditionalAgencyIds(), contains(15L));
+    assertThat(input.getCreateDate(), notNullValue());
+    assertThat(input.getUpdateDate(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
@@ -1,0 +1,217 @@
+package de.caritas.cob.userservice.api.service.agency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyMatrixCredentialClientTest {
+
+  private static final String AGENCY_SERVICE_BASE_URL = "http://agency-service";
+  private static final Long AGENCY_ID = 42L;
+  private static final String MATRIX_USER_ID = "@agency:matrix.example.com";
+  private static final String MATRIX_PASSWORD = "matrix-password";
+
+  @InjectMocks private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
+
+  @Mock private RestTemplate restTemplate;
+  @Mock private SecurityHeaderSupplier securityHeaderSupplier;
+  @Mock private TenantHeaderSupplier tenantHeaderSupplier;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(
+        agencyMatrixCredentialClient, "agencyServiceBaseUrl", AGENCY_SERVICE_BASE_URL);
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_agencyIdIsNull() {
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(null);
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(restTemplate, securityHeaderSupplier, tenantHeaderSupplier);
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnCredentials_When_requestSucceeds() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
+    AgencyMatrixCredentialsDTO credentials = credentials();
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenReturn(ResponseEntity.ok(credentials));
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).contains(credentials);
+    verify(tenantHeaderSupplier).addTenantHeader(headers);
+
+    ArgumentCaptor<HttpEntity<?>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            requestCaptor.capture(),
+            eq(AgencyMatrixCredentialsDTO.class));
+    assertThat(requestCaptor.getValue().getHeaders().getFirst("agencyId"))
+        .isEqualTo(String.valueOf(AGENCY_ID));
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_responseIsNotSuccessful() {
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.NO_CONTENT).build());
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_responseIsErrorWithBody() {
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(credentials()));
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_responseBodyIsNull() {
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenReturn(ResponseEntity.ok(null));
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_agencyHasNoCredentials() {
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                HttpHeaders.EMPTY,
+                new byte[0],
+                StandardCharsets.UTF_8));
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_returnEmpty_When_requestFails() {
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenThrow(new RestClientException("connection failed"));
+
+    Optional<AgencyMatrixCredentialsDTO> result =
+        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentials_Should_forwardTenantHeader_When_tenantSupplierAddsHeader() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
+    doAnswer(
+            invocation -> {
+              headers.add("tenantId", "7");
+              return null;
+            })
+        .when(tenantHeaderSupplier)
+        .addTenantHeader(headers);
+    when(restTemplate.exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(AgencyMatrixCredentialsDTO.class)))
+        .thenReturn(ResponseEntity.ok(credentials()));
+
+    agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+
+    ArgumentCaptor<HttpEntity<?>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate)
+        .exchange(
+            eq(expectedUrl()),
+            eq(HttpMethod.GET),
+            requestCaptor.capture(),
+            eq(AgencyMatrixCredentialsDTO.class));
+    assertThat(requestCaptor.getValue().getHeaders().getFirst("tenantId")).isEqualTo("7");
+  }
+
+  private static String expectedUrl() {
+    return AGENCY_SERVICE_BASE_URL + "/internal/agencies/" + AGENCY_ID + "/matrix-service-account";
+  }
+
+  private static AgencyMatrixCredentialsDTO credentials() {
+    AgencyMatrixCredentialsDTO credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId(MATRIX_USER_ID);
+    credentials.setMatrixPassword(MATRIX_PASSWORD);
+    return credentials;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
@@ -1,32 +1,50 @@
 package de.caritas.cob.userservice.api.service.agency;
 
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_DTO_SUCHT;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_ID;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_ID_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.agencyserivce.generated.ApiClient;
 import de.caritas.cob.userservice.agencyserivce.generated.web.AgencyControllerApi;
+import de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.service.httpheader.HttpHeadersResolver;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AgencyServiceTest {
-
-  private static final String ORIGIN_URL = "subdomain.onlineberatung.net";
 
   @InjectMocks AgencyService agencyService;
 
@@ -39,6 +57,19 @@ class AgencyServiceTest {
   @Mock SecurityHeaderSupplier securityHeaderSupplier;
 
   @Mock ApiClient apiClient;
+
+  @BeforeEach
+  void setUp() {
+    lenient()
+        .when(agencyServiceApiControllerFactory.createControllerApi())
+        .thenReturn(agencyControllerApi);
+    lenient().when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
 
   @ParameterizedTest
   @NullAndEmptySource
@@ -55,29 +86,28 @@ class AgencyServiceTest {
     ReflectionTestUtils.setField(agencyService, "tenantHeaderSupplier", tenantHeaderSupplier);
     HttpHeaders headers = new HttpHeaders();
     when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(this.agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    var agencyDTOS =
-        Lists.newArrayList(
-            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(this.agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(agencyDTOS);
+    when(this.agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L)))
+        .thenReturn(List.of(new AgencyResponseDTO()));
 
     this.agencyService.getAgency(1L);
 
     assertThat(headers.get("tenantId").get(0)).isEqualTo("1");
-    TenantContext.clear();
+  }
+
+  @Test
+  void getAgency_Should_returnMappedAgency_When_agencyFound() {
+    stubAgencyLookup(List.of(toAgencyResponseDTO(AGENCY_DTO_SUCHT)));
+
+    AgencyDTO result = agencyService.getAgency(AGENCY_ID);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(AGENCY_ID);
+    assertThat(result.getName()).isEqualTo(AGENCY_DTO_SUCHT.getName());
   }
 
   @Test
   void getAgencyWithoutCaching_Should_returnAgency() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    var agencyDTOS =
-        Lists.newArrayList(
-            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
-    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(agencyDTOS);
+    stubAgencyLookup(List.of(new AgencyResponseDTO()));
 
     AgencyDTO result = agencyService.getAgencyWithoutCaching(1L);
 
@@ -86,11 +116,7 @@ class AgencyServiceTest {
 
   @Test
   void getAgencyWithoutCaching_Should_returnNull_When_agencyNotFound() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(List.of());
+    stubAgencyLookup(List.of());
 
     AgencyDTO result = agencyService.getAgencyWithoutCaching(1L);
 
@@ -99,11 +125,7 @@ class AgencyServiceTest {
 
   @Test
   void getAgency_Should_returnNull_When_agencyNotFound() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(List.of());
+    stubAgencyLookup(List.of());
 
     AgencyDTO result = agencyService.getAgency(1L);
 
@@ -118,18 +140,21 @@ class AgencyServiceTest {
 
   @Test
   void getAgenciesNotCached_Should_returnAgencies_When_idsProvided() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    var agencyDTOS =
-        Lists.newArrayList(
-            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
-    when(agencyControllerApi.getAgenciesByIds(Lists.newArrayList(1L))).thenReturn(agencyDTOS);
+    stubAgencyLookup(List.of(new AgencyResponseDTO()));
 
     List<AgencyDTO> result = agencyService.getAgenciesNotCached(Lists.newArrayList(1L));
 
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void getAgencies_Should_returnMappedAgencies_When_idsProvided() {
+    stubAgencyLookup(List.of(toAgencyResponseDTO(AGENCY_DTO_SUCHT)));
+
+    List<AgencyDTO> result = agencyService.getAgencies(AGENCY_ID_LIST);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isEqualTo(AGENCY_ID);
   }
 
   @Test
@@ -139,18 +164,71 @@ class AgencyServiceTest {
   }
 
   @Test
+  void getAgenciesWithoutCaching_Should_returnMappedAgencies_When_idsProvided() {
+    stubAgencyLookup(List.of(toAgencyResponseDTO(AGENCY_DTO_SUCHT)));
+
+    List<AgencyDTO> result = agencyService.getAgenciesWithoutCaching(AGENCY_ID_LIST);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getConsultingType()).isEqualTo(AGENCY_DTO_SUCHT.getConsultingType());
+  }
+
+  @Test
   void getAgenciesByConsultingType_Should_returnMappedAgencies() {
     HttpHeaders headers = new HttpHeaders();
     when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
-    when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
-    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
-    var agencyDTOS =
-        Lists.newArrayList(
-            new de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO());
-    when(agencyControllerApi.getAgenciesByConsultingType(1)).thenReturn(agencyDTOS);
+    when(agencyControllerApi.getAgenciesByConsultingType(1))
+        .thenReturn(List.of(new AgencyResponseDTO()));
 
     List<AgencyDTO> result = agencyService.getAgenciesByConsultingType(1);
 
     assertThat(result).hasSize(1);
+    verify(tenantHeaderSupplier).addTenantHeader(headers);
+  }
+
+  @Test
+  void getAgenciesByConsultingType_Should_addAuthorizationHeader_When_tokenPresent() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Bearer token");
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyControllerApi.getAgenciesByConsultingType(1))
+        .thenReturn(List.of(new AgencyResponseDTO()));
+
+    agencyService.getAgenciesByConsultingType(1);
+
+    verify(apiClient).addDefaultHeader(eq("Authorization"), eq("Bearer token"));
+    verify(tenantHeaderSupplier).addTenantHeader(headers);
+  }
+
+  @Test
+  void getAgenciesByConsultingType_Should_throwInternalServerErrorException_When_mappingFails() {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyControllerApi.getAgenciesByConsultingType(1))
+        .thenReturn(List.of(new AgencyResponseDTO()));
+
+    try (MockedConstruction<ObjectMapper> ignored =
+        mockConstruction(
+            ObjectMapper.class,
+            (mock, context) ->
+                when(mock.writeValueAsString(any()))
+                    .thenThrow(new JsonProcessingException("mapping failed") {}))) {
+      assertThatThrownBy(() -> agencyService.getAgenciesByConsultingType(1))
+          .isInstanceOf(InternalServerErrorException.class)
+          .hasMessageContaining("does not match");
+    }
+  }
+
+  private void stubAgencyLookup(List<AgencyResponseDTO> agencyResponseDTOS) {
+    HttpHeaders headers = new HttpHeaders();
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    when(agencyControllerApi.getAgenciesByIds(any())).thenReturn(agencyResponseDTOS);
+  }
+
+  @SneakyThrows
+  private AgencyResponseDTO toAgencyResponseDTO(AgencyDTO agencyDTO) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readValue(
+        objectMapper.writeValueAsString(agencyDTO), AgencyResponseDTO.class);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/dto/AgencyMatrixCredentialsDTOTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/dto/AgencyMatrixCredentialsDTOTest.java
@@ -1,0 +1,48 @@
+package de.caritas.cob.userservice.api.service.agency.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AgencyMatrixCredentialsDTOTest {
+
+  @Test
+  void gettersAndSetters_Should_roundTripValues() {
+    AgencyMatrixCredentialsDTO dto = new AgencyMatrixCredentialsDTO();
+    dto.setMatrixUserId("@agency:matrix.example.com");
+    dto.setMatrixPassword("secret");
+
+    assertThat(dto.getMatrixUserId()).isEqualTo("@agency:matrix.example.com");
+    assertThat(dto.getMatrixPassword()).isEqualTo("secret");
+  }
+
+  @Test
+  void equalsAndHashCode_Should_matchForSameValues() {
+    AgencyMatrixCredentialsDTO first = credentials("@user:matrix", "password");
+    AgencyMatrixCredentialsDTO second = credentials("@user:matrix", "password");
+
+    assertThat(first).isEqualTo(second).hasSameHashCodeAs(second);
+  }
+
+  @Test
+  void equals_Should_notMatch_When_valuesDiffer() {
+    AgencyMatrixCredentialsDTO first = credentials("@user:matrix", "password");
+    AgencyMatrixCredentialsDTO second = credentials("@other:matrix", "password");
+
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  void toString_Should_containFieldValues() {
+    AgencyMatrixCredentialsDTO dto = credentials("@user:matrix", "password");
+
+    assertThat(dto.toString()).contains("@user:matrix").contains("password");
+  }
+
+  private static AgencyMatrixCredentialsDTO credentials(String matrixUserId, String password) {
+    AgencyMatrixCredentialsDTO dto = new AgencyMatrixCredentialsDTO();
+    dto.setMatrixUserId(matrixUserId);
+    dto.setMatrixPassword(password);
+    return dto;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
@@ -429,7 +429,9 @@ class GroupChatMembershipServiceTest {
 
   @Test
   void resolveMatrixRoomId_Should_ReturnNull_When_SessionIsNull() {
-    assertNull(groupChatMembershipService.resolveMatrixRoomId((de.caritas.cob.userservice.api.model.Session) null));
+    assertNull(
+        groupChatMembershipService.resolveMatrixRoomId(
+            (de.caritas.cob.userservice.api.model.Session) null));
   }
 
   @Test
@@ -437,7 +439,8 @@ class GroupChatMembershipServiceTest {
     when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID)).thenReturn(null);
 
     org.junit.jupiter.api.Assertions.assertDoesNotThrow(
-        () -> groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
+        () ->
+            groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
 
     verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
     assertTrue(
@@ -454,7 +457,8 @@ class GroupChatMembershipServiceTest {
         .thenThrow(new RuntimeException("synapse down"));
 
     org.junit.jupiter.api.Assertions.assertDoesNotThrow(
-        () -> groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
+        () ->
+            groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
 
     verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
   }
@@ -466,7 +470,8 @@ class GroupChatMembershipServiceTest {
     when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(
             "@group-chat-system:matrix.oriso.org"))
         .thenReturn(Optional.empty());
-    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull("@group-chat-system:matrix.oriso.org"))
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(
+            "@group-chat-system:matrix.oriso.org"))
         .thenReturn(Optional.of(user));
     when(user.getUserId()).thenReturn("group-chat-system");
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
@@ -426,4 +426,52 @@ class GroupChatMembershipServiceTest {
     assertEquals("consultant-id", resolved.get(0).accountId());
     assertTrue(resolved.get(0).consultant());
   }
+
+  @Test
+  void resolveMatrixRoomId_Should_ReturnNull_When_SessionIsNull() {
+    assertNull(groupChatMembershipService.resolveMatrixRoomId((de.caritas.cob.userservice.api.model.Session) null));
+  }
+
+  @Test
+  void removeMemberFromRoom_Should_WarnAndNotThrow_When_TokenMintingFails() {
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID)).thenReturn(null);
+
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+        () -> groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
+
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
+    assertTrue(
+        logAppender.list.stream()
+            .anyMatch(
+                e ->
+                    e.getLevel().toString().equals("WARN")
+                        && e.getFormattedMessage().contains("Could not mint Matrix token")));
+  }
+
+  @Test
+  void removeMemberFromRoom_Should_NotThrow_When_MatrixCallFails() {
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID))
+        .thenThrow(new RuntimeException("synapse down"));
+
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+        () -> groupChatMembershipService.removeMemberFromRoom(MATRIX_ROOM_ID, CONSULTANT_MATRIX_ID));
+
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), any());
+  }
+
+  @Test
+  void hasRemainingHumanMembers_Should_FilterExactGroupChatSystemPrefix() {
+    when(matrixSynapseService.getRoomMembers(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(List.of(LEAVER_MATRIX_ID, "@group-chat-system:matrix.oriso.org")));
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(
+            "@group-chat-system:matrix.oriso.org"))
+        .thenReturn(Optional.empty());
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull("@group-chat-system:matrix.oriso.org"))
+        .thenReturn(Optional.of(user));
+    when(user.getUserId()).thenReturn("group-chat-system");
+
+    assertFalse(
+        groupChatMembershipService.hasRemainingHumanMembers(
+            chatWithMatrixRoom(), LEAVER_MATRIX_ID));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -756,7 +755,8 @@ class MatrixEventListenerServiceTest {
   void getRecipientCandidatesForRoom_shouldLoadFromRepository_whenCacheEmpty() {
     var service = newService();
     var session =
-        sessionWithParticipants(userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
+        sessionWithParticipants(
+            userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
     session.setId(5L);
     when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.of(session));
 
@@ -891,7 +891,8 @@ class MatrixEventListenerServiceTest {
         .createMessageNotificationFromRoom(
             eq(MATRIX_ROOM_ID), eq(CONSULTANT_DOMAIN_ID), eq(true), any(PrivacyEnvelope.class));
     verify(eventNotificationService, never())
-        .createThreadReplyNotificationFromRoom(anyString(), any(), anyString(), anyBoolean(), any());
+        .createThreadReplyNotificationFromRoom(
+            anyString(), any(), anyString(), anyBoolean(), any());
   }
 
   @Test
@@ -940,7 +941,8 @@ class MatrixEventListenerServiceTest {
 
     var syncResult =
         syncResultWithEvents(
-            MATRIX_ROOM_ID, List.of(messageEvent(SENDER_MATRIX_ID, "m.text", "mirror me", "$evt-m")));
+            MATRIX_ROOM_ID,
+            List.of(messageEvent(SENDER_MATRIX_ID, "m.text", "mirror me", "$evt-m")));
 
     invokeProcessMatrixSyncEvents(service, syncResult);
 
@@ -1026,7 +1028,8 @@ class MatrixEventListenerServiceTest {
   void processMatrixSyncEvents_shouldResolveSessionFromRepository_whenRoomNotPreRegistered() {
     var service = newServiceWithSyncExecutor();
     var session =
-        sessionWithParticipants(userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
+        sessionWithParticipants(
+            userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
     session.setId(16L);
     when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.of(session));
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -2,8 +2,17 @@ package de.caritas.cob.userservice.api.service.matrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
@@ -22,11 +31,13 @@ import de.caritas.cob.userservice.api.service.notification.EventNotificationServ
 import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -57,9 +68,16 @@ class MatrixEventListenerServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private ConsultantRepository consultantRepository;
   @Mock private SessionRepository sessionRepository;
+  @Mock private RedisMessageMirrorService redisMessageMirrorService;
 
   private Logger logger;
   private ListAppender<ILoggingEvent> logAppender;
+
+  private static final String MATRIX_ROOM_ID = "!room:matrix.oriso.org";
+  private static final String SENDER_MATRIX_ID = "@asker:matrix.oriso.org";
+  private static final String CONSULTANT_MATRIX_ID = "@consultant:matrix.oriso.org";
+  private static final String ASKER_DOMAIN_ID = "asker-user-id";
+  private static final String CONSULTANT_DOMAIN_ID = "consultant-id";
 
   @BeforeEach
   void setUpLogging() {
@@ -76,15 +94,39 @@ class MatrixEventListenerServiceTest {
   }
 
   private MatrixEventListenerService newService() {
+    return newService(Optional.empty());
+  }
+
+  private MatrixEventListenerService newService(Optional<RedisMessageMirrorService> mirror) {
     return new MatrixEventListenerService(
         matrixSynapseService,
         sessionService,
         liveEventNotificationService,
         eventNotificationService,
-        Optional.empty(),
+        mirror,
         userRepository,
         consultantRepository,
         sessionRepository);
+  }
+
+  private MatrixEventListenerService newServiceWithSyncExecutor() {
+    var service = newService();
+    wireSynchronousExecutor(service);
+    return service;
+  }
+
+  private void wireSynchronousExecutor(MatrixEventListenerService service) {
+    ExecutorService syncExecutor = mock(ExecutorService.class);
+    lenient()
+        .doAnswer(
+            invocation -> {
+              Runnable task = invocation.getArgument(0);
+              task.run();
+              return null;
+            })
+        .when(syncExecutor)
+        .submit(any(Runnable.class));
+    ReflectionTestUtils.setField(service, "executorService", syncExecutor);
   }
 
   @Test
@@ -548,6 +590,703 @@ class MatrixEventListenerServiceTest {
                     && e.getFormattedMessage().contains("messageId=$evt")
                     && e.getFormattedMessage().contains("contentClass=TEXT")
                     && e.getFormattedMessage().contains("hasAttachment=true"));
+  }
+
+  // ── bootstrapAdminToken (exception path) ────────────────────────────────────
+
+  @Test
+  void bootstrapAdminToken_shouldRecoverAfterException_thenReturnToken() {
+    MatrixEventListenerService service =
+        new MatrixEventListenerService(
+            matrixSynapseService,
+            sessionService,
+            liveEventNotificationService,
+            eventNotificationService,
+            Optional.empty(),
+            userRepository,
+            consultantRepository,
+            sessionRepository) {
+          @Override
+          void sleep(long millis) {
+            // no-op
+          }
+        };
+    ReflectionTestUtils.setField(service, "running", true);
+
+    when(matrixSynapseService.getAdminToken())
+        .thenThrow(new RuntimeException("transient"))
+        .thenReturn("admin-token-after-error");
+
+    boolean acquired = (boolean) ReflectionTestUtils.invokeMethod(service, "bootstrapAdminToken");
+
+    assertThat(acquired).isTrue();
+    assertThat(ReflectionTestUtils.getField(service, "adminAccessToken"))
+        .isEqualTo("admin-token-after-error");
+    verify(matrixSynapseService, atLeast(2)).getAdminToken();
+  }
+
+  @Test
+  void bootstrapAdminToken_shouldReturnFalse_whenInterruptedDuringBackoff() {
+    MatrixEventListenerService service =
+        new MatrixEventListenerService(
+            matrixSynapseService,
+            sessionService,
+            liveEventNotificationService,
+            eventNotificationService,
+            Optional.empty(),
+            userRepository,
+            consultantRepository,
+            sessionRepository) {
+          @Override
+          void sleep(long millis) throws InterruptedException {
+            throw new InterruptedException("shutdown");
+          }
+        };
+    ReflectionTestUtils.setField(service, "running", true);
+    when(matrixSynapseService.getAdminToken()).thenReturn(null);
+
+    boolean acquired = (boolean) ReflectionTestUtils.invokeMethod(service, "bootstrapAdminToken");
+
+    assertThat(acquired).isFalse();
+    assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    Thread.interrupted();
+  }
+
+  // ── shutdown ───────────────────────────────────────────────────────────────
+
+  @Test
+  void shutdown_shouldStopExecutorWithoutThrowing() {
+    var service = newService();
+    var executor = Executors.newSingleThreadExecutor();
+    ReflectionTestUtils.setField(service, "executorService", executor);
+    ReflectionTestUtils.setField(service, "running", true);
+
+    assertThatCode(service::shutdown).doesNotThrowAnyException();
+    assertThat(executor.isShutdown()).isTrue();
+  }
+
+  // ── resolveDomainUserIdFromMatrixUserId ────────────────────────────────────
+
+  @Test
+  void resolveDomainUserIdFromMatrixUserId_shouldReturnNull_whenMatrixUserIdBlank() {
+    assertThat(invokeResolveDomainUserId(newService(), null)).isNull();
+    assertThat(invokeResolveDomainUserId(newService(), "  ")).isNull();
+    verifyNoInteractions(userRepository, consultantRepository);
+  }
+
+  @Test
+  void resolveDomainUserIdFromMatrixUserId_shouldPreferUserRepository() {
+    var user = new User();
+    user.setUserId(ASKER_DOMAIN_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+
+    assertThat(invokeResolveDomainUserId(newService(), SENDER_MATRIX_ID))
+        .isEqualTo(ASKER_DOMAIN_ID);
+    verify(consultantRepository, never()).findByMatrixUserIdAndDeleteDateIsNull(anyString());
+  }
+
+  @Test
+  void resolveDomainUserIdFromMatrixUserId_shouldFallBackToConsultantRepository() {
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_DOMAIN_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultant));
+
+    assertThat(invokeResolveDomainUserId(newService(), CONSULTANT_MATRIX_ID))
+        .isEqualTo(CONSULTANT_DOMAIN_ID);
+  }
+
+  @Test
+  void resolveDomainUserIdFromMatrixUserId_shouldReturnNull_whenUnknownMatrixUser() {
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.empty());
+
+    assertThat(invokeResolveDomainUserId(newService(), SENDER_MATRIX_ID)).isNull();
+  }
+
+  // ── resolveSessionIdForRoom / getRecipientCandidatesForRoom ────────────────
+
+  @Test
+  void resolveSessionIdForRoom_shouldReturnCachedValue_whenAlreadyRegistered() {
+    var service = newService();
+    service.registerRoom(77L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID));
+
+    assertThat(invokeResolveSessionIdForRoom(service, MATRIX_ROOM_ID)).contains(77L);
+    verifyNoInteractions(sessionRepository);
+  }
+
+  @Test
+  void resolveSessionIdForRoom_shouldLoadFromRepositoryAndCache_whenNotRegistered() {
+    var service = newService();
+    var session = sessionWithParticipants(userWithId(ASKER_DOMAIN_ID), null);
+    session.setId(88L);
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.of(session));
+
+    assertThat(invokeResolveSessionIdForRoom(service, MATRIX_ROOM_ID)).contains(88L);
+
+    @SuppressWarnings("unchecked")
+    var roomToSession =
+        (Map<String, Long>) ReflectionTestUtils.getField(service, "roomToSessionMap");
+    assertThat(roomToSession).containsEntry(MATRIX_ROOM_ID, 88L);
+  }
+
+  @Test
+  void resolveSessionIdForRoom_shouldReturnEmpty_whenRoomUnknown() {
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.empty());
+
+    assertThat(invokeResolveSessionIdForRoom(newService(), MATRIX_ROOM_ID)).isEmpty();
+  }
+
+  @Test
+  void getRecipientCandidatesForRoom_shouldReturnCachedRecipients_whenRegistered() {
+    var service = newService();
+    service.registerRoom(1L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    assertThat(invokeGetRecipientCandidatesForRoom(service, MATRIX_ROOM_ID))
+        .containsExactlyInAnyOrder(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID);
+    verifyNoInteractions(sessionRepository);
+  }
+
+  @Test
+  void getRecipientCandidatesForRoom_shouldLoadFromRepository_whenCacheEmpty() {
+    var service = newService();
+    var session =
+        sessionWithParticipants(userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
+    session.setId(5L);
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.of(session));
+
+    assertThat(invokeGetRecipientCandidatesForRoom(service, MATRIX_ROOM_ID))
+        .containsExactlyInAnyOrder(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID);
+  }
+
+  @Test
+  void getRecipientCandidatesForRoom_shouldReturnEmpty_whenSessionNotFound() {
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.empty());
+
+    assertThat(invokeGetRecipientCandidatesForRoom(newService(), MATRIX_ROOM_ID)).isEmpty();
+  }
+
+  // ── performMatrixSync ──────────────────────────────────────────────────────
+
+  @Test
+  void performMatrixSync_shouldAppendSinceToken_whenSyncTokenPresent() {
+    var service = newService();
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    ReflectionTestUtils.setField(service, "syncToken", "s0");
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(
+            eq("https://matrix.example/_matrix/client/r0/sync?since=s0&timeout=30000"),
+            eq("GET"),
+            eq("admin-token"),
+            eq(null)))
+        .thenReturn(Map.of("next_batch", "s1"));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> result =
+        (Map<String, Object>) ReflectionTestUtils.invokeMethod(service, "performMatrixSync");
+
+    assertThat(result).containsEntry("next_batch", "s1");
+    assertThat(ReflectionTestUtils.getField(service, "syncToken")).isEqualTo("s1");
+  }
+
+  @Test
+  void performMatrixSync_shouldOmitSinceToken_whenSyncTokenNull() {
+    var service = newService();
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(
+            eq("https://matrix.example/_matrix/client/r0/sync?timeout=30000"),
+            eq("GET"),
+            eq("admin-token"),
+            eq(null)))
+        .thenReturn(Map.of());
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> result =
+        (Map<String, Object>) ReflectionTestUtils.invokeMethod(service, "performMatrixSync");
+
+    assertThat(result).isNotNull();
+    assertThat(ReflectionTestUtils.getField(service, "syncToken")).isNull();
+  }
+
+  @Test
+  void performMatrixSync_shouldReturnNull_whenMatrixRequestThrows() {
+    var service = newService();
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(anyString(), anyString(), anyString(), eq(null)))
+        .thenThrow(new RuntimeException("sync failed"));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> result =
+        (Map<String, Object>) ReflectionTestUtils.invokeMethod(service, "performMatrixSync");
+
+    assertThat(result).isNull();
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("ERROR")
+                    && e.getFormattedMessage().contains("Matrix sync failed"));
+  }
+
+  // ── processMatrixSyncEvents ────────────────────────────────────────────────
+
+  @Test
+  void processMatrixSyncEvents_shouldReturnEarly_whenSyncResultNull() {
+    assertThatCode(() -> invokeProcessMatrixSyncEvents(newService(), null))
+        .doesNotThrowAnyException();
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldReturnEarly_whenRoomsKeyMissing() {
+    invokeProcessMatrixSyncEvents(newService(), Map.of("next_batch", "s1"));
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldReturnEarly_whenJoinKeyMissing() {
+    invokeProcessMatrixSyncEvents(newService(), Map.of("rooms", Map.of()));
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldSkipRoom_whenSessionCannotBeResolved() {
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID, List.of(messageEvent(SENDER_MATRIX_ID, "m.text", "hello", null)));
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.empty());
+
+    invokeProcessMatrixSyncEvents(newService(), syncResult);
+
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldTriggerDirectMessageNotification_onRegisteredRoomMessage() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(10L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    var sender = consultantWithId(CONSULTANT_DOMAIN_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(sender));
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID,
+            List.of(
+                messageEvent(CONSULTANT_MATRIX_ID, "m.text", "hello counsellor", "$evt-direct")));
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verify(liveEventNotificationService).sendLiveDirectMessageEventToUsers(MATRIX_ROOM_ID);
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            eq(MATRIX_ROOM_ID), eq(CONSULTANT_DOMAIN_ID), eq(true), any(PrivacyEnvelope.class));
+    verify(eventNotificationService, never())
+        .createThreadReplyNotificationFromRoom(anyString(), any(), anyString(), anyBoolean(), any());
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldTriggerThreadReplyNotification_whenThreadRelationPresent() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(11L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    var user = userWithId(ASKER_DOMAIN_ID);
+    user.setMatrixUserId(SENDER_MATRIX_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+
+    var content = new HashMap<String, Object>();
+    content.put("msgtype", "m.text");
+    content.put("body", "thread reply");
+    content.put("m.relates_to", Map.of("rel_type", "m.thread", "event_id", "$root-thread"));
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID,
+            List.of(messageEventWithContent(SENDER_MATRIX_ID, content, "$evt-thread")));
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verify(eventNotificationService)
+        .createThreadReplyNotificationFromRoom(
+            eq(MATRIX_ROOM_ID),
+            eq(ASKER_DOMAIN_ID),
+            eq("$root-thread"),
+            eq(true),
+            any(PrivacyEnvelope.class));
+    verify(eventNotificationService, never())
+        .createMessageNotificationFromRoom(anyString(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldMirrorMessage_whenRedisMirrorPresent() {
+    var service = newService(Optional.of(redisMessageMirrorService));
+    wireSynchronousExecutor(service);
+    service.registerRoom(12L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID));
+
+    var user = userWithId(ASKER_DOMAIN_ID);
+    user.setMatrixUserId(SENDER_MATRIX_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID, List.of(messageEvent(SENDER_MATRIX_ID, "m.text", "mirror me", "$evt-m")));
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verify(redisMessageMirrorService)
+        .mirrorOutgoingMessage(
+            eq(12L),
+            eq(MATRIX_ROOM_ID),
+            eq(SENDER_MATRIX_ID),
+            eq(false),
+            eq("mirror me"),
+            eq("$evt-m"));
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldNotNotify_whenSenderIsOnlyRecipient() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(13L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID));
+
+    var user = userWithId(ASKER_DOMAIN_ID);
+    user.setMatrixUserId(SENDER_MATRIX_ID);
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
+        .thenReturn(Optional.of(user));
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID, List.of(messageEvent(SENDER_MATRIX_ID, "m.text", "solo", "$evt-solo")));
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verify(liveEventNotificationService, never()).sendLiveDirectMessageEventToUsers(anyString());
+    verify(eventNotificationService, never())
+        .createMessageNotificationFromRoom(anyString(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldNotNotify_whenMessageContentIsNull() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(14L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    var event = new HashMap<String, Object>();
+    event.put("type", "m.room.message");
+    event.put("sender", CONSULTANT_MATRIX_ID);
+    event.put("event_id", "$evt-empty");
+    event.put("content", null);
+
+    invokeProcessMatrixSyncEvents(service, syncResultWithEvents(MATRIX_ROOM_ID, List.of(event)));
+
+    verifyNoInteractions(liveEventNotificationService, eventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldReturnEarly_whenJoinedRoomsNull() {
+    var rooms = new HashMap<String, Object>();
+    rooms.put("join", null);
+    var syncResult = new HashMap<String, Object>();
+    syncResult.put("rooms", rooms);
+
+    invokeProcessMatrixSyncEvents(newService(), syncResult);
+
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldSkipRoom_whenTimelineMissing() {
+    var service = newServiceWithSyncExecutor();
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID))
+        .thenReturn(Optional.of(sessionWithId(15L)));
+
+    var roomData = Map.<String, Object>of();
+    var join = new HashMap<String, Object>();
+    join.put(MATRIX_ROOM_ID, roomData);
+    var rooms = new HashMap<String, Object>();
+    rooms.put("join", join);
+    var syncResult = new HashMap<String, Object>();
+    syncResult.put("rooms", rooms);
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixSyncEvents_shouldResolveSessionFromRepository_whenRoomNotPreRegistered() {
+    var service = newServiceWithSyncExecutor();
+    var session =
+        sessionWithParticipants(userWithId(ASKER_DOMAIN_ID), consultantWithId(CONSULTANT_DOMAIN_ID));
+    session.setId(16L);
+    when(sessionRepository.findByMatrixRoomId(MATRIX_ROOM_ID)).thenReturn(Optional.of(session));
+
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultantWithId(CONSULTANT_DOMAIN_ID)));
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID,
+            List.of(messageEvent(CONSULTANT_MATRIX_ID, "m.text", "from repo", "$evt-repo")));
+
+    invokeProcessMatrixSyncEvents(service, syncResult);
+
+    verify(sessionRepository).findByMatrixRoomId(MATRIX_ROOM_ID);
+    verify(liveEventNotificationService).sendLiveDirectMessageEventToUsers(MATRIX_ROOM_ID);
+  }
+
+  // ── processMatrixEvent (call events) ───────────────────────────────────────
+
+  @Test
+  void processMatrixEvent_shouldIgnoreUnknownEventTypes() {
+    var service = newService();
+    var event = Map.<String, Object>of("type", "m.room.member", "sender", SENDER_MATRIX_ID);
+
+    assertThatCode(() -> invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event))
+        .doesNotThrowAnyException();
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void processMatrixEvent_shouldReturnEarly_whenEventTypeNull() {
+    invokeProcessMatrixEvent(newService(), MATRIX_ROOM_ID, new HashMap<>());
+    verifyNoInteractions(liveEventNotificationService);
+  }
+
+  @Test
+  void handleCallInvite_shouldWarnAboutUnimplementedLiveEvent_whenRecipientsExist() {
+    var service = newService();
+    service.registerRoom(20L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    var event = new HashMap<String, Object>();
+    event.put("type", "m.call.invite");
+    event.put("sender", CONSULTANT_MATRIX_ID);
+    event.put("content", Map.of("call_id", "call-1", "lifetime", 30_000));
+
+    invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event);
+
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("WARN")
+                    && e.getFormattedMessage()
+                        .contains("videoCallRequest live event not yet implemented"));
+  }
+
+  @Test
+  void handleCallInvite_shouldReturnEarly_whenContentNull() {
+    var service = newService();
+    service.registerRoom(21L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID));
+
+    var event = new HashMap<String, Object>();
+    event.put("type", "m.call.invite");
+    event.put("sender", CONSULTANT_MATRIX_ID);
+
+    invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event);
+
+    assertThat(logAppender.list)
+        .noneMatch(e -> e.getFormattedMessage().contains("videoCallRequest live event"));
+  }
+
+  @Test
+  void handleCallInvite_shouldReturnEarly_whenNoRegisteredRecipients() {
+    var service = newService();
+    var event = new HashMap<String, Object>();
+    event.put("type", "m.call.invite");
+    event.put("sender", CONSULTANT_MATRIX_ID);
+    event.put("content", Map.of("call_id", "call-2", "lifetime", 10_000));
+
+    invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event);
+
+    assertThat(logAppender.list)
+        .noneMatch(e -> e.getFormattedMessage().contains("videoCallRequest live event"));
+  }
+
+  @Test
+  void handleCallAnswerAndHangup_shouldLogWithoutThrowing() {
+    var service = newService();
+
+    var answer = Map.<String, Object>of("type", "m.call.answer", "sender", CONSULTANT_MATRIX_ID);
+    var hangup = Map.<String, Object>of("type", "m.call.hangup", "sender", CONSULTANT_MATRIX_ID);
+
+    assertThatCode(() -> invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, answer))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, hangup))
+        .doesNotThrowAnyException();
+
+    assertThat(logAppender.list).anyMatch(e -> e.getFormattedMessage().contains("Call answered"));
+    assertThat(logAppender.list).anyMatch(e -> e.getFormattedMessage().contains("Call ended"));
+  }
+
+  @Test
+  void handleRoomMessage_shouldSwallowNotificationErrors_withoutBreakingSync() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(30L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultantWithId(CONSULTANT_DOMAIN_ID)));
+
+    org.mockito.Mockito.doThrow(new RuntimeException("live down"))
+        .when(liveEventNotificationService)
+        .sendLiveDirectMessageEventToUsers(MATRIX_ROOM_ID);
+
+    var syncResult =
+        syncResultWithEvents(
+            MATRIX_ROOM_ID,
+            List.of(messageEvent(CONSULTANT_MATRIX_ID, "m.text", "boom", "$evt-err")));
+
+    assertThatCode(() -> invokeProcessMatrixSyncEvents(service, syncResult))
+        .doesNotThrowAnyException();
+    assertThat(logAppender.list)
+        .anyMatch(
+            e ->
+                e.getLevel().toString().equals("ERROR")
+                    && e.getFormattedMessage().contains("Failed to send LiveService notification"));
+  }
+
+  @Test
+  void buildRecipientSet_shouldIgnoreParticipantsWithNullIds() {
+    var user = mock(User.class);
+    when(user.getUserId()).thenReturn(null);
+    var consultant = mock(Consultant.class);
+    when(consultant.getId()).thenReturn(null);
+
+    assertThat(invokeBuildRecipientSet(newService(), sessionWithParticipants(user, consultant)))
+        .isEmpty();
+  }
+
+  @Test
+  void extractThreadRootId_shouldReturnNull_whenThreadEventIdMissing() {
+    var content = contentMap("m.relates_to", Map.of("rel_type", "m.thread"));
+    assertThat(invokeExtractThreadRootId(newService(), content)).isNull();
+  }
+
+  @Test
+  void extractMessageBody_shouldPreferBody_overFormattedBody() {
+    var content = new HashMap<String, Object>();
+    content.put("body", "plain");
+    content.put("formatted_body", "<b>rich</b>");
+    assertThat(invokeExtractMessageBody(newService(), content)).isEqualTo("plain");
+  }
+
+  @Test
+  void buildPrivacyEnvelope_shouldClassifyFileAudioVideoAttachmentTypes() {
+    assertThat(
+            invokeBuildPrivacyEnvelope(
+                newService(),
+                Map.of("event_id", "$f"),
+                MATRIX_ROOM_ID,
+                SENDER_MATRIX_ID,
+                "m.file",
+                Map.of("body", "doc")))
+        .satisfies(
+            e -> {
+              assertThat(e.getContentClass()).isEqualTo("FILE");
+              assertThat(e.isHasAttachment()).isTrue();
+            });
+    assertThat(
+            invokeBuildPrivacyEnvelope(
+                newService(),
+                Map.of("event_id", "$a"),
+                MATRIX_ROOM_ID,
+                SENDER_MATRIX_ID,
+                "m.audio",
+                Map.of("body", "voice")))
+        .satisfies(
+            e -> {
+              assertThat(e.getContentClass()).isEqualTo("AUDIO");
+              assertThat(e.isHasAttachment()).isTrue();
+            });
+  }
+
+  private static Session sessionWithId(long sessionId) {
+    var session = new Session();
+    session.setId(sessionId);
+    return session;
+  }
+
+  private static User userWithId(String userId) {
+    var user = new User();
+    user.setUserId(userId);
+    return user;
+  }
+
+  private static Consultant consultantWithId(String consultantId) {
+    var consultant = new Consultant();
+    consultant.setId(consultantId);
+    return consultant;
+  }
+
+  private static Map<String, Object> messageEvent(
+      String sender, String msgtype, String body, String eventId) {
+    var content = new HashMap<String, Object>();
+    content.put("msgtype", msgtype);
+    content.put("body", body);
+    return messageEventWithContent(sender, content, eventId);
+  }
+
+  private static Map<String, Object> messageEventWithContent(
+      String sender, Map<String, Object> content, String eventId) {
+    var event = new HashMap<String, Object>();
+    event.put("type", "m.room.message");
+    event.put("sender", sender);
+    event.put("content", content);
+    if (eventId != null) {
+      event.put("event_id", eventId);
+    }
+    return event;
+  }
+
+  private static Map<String, Object> syncResultWithEvents(
+      String roomId, List<Map<String, Object>> events) {
+    var timeline = Map.<String, Object>of("events", events);
+    var roomData = Map.<String, Object>of("timeline", timeline);
+    var join = Map.<String, Object>of(roomId, roomData);
+    var rooms = Map.<String, Object>of("join", join);
+    return Map.of("rooms", rooms);
+  }
+
+  private static void invokeProcessMatrixSyncEvents(
+      MatrixEventListenerService service, Map<String, Object> syncResult) {
+    ReflectionTestUtils.invokeMethod(service, "processMatrixSyncEvents", syncResult);
+  }
+
+  private static void invokeProcessMatrixEvent(
+      MatrixEventListenerService service, String roomId, Map<String, Object> event) {
+    ReflectionTestUtils.invokeMethod(service, "processMatrixEvent", roomId, event);
+  }
+
+  private static Optional<Long> invokeResolveSessionIdForRoom(
+      MatrixEventListenerService service, String roomId) {
+    return (Optional<Long>)
+        ReflectionTestUtils.invokeMethod(service, "resolveSessionIdForRoom", roomId);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Set<String> invokeGetRecipientCandidatesForRoom(
+      MatrixEventListenerService service, String roomId) {
+    return (Set<String>)
+        ReflectionTestUtils.invokeMethod(service, "getRecipientCandidatesForRoom", roomId);
+  }
+
+  private static String invokeResolveDomainUserId(
+      MatrixEventListenerService service, String matrixUserId) {
+    return (String)
+        ReflectionTestUtils.invokeMethod(
+            service, "resolveDomainUserIdFromMatrixUserId", matrixUserId);
   }
 
   private static Map<String, Object> contentMap(String key, Object value) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
@@ -336,7 +336,8 @@ class MatrixSessionSystemMessageServiceTest {
   @Test
   void postUserLeftChatMessage_shouldNotSendMessage_whenAgencyCredentialsEmpty() {
     var session = sessionWithoutHumanMatrixIds();
-    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.empty());
 
     matrixSessionSystemMessageService.postUserLeftChatMessage(session);
 
@@ -355,7 +356,8 @@ class MatrixSessionSystemMessageServiceTest {
     session.setConsultant(consultant);
 
     when(consultantService.getConsultant(CONSULTANT_ID)).thenReturn(Optional.of(consultant));
-    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.empty());
 
     matrixSessionSystemMessageService.postUserLeftChatMessage(session);
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
@@ -293,6 +293,76 @@ class MatrixSessionSystemMessageServiceTest {
         () -> matrixSessionSystemMessageService.postUserLeftChatMessage(session));
   }
 
+  @Test
+  void postUserLeftChatMessage_shouldReloadUsernameFromSession_whenBlankOnUser() {
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "  ");
+    var persistedUser = new User();
+    persistedUser.setUsername("persisted.username");
+    var persisted = baseSession();
+    persisted.setUser(persistedUser);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(persisted));
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    var bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService).sendMessage(anyString(), bodyCaptor.capture(), anyString());
+    assertThat(bodyCaptor.getValue()).contains("\"username\":\"persisted.username\"");
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldUseEmptyUsername_whenReloadAlsoBlank() {
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "");
+    var persisted = baseSession();
+    var persistedUser = new User();
+    persistedUser.setUsername("");
+    persisted.setUser(persistedUser);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(persisted));
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    var bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService).sendMessage(anyString(), bodyCaptor.capture(), anyString());
+    assertThat(bodyCaptor.getValue()).contains("\"username\":\"\"");
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldNotSendMessage_whenAgencyCredentialsEmpty() {
+    var session = sessionWithoutHumanMatrixIds();
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(agencyMatrixCredentialClient).fetchMatrixCredentials(AGENCY_ID);
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void postUserLeftChatMessage_shouldNotSendMessage_whenConsultantHasNoMatrixIdAfterReload() {
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    consultant.setMatrixUserId(null);
+
+    var session = baseSession();
+    session.setUser(new User());
+    session.setConsultant(consultant);
+
+    when(consultantService.getConsultant(CONSULTANT_ID)).thenReturn(Optional.of(consultant));
+    when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+
+    matrixSessionSystemMessageService.postUserLeftChatMessage(session);
+
+    verify(consultantService).getConsultant(CONSULTANT_ID);
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+  }
+
   private Session baseSession() {
     var session = new Session();
     session.setId(SESSION_ID);

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/RedisMessageMirrorServiceTest.java
@@ -295,6 +295,40 @@ class RedisMessageMirrorServiceTest {
     }
   }
 
+  @Test
+  void constructor_shouldLogDebugOnlyWarning() {
+    Logger ctorLogger = (Logger) LoggerFactory.getLogger(RedisMessageMirrorService.class);
+    ListAppender<ILoggingEvent> ctorAppender = new ListAppender<>();
+    ctorAppender.start();
+    ctorLogger.addAppender(ctorAppender);
+    try {
+      new RedisMessageMirrorService(redisTemplateProvider, objectMapper);
+      assertThat(ctorAppender.list)
+          .anyMatch(
+              e ->
+                  e.getLevel().toString().equals("WARN")
+                      && e.getFormattedMessage().contains("debug only"));
+    } finally {
+      ctorLogger.detachAppender(ctorAppender);
+    }
+  }
+
+  @Test
+  void mirrorOutgoingMessage_shouldIncludeRoomIdInPayload_whenEnabled() throws Exception {
+    ReflectionTestUtils.setField(service, "enabled", true);
+    when(redisTemplateProvider.getIfAvailable()).thenReturn(redisTemplate);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    service.mirrorOutgoingMessage(
+        99L, "!room:custom.org", SENDER_USERNAME, false, SENSITIVE_MESSAGE, "$evt");
+
+    ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).set(anyString(), payloadCaptor.capture(), any(Duration.class));
+    JsonNode payload = objectMapper.readTree(payloadCaptor.getValue());
+    assertThat(payload.get("roomId").asText()).isEqualTo("!room:custom.org");
+    assertThat(payload.has("ts")).isTrue();
+  }
+
   private static String sha256Prefix(String input, int hexChars) throws NoSuchAlgorithmException {
     MessageDigest digest = MessageDigest.getInstance("SHA-256");
     byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Closes [#367](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/367)

## Summary

This PR improves unit test coverage for the following packages:

- `de.caritas.cob.userservice.api.admin.service.consultant.create`
- `de.caritas.cob.userservice.api.service.matrix`
- `de.caritas.cob.userservice.api.service.agency`

The focus of this PR is to increase test coverage without modifying any production code.

## Changes

### Consultant Create

Added:

- `CreateConsultantSagaTest`
- `CreateConsultantDTOCreationInputAdapterTest`
- `ImportRecordCreationInputAdapterTest`
- `CreateConsultantAgencyDTOInputAdapterTest`

Expanded:

- `GrantConsultantIdentityServiceTest`
- `ConsultantAgencyRelationCreatorServiceTest`

Coverage improvements include:

- Happy paths
- Business logic
- Validation
- Error handling
- Rollback scenarios
- Edge cases
- Dependency interactions

---

### Matrix

Expanded test coverage for:

- `MatrixEventListenerService`
- `MatrixSessionSystemMessageService`
- `GroupChatMembershipService`
- `RedisMessageMirrorService`

Coverage improvements include:

- Matrix sync flows
- Event processing
- Notifications
- Redis mirroring
- Call events
- Error handling
- Edge cases

---

### Agency

Expanded coverage for:

- `AgencyService`

Added tests for:

- `AgencyMatrixCredentialClient`
- `AgencyMatrixCredentialsDTO`

Coverage improvements include:

- Happy paths
- Error handling
- Empty/null inputs
- REST client behavior
- DTO accessors and equality

## How to Test

Run only the tests included in this PR:

```bash
mvn test ^
"-Dtest=CreateConsultantSagaTest,\
GrantConsultantIdentityServiceTest,\
CreateConsultantDTOCreationInputAdapterTest,\
ImportRecordCreationInputAdapterTest,\
CreateConsultantAgencyDTOInputAdapterTest,\
ConsultantAgencyRelationCreatorServiceTest,\
MatrixEventListenerServiceTest,\
MatrixSessionSystemMessageServiceTest,\
GroupChatMembershipServiceTest,\
RedisMessageMirrorServiceTest,\
AgencyServiceTest,\
AgencyMatrixCredentialClientTest,\
AgencyMatrixCredentialsDTOTest"
```

Or run the full test suite:

```bash
mvn clean test
```

## Verification

- ✅ No production code changes
- ✅ Unit tests only
- ✅ Existing and new tests pass successfully
- ✅ Test coverage significantly improved

## Notes

- This PR only modifies files under `src/test/java`.
- No files under `src/main/java` were changed.