### PR TITLE
fix(build): stop surefire running the unit tests twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1175,6 +1175,14 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId> <!-- surefire plugin version managed by Spring Boot -->
 				<executions>
+					<!-- Surefire binds an implicit `default-test` execution to the `test` phase.
+					     Left enabled it runs the unit tests a SECOND time alongside the explicit
+					     `unit-tests` execution below, and it ignores `${skip.unit-tests}`.
+					     Disable it so `unit-tests` solely owns the phase. -->
+					<execution>
+						<id>default-test</id>
+						<phase>none</phase>
+					</execution>
 					<execution>
 						<id>unit-tests</id>
 						<phase>test</phase>


### PR DESCRIPTION
## Every `mvn test` runs the whole unit suite twice

`maven-surefire-plugin` declares an explicit `unit-tests` execution bound to the `test` phase, but never disables surefire's **implicit `default-test` execution**, which is bound to the same phase. Both run.

A second, quieter bug falls out of the same cause: `${skip.unit-tests}` is configured only on the `unit-tests` execution, so the implicit one ignores it — **`-Dskip.unit-tests=true` did not skip anything.**

## Fix

Disable `default-test` with `<phase>none</phase>` and let `unit-tests` own the phase. The `integration-tests` execution (bound to `integration-test`) is untouched.

## Nothing is excluded

`default-test`'s default includes are `**/Test*.java`, `**/*Test.java`, `**/*Tests.java`, `**/*TestCase.java`; `unit-tests` includes only `**/*Test.java`. The difference is therefore `Test*.java`, `*Tests.java`, `*TestCase.java`. In this repo:

| pattern | count |
|---|---|
| `*Test.java` | 329 |
| `*Tests.java` | 0 |
| `*TestCase.java` | 0 |
| `Test*.java` (not `*Test.java`) | 4 |

Those four are `TestMailsControllerApi`, `TestAgencyControllerApi`, `TestConstants`, `TestLogAppender` — **helper classes with zero `@Test` methods**. So no executable test is lost.

## Verification (Java 21, on `pre-dev`, scoped to `MatrixIdsTest,AssignEnquiryFacadeTest`)

| | before | after |
|---|---|---|
| per-class `Tests run:` summary | printed **2×** each | printed **1×** each |
| aggregate | `Tests run: 45` **2×** | `Tests run: 45` **1×** |
| per-class counts | 19 + 26 | **19 + 26 (unchanged)** |
| `-Dskip.unit-tests=true` | still ran the class (**1×**) | correctly skips (**0×**) |

Measured by restoring the unpatched `pom.xml` for the "before" run so both runs are on the same tree.

## Notes
- Pre-existing; found incidentally while adding the ADR-005 tests (PR #370). Unrelated to that change.
- The repo targets **Java 21** and no JDK is on `PATH` by default (`JAVA_HOME=$(/usr/libexec/java_home -v 21)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
