### PR TITLE
test: lock Matrix server_name invariants (ADR-005 / DB-M04)

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/NoHardcodedMatrixServerIpTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/NoHardcodedMatrixServerIpTest.java
@@ -1,0 +1,136 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-005 / DB-M04 source guard.
+ *
+ * <p>The Matrix {@code server_name} used to be a bare Hetzner IP (finding DB-M04), baking the host
+ * address into every MXID ({@code @alice:91.99.219.182}) and room ID. This test scans {@code
+ * src/main} and fails if any source file hardcodes an IPv4 address as a Matrix server name /
+ * homeserver URL, so the bare-IP class can never silently come back.
+ *
+ * <p>The guard is deliberately precise, not a blunt "no IPv4 anywhere": it only flags an IPv4 that
+ * (a) sits on a line referencing Matrix / Synapse / homeserver configuration, or (b) is one of the
+ * known former homeserver IPs. It tolerates loopback / wildcard addresses and the explanatory
+ * {@code "NOT hardcoded IPs like ..."} documentation comments (e.g. {@code application.properties}
+ * around line 316), which intentionally mention the old IP to warn future editors off it.
+ */
+class NoHardcodedMatrixServerIpTest {
+
+  private static final Path SOURCE_ROOT = Path.of("src/main");
+
+  private static final Pattern IPV4 = Pattern.compile("\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b");
+
+  /** Loopback / wildcard addresses are never a homeserver identity — allowed everywhere. */
+  private static final Set<String> ALLOWED_IPS = Set.of("0.0.0.0", "127.0.0.1");
+
+  /** Former Matrix homeserver IPs (finding DB-M04) — must never reappear as an identity. */
+  private static final Set<String> KNOWN_FORMER_HOMESERVER_IPS =
+      Set.of("91.99.219.182", "91.99.183.160");
+
+  /** Markers meaning an IPv4 on the same line is being used as a Matrix host / server name. */
+  private static final List<String> MATRIX_CONTEXT_MARKERS =
+      List.of(
+          "matrix", "synapse", "homeserver", "server_name", "servername", "mxid", ":8008", ":8448");
+
+  private static final Set<String> TEXT_EXTENSIONS =
+      Set.of(
+          ".java",
+          ".properties",
+          ".yml",
+          ".yaml",
+          ".xml",
+          ".json",
+          ".sql",
+          ".conf",
+          ".factories",
+          ".txt",
+          ".md");
+
+  @Test
+  void noSourceFileHardcodesAnIpv4AsMatrixServerName() throws IOException {
+    assertThat(Files.isDirectory(SOURCE_ROOT))
+        .as("expected %s relative to module root %s", SOURCE_ROOT, Path.of("").toAbsolutePath())
+        .isTrue();
+
+    List<String> violations = new ArrayList<>();
+    try (Stream<Path> paths = Files.walk(SOURCE_ROOT)) {
+      paths
+          .filter(Files::isRegularFile)
+          .filter(this::isTextFile)
+          .forEach(path -> scanFile(path, violations));
+    }
+
+    assertThat(violations)
+        .as(
+            "hardcoded Matrix homeserver IPv4 found (ADR-005 / DB-M04) — use the configured "
+                + "matrix.serverName / matrix.apiUrl instead of a literal IP:%n%s",
+            String.join(System.lineSeparator(), violations))
+        .isEmpty();
+  }
+
+  private boolean isTextFile(Path path) {
+    String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+    return TEXT_EXTENSIONS.stream().anyMatch(name::endsWith);
+  }
+
+  private void scanFile(Path file, List<String> violations) {
+    List<String> lines;
+    try {
+      lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Could not read " + file, e);
+    }
+    for (int i = 0; i < lines.size(); i++) {
+      collectViolations(file, i + 1, lines.get(i), violations);
+    }
+  }
+
+  private void collectViolations(Path file, int lineNumber, String line, List<String> violations) {
+    if (!IPV4.matcher(line).find()) {
+      return;
+    }
+    // Sanctioned documentation: a full-line comment that explicitly flags the IP as NOT hardcoded.
+    if (isExplanatoryNotHardcodedComment(line)) {
+      return;
+    }
+    String lower = line.toLowerCase(Locale.ROOT);
+    boolean matrixContext = MATRIX_CONTEXT_MARKERS.stream().anyMatch(lower::contains);
+
+    Matcher matcher = IPV4.matcher(line);
+    while (matcher.find()) {
+      String ip = matcher.group();
+      if (ALLOWED_IPS.contains(ip)) {
+        continue;
+      }
+      if (matrixContext || KNOWN_FORMER_HOMESERVER_IPS.contains(ip)) {
+        violations.add(file + ":" + lineNumber + " -> " + ip + "    | " + line.trim());
+      }
+    }
+  }
+
+  private boolean isExplanatoryNotHardcodedComment(String line) {
+    String trimmed = line.trim();
+    boolean isComment =
+        trimmed.startsWith("#")
+            || trimmed.startsWith("//")
+            || trimmed.startsWith("*")
+            || trimmed.startsWith("/*");
+    return isComment && trimmed.toLowerCase(Locale.ROOT).contains("not hardcoded");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfigPropertiesTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfigPropertiesTest.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api.adapters.matrix.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-005 / DB-M04 regression guard for the production {@code application.properties}.
+ *
+ * <p>The Matrix homeserver address (finding DB-M04) must never be baked into the service. {@code
+ * matrix.serverName} and {@code matrix.apiUrl} must resolve from the {@code MATRIX_SERVER_NAME} /
+ * {@code MATRIX_API_URL} environment variables with NO hardcoded, non-empty default — so the
+ * homeserver can be moved (e.g. to {@code matrix.oriso.org}) purely via configuration, without a
+ * host address leaking into the source tree.
+ */
+class MatrixConfigPropertiesTest {
+
+  private static final Path APPLICATION_PROPERTIES =
+      Path.of("src/main/resources/application.properties");
+
+  @Test
+  void matrixServerName_should_resolve_from_env_with_no_hardcoded_default() throws IOException {
+    assertEnvDrivenWithEmptyDefault("matrix.serverName", "MATRIX_SERVER_NAME");
+  }
+
+  @Test
+  void matrixApiUrl_should_resolve_from_env_with_no_hardcoded_default() throws IOException {
+    assertEnvDrivenWithEmptyDefault("matrix.apiUrl", "MATRIX_API_URL");
+  }
+
+  private void assertEnvDrivenWithEmptyDefault(String propertyKey, String envVar)
+      throws IOException {
+    String rawValue = loadRawProperty(propertyKey);
+    assertThat(rawValue)
+        .as("%s must be present in application.properties", propertyKey)
+        .isNotNull();
+
+    // Must be a pure ${ENV:default} placeholder referencing the expected environment variable...
+    Matcher matcher =
+        Pattern.compile("^\\$\\{" + Pattern.quote(envVar) + ":(.*)}$").matcher(rawValue.trim());
+    assertThat(matcher.matches())
+        .as("%s must resolve from a ${%s:...} placeholder (was: %s)", propertyKey, envVar, rawValue)
+        .isTrue();
+    // ...with NO hardcoded, non-empty default baked in (the segment after the colon must be blank).
+    assertThat(matcher.group(1))
+        .as("%s must not carry a hardcoded, non-empty default (was: %s)", propertyKey, rawValue)
+        .isBlank();
+  }
+
+  /** Reads the raw, unresolved property value straight from the file (no Spring interpolation). */
+  private String loadRawProperty(String key) throws IOException {
+    assertThat(Files.exists(APPLICATION_PROPERTIES))
+        .as(
+            "expected %s relative to module root %s",
+            APPLICATION_PROPERTIES, Path.of("").toAbsolutePath())
+        .isTrue();
+    var properties = new Properties();
+    try (InputStream in = Files.newInputStream(APPLICATION_PROPERTIES)) {
+      properties.load(in);
+    }
+    return properties.getProperty(key);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -227,6 +227,34 @@ class AssignEnquiryFacadeTest {
   }
 
   @Test
+  void
+      assignEnquiry_Should_DeriveConstructedMxidServerPartFromConfiguredServerName_SoConfigChangesTheMxid()
+          throws MatrixCreateUserException {
+    // ADR-005 / DB-M04: AssignEnquiryFacade is the ONE place the service constructs a Matrix user
+    // ID. Its server part must come from the injected MatrixConfig, never a literal (and certainly
+    // never a bare IP). Inject a distinctive server name that production code could not plausibly
+    // hardcode and prove it flows verbatim into the constructed MXID — i.e. change the config,
+    // change the MXID.
+    TenantContext.setCurrentTenant(CURRENT_TENANT_ID);
+    when(matrixConfig.getServerName()).thenReturn("test.example.org");
+    USER_WITH_RC_ID.setMatrixUserId(null);
+    USER_WITH_RC_ID.setUsername("probeuser");
+    lenient()
+        .when(rocketChatFacade.retrieveRocketChatMembers(anyString()))
+        .thenReturn(LIST_GROUP_MEMBER_DTO);
+    // Force the create path to fail so the MXID-construction fallback branch runs.
+    when(matrixSynapseService.createUser(eq("probeuser"), anyString(), eq("probeuser")))
+        .thenThrow(new MatrixCreateUserException("User ID already taken"));
+
+    assignEnquiryFacade.assignRegisteredEnquiry(SESSION_WITHOUT_CONSULTANT, CONSULTANT_WITH_AGENCY);
+
+    // The constructed candidate MXID must use the configured server name verbatim.
+    assertThat(USER_WITH_RC_ID.getMatrixUserId()).isEqualTo("@probeuser:test.example.org");
+    verify(matrixSynapseService, atLeastOnce())
+        .loginAsUserAccessToken("@probeuser:test.example.org");
+  }
+
+  @Test
   void assignEnquiry_Should_ReturnOKAndRemoveSystemMessagesFromGroup() {
     // given
     TenantContext.setCurrentTenant(CURRENT_TENANT_ID);

--- a/src/test/java/de/caritas/cob/userservice/api/helper/MatrixIdsTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/MatrixIdsTest.java
@@ -111,4 +111,90 @@ class MatrixIdsTest {
         .isInstanceOf(java.lang.reflect.InvocationTargetException.class)
         .hasCauseInstanceOf(UnsupportedOperationException.class);
   }
+
+  // ---------------------------------------------------------------------------
+  // ADR-005 / DB-M04 regression: the server part of a Matrix ID is opaque to
+  // MatrixIds. Parsing must stay correct whether the server is a DNS name
+  // (matrix.oriso.org), carries a port, or is a bare IPv4. These lock the CURRENT
+  // behaviour (documenting, not inventing) so the former bare-Hetzner-IP class of
+  // Matrix ID can never silently slip back in unnoticed.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void localpart_should_extract_when_server_has_dots_and_port() {
+    // Only the first colon separates the local part; dots and the port colon are ignored.
+    assertThat(MatrixIds.localpart("@alice:matrix.oriso.org:8448")).isEqualTo("alice");
+  }
+
+  @Test
+  void localpart_should_extract_from_room_id_with_dotted_server_and_port() {
+    assertThat(MatrixIds.localpart("!abc123:matrix.oriso.org:8448")).isEqualTo("abc123");
+  }
+
+  @Test
+  void localpart_should_extract_when_server_is_bare_ipv4() {
+    // Documents current behaviour: the IPv4 lives only in the (ignored) server part.
+    assertThat(MatrixIds.localpart("@alice:91.99.219.182")).isEqualTo("alice");
+  }
+
+  @Test
+  void localpart_should_extract_when_server_is_bare_ipv4_with_port() {
+    assertThat(MatrixIds.localpart("@alice:91.99.219.182:8008")).isEqualTo("alice");
+  }
+
+  @Test
+  void localpart_should_return_empty_when_localpart_is_missing() {
+    // Documents current behaviour: "@:server" has its colon at index 1, so substring(1, 1) == "".
+    assertThat(MatrixIds.localpart("@:matrix.oriso.org")).isEmpty();
+  }
+
+  @Test
+  void localpart_should_extract_when_server_part_is_empty() {
+    assertThat(MatrixIds.localpart("@alice:")).isEqualTo("alice");
+  }
+
+  @Test
+  void localpart_should_throw_when_colon_is_first_char() {
+    assertThatThrownBy(() -> MatrixIds.localpart(":matrix.oriso.org"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("no colon separator");
+  }
+
+  @Test
+  void localpartLenient_should_extract_when_server_has_dots_and_port() {
+    assertThat(MatrixIds.localpartLenient("@alice:matrix.oriso.org:8448")).isEqualTo("alice");
+  }
+
+  @Test
+  void localpartLenient_should_extract_when_server_is_bare_ipv4() {
+    assertThat(MatrixIds.localpartLenient("@bob:91.99.219.182")).isEqualTo("bob");
+  }
+
+  @Test
+  void localpartLenient_should_return_server_part_when_localpart_is_missing() {
+    // Documents current behaviour: after stripping "@", ":server" has its colon at index 0, so the
+    // lenient parser returns the remainder unchanged instead of throwing.
+    assertThat(MatrixIds.localpartLenient("@:matrix.oriso.org")).isEqualTo(":matrix.oriso.org");
+  }
+
+  @Test
+  void isUserId_should_return_false_for_empty_string() {
+    assertThat(MatrixIds.isUserId("")).isFalse();
+  }
+
+  @Test
+  void isRoomId_should_return_false_for_empty_string() {
+    assertThat(MatrixIds.isRoomId("")).isFalse();
+  }
+
+  @Test
+  void isUserId_should_detect_sigil_independently_of_ipv4_server() {
+    // Sigil detection must not depend on the server part being a DNS name rather than an IP.
+    assertThat(MatrixIds.isUserId("@alice:91.99.219.182")).isTrue();
+  }
+
+  @Test
+  void isRoomId_should_detect_sigil_independently_of_ipv4_server() {
+    assertThat(MatrixIds.isRoomId("!abc123:91.99.219.182")).isTrue();
+  }
 }


### PR DESCRIPTION
## Why

ADR-005 rebuilds the Matrix homeserver with `server_name = matrix.oriso.org`. The `server_name` is immutable inside every Matrix user ID (`@alice:matrix.oriso.org`) and room ID (`!abc:matrix.oriso.org`), so it used to bake a bare Hetzner IP (`91.99.219.182` / `91.99.183.160`) into every MXID — finding **DB-M04**. This PR adds regression tests that lock the invariants which keep that class of bug from silently coming back. No production behaviour changes.

Part of the ADR-005 homeserver rebuild tracked in the epic `OpenResilienceInitiative/ORISO-Helm#31`.

## What (tests only)

- **`MatrixIdsTest`** (extended) — edge cases documenting current `MatrixIds` parsing: server parts with dots and ports, bare IPv4 servers (with/without port), empty local part, colon-first input that throws, lenient-variant behaviour, and `isUserId` / `isRoomId` sigil detection being independent of whether the server part is a DNS name or an IP.
- **`AssignEnquiryFacadeTest`** (extended) — proves the one place the service constructs an MXID (`AssignEnquiryFacade`, the `"@" + localpart + ":" + matrixConfig.getServerName()` fallback) derives its server part from the injected `MatrixConfig.serverName`. A distinctive `test.example.org` is injected (not the production value) and asserted to appear verbatim in the constructed MXID — change the config, change the MXID.
- **`MatrixConfigPropertiesTest`** (new) — asserts `matrix.serverName` / `matrix.apiUrl` in `application.properties` resolve from `MATRIX_SERVER_NAME` / `MATRIX_API_URL` with **no** hardcoded, non-empty default.
- **`NoHardcodedMatrixServerIpTest`** (new) — source guard scanning `src/main`; fails if any file hardcodes an IPv4 as a Matrix server name / homeserver URL. Deliberately precise (only IPs in a Matrix/Synapse/homeserver context, plus the known former homeserver IPs), and tolerant of loopback/wildcard addresses and the explanatory `# NOT hardcoded IPs like ...` documentation comments.

## Red/green discipline

Every assertion was proven capable of failing by temporarily mutating production code/config, then reverted:

| Mutation | Test that caught it |
| --- | --- |
| `MatrixIds.localpart` `indexOf(':')` → `lastIndexOf(':')` | `MatrixIdsTest` (dotted-server / IPv4-with-port cases) |
| `AssignEnquiryFacade` MXID server part hardcoded to `":91.99.219.182"` | `AssignEnquiryFacadeTest.assignEnquiry_Should_DeriveConstructedMxidServerPartFromConfiguredServerName...` |
| `matrix.serverName=${MATRIX_SERVER_NAME:matrix.oriso.org}` (literal default) | `MatrixConfigPropertiesTest` |
| `matrix.serverName=91.99.219.182` (real hardcoded IP) | `NoHardcodedMatrixServerIpTest` |

## Verification

`mvn -Dtest=MatrixIdsTest,AssignEnquiryFacadeTest,MatrixConfigPropertiesTest,NoHardcodedMatrixServerIpTest test` → **BUILD SUCCESS**, 63 tests, 0 failures. Pure unit tests, so the docker `make verify` stack is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added safeguards preventing hardcoded Matrix server addresses in application code and configuration.
  * Added regression coverage for Matrix server name configuration and user assignment.
  * Expanded Matrix ID parsing validation for domains, ports, IPv4 addresses, missing localparts, empty values, and sigil detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->