### PR TITLE
feat: promote self-help group lifecycle to dev

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -1881,8 +1881,192 @@ paths:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
       security:
         - Bearer: [ ]
+  /users/chat-series/{seriesId}/occurrences:
+    get:
+      tags:
+        - chat-series-controller
+      operationId: getChatSeriesOccurrences
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+        - name: from
+          in: query
+          required: true
+          schema: { type: string, format: date-time }
+        - name: to
+          in: query
+          required: true
+          schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, default: 50 }
+      responses:
+        '200':
+          description: Bounded virtual occurrence projection
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    seriesId: { type: integer, format: int64 }
+                    occurrenceIndex: { type: integer, format: int32 }
+                    originalStart: { type: string, format: date-time }
+                    start: { type: string, format: date-time }
+                    duration: { type: integer, format: int32 }
+                    capacity: { type: integer, format: int32 }
+                    modality: { type: string, enum: [TEXT, AUDIO, VIDEO] }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+  /users/chat-series/{seriesId}/occurrences/skip:
+    post:
+      tags: [chat-series-controller]
+      operationId: skipChatSeriesOccurrence
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+        - name: originalStartUtc
+          in: query
+          required: true
+          schema: { type: string, format: date-time }
+      responses:
+        '204': { description: Occurrence skipped }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not an Owner or Co-Moderator }
+  /users/chat-series/{seriesId}/occurrences/override:
+    put:
+      tags: [chat-series-controller]
+      operationId: overrideChatSeriesOccurrence
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/OccurrenceOverrideRequest' }
+      responses:
+        '204': { description: Occurrence overridden }
+        '400': { description: Invalid occurrence override }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not an Owner or Co-Moderator }
+  /users/chat-series/{seriesId}/participants/{consultantId}/role:
+    put:
+      tags: [chat-series-controller]
+      operationId: changeChatSeriesParticipantRole
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+        - name: consultantId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/RoleRequest' }
+      responses:
+        '204': { description: Role changed }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not an Owner }
+  /users/chat-series/consultants:
+    get:
+      tags: [chat-series-controller]
+      operationId: getChatSeriesConsultants
+      summary: Returns active consultants in the authenticated consultant's tenant
+      security:
+        - Bearer: [ ]
+      responses:
+        '200':
+          description: Tenant consultant directory
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ConsultantResponseDTO' }
+        '204': { description: No active consultants in this tenant }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not a consultant }
+  /users/chat-series/{seriesId}/participants/{consultantId}:
+    delete:
+      tags: [chat-series-controller]
+      operationId: removeChatSeriesParticipant
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+        - name: consultantId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: Participant removed and Matrix membership revoked }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not an Owner }
+        '409': { description: Target is still an Owner }
+  /users/chat-series/{seriesId}/transfer-ownership:
+    post:
+      tags: [chat-series-controller]
+      operationId: transferChatSeriesOwnership
+      security:
+        - Bearer: [ ]
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TransferOwnershipRequest' }
+      responses:
+        '204': { description: Primary ownership transferred }
+        '401': { description: UNAUTHORIZED - no/invalid Keycloak token }
+        '403': { description: Caller is not an Owner }
+
 components:
   schemas:
+    OccurrenceOverrideRequest:
+      type: object
+      required: [originalStartUtc]
+      properties:
+        originalStartUtc: { type: string, format: date-time }
+        overrideStartUtc: { type: string, format: date-time }
+        duration: { type: integer, minimum: 1 }
+        capacity: { type: integer, minimum: 1 }
+        modality: { type: string, enum: [TEXT, AUDIO, VIDEO] }
+    RoleRequest:
+      type: object
+      required: [role]
+      properties:
+        role: { type: string, enum: [OWNER, CO_MODERATOR, PARTICIPANT] }
+    TransferOwnershipRequest:
+      type: object
+      required: [consultantId]
+      properties:
+        consultantId: { type: string }
     UserDTO:
       allOf:
         - $ref: '#/components/schemas/SessionDataDTO'
@@ -2308,6 +2492,24 @@ components:
         repetitive:
           type: boolean
           example: false
+        repeatCount:
+          type: integer
+          minimum: 1
+          maximum: 365
+          example: 6
+        currentOccurrenceIndex:
+          type: integer
+          minimum: 0
+          example: 0
+        chatInterval:
+          type: string
+          enum: [DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY]
+        modality:
+          type: string
+          enum: [TEXT, AUDIO, VIDEO]
+        timezone:
+          type: string
+          example: Europe/Berlin
         active:
           type: boolean
           example: false
@@ -2338,6 +2540,10 @@ components:
           type: array
           items:
             type: string
+        participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupChatParticipantDTO'
         startDateWithTime:
           type: string
           format: date-time
@@ -2354,6 +2560,35 @@ components:
           type: string
           example: "Hint"
           maxLength: 300
+        sourceLanguage:
+          type: string
+          example: de
+          maxLength: 10
+        hintMessageTranslations:
+          type: object
+          additionalProperties:
+            type: string
+            maxLength: 120
+        groupChatRulesTranslations:
+          type: object
+          additionalProperties:
+            type: array
+            maxItems: 10
+            items:
+              type: string
+              maxLength: 120
+
+    GroupChatParticipantDTO:
+      type: object
+      required: [consultantId, role, displayName]
+      properties:
+        consultantId:
+          type: string
+        role:
+          type: string
+          enum: [OWNER, CO_MODERATOR, PARTICIPANT]
+        displayName:
+          type: string
 
     SessionUserDTO:
       type: object
@@ -2801,10 +3036,43 @@ components:
         repetitive:
           type: boolean
           example: false
+        repeatCount:
+          type: integer
+          minimum: 1
+          maximum: 365
+          default: 1
+        chatInterval:
+          type: string
+          enum: [DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY]
+        modality:
+          type: string
+          enum: [TEXT, AUDIO, VIDEO]
+          default: TEXT
+        timezone:
+          type: string
+          example: Europe/Berlin
+          default: UTC
         hintMessage:
           type: string
           example: "Hint"
           maxLength: 300
+        sourceLanguage:
+          type: string
+          example: de
+          maxLength: 10
+        hintMessageTranslations:
+          type: object
+          additionalProperties:
+            type: string
+            maxLength: 120
+        groupChatRulesTranslations:
+          type: object
+          additionalProperties:
+            type: array
+            maxItems: 10
+            items:
+              type: string
+              maxLength: 120
 
     CreateChatResponseDTO:
       type: object

--- a/services/tenantservice.yaml
+++ b/services/tenantservice.yaml
@@ -89,6 +89,15 @@ components:
         content:
           $ref:
             '#/components/schemas/Content'
+        settings:
+          $ref:
+            '#/components/schemas/RestrictedTenantSettings'
+    RestrictedTenantSettings:
+      type: object
+      properties:
+        featureGroupChatV2Enabled:
+          type: boolean
+          default: false
     Licensing:
       type: object
       required:

--- a/src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java
@@ -45,9 +45,11 @@ public class ChatReCreator {
    * @param matrixRoomId the id of the freshly created Matrix room
    */
   public void updateAsNextChat(Chat chat, String matrixRoomId) {
+    var nextStart = chat.nextStart();
     chat.setGroupId(matrixRoomId);
     chat.setMatrixRoomId(matrixRoomId);
-    chat.setStartDate(chat.nextStart());
+    chat.setStartDate(nextStart);
+    chat.setCurrentOccurrenceIndex(chat.getCurrentOccurrenceIndex() + 1);
     chat.setUpdateDate(nowInUtc());
     chat.setActive(false);
 

--- a/src/main/java/de/caritas/cob/userservice/api/actions/chat/MatrixChatShutdownService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/chat/MatrixChatShutdownService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.actions.chat;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.model.Chat;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,9 @@ public class MatrixChatShutdownService {
    */
   public void shutdownRoom(Chat chat) {
     var matrixRoomId = chat.getMatrixRoomId();
+    if (isBlank(matrixRoomId) && MatrixIds.isRoomId(chat.getGroupId())) {
+      matrixRoomId = chat.getGroupId();
+    }
     if (isBlank(matrixRoomId)) {
       log.debug("Chat {} has no Matrix room id; skipping Matrix room shutdown", chat.getId());
       return;

--- a/src/main/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommand.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommand.java
@@ -8,6 +8,7 @@ import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.service.ChatService;
 import lombok.RequiredArgsConstructor;
@@ -35,20 +36,38 @@ public class StopChatActionCommand implements ActionCommand<Chat> {
   public void execute(Chat chat) {
     checkActiveState(chat);
 
-    if (isNull(chat.getGroupId())) {
+    var matrixChat = isMatrixChat(chat);
+    if (isNull(chat.getGroupId()) && !matrixChat) {
       throw new InternalServerErrorException(
           String.format("Chat with id %s has no Rocket.Chat group id", chat.getId()));
     }
 
-    if (!chat.isRepetitive() || nonNull(chat.nextStart())) {
-      deleteMessengerChat(chat);
-      if (chat.isRepetitive()) {
-        var rcGroupId = chatReCreator.recreateMessengerChat(chat);
-        chatReCreator.updateAsNextChat(chat, rcGroupId);
+    if (chat.isRepetitive() && isNull(chat.getChatInterval())) {
+      throw new InternalServerErrorException(
+          String.format("Finite chat series with id %s has no interval", chat.getId()));
+    }
+
+    if (chat.isRepetitive()) {
+      if (nonNull(chat.nextStart())) {
+        if (!matrixChat) {
+          deleteMessengerChat(chat);
+        }
+        var matrixRoomId = chatReCreator.recreateMessengerChat(chat);
+        chatReCreator.updateAsNextChat(chat, matrixRoomId);
       } else {
-        chatService.deleteChat(chat);
+        if (!matrixChat) {
+          deleteMessengerChat(chat);
+        }
         matrixChatShutdownService.shutdownRoom(chat);
+        chat.setActive(false);
+        chatService.saveChat(chat);
       }
+    } else {
+      if (!matrixChat) {
+        deleteMessengerChat(chat);
+      }
+      chatService.deleteChat(chat);
+      matrixChatShutdownService.shutdownRoom(chat);
     }
   }
 
@@ -64,5 +83,10 @@ public class StopChatActionCommand implements ActionCommand<Chat> {
       throw new InternalServerErrorException(
           String.format("Could not delete Rocket.Chat group with id %s", chat.getGroupId()));
     }
+  }
+
+  private boolean isMatrixChat(Chat chat) {
+    return MatrixIds.isRoomId(chat.getGroupId())
+        || (isNull(chat.getGroupId()) && MatrixIds.isRoomId(chat.getMatrixRoomId()));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -29,6 +29,8 @@ import org.springframework.web.client.RestTemplate;
 public class MatrixRoomClient {
 
   private static final String ENDPOINT_CREATE_ROOM = "/_matrix/client/r0/createRoom";
+  private static final String ROOM_ENCRYPTION_EVENT_TYPE = "m.room.encryption";
+  private static final String MEGOLM_ALGORITHM = "m.megolm.v1.aes-sha2";
   private static final String ENDPOINT_INVITE_USER = "/_matrix/client/r0/rooms/{roomId}/invite";
   private static final String ENDPOINT_JOIN_ROOM = "/_matrix/client/r0/rooms/{roomId}/join";
   private static final String ENDPOINT_LEAVE_ROOM = "/_matrix/client/r0/rooms/{roomId}/leave";
@@ -45,6 +47,13 @@ public class MatrixRoomClient {
   public ResponseEntity<MatrixCreateRoomResponseDTO> createRoom(
       String roomName, String roomAlias, String accessToken) throws MatrixCreateRoomException {
 
+    return createRoom(roomName, roomAlias, accessToken, false);
+  }
+
+  public ResponseEntity<MatrixCreateRoomResponseDTO> createRoom(
+      String roomName, String roomAlias, String accessToken, boolean encryptionEnabled)
+      throws MatrixCreateRoomException {
+
     try {
       var headers = getClientHttpHeaders(accessToken);
       headers.setContentType(MediaType.APPLICATION_JSON);
@@ -55,8 +64,7 @@ public class MatrixRoomClient {
       roomCreateRequest.setPreset("private_chat");
       roomCreateRequest.setVisibility("private");
 
-      // Matrix E2EE is disabled because the frontend applies its own encryption layer.
-      roomCreateRequest.setInitialState(new java.util.ArrayList<>());
+      roomCreateRequest.setInitialState(buildInitialState(encryptionEnabled));
 
       HttpEntity<MatrixCreateRoomRequestDTO> request = new HttpEntity<>(roomCreateRequest, headers);
 
@@ -87,6 +95,19 @@ public class MatrixRoomClient {
       throw new MatrixCreateRoomException(
           String.format("Could not create room (%s) in Matrix", roomName));
     }
+  }
+
+  private java.util.List<MatrixCreateRoomRequestDTO.InitialStateEvent> buildInitialState(
+      boolean encryptionEnabled) {
+    if (!encryptionEnabled) {
+      return java.util.List.of();
+    }
+
+    var encryptionEvent = new MatrixCreateRoomRequestDTO.InitialStateEvent();
+    encryptionEvent.setType(ROOM_ENCRYPTION_EVENT_TYPE);
+    encryptionEvent.setStateKey("");
+    encryptionEvent.setContent(Map.of("algorithm", MEGOLM_ALGORITHM));
+    return java.util.List.of(encryptionEvent);
   }
 
   public ResponseEntity<MatrixInviteUserResponseDTO> inviteUserToRoom(

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +68,10 @@ public class MatrixSynapseService {
   // password reset) is not served indefinitely. Mirrors the impersonationTokenCache mechanism
   // below.
   private final java.util.Map<String, CachedAccessToken> accessTokenCache =
+      new java.util.concurrent.ConcurrentHashMap<>();
+
+  // Rotating a browser-login password and consuming it must be atomic per Matrix identity.
+  private final java.util.Map<String, java.util.concurrent.locks.ReentrantLock> browserLoginLocks =
       new java.util.concurrent.ConcurrentHashMap<>();
 
   private static final long ACCESS_TOKEN_CACHE_TTL_MS = 50 * 60 * 1000L;
@@ -382,6 +387,85 @@ public class MatrixSynapseService {
       return null;
     }
     return String.valueOf(tokenResponse.get("access_token"));
+  }
+
+  /**
+   * Creates a device-bound Matrix login for browser E2EE without persisting a Matrix password.
+   *
+   * <p>Synapse admin impersonation tokens deliberately have no device and therefore cannot upload
+   * encryption keys. A random password is rotated server-side, existing devices remain logged in,
+   * and the password is used exactly once for the standard client login that binds the returned
+   * token to {@code deviceId}.
+   *
+   * @param matrixUserId full local Matrix user ID
+   * @param deviceId stable browser device ID
+   * @return standard Matrix login response, or {@code null} when the login cannot be created
+   */
+  public java.util.Map<String, Object> loginBrowserDevice(String matrixUserId, String deviceId) {
+    if (matrixUserId == null
+        || matrixUserId.isBlank()
+        || deviceId == null
+        || !deviceId.matches("[A-Za-z0-9._=-]{1,255}")) {
+      return null;
+    }
+
+    String adminToken = getAdminAccessToken();
+    if (adminToken == null) {
+      return null;
+    }
+
+    var browserLoginLock =
+        browserLoginLocks.computeIfAbsent(
+            matrixUserId, ignored -> new java.util.concurrent.locks.ReentrantLock());
+    browserLoginLock.lock();
+    try {
+      String transientPassword = UUID.randomUUID() + "-" + UUID.randomUUID();
+      var adminHeaders = getClientHttpHeaders(adminToken);
+      adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+      var updateBody =
+          java.util.Map.<String, Object>of("password", transientPassword, "logout_devices", false);
+      var updateUri =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
+      restTemplate.exchange(
+          updateUri,
+          org.springframework.http.HttpMethod.PUT,
+          new HttpEntity<>(updateBody, adminHeaders),
+          java.util.Map.class);
+
+      var loginHeaders = new HttpHeaders();
+      loginHeaders.setContentType(MediaType.APPLICATION_JSON);
+      var loginBody = new java.util.HashMap<String, Object>();
+      loginBody.put("type", "m.login.password");
+      loginBody.put("user", matrixUserId);
+      loginBody.put("password", transientPassword);
+      loginBody.put("device_id", deviceId);
+      loginBody.put("initial_device_display_name", "ORISO Web");
+
+      var response =
+          restTemplate.postForEntity(
+              matrixConfig.getApiUrl(ENDPOINT_LOGIN),
+              new HttpEntity<>(loginBody, loginHeaders),
+              java.util.Map.class);
+      if (response.getBody() == null
+          || response.getBody().get("access_token") == null
+          || response.getBody().get("device_id") == null) {
+        return null;
+      }
+
+      @SuppressWarnings("unchecked")
+      var responseBody = (java.util.Map<String, Object>) response.getBody();
+      return responseBody;
+    } catch (Exception ex) {
+      log.error(
+          "Matrix browser device login failed for user {} and device {}: {}",
+          matrixUserId,
+          deviceId,
+          ex.getMessage());
+      return null;
+    } finally {
+      browserLoginLock.unlock();
+    }
   }
 
   /**
@@ -722,7 +806,8 @@ public class MatrixSynapseService {
   public ResponseEntity<MatrixCreateRoomResponseDTO> createRoom(
       String roomName, String roomAlias, String accessToken) throws MatrixCreateRoomException {
 
-    return matrixRoomClient.createRoom(roomName, roomAlias, accessToken);
+    return matrixRoomClient.createRoom(
+        roomName, roomAlias, accessToken, matrixConfig.isEncryptionEnabled());
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserRespon
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.helper.MatrixIds;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -402,10 +403,7 @@ public class MatrixSynapseService {
    * @return standard Matrix login response, or {@code null} when the login cannot be created
    */
   public java.util.Map<String, Object> loginBrowserDevice(String matrixUserId, String deviceId) {
-    if (matrixUserId == null
-        || matrixUserId.isBlank()
-        || deviceId == null
-        || !deviceId.matches("[A-Za-z0-9._=-]{1,255}")) {
+    if (matrixUserId == null || matrixUserId.isBlank() || !MatrixIds.isDeviceId(deviceId)) {
       return null;
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixConfig.java
@@ -17,6 +17,7 @@ public class MatrixConfig {
   private String serverName = "caritas.local";
   private String adminUsername;
   private String adminPassword;
+  private boolean encryptionEnabled = false;
 
   /**
    * When {@code true}, consultant live-chat availability is derived from real-time Matrix presence.

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
@@ -52,6 +52,9 @@ public class MatrixMessageController {
   @GetMapping("/me/token")
   public ResponseEntity<?> getCurrentUserMatrixToken(
       @RequestParam(name = "deviceId") String deviceId) {
+    if (!MatrixIds.isDeviceId(deviceId)) {
+      return ResponseEntity.badRequest().body(Map.of("error", "Invalid Matrix device ID"));
+    }
     try {
       String matrixUserId = getCurrentMatrixUserId();
       if (matrixUserId == null || matrixUserId.isBlank()) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
@@ -50,7 +50,8 @@ public class MatrixMessageController {
    * MariaDB.
    */
   @GetMapping("/me/token")
-  public ResponseEntity<?> getCurrentUserMatrixToken() {
+  public ResponseEntity<?> getCurrentUserMatrixToken(
+      @RequestParam(name = "deviceId") String deviceId) {
     try {
       String matrixUserId = getCurrentMatrixUserId();
       if (matrixUserId == null || matrixUserId.isBlank()) {
@@ -58,8 +59,7 @@ public class MatrixMessageController {
             .body(Map.of("error", "Matrix user not configured"));
       }
 
-      var tokenResponse =
-          matrixSynapseService.loginAsUser(matrixUserId, MATRIX_BROWSER_TOKEN_TTL_MS);
+      var tokenResponse = matrixSynapseService.loginBrowserDevice(matrixUserId, deviceId);
       if (tokenResponse == null || tokenResponse.get("access_token") == null) {
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
             .body(Map.of("error", "Matrix token unavailable"));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
@@ -90,7 +90,7 @@ class UserChatControllerDelegate {
 
   ResponseEntity<Void> assignChat(String groupId) {
     if (groupId.matches("\\d+")) {
-      joinAndLeaveChatFacade.joinChat(Long.parseLong(groupId), authenticatedUser);
+      assignChatFacade.assignChat(Long.parseLong(groupId), authenticatedUser);
     } else {
       assignChatFacade.assignChat(groupId, authenticatedUser);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
@@ -90,7 +90,11 @@ class UserChatControllerDelegate {
 
   ResponseEntity<Void> assignChat(String groupId) {
     if (groupId.matches("\\d+")) {
-      assignChatFacade.assignChat(Long.parseLong(groupId), authenticatedUser);
+      try {
+        assignChatFacade.assignChat(Long.parseLong(groupId), authenticatedUser);
+      } catch (NumberFormatException exception) {
+        throw new BadRequestException("Numeric chat id is outside the supported range.");
+      }
     } else {
       assignChatFacade.assignChat(groupId, authenticatedUser);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatFeatureGate;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ class UserChatControllerDelegate {
   private final @NonNull Messaging messenger;
   private final @NonNull UserDtoMapper userDtoMapper;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull GroupChatFeatureGate groupChatFeatureGate;
 
   ResponseEntity<CreateChatResponseDTO> createChatV1(ChatDTO chatDTO) {
     var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
@@ -53,6 +55,7 @@ class UserChatControllerDelegate {
 
   ResponseEntity<CreateChatResponseDTO> createChatV2(ChatDTO chatDTO) {
     var callingConsultant = this.userAccountProvider.retrieveValidatedConsultant();
+    groupChatFeatureGate.requireEnabled(callingConsultant);
     var response = createChatFacade.createChatV2(chatDTO, callingConsultant);
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegate.java
@@ -89,7 +89,11 @@ class UserChatControllerDelegate {
   }
 
   ResponseEntity<Void> assignChat(String groupId) {
-    assignChatFacade.assignChat(groupId, authenticatedUser);
+    if (groupId.matches("\\d+")) {
+      joinAndLeaveChatFacade.joinChat(Long.parseLong(groupId), authenticatedUser);
+    } else {
+      assignChatFacade.assignChat(groupId, authenticatedUser);
+    }
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
@@ -56,6 +56,28 @@ class UserConsultantControllerDelegate {
         : new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
+  ResponseEntity<List<ConsultantResponseDTO>> getTenantConsultants() {
+    var consultants =
+        consultantService.findActiveConsultantsForTenant(authenticatedUser.getTenantId()).stream()
+            .map(
+                consultant ->
+                    new ConsultantResponseDTO()
+                        .consultantId(consultant.getId())
+                        .firstName(consultant.getFirstName())
+                        .lastName(consultant.getLastName())
+                        .username(consultant.getUsername())
+                        .displayName(
+                            consultant.getDisplayName() != null
+                                    && !consultant.getDisplayName().isBlank()
+                                ? consultant.getDisplayName()
+                                : consultant.getFullName())
+                        .isSupervisor(consultant.isSupervisor()))
+            .toList();
+    return isNotEmpty(consultants)
+        ? new ResponseEntity<>(consultants, HttpStatus.OK)
+        : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
   ResponseEntity<ConsultantSearchResultDTO> searchConsultants(
       String query, Integer page, Integer perPage, String field, String order) {
     var decodedInfix = determineDecodedInfix(query).trim();

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.E2eKeyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailNotificationsDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EnquiryMessageDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.GetChatSeriesOccurrences200ResponseInner;
 import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionListResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
@@ -25,22 +26,33 @@ import de.caritas.cob.userservice.api.adapters.web.dto.MobileTokenDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewMessageNotificationDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.OccurrenceOverrideRequest;
 import de.caritas.cob.userservice.api.adapters.web.dto.OneTimePasswordDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PatchUserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ReassignmentNotificationDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.RocketChatGroupIdDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.RoleRequest;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDataDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.TransferOwnershipRequest;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateChatResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionListResponseDTO;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.service.chat.ChatOccurrenceCommandService;
+import de.caritas.cob.userservice.api.service.chat.ChatOccurrenceQueryService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatRoleService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UsersApi;
 import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -71,6 +83,10 @@ public class UserController implements UsersApi {
   private final @NotNull UserRegistrationControllerDelegate userRegistrationControllerDelegate;
   private final @NotNull UserConsultantControllerDelegate userConsultantControllerDelegate;
   private final @NotNull UserSupportControllerDelegate userSupportControllerDelegate;
+  private final @NotNull ChatOccurrenceQueryService chatOccurrenceQueryService;
+  private final @NotNull ChatOccurrenceCommandService chatOccurrenceCommandService;
+  private final @NotNull GroupChatRoleService groupChatRoleService;
+  private final @NotNull AuthenticatedUser authenticatedUser;
 
   @Override
   public ResponseEntity<Void> userExists(String username) {
@@ -444,6 +460,87 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<CreateChatResponseDTO> createChatV2(@RequestBody ChatDTO chatDTO) {
     return userChatControllerDelegate.createChatV2(chatDTO);
+  }
+
+  @Override
+  public ResponseEntity<List<GetChatSeriesOccurrences200ResponseInner>> getChatSeriesOccurrences(
+      Long seriesId, OffsetDateTime from, OffsetDateTime to, Integer limit) {
+    var occurrences =
+        chatOccurrenceQueryService.getOccurrences(
+            seriesId, toUtcLocalDateTime(from), toUtcLocalDateTime(to), limit);
+    return ResponseEntity.ok(
+        occurrences.stream()
+            .map(
+                occurrence ->
+                    new GetChatSeriesOccurrences200ResponseInner()
+                        .seriesId(occurrence.seriesId())
+                        .occurrenceIndex(occurrence.occurrenceIndex())
+                        .originalStart(occurrence.originalStart().atOffset(ZoneOffset.UTC))
+                        .start(occurrence.start().atOffset(ZoneOffset.UTC))
+                        .duration(occurrence.duration())
+                        .capacity(occurrence.capacity())
+                        .modality(
+                            GetChatSeriesOccurrences200ResponseInner.ModalityEnum.fromValue(
+                                occurrence.modality().name())))
+            .toList());
+  }
+
+  @Override
+  public ResponseEntity<Void> skipChatSeriesOccurrence(
+      Long seriesId, OffsetDateTime originalStartUtc) {
+    chatOccurrenceCommandService.skip(
+        seriesId, authenticatedUser.getUserId(), toUtcLocalDateTime(originalStartUtc));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> overrideChatSeriesOccurrence(
+      Long seriesId, OccurrenceOverrideRequest request) {
+    var overrideStart = request.getOverrideStartUtc();
+    var modality = request.getModality();
+    chatOccurrenceCommandService.override(
+        seriesId,
+        authenticatedUser.getUserId(),
+        toUtcLocalDateTime(request.getOriginalStartUtc()),
+        overrideStart == null ? null : toUtcLocalDateTime(overrideStart),
+        request.getDuration(),
+        request.getCapacity(),
+        modality == null ? null : ChatModality.valueOf(modality.getValue()));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> changeChatSeriesParticipantRole(
+      Long seriesId, String consultantId, RoleRequest request) {
+    groupChatRoleService.changeRole(
+        seriesId,
+        authenticatedUser.getUserId(),
+        consultantId,
+        ParticipantRole.valueOf(request.getRole().getValue()));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> removeChatSeriesParticipant(Long seriesId, String consultantId) {
+    groupChatRoleService.removeParticipant(seriesId, authenticatedUser.getUserId(), consultantId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<List<ConsultantResponseDTO>> getChatSeriesConsultants() {
+    return userConsultantControllerDelegate.getTenantConsultants();
+  }
+
+  @Override
+  public ResponseEntity<Void> transferChatSeriesOwnership(
+      Long seriesId, TransferOwnershipRequest request) {
+    groupChatRoleService.transferPrimaryOwnership(
+        seriesId, authenticatedUser.getUserId(), request.getConsultantId());
+    return ResponseEntity.noContent().build();
+  }
+
+  private static java.time.LocalDateTime toUtcLocalDateTime(OffsetDateTime value) {
+    return value.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime();
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -334,7 +334,10 @@ class UserSessionControllerDelegate {
 
   private RocketChatCredentials buildUserRocketChatCredentials(User user, String rcToken) {
     var token = rcToken != null ? rcToken : DUMMY_ROCKET_CHAT_TOKEN;
-    var rcUserId = user.getRcUserId() != null ? user.getRcUserId() : DUMMY_ROCKET_CHAT_USER_ID;
+    var rcUserId =
+        user.getRcUserId() != null
+            ? user.getRcUserId()
+            : user.getMatrixUserId() != null ? user.getMatrixUserId() : DUMMY_ROCKET_CHAT_USER_ID;
     return RocketChatCredentials.builder()
         .rocketChatUserId(rcUserId)
         .rocketChatToken(token)

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/ChatDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/ChatDTO.java
@@ -7,6 +7,8 @@ import static de.caritas.cob.userservice.api.helper.UserHelper.CHAT_TOPIC_MIN_LE
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import jakarta.validation.constraints.Max;
@@ -15,6 +17,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +36,26 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 @Builder
 @ApiModel(value = "Chat")
 public class ChatDTO {
+
+  /** Compatibility constructor for existing V1/V2 callers. */
+  public ChatDTO(
+      String topic,
+      LocalDate startDate,
+      LocalTime startTime,
+      Integer duration,
+      Boolean repetitive,
+      Long agencyId,
+      String hintMessage,
+      java.util.List<String> consultantIds) {
+    this.topic = topic;
+    this.startDate = startDate;
+    this.startTime = startTime;
+    this.duration = duration;
+    this.repetitive = repetitive;
+    this.agencyId = agencyId;
+    this.hintMessage = hintMessage;
+    this.consultantIds = consultantIds;
+  }
 
   @Size(min = CHAT_TOPIC_MIN_LENGTH, max = CHAT_TOPIC_MAX_LENGTH)
   @NotBlank(message = "{chat.name.notBlank}")
@@ -60,20 +84,55 @@ public class ChatDTO {
   @JsonProperty("repetitive")
   private Boolean repetitive;
 
-  @ApiModelProperty(required = true, example = "5", position = 5)
+  @Min(value = 1, message = "{chat.repeatCount.invalid}")
+  @Max(value = 365, message = "{chat.repeatCount.invalid}")
+  @ApiModelProperty(required = false, example = "6", position = 5)
+  @JsonProperty("repeatCount")
+  private Integer repeatCount;
+
+  @ApiModelProperty(required = false, example = "WEEKLY", position = 6)
+  @JsonProperty("chatInterval")
+  private ChatInterval chatInterval;
+
+  @ApiModelProperty(required = false, example = "TEXT", position = 7)
+  @JsonProperty("modality")
+  private ChatModality modality;
+
+  @Size(max = 100)
+  @ApiModelProperty(required = false, example = "Europe/Berlin", position = 8)
+  @JsonProperty("timezone")
+  private String timezone;
+
+  @ApiModelProperty(required = true, example = "5", position = 9)
   @Min(value = 0, message = "{chat.agencyId.invalid}")
   @JsonProperty("agencyId")
   private Long agencyId;
 
-  @ApiModelProperty(required = true, example = "5", position = 6)
+  @ApiModelProperty(required = true, example = "5", position = 10)
   @Length(max = 300, message = "{chat.hintMessage.invalid}")
   @JsonProperty("hintMessage")
   private String hintMessage;
 
+  @Size(max = 10)
+  @ApiModelProperty(required = false, example = "de", position = 11)
+  @JsonProperty("sourceLanguage")
+  private String sourceLanguage;
+
+  @Size(max = 10)
+  @ApiModelProperty(required = false, position = 12)
+  @JsonProperty("hintMessageTranslations")
+  private Map<@Size(max = 10) String, @Size(max = 120) String> hintMessageTranslations;
+
+  @Size(max = 10)
+  @ApiModelProperty(required = false, position = 13)
+  @JsonProperty("groupChatRulesTranslations")
+  private Map<@Size(max = 10) String, @Size(max = 10) List<@NotBlank @Size(max = 120) String>>
+      groupChatRulesTranslations;
+
   @ApiModelProperty(
       required = false,
       example = "[\"consultant-id-1\", \"consultant-id-2\"]",
-      position = 7)
+      position = 14)
   @JsonProperty("consultantIds")
   private java.util.List<String> consultantIds;
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/UserChatDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/UserChatDTO.java
@@ -1,12 +1,15 @@
 package de.caritas.cob.userservice.api.adapters.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +24,50 @@ import lombok.Setter;
 @Setter
 @ApiModel(value = "UserChat")
 public class UserChatDTO {
+
+  /** Compatibility constructor for consumers of the pre-Series DTO. */
+  public UserChatDTO(
+      Long id,
+      String topic,
+      LocalDate startDate,
+      LocalTime startTime,
+      int duration,
+      boolean repetitive,
+      boolean active,
+      Integer consultingType,
+      String lastMessage,
+      Long messageDate,
+      boolean messagesRead,
+      String groupId,
+      SessionAttachmentDTO attachment,
+      boolean subscribed,
+      String[] moderators,
+      LocalDateTime startDateWithTime,
+      LastMessageDTO e2eLastMessage,
+      String createdAt,
+      List<AgencyDTO> assignedAgencies,
+      String hintMessage) {
+    this.id = id;
+    this.topic = topic;
+    this.startDate = startDate;
+    this.startTime = startTime;
+    this.duration = duration;
+    this.repetitive = repetitive;
+    this.active = active;
+    this.consultingType = consultingType;
+    this.lastMessage = lastMessage;
+    this.messageDate = messageDate;
+    this.messagesRead = messagesRead;
+    this.groupId = groupId;
+    this.attachment = attachment;
+    this.subscribed = subscribed;
+    this.moderators = moderators;
+    this.startDateWithTime = startDateWithTime;
+    this.e2eLastMessage = e2eLastMessage;
+    this.createdAt = createdAt;
+    this.assignedAgencies = assignedAgencies;
+    this.hintMessage = hintMessage;
+  }
 
   @ApiModelProperty(example = "153918", position = 0)
   private Long id;
@@ -76,4 +123,27 @@ public class UserChatDTO {
   @ApiModelProperty private List<AgencyDTO> assignedAgencies;
 
   @ApiModelProperty private String hintMessage;
+
+  @ApiModelProperty private String sourceLanguage;
+
+  @ApiModelProperty private Map<String, String> hintMessageTranslations;
+
+  @ApiModelProperty private Map<String, List<String>> groupChatRulesTranslations;
+
+  @ApiModelProperty(example = "6")
+  private int repeatCount;
+
+  @ApiModelProperty(example = "0")
+  private int currentOccurrenceIndex;
+
+  @ApiModelProperty(example = "WEEKLY")
+  private ChatInterval chatInterval;
+
+  @ApiModelProperty(example = "TEXT")
+  private ChatModality modality;
+
+  @ApiModelProperty(example = "Europe/Berlin")
+  private String timezone;
+
+  @ApiModelProperty private List<GroupChatParticipantDTO> participants;
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -153,7 +153,7 @@ public class SecurityConfig {
                     "/users/chat/{chatId:[0-9]+}/join",
                     "/users/chat/{chatId:[0-9]+}/members",
                     "/users/chat/{chatId:[0-9]+}/leave",
-                    "/users/chat/{groupId:[\\dA-Za-z-,]+}/assign",
+                    "/users/chat/{groupId}/assign",
                     "/users/consultants/toggleWalkThrough",
                     "/matrix/**",
                     "/service/matrix/**")
@@ -221,6 +221,8 @@ public class SecurityConfig {
                     "/service/users/case-handover/candidates",
                     "/users/case-handover/batch",
                     "/service/users/case-handover/batch",
+                    "/users/chat-series/**",
+                    "/service/users/chat-series/**",
                     "/users/sessions/{sessionId:[0-9]+}/case-handover",
                     "/service/users/sessions/{sessionId:[0-9]+}/case-handover",
                     "/users/sessions/{sessionId:[0-9]+}/supervisors",

--- a/src/main/java/de/caritas/cob/userservice/api/facade/AssignChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/AssignChatFacade.java
@@ -30,6 +30,19 @@ public class AssignChatFacade {
    */
   public void assignChat(String groupId, AuthenticatedUser authenticatedUser) {
     Chat chat = getChat(groupId);
+    assignChat(chat, authenticatedUser);
+  }
+
+  /** Assigns a V2 chat resolved by its stable numeric Series id. */
+  public void assignChat(Long chatId, AuthenticatedUser authenticatedUser) {
+    Chat chat =
+        chatService
+            .getChat(chatId)
+            .orElseThrow(() -> new NotFoundException("Chat with id %s not found", chatId));
+    assignChat(chat, authenticatedUser);
+  }
+
+  private void assignChat(Chat chat, AuthenticatedUser authenticatedUser) {
     User user = getUser(authenticatedUser);
 
     chatService.saveUserChatRelation(UserChat.builder().user(user).chat(chat).build());

--- a/src/main/java/de/caritas/cob/userservice/api/facade/ChatConverter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/ChatConverter.java
@@ -6,10 +6,15 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import de.caritas.cob.userservice.api.model.Consultant;
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,10 +27,33 @@ public class ChatConverter {
   public Chat convertToEntity(ChatDTO chatDTO, Consultant consultant, AgencyDTO agencyDTO) {
     // Handle null dates for group chats (they may not have scheduled start times)
     // Use current time as default for non-scheduled chats
+    String timezone =
+        nonNull(chatDTO.getTimezone()) && !chatDTO.getTimezone().isBlank()
+            ? chatDTO.getTimezone()
+            : "UTC";
+    ZoneId zoneId;
+    try {
+      zoneId = ZoneId.of(timezone);
+    } catch (DateTimeException invalidTimezone) {
+      throw new BadRequestException("Invalid timezone: " + timezone, invalidTimezone);
+    }
     LocalDateTime startDate = nowInUtc();
     if (nonNull(chatDTO.getStartDate()) && nonNull(chatDTO.getStartTime())) {
-      startDate = LocalDateTime.of(chatDTO.getStartDate(), chatDTO.getStartTime());
+      startDate =
+          LocalDateTime.of(chatDTO.getStartDate(), chatDTO.getStartTime())
+              .atZone(zoneId)
+              .withZoneSameInstant(ZoneOffset.UTC)
+              .toLocalDateTime();
     }
+
+    int repeatCount =
+        nonNull(chatDTO.getRepeatCount())
+            ? chatDTO.getRepeatCount()
+            : (isTrue(chatDTO.getRepetitive()) ? 12 : 1);
+    ChatInterval interval =
+        repeatCount > 1
+            ? (nonNull(chatDTO.getChatInterval()) ? chatDTO.getChatInterval() : ChatInterval.WEEKLY)
+            : null;
 
     Chat.ChatBuilder builder =
         Chat.builder()
@@ -34,12 +62,19 @@ public class ChatConverter {
             .initialStartDate(startDate)
             .startDate(startDate)
             .duration(chatDTO.getDuration() != null ? chatDTO.getDuration() : 0)
-            .repetitive(isTrue(chatDTO.getRepetitive()))
-            // Note that the repetition interval can only be weekly atm.
-            .chatInterval(isTrue(chatDTO.getRepetitive()) ? ChatInterval.WEEKLY : null)
+            .repetitive(repeatCount > 1)
+            .repeatCount(repeatCount)
+            .currentOccurrenceIndex(0)
+            .chatInterval(interval)
+            .timezone(timezone)
+            .chatModality(
+                nonNull(chatDTO.getModality()) ? chatDTO.getModality() : ChatModality.TEXT)
             .updateDate(nowInUtc())
             .createDate(nowInUtc())
-            .hintMessage(chatDTO.getHintMessage());
+            .hintMessage(chatDTO.getHintMessage())
+            .sourceLanguage(chatDTO.getSourceLanguage())
+            .hintMessageTranslations(chatDTO.getHintMessageTranslations())
+            .groupChatRulesTranslations(chatDTO.getGroupChatRulesTranslations());
 
     if (nonNull(agencyDTO)) {
       builder.consultingTypeId(agencyDTO.getConsultingType());

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -272,7 +272,10 @@ public class CreateChatFacade {
 
     // Create a Chat entity (needed for frontend - has topic field!)
     Chat chat = chatConverter.convertToEntity(chatDTO, consultant, agency);
-    chat.setActive(true); // Mark as active
+    // A Series is visible immediately, but its occurrence is opened explicitly by a counsellor.
+    // Keeping it inactive here preserves the Waiting Area and makes the opened lifecycle event
+    // observable exactly once through StartChatFacade.
+    chat.setActive(false);
     chat = chatService.saveChat(chat);
     Long chatId = chat.getId();
     log.info("Created chat {} for group chat", chatId);
@@ -315,6 +318,8 @@ public class CreateChatFacade {
       // IMPORTANT: Add the CREATOR to group_chat_participant table!
       GroupChatParticipant creatorParticipant = new GroupChatParticipant();
       creatorParticipant.setChatId(sessionId); // consistent with other participants
+      creatorParticipant.setSeriesId(chatId);
+      creatorParticipant.setRole(GroupChatParticipant.ParticipantRole.OWNER);
       creatorParticipant.setConsultantId(consultant.getId());
       groupChatParticipantRepository.save(creatorParticipant);
       log.info("Added creator consultant {} to group_chat_participant", consultant.getId());
@@ -343,6 +348,8 @@ public class CreateChatFacade {
           // Save participant in group_chat_participant table (for querying who's in the group)
           GroupChatParticipant gcp = new GroupChatParticipant();
           gcp.setChatId(sessionId); // Link to session ID
+          gcp.setSeriesId(chatId);
+          gcp.setRole(GroupChatParticipant.ParticipantRole.CO_MODERATOR);
           gcp.setConsultantId(participantId);
           groupChatParticipantRepository.save(gcp);
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.LogService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatRoleService;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.Optional;
@@ -39,6 +40,7 @@ public class JoinAndLeaveChatFacade {
   private final ChatReCreator chatReCreator;
   private final GroupChatMembershipService groupChatMembershipService;
   private final MatrixChatShutdownService matrixChatShutdownService;
+  private final GroupChatRoleService groupChatRoleService;
 
   /**
    * Join a chat.
@@ -48,7 +50,25 @@ public class JoinAndLeaveChatFacade {
    */
   public void joinChat(Long chatId, AuthenticatedUser authenticatedUser) {
     Chat chat = getChat(chatId);
-    String rcUserId = checkPermissionAndGetRcUserId(authenticatedUser, chat);
+    this.chatPermissionVerifier.verifyPermissionForChat(chat);
+
+    if (!isBlank(groupChatMembershipService.resolveMatrixRoomId(chat))) {
+      String matrixUserId = retrieveMatrixUserId(authenticatedUser);
+      if (isBlank(matrixUserId)
+          || !groupChatMembershipService.addMemberToRoom(chat, matrixUserId)) {
+        throw new InternalServerErrorException(
+            String.format(
+                "User with id %s could not join the Matrix group chat.",
+                authenticatedUser.getUserId()));
+      }
+      return;
+    }
+
+    String rcUserId = retrieveRcUserId(authenticatedUser);
+    if (isBlank(rcUserId)) {
+      throw new InternalServerErrorException(
+          String.format("User with id %s has no Rocket.Chat-ID.", authenticatedUser.getUserId()));
+    }
 
     try {
       rocketChatService.addUserToGroup(rcUserId, chat.getGroupId());
@@ -75,13 +95,7 @@ public class JoinAndLeaveChatFacade {
    */
   public void leaveChat(Long chatId, AuthenticatedUser authenticatedUser) {
     Chat chat = getChat(chatId);
-    String rcUserId = checkPermissionAndGetRcUserId(authenticatedUser, chat);
-
-    try {
-      rocketChatService.removeUserFromGroup(rcUserId, chat.getGroupId());
-    } catch (RocketChatRemoveUserFromGroupException e) {
-      throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
-    }
+    this.chatPermissionVerifier.verifyPermissionForChat(chat);
 
     Optional<Consultant> leavingConsultant =
         consultantService.getConsultantViaAuthenticatedUser(authenticatedUser);
@@ -94,15 +108,46 @@ public class JoinAndLeaveChatFacade {
             .map(Consultant::getMatrixUserId)
             .or(() -> leavingUser.map(User::getMatrixUserId))
             .orElse(null);
+    boolean matrixChat = !isBlank(groupChatMembershipService.resolveMatrixRoomId(chat));
 
-    groupChatMembershipService.removeLeavingMemberFromRoom(chat, leavingMatrixUserId);
-    leavingUser.ifPresent(leaver -> chatService.deleteUserChatRelation(chat, leaver));
+    if (matrixChat) {
+      if (isBlank(leavingMatrixUserId)) {
+        throw new InternalServerErrorException(
+            String.format("User with id %s has no Matrix user ID.", authenticatedUser.getUserId()));
+      }
+      if (leavingConsultant.isPresent()) {
+        groupChatRoleService.leaveSeries(chat, leavingConsultant.get());
+      } else {
+        groupChatMembershipService.removeLeavingMemberFromRoom(chat, leavingMatrixUserId);
+        leavingUser.ifPresent(leaver -> chatService.deleteUserChatRelation(chat, leaver));
+      }
+    } else {
+      String rcUserId =
+          leavingConsultant
+              .map(Consultant::getRocketChatId)
+              .or(() -> leavingUser.map(User::getRcUserId))
+              .orElse(null);
+      if (isBlank(rcUserId)) {
+        throw new InternalServerErrorException(
+            String.format("User with id %s has no Rocket.Chat-ID.", authenticatedUser.getUserId()));
+      }
+      try {
+        rocketChatService.removeUserFromGroup(rcUserId, chat.getGroupId());
+      } catch (RocketChatRemoveUserFromGroupException e) {
+        throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
+      }
+
+      groupChatMembershipService.removeLeavingMemberFromRoom(chat, leavingMatrixUserId);
+      leavingUser.ifPresent(leaver -> chatService.deleteUserChatRelation(chat, leaver));
+    }
 
     if (groupChatMembershipService.hasRemainingHumanMembers(chat, leavingMatrixUserId)) {
       return;
     }
 
-    deleteMessengerChat(chat.getGroupId());
+    if (!matrixChat) {
+      deleteMessengerChat(chat.getGroupId());
+    }
     if (chat.isRepetitive()) {
       var rcGroupId = chatReCreator.recreateMessengerChat(chat);
       chatReCreator.updateAsNextChat(chat, rcGroupId);
@@ -135,18 +180,6 @@ public class JoinAndLeaveChatFacade {
     return chat;
   }
 
-  private String checkPermissionAndGetRcUserId(AuthenticatedUser authenticatedUser, Chat chat) {
-    this.chatPermissionVerifier.verifyPermissionForChat(chat);
-
-    String rcUserId = retrieveRcUserId(authenticatedUser);
-    if (isBlank(rcUserId)) {
-      throw new InternalServerErrorException(
-          String.format("User with id %s has no Rocket.Chat-ID.", authenticatedUser.getUserId()));
-    }
-
-    return rcUserId;
-  }
-
   private String retrieveRcUserId(AuthenticatedUser authenticatedUser) {
     final AtomicReference<String> rcUserId = new AtomicReference<>();
     consultantService
@@ -159,5 +192,19 @@ public class JoinAndLeaveChatFacade {
                     .ifPresent(user -> rcUserId.set(user.getRcUserId())));
 
     return rcUserId.get();
+  }
+
+  private String retrieveMatrixUserId(AuthenticatedUser authenticatedUser) {
+    final AtomicReference<String> matrixUserId = new AtomicReference<>();
+    consultantService
+        .getConsultantViaAuthenticatedUser(authenticatedUser)
+        .ifPresentOrElse(
+            consultant -> matrixUserId.set(consultant.getMatrixUserId()),
+            () ->
+                userService
+                    .getUserViaAuthenticatedUser(authenticatedUser)
+                    .ifPresent(user -> matrixUserId.set(user.getMatrixUserId())));
+
+    return matrixUserId.get();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacade.java
@@ -149,8 +149,14 @@ public class JoinAndLeaveChatFacade {
       deleteMessengerChat(chat.getGroupId());
     }
     if (chat.isRepetitive()) {
-      var rcGroupId = chatReCreator.recreateMessengerChat(chat);
-      chatReCreator.updateAsNextChat(chat, rcGroupId);
+      if (chat.nextStart() != null) {
+        var matrixRoomId = chatReCreator.recreateMessengerChat(chat);
+        chatReCreator.updateAsNextChat(chat, matrixRoomId);
+      } else {
+        matrixChatShutdownService.shutdownRoom(chat);
+        chat.setActive(false);
+        chatService.saveChat(chat);
+      }
     } else {
       chatService.deleteChat(chat);
       matrixChatShutdownService.shutdownRoom(chat);

--- a/src/main/java/de/caritas/cob/userservice/api/facade/StartChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/StartChatFacade.java
@@ -5,14 +5,16 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
-import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatAddUserToGroupException;
-import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
+import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.LogService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatPermissionService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatNotificationRecipientService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,10 @@ public class StartChatFacade {
 
   private final @NonNull ChatService chatService;
   private final @NonNull RocketChatService rocketChatService;
-  private final @NonNull ChatPermissionVerifier chatPermissionVerifier;
+  private final @NonNull GroupChatPermissionService groupChatPermissionService;
+  private final @NonNull GroupChatNotificationRecipientService notificationRecipientService;
+  private final @NonNull GroupChatLifecycleNotificationService
+      groupChatLifecycleNotificationService;
 
   /**
    * Starts the given {@link Chat}.
@@ -34,25 +39,23 @@ public class StartChatFacade {
    */
   public void startChat(Chat chat, Consultant consultant) {
 
-    checkConsultantsPermission(chat, consultant);
+    groupChatPermissionService.requireCanModerate(chat, consultant);
     checkIfChatIsAlreadyActive(chat);
-    checkRocketChatGroup(chat);
+    checkChatGroup(chat);
 
     try {
-      rocketChatService.addUserToGroup(consultant.getRocketChatId(), chat.getGroupId());
+      if (!isMatrixChat(chat)) {
+        rocketChatService.addUserToGroup(consultant.getRocketChatId(), chat.getGroupId());
+      }
       chat.setActive(true);
       chatService.saveChat(chat);
+      try {
+        publishOpenedNotification(chat);
+      } catch (RuntimeException notificationException) {
+        LogService.logInternalServerError(notificationException);
+      }
     } catch (RocketChatAddUserToGroupException e) {
       throw new InternalServerErrorException(e.getMessage(), LogService::logRocketChatError);
-    }
-  }
-
-  private void checkConsultantsPermission(Chat chat, Consultant consultant) {
-    if (!chatPermissionVerifier.hasSameAgencyAssigned(chat, consultant)) {
-      throw new ForbiddenException(
-          String.format(
-              "Consultant with id %s has no permission to start chat with id %s",
-              consultant.getId(), chat.getId()));
     }
   }
 
@@ -63,10 +66,29 @@ public class StartChatFacade {
     }
   }
 
-  private void checkRocketChatGroup(Chat chat) {
-    if (isNull(chat.getGroupId())) {
+  private void checkChatGroup(Chat chat) {
+    if (isNull(chat.getGroupId()) && !isMatrixChat(chat)) {
       throw new InternalServerErrorException(
           String.format("Chat with id %s has no Rocket.Chat group id", chat.getId()));
     }
+  }
+
+  private boolean isMatrixChat(Chat chat) {
+    return MatrixIds.isRoomId(chat.getGroupId())
+        || (isNull(chat.getGroupId()) && MatrixIds.isRoomId(chat.getMatrixRoomId()));
+  }
+
+  private void publishOpenedNotification(Chat chat) {
+    if (!isMatrixChat(chat) || chat.getId() == null) {
+      return;
+    }
+    groupChatLifecycleNotificationService.createOpenedNotifications(
+        chat.getId(),
+        chat.getCurrentOccurrenceIndex(),
+        chat.getStartDate(),
+        chat.getMatrixRoomId() != null ? chat.getMatrixRoomId() : chat.getGroupId(),
+        null,
+        chat.getChatModality() == Chat.ChatModality.VIDEO,
+        notificationRecipientService.resolveRecipientIds(chat));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/StopChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/StopChatFacade.java
@@ -2,10 +2,9 @@ package de.caritas.cob.userservice.api.facade;
 
 import de.caritas.cob.userservice.api.actions.chat.StopChatActionCommand;
 import de.caritas.cob.userservice.api.actions.registry.ActionsRegistry;
-import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
-import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.service.chat.GroupChatPermissionService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StopChatFacade {
 
-  private final @NonNull ChatPermissionVerifier chatPermissionVerifier;
+  private final @NonNull GroupChatPermissionService groupChatPermissionService;
   private final @NonNull ActionsRegistry actionsRegistry;
 
   /**
@@ -27,20 +26,11 @@ public class StopChatFacade {
    * @param consultant {@link Consultant}
    */
   public void stopChat(Chat chat, Consultant consultant) {
-    checkConsultantChatPermission(chat, consultant);
+    groupChatPermissionService.requireCanModerate(chat, consultant);
 
     this.actionsRegistry
         .buildContainerForType(Chat.class)
         .addActionToExecute(StopChatActionCommand.class)
         .executeActions(chat);
-  }
-
-  private void checkConsultantChatPermission(Chat chat, Consultant consultant) {
-    if (!chatPermissionVerifier.hasSameAgencyAssigned(chat, consultant)) {
-      throw new ForbiddenException(
-          String.format(
-              "Consultant with id %s has no permission to stop chat with id %s",
-              consultant.getId(), chat.getId()));
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProvider.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.adapters.rocketchat.dto.subscriptions.Subs
 import de.caritas.cob.userservice.api.container.RocketChatRoomInformation;
 import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ public class RocketChatRoomInformationProvider {
   private final RocketChatService rocketChatService;
   private final MatrixSynapseService matrixSynapseService;
   private final ConsultantRepository consultantRepository;
+  private final UserRepository userRepository;
 
   /** ADR-004: with Rocket.Chat disabled room information is always Matrix-derived. */
   @Value("${rocket-chat.enabled:false}")
@@ -37,10 +39,12 @@ public class RocketChatRoomInformationProvider {
   public RocketChatRoomInformationProvider(
       RocketChatService rocketChatService,
       MatrixSynapseService matrixSynapseService,
-      ConsultantRepository consultantRepository) {
+      ConsultantRepository consultantRepository,
+      UserRepository userRepository) {
     this.rocketChatService = requireNonNull(rocketChatService);
     this.matrixSynapseService = requireNonNull(matrixSynapseService);
     this.consultantRepository = requireNonNull(consultantRepository);
+    this.userRepository = requireNonNull(userRepository);
   }
 
   /**
@@ -178,10 +182,19 @@ public class RocketChatRoomInformationProvider {
     }
 
     try {
+      if (rcUserId.startsWith("@")) {
+        return matrixSynapseService.getJoinedRoomsForMatrixUser(rcUserId);
+      }
+
       // Try to find consultant by ID (rcUserId is actually Keycloak ID)
       var consultantOpt = consultantRepository.findById(rcUserId);
       if (consultantOpt.isPresent()) {
         return getMatrixRoomsForConsultant(consultantOpt.get());
+      }
+
+      var userOpt = userRepository.findByRcUserIdAndDeleteDateIsNull(rcUserId);
+      if (userOpt.isPresent() && !isBlank(userOpt.get().getMatrixUserId())) {
+        return matrixSynapseService.getJoinedRoomsForMatrixUser(userOpt.get().getMatrixUserId());
       }
 
       log.warn("Could not find Matrix credentials for user {}", rcUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/helper/MatrixIds.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/MatrixIds.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.userservice.api.helper;
 
+import java.util.regex.Pattern;
+
 /**
  * Utility for parsing Matrix IDs.
  *
@@ -15,6 +17,8 @@ package de.caritas.cob.userservice.api.helper;
  * </pre>
  */
 public final class MatrixIds {
+
+  private static final Pattern DEVICE_ID_PATTERN = Pattern.compile("[A-Za-z0-9._=-]{1,255}");
 
   private MatrixIds() {
     throw new UnsupportedOperationException("Utility class — do not instantiate");
@@ -68,5 +72,10 @@ public final class MatrixIds {
   /** Returns {@code true} if the given ID starts with {@code @} (user ID sigil). */
   public static boolean isUserId(String id) {
     return id != null && id.startsWith("@");
+  }
+
+  /** Returns {@code true} for a non-blank Matrix device identifier safe for client login. */
+  public static boolean isDeviceId(String id) {
+    return id != null && DEVICE_ID_PATTERN.matcher(id).matches();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/Chat.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Chat.java
@@ -15,7 +15,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -42,7 +48,18 @@ import org.hibernate.type.SqlTypes;
 public class Chat {
 
   public enum ChatInterval {
-    WEEKLY
+    DAILY,
+    WEEKLY,
+    BIWEEKLY,
+    MONTHLY,
+    QUARTERLY,
+    YEARLY
+  }
+
+  public enum ChatModality {
+    TEXT,
+    AUDIO,
+    VIDEO
   }
 
   @Id
@@ -74,6 +91,23 @@ public class Chat {
 
   @Column(name = "is_repetitive", nullable = false)
   private boolean repetitive;
+
+  @Builder.Default
+  @Column(name = "repeat_count", nullable = false)
+  private int repeatCount = 1;
+
+  @Builder.Default
+  @Column(name = "current_occurrence_index", nullable = false)
+  private int currentOccurrenceIndex = 0;
+
+  @Builder.Default
+  @Column(name = "timezone", nullable = false)
+  private String timezone = "UTC";
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(name = "modality", nullable = false)
+  private ChatModality chatModality = ChatModality.TEXT;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "chat_interval")
@@ -114,6 +148,17 @@ public class Chat {
   @Column(name = "hint_message")
   private String hintMessage;
 
+  @Column(name = "source_language", length = 10)
+  private String sourceLanguage;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "hint_message_translations", columnDefinition = "json")
+  private Map<String, String> hintMessageTranslations;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "group_chat_rules_translations", columnDefinition = "json")
+  private Map<String, List<String>> groupChatRulesTranslations;
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -133,15 +178,45 @@ public class Chat {
 
   @JsonIgnore
   public LocalDateTime nextStart() {
-    if (!repetitive) {
+    if (repeatCount <= 1 || currentOccurrenceIndex + 1 >= repeatCount) {
       return null;
     }
+    return occurrenceStart(currentOccurrenceIndex + 1);
+  }
 
-    if (!ChatInterval.WEEKLY.equals(chatInterval)) {
-      var message = "Repetitive chat with id %s does not have a valid interval.";
-      throw new InternalServerErrorException(String.format(message, id));
+  /** Returns a virtual occurrence calculated from the immutable series anchor. */
+  @JsonIgnore
+  public LocalDateTime occurrenceStart(int occurrenceIndex) {
+    if (occurrenceIndex < 0) {
+      throw new IllegalArgumentException("Occurrence index must not be negative");
     }
-
-    return startDate.plusWeeks(1);
+    if (initialStartDate == null) {
+      throw new InternalServerErrorException(
+          String.format("Chat with id %s does not have an initial start date.", id));
+    }
+    if (occurrenceIndex == 0) {
+      return initialStartDate;
+    }
+    if (chatInterval == null) {
+      throw new InternalServerErrorException(
+          String.format("Chat with id %s does not have a valid interval.", id));
+    }
+    ZoneId zoneId;
+    try {
+      zoneId = ZoneId.of(timezone == null ? "UTC" : timezone);
+    } catch (DateTimeException invalidPersistedTimezone) {
+      zoneId = ZoneOffset.UTC;
+    }
+    var localAnchor = initialStartDate.atZone(ZoneOffset.UTC).withZoneSameInstant(zoneId);
+    ZonedDateTime occurrence =
+        switch (chatInterval) {
+          case DAILY -> localAnchor.plusDays(occurrenceIndex);
+          case WEEKLY -> localAnchor.plusWeeks(occurrenceIndex);
+          case BIWEEKLY -> localAnchor.plusWeeks(2L * occurrenceIndex);
+          case MONTHLY -> localAnchor.plusMonths(occurrenceIndex);
+          case QUARTERLY -> localAnchor.plusMonths(3L * occurrenceIndex);
+          case YEARLY -> localAnchor.plusYears(occurrenceIndex);
+        };
+    return occurrence.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/ChatOccurrenceException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/ChatOccurrenceException.java
@@ -1,0 +1,83 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "chat_occurrence_exception",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_chat_occurrence_exception_series_start",
+            columnNames = {"series_id", "original_occurrence_start_utc"}))
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatOccurrenceException {
+
+  public enum ExceptionType {
+    SKIP,
+    OVERRIDE
+  }
+
+  @Id
+  @SequenceGenerator(
+      name = "chat_occurrence_exception_id_seq",
+      allocationSize = 1,
+      sequenceName = "sequence_chat_occurrence_exception")
+  @GeneratedValue(
+      strategy = GenerationType.SEQUENCE,
+      generator = "chat_occurrence_exception_id_seq")
+  private Long id;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "series_id", nullable = false)
+  private Chat series;
+
+  @Column(name = "original_occurrence_start_utc", nullable = false)
+  private LocalDateTime originalOccurrenceStartUtc;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "exception_type", nullable = false)
+  private ExceptionType exceptionType;
+
+  @Column(name = "override_start_utc")
+  private LocalDateTime overrideStartUtc;
+
+  @Column(name = "override_duration")
+  private Integer overrideDuration;
+
+  @Column(name = "override_capacity")
+  private Integer overrideCapacity;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "override_modality")
+  private ChatModality overrideModality;
+
+  public static ChatOccurrenceException skip(Chat series, LocalDateTime originalStartUtc) {
+    return ChatOccurrenceException.builder()
+        .series(series)
+        .originalOccurrenceStartUtc(originalStartUtc)
+        .exceptionType(ExceptionType.SKIP)
+        .build();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
@@ -74,6 +74,10 @@ public class EventNotification implements TenantAware {
   @Column(name = "source_session_id")
   private Long sourceSessionId;
 
+  /** Stable producer-owned key used to make scheduled/lifecycle events idempotent per recipient. */
+  @Column(name = "deduplication_key", length = 191)
+  private String deduplicationKey;
+
   @Column(name = "read_date", columnDefinition = "datetime")
   private LocalDateTime readDate;
 

--- a/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/GroupChatParticipant.java
@@ -2,6 +2,8 @@ package de.caritas.cob.userservice.api.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,6 +28,12 @@ import lombok.Setter;
 @Builder
 public class GroupChatParticipant {
 
+  public enum ParticipantRole {
+    OWNER,
+    CO_MODERATOR,
+    PARTICIPANT
+  }
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", updatable = false, nullable = false)
@@ -45,6 +53,15 @@ public class GroupChatParticipant {
   @Column(name = "consultant_id", nullable = false, length = 36)
   private String consultantId;
 
+  /** Canonical Series relation for new self-help-group data. */
+  @Column(name = "series_id")
+  private Long seriesId;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(name = "participant_role", nullable = false)
+  private ParticipantRole role = ParticipantRole.PARTICIPANT;
+
   public GroupChatParticipant(Long chatId, String consultantId) {
     this.chatId = chatId;
     this.consultantId = consultantId;
@@ -56,6 +73,10 @@ public class GroupChatParticipant {
         + id
         + ", chatId="
         + chatId
+        + ", seriesId="
+        + seriesId
+        + ", role="
+        + role
         + ", consultantId="
         + consultantId
         + "]";

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ChatOccurrenceExceptionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ChatOccurrenceExceptionRepository.java
@@ -1,0 +1,16 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ChatOccurrenceExceptionRepository
+    extends CrudRepository<ChatOccurrenceException, Long> {
+
+  List<ChatOccurrenceException> findBySeries_Id(Long seriesId);
+
+  Optional<ChatOccurrenceException> findBySeries_IdAndOriginalOccurrenceStartUtc(
+      Long seriesId, LocalDateTime originalOccurrenceStartUtc);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ChatRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ChatRepository.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -15,7 +16,10 @@ public interface ChatRepository extends CrudRepository<Chat, Long> {
       value =
           "SELECT c.id, c.topic, c.consulting_type, c.initial_start_date, c.start_date, "
               + "c.duration, c.is_repetitive, c.chat_interval, c.is_active, c.max_participants, "
-              + "c.consultant_id_owner, c.rc_group_id, c.matrix_room_id, c.update_date, c.create_date, c.hint_message FROM chat c JOIN chat_agency ca ON c"
+              + "c.repeat_count, c.current_occurrence_index, c.timezone, c.modality, "
+              + "c.consultant_id_owner, c.rc_group_id, c.matrix_room_id, c.update_date, c.create_date, "
+              + "c.hint_message, c.source_language, c.hint_message_translations, "
+              + "c.group_chat_rules_translations FROM chat c JOIN chat_agency ca ON c"
               + ".id = ca.chat_id JOIN user_agency ua ON ca.agency_id = ua.agency_id AND ua.user_id = :user_id",
       nativeQuery = true)
   List<Chat> findByUserId(@Param(value = "user_id") String userId);
@@ -24,7 +28,10 @@ public interface ChatRepository extends CrudRepository<Chat, Long> {
       value =
           "SELECT c.id, c.topic, c.consulting_type, c.initial_start_date, c.start_date, "
               + "c.duration, c.is_repetitive, c.chat_interval, c.is_active, c.max_participants, "
-              + "c.consultant_id_owner, c.rc_group_id, c.matrix_room_id, c.update_date, c.create_date, c.hint_message FROM chat c "
+              + "c.repeat_count, c.current_occurrence_index, c.timezone, c.modality, "
+              + "c.consultant_id_owner, c.rc_group_id, c.matrix_room_id, c.update_date, c.create_date, "
+              + "c.hint_message, c.source_language, c.hint_message_translations, "
+              + "c.group_chat_rules_translations FROM chat c "
               + "JOIN user_chat uc ON c.id = uc.chat_id AND uc.user_id = :user_id",
       nativeQuery = true)
   List<Chat> findAssignedByUserId(@Param(value = "user_id") String userId);
@@ -52,4 +59,7 @@ public interface ChatRepository extends CrudRepository<Chat, Long> {
   List<Chat> findByChatOwner(Consultant chatOwner);
 
   List<Chat> findAllByActiveIsTrue();
+
+  List<Chat> findAllByActiveIsFalseAndStartDateBetween(
+      LocalDateTime startInclusive, LocalDateTime endInclusive);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantRepository.java
@@ -36,6 +36,8 @@ public interface ConsultantRepository
 
   List<Consultant> findByDeleteDateIsNull();
 
+  List<Consultant> findByTenantIdAndDeleteDateIsNullOrderByFirstNameAscLastNameAsc(Long tenantId);
+
   List<Consultant> findAllByIdIn(List<String> ids);
 
   @Query("SELECT c.id FROM Consultant c WHERE c.id IN :ids AND c.deleteDate IS NULL")

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
@@ -17,5 +17,8 @@ public interface EventNotificationRepository extends JpaRepository<EventNotifica
 
   List<EventNotification> findByRecipientUserIdAndReadDateIsNull(String recipientUserId);
 
+  boolean existsByRecipientUserIdAndDeduplicationKey(
+      String recipientUserId, String deduplicationKey);
+
   void deleteByRecipientUserId(String recipientUserId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/GroupChatParticipantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/GroupChatParticipantRepository.java
@@ -1,8 +1,13 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repository for {@link GroupChatParticipant}. Manages the many-to-many relationship between group
@@ -25,6 +30,18 @@ public interface GroupChatParticipantRepository extends CrudRepository<GroupChat
    * @return list of participants
    */
   List<GroupChatParticipant> findByChatId(Long chatId);
+
+  List<GroupChatParticipant> findBySeriesId(Long seriesId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "SELECT participant FROM GroupChatParticipant participant WHERE participant.seriesId = :seriesId")
+  List<GroupChatParticipant> findBySeriesIdForUpdate(@Param("seriesId") Long seriesId);
+
+  Optional<GroupChatParticipant> findBySeriesIdAndConsultantId(Long seriesId, String consultantId);
+
+  /** Delete all canonical participant relations before deleting their chat series. */
+  void deleteBySeriesId(Long seriesId);
 
   /**
    * Delete all participants for a group chat.

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/UserChatRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/UserChatRepository.java
@@ -3,10 +3,13 @@ package de.caritas.cob.userservice.api.port.out;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserChat;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserChatRepository extends CrudRepository<UserChat, Long> {
 
   Optional<UserChat> findByChatAndUser(Chat chat, User user);
+
+  List<UserChat> findByChat(Chat chat);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
@@ -5,11 +5,13 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserRepository extends CrudRepository<User, String> {
 
+  @EntityGraph(attributePaths = "userAgencies")
   Optional<User> findByUserIdAndDeleteDateIsNull(String userId);
 
   Optional<User> findByEmailAndDeleteDateIsNull(String email);

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.GroupChatParticipantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateChatResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserChatDTO;
@@ -17,27 +18,30 @@ import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserChat;
 import de.caritas.cob.userservice.api.port.out.ChatAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Chat service class */
 @Service
@@ -49,6 +53,7 @@ public class ChatService {
   private final @NonNull ChatAgencyRepository chatAgencyRepository;
   private final @NonNull UserChatRepository userChatRepository;
   private final @NonNull ConsultantService consultantService;
+  private final @NonNull GroupChatParticipantRepository groupChatParticipantRepository;
 
   private final @NonNull AgencyService agencyService;
 
@@ -67,7 +72,10 @@ public class ChatService {
         consultant.getUsername(),
         agencyIds);
 
-    var chats = chatRepository.findByAgencyIds(agencyIds);
+    var chats =
+        chatRepository.findByAgencyIds(agencyIds).stream()
+            .filter(chat -> isVisibleToConsultant(chat, consultant))
+            .toList();
     log.info("🔍 ChatService: Found {} chats for agencyIds {}", chats.size(), agencyIds);
     chats.forEach(
         chat ->
@@ -89,6 +97,13 @@ public class ChatService {
         .collect(Collectors.toList());
   }
 
+  private boolean isVisibleToConsultant(Chat chat, Consultant consultant) {
+    var explicitParticipants = groupChatParticipantRepository.findBySeriesId(chat.getId());
+    return explicitParticipants.isEmpty()
+        || explicitParticipants.stream()
+            .anyMatch(participant -> consultant.getId().equals(participant.getConsultantId()));
+  }
+
   private ConsultantSessionResponseDTO convertChatToConsultantSessionResponseDTO(
       Chat chat, Set<ChatAgency> chatAgencies) {
     return new ConsultantSessionResponseDTO()
@@ -105,7 +120,17 @@ public class ChatService {
     return convertChatToConsultantSessionResponseDTO(chat, loadChatAgencies(chat.getId()));
   }
 
-  private String[] getChatModerators(Set<ChatAgency> chatAgencies) {
+  private String[] getChatModerators(Chat chat, Set<ChatAgency> chatAgencies) {
+    var explicitParticipants = groupChatParticipantRepository.findBySeriesId(chat.getId());
+    if (!explicitParticipants.isEmpty()) {
+      return explicitParticipants.stream()
+          .filter(
+              participant ->
+                  participant.getRole() == ParticipantRole.OWNER
+                      || participant.getRole() == ParticipantRole.CO_MODERATOR)
+          .map(participant -> participant.getConsultantId())
+          .toArray(String[]::new);
+    }
     return consultantService.findConsultantsByAgencyIds(chatAgencies).stream()
         .map(Consultant::getRocketChatId)
         .toArray(String[]::new);
@@ -166,10 +191,17 @@ public class ChatService {
    * @return list of user chats as {@link UserSessionResponseDTO}
    */
   public List<UserSessionResponseDTO> getChatsForUserId(String userId) {
-    List<Chat> chats = chatRepository.findByUserId(userId);
+    List<Chat> chats =
+        chatRepository.findByUserId(userId).stream()
+            .filter(chat -> groupChatParticipantRepository.findBySeriesId(chat.getId()).isEmpty())
+            .toList();
     List<Chat> assignedChats = chatRepository.findAssignedByUserId(userId);
-    var allChats =
-        Stream.concat(chats.stream(), assignedChats.stream()).collect(Collectors.toList());
+    var allChats = new ArrayList<>(chats);
+    assignedChats.stream()
+        .filter(
+            assigned ->
+                allChats.stream().noneMatch(existing -> existing.getId().equals(assigned.getId())))
+        .forEach(allChats::add);
     var chatAgenciesByChatId = loadChatAgenciesByChatId(allChats);
     return allChats.stream()
         .map(
@@ -216,33 +248,62 @@ public class ChatService {
             .map(chatAgency -> agencyService.getAgency(chatAgency.getAgencyId()))
             .collect(Collectors.toList());
 
-    return new UserChatDTO(
-        chat.getId(),
-        chat.getTopic(),
-        LocalDate.of(
-            chat.getStartDate().getYear(),
-            chat.getStartDate().getMonth(),
-            chat.getStartDate().getDayOfMonth()),
-        LocalTime.of(
-            chat.getStartDate().getHour(),
-            chat.getStartDate().getMinute(),
-            chat.getStartDate().getSecond()),
-        chat.getDuration(),
-        isTrue(chat.isRepetitive()),
-        isTrue(chat.isActive()),
-        chat.getConsultingTypeId(),
-        null,
-        null,
-        false,
-        chat.getGroupId(),
-        null,
-        false,
-        getChatModerators(chatAgencies),
-        chat.getStartDate(),
-        null,
-        chat.getCreateDate() != null ? chat.getCreateDate().toString() : null,
-        agencies,
-        chat.getHintMessage());
+    var result =
+        new UserChatDTO(
+            chat.getId(),
+            chat.getTopic(),
+            LocalDate.of(
+                chat.getStartDate().getYear(),
+                chat.getStartDate().getMonth(),
+                chat.getStartDate().getDayOfMonth()),
+            LocalTime.of(
+                chat.getStartDate().getHour(),
+                chat.getStartDate().getMinute(),
+                chat.getStartDate().getSecond()),
+            chat.getDuration(),
+            isTrue(chat.isRepetitive()),
+            isTrue(chat.isActive()),
+            chat.getConsultingTypeId(),
+            null,
+            null,
+            false,
+            chat.getGroupId(),
+            null,
+            false,
+            getChatModerators(chat, chatAgencies),
+            chat.getStartDate(),
+            null,
+            chat.getCreateDate() != null ? chat.getCreateDate().toString() : null,
+            agencies,
+            chat.getHintMessage());
+    result.setRepeatCount(chat.getRepeatCount());
+    result.setCurrentOccurrenceIndex(chat.getCurrentOccurrenceIndex());
+    result.setChatInterval(chat.getChatInterval());
+    result.setModality(chat.getChatModality());
+    result.setTimezone(chat.getTimezone());
+    result.setParticipants(getSeriesParticipants(chat));
+    result.setSourceLanguage(chat.getSourceLanguage());
+    result.setHintMessageTranslations(chat.getHintMessageTranslations());
+    result.setGroupChatRulesTranslations(chat.getGroupChatRulesTranslations());
+    return result;
+  }
+
+  private List<GroupChatParticipantDTO> getSeriesParticipants(Chat chat) {
+    return groupChatParticipantRepository.findBySeriesId(chat.getId()).stream()
+        .map(
+            participant -> {
+              var displayName =
+                  consultantService
+                      .getConsultant(participant.getConsultantId())
+                      .map(Consultant::getDisplayName)
+                      .filter(name -> name != null && !name.isBlank())
+                      .orElse(participant.getConsultantId());
+              return new GroupChatParticipantDTO()
+                  .consultantId(participant.getConsultantId())
+                  .role(GroupChatParticipantDTO.RoleEnum.fromValue(participant.getRole().name()))
+                  .displayName(displayName);
+            })
+        .toList();
   }
 
   private Set<ChatAgency> loadChatAgencies(Long chatId) {
@@ -354,7 +415,9 @@ public class ChatService {
    *
    * @param chat the {@link Chat}
    */
+  @Transactional
   public void deleteChat(Chat chat) {
+    groupChatParticipantRepository.deleteBySeriesId(chat.getId());
     chatRepository.delete(chat);
   }
 
@@ -394,6 +457,9 @@ public class ChatService {
     chat.setStartDate(startDate);
     chat.setInitialStartDate(startDate);
     chat.setHintMessage(chatDTO.getHintMessage());
+    chat.setSourceLanguage(chatDTO.getSourceLanguage());
+    chat.setHintMessageTranslations(chatDTO.getHintMessageTranslations());
+    chat.setGroupChatRulesTranslations(chatDTO.getGroupChatRulesTranslations());
 
     this.saveChat(chat);
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/ConsultantService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ConsultantService.java
@@ -147,6 +147,11 @@ public class ConsultantService {
     return consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(agencyId);
   }
 
+  public List<Consultant> findActiveConsultantsForTenant(Long tenantId) {
+    return consultantRepository.findByTenantIdAndDeleteDateIsNullOrderByFirstNameAscLastNameAsc(
+        tenantId);
+  }
+
   /**
    * Adds a mobile client token of the current authenticated consultant in database.
    *

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
@@ -41,12 +41,12 @@ public class AgencyMatrixCredentialClient {
         String.format(
             "%s/internal/agencies/%d/matrix-service-account", agencyServiceBaseUrl, agencyId);
 
-    HttpHeaders headers = technicalUserHeaders();
-    // In single-domain multitenancy, non-auth internal calls can miss tenant context.
-    // Passing agencyId lets AgencyService resolve the tenant from the target agency.
-    headers.add("agencyId", String.valueOf(agencyId));
-
     try {
+      HttpHeaders headers = technicalUserHeaders();
+      // In single-domain multitenancy, non-auth internal calls can miss tenant context.
+      // Passing agencyId lets AgencyService resolve the tenant from the target agency.
+      headers.add("agencyId", String.valueOf(agencyId));
+
       ResponseEntity<AgencyMatrixCredentialsDTO> response =
           restTemplate.exchange(
               url, HttpMethod.GET, new HttpEntity<>(headers), AgencyMatrixCredentialsDTO.class);

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.userservice.api.service.agency;
 
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
@@ -24,6 +26,8 @@ public class AgencyMatrixCredentialClient {
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
+  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityClientConfig identityClientConfig;
 
   @Value("${agency.service.api.url}")
   private String agencyServiceBaseUrl;
@@ -37,8 +41,7 @@ public class AgencyMatrixCredentialClient {
         String.format(
             "%s/internal/agencies/%d/matrix-service-account", agencyServiceBaseUrl, agencyId);
 
-    HttpHeaders headers = securityHeaderSupplier.getCsrfHttpHeaders();
-    tenantHeaderSupplier.addTenantHeader(headers);
+    HttpHeaders headers = technicalUserHeaders();
     // In single-domain multitenancy, non-auth internal calls can miss tenant context.
     // Passing agencyId lets AgencyService resolve the tenant from the target agency.
     headers.add("agencyId", String.valueOf(agencyId));
@@ -59,5 +62,14 @@ public class AgencyMatrixCredentialClient {
     }
 
     return Optional.empty();
+  }
+
+  private HttpHeaders technicalUserHeaders() {
+    var techUser = identityClientConfig.getTechnicalUser();
+    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var headers =
+        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+    tenantHeaderSupplier.addTenantHeader(headers);
+    return headers;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrence.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrence.java
@@ -1,0 +1,13 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import java.time.LocalDateTime;
+
+public record ChatOccurrence(
+    long seriesId,
+    int occurrenceIndex,
+    LocalDateTime originalStart,
+    LocalDateTime start,
+    int duration,
+    Integer capacity,
+    ChatModality modality) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceCommandService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceCommandService.java
@@ -1,0 +1,134 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException.ExceptionType;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ChatOccurrenceExceptionRepository;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatNotificationRecipientService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Authorized commands that alter exactly one virtual occurrence of a finite Chat Series. */
+@Service
+@RequiredArgsConstructor
+public class ChatOccurrenceCommandService {
+
+  private final ChatRepository chatRepository;
+  private final ChatOccurrenceExceptionRepository exceptionRepository;
+  private final GroupChatParticipantRepository participantRepository;
+  private final GroupChatLifecycleNotificationService lifecycleNotificationService;
+  private final GroupChatNotificationRecipientService notificationRecipientService;
+
+  @Transactional
+  public void skip(Long seriesId, String actingConsultantId, LocalDateTime originalStartUtc) {
+    assertCanModerate(seriesId, actingConsultantId);
+    var series =
+        chatRepository
+            .findById(seriesId)
+            .orElseThrow(() -> new NotFoundException("Chat Series not found"));
+    var exception =
+        exceptionRepository
+            .findBySeries_IdAndOriginalOccurrenceStartUtc(seriesId, originalStartUtc)
+            .orElseGet(() -> ChatOccurrenceException.skip(series, requireStart(originalStartUtc)));
+    exception.setExceptionType(ExceptionType.SKIP);
+    exception.setOverrideStartUtc(null);
+    exception.setOverrideDuration(null);
+    exception.setOverrideCapacity(null);
+    exception.setOverrideModality(null);
+    exceptionRepository.save(exception);
+    publishCancelled(series, originalStartUtc);
+  }
+
+  @Transactional
+  public void override(
+      Long seriesId,
+      String actingConsultantId,
+      LocalDateTime originalStartUtc,
+      LocalDateTime overrideStartUtc,
+      Integer overrideDuration,
+      Integer overrideCapacity,
+      ChatModality overrideModality) {
+    assertCanModerate(seriesId, actingConsultantId);
+    validateOverride(overrideStartUtc, overrideDuration, overrideCapacity, overrideModality);
+    var series =
+        chatRepository
+            .findById(seriesId)
+            .orElseThrow(() -> new NotFoundException("Chat Series not found"));
+    var exception =
+        exceptionRepository
+            .findBySeries_IdAndOriginalOccurrenceStartUtc(seriesId, originalStartUtc)
+            .orElseGet(
+                () ->
+                    ChatOccurrenceException.builder()
+                        .series(series)
+                        .originalOccurrenceStartUtc(requireStart(originalStartUtc))
+                        .build());
+    exception.setExceptionType(ExceptionType.OVERRIDE);
+    exception.setOverrideStartUtc(overrideStartUtc);
+    exception.setOverrideDuration(overrideDuration);
+    exception.setOverrideCapacity(overrideCapacity);
+    exception.setOverrideModality(overrideModality);
+    exceptionRepository.save(exception);
+  }
+
+  private void assertCanModerate(Long seriesId, String actingConsultantId) {
+    var membership =
+        participantRepository
+            .findBySeriesIdAndConsultantId(seriesId, actingConsultantId)
+            .orElseThrow(() -> new ForbiddenException("Actor is not a member of this Series"));
+    if (membership.getRole() != ParticipantRole.OWNER
+        && membership.getRole() != ParticipantRole.CO_MODERATOR) {
+      throw new ForbiddenException("Only an Owner or Co-Moderator can edit an occurrence");
+    }
+  }
+
+  private static LocalDateTime requireStart(LocalDateTime value) {
+    if (value == null) {
+      throw new BadRequestException("originalStartUtc is required");
+    }
+    return value;
+  }
+
+  private static void validateOverride(
+      LocalDateTime start, Integer duration, Integer capacity, ChatModality modality) {
+    if (start == null && duration == null && capacity == null && modality == null) {
+      throw new BadRequestException("At least one occurrence override is required");
+    }
+    if (duration != null && duration <= 0) {
+      throw new BadRequestException("Occurrence duration must be positive");
+    }
+    if (capacity != null && capacity <= 0) {
+      throw new BadRequestException("Occurrence capacity must be positive");
+    }
+  }
+
+  private void publishCancelled(Chat series, LocalDateTime originalStartUtc) {
+    lifecycleNotificationService.createCancelledNotifications(
+        series.getId(),
+        occurrenceIndex(series, originalStartUtc),
+        originalStartUtc,
+        series.getMatrixRoomId() != null ? series.getMatrixRoomId() : series.getGroupId(),
+        null,
+        series.getChatModality() == ChatModality.VIDEO,
+        notificationRecipientService.resolveRecipientIds(series));
+  }
+
+  private Integer occurrenceIndex(Chat series, LocalDateTime originalStartUtc) {
+    for (int index = 0; index < series.getRepeatCount(); index++) {
+      if (series.occurrenceStart(index).equals(originalStartUtc)) {
+        return index;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceProjector.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceProjector.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException.ExceptionType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ChatOccurrenceProjector {
+
+  public List<ChatOccurrence> project(
+      Chat series,
+      List<ChatOccurrenceException> exceptions,
+      LocalDateTime windowStart,
+      LocalDateTime windowEnd,
+      int limit) {
+    if (limit < 1 || limit > 100) {
+      throw new IllegalArgumentException("Occurrence projection limit must be between 1 and 100");
+    }
+    if (!windowStart.isBefore(windowEnd)) {
+      throw new IllegalArgumentException("Occurrence projection window must be positive");
+    }
+
+    Map<LocalDateTime, ChatOccurrenceException> exceptionsByStart =
+        exceptions.stream()
+            .collect(
+                Collectors.toMap(
+                    ChatOccurrenceException::getOriginalOccurrenceStartUtc, Function.identity()));
+
+    var result = new java.util.ArrayList<ChatOccurrence>();
+    for (int index = 0; index < series.getRepeatCount() && result.size() < limit; index++) {
+      var originalStart = series.occurrenceStart(index);
+      var exception = exceptionsByStart.get(originalStart);
+      if (exception != null && exception.getExceptionType() == ExceptionType.SKIP) {
+        continue;
+      }
+      var effectiveStart =
+          exception != null && exception.getOverrideStartUtc() != null
+              ? exception.getOverrideStartUtc()
+              : originalStart;
+      var duration =
+          exception != null && exception.getOverrideDuration() != null
+              ? exception.getOverrideDuration()
+              : series.getDuration();
+      var capacity =
+          exception != null && exception.getOverrideCapacity() != null
+              ? exception.getOverrideCapacity()
+              : series.getMaxParticipants();
+      var modality =
+          exception != null && exception.getOverrideModality() != null
+              ? exception.getOverrideModality()
+              : series.getChatModality();
+      if (!effectiveStart.isBefore(windowStart) && effectiveStart.isBefore(windowEnd)) {
+        result.add(
+            new ChatOccurrence(
+                series.getId(),
+                index,
+                originalStart,
+                effectiveStart,
+                duration,
+                capacity,
+                modality));
+      }
+    }
+    return List.copyOf(result);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceQueryService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceQueryService.java
@@ -1,0 +1,35 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.port.out.ChatOccurrenceExceptionRepository;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatOccurrenceQueryService {
+
+  private final ChatRepository chatRepository;
+  private final ChatOccurrenceExceptionRepository exceptionRepository;
+  private final ChatOccurrenceProjector projector = new ChatOccurrenceProjector();
+
+  public List<ChatOccurrence> getOccurrences(
+      Long seriesId, LocalDateTime from, LocalDateTime to, int limit) {
+    if (from == null || to == null || !from.isBefore(to)) {
+      throw new BadRequestException("Occurrence window must have a start before its end");
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException("Occurrence projection limit must be between 1 and 100");
+    }
+    var series =
+        chatRepository
+            .findById(seriesId)
+            .orElseThrow(() -> new NotFoundException("Chat Series not found"));
+    return projector.project(
+        series, exceptionRepository.findBySeries_Id(seriesId), from, to, limit);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGate.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Enforces the tenant-owned self-help group activation at the backend boundary. */
+@Service
+@RequiredArgsConstructor
+public class GroupChatFeatureGate {
+
+  private final @NonNull TenantService tenantService;
+
+  public void requireEnabled(Consultant consultant) {
+    if (consultant == null || consultant.getTenantId() == null) {
+      throw disabled();
+    }
+
+    var tenant = tenantService.getRestrictedTenantData(consultant.getTenantId());
+    if (tenant == null
+        || tenant.getSettings() == null
+        || !Boolean.TRUE.equals(tenant.getSettings().getFeatureGroupChatV2Enabled())) {
+      throw disabled();
+    }
+  }
+
+  private ForbiddenException disabled() {
+    return new ForbiddenException("Self-help group chat is disabled for this tenant");
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatPermissionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatPermissionService.java
@@ -1,0 +1,51 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Central authorization boundary for opening, moderating, and ending a Chat Series occurrence. */
+@Service
+@RequiredArgsConstructor
+public class GroupChatPermissionService {
+
+  private final GroupChatParticipantRepository participantRepository;
+  private final ChatPermissionVerifier legacyPermissionVerifier;
+
+  public void requireCanModerate(Chat chat, Consultant consultant) {
+    if (chat == null || consultant == null) {
+      throw forbidden();
+    }
+
+    var participants =
+        chat.getId() == null
+            ? java.util.List.<de.caritas.cob.userservice.api.model.GroupChatParticipant>of()
+            : participantRepository.findBySeriesId(chat.getId());
+    if (participants.isEmpty()) {
+      if (!legacyPermissionVerifier.hasSameAgencyAssigned(chat, consultant)) {
+        throw forbidden();
+      }
+      return;
+    }
+
+    var authorized =
+        participants.stream()
+            .filter(participant -> consultant.getId().equals(participant.getConsultantId()))
+            .map(participant -> participant.getRole())
+            .anyMatch(
+                role -> role == ParticipantRole.OWNER || role == ParticipantRole.CO_MODERATOR);
+    if (!authorized) {
+      throw forbidden();
+    }
+  }
+
+  private ForbiddenException forbidden() {
+    return new ForbiddenException(
+        "Only a Series Owner or Co-Moderator may moderate this occurrence");
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatRoleService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatRoleService.java
@@ -1,0 +1,175 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupChatRoleService {
+
+  private final GroupChatParticipantRepository participantRepository;
+  private final ChatRepository chatRepository;
+  private final ConsultantRepository consultantRepository;
+  private final GroupChatMembershipService groupChatMembershipService;
+
+  @Transactional
+  public void changeRole(
+      Long seriesId,
+      String actingConsultantId,
+      String targetConsultantId,
+      ParticipantRole newRole) {
+    var participants = participantRepository.findBySeriesIdForUpdate(seriesId);
+    var actor =
+        requireParticipant(
+            participants,
+            actingConsultantId,
+            () -> new ForbiddenException("Actor is not a member of this Series"));
+    if (actor.getRole() != ParticipantRole.OWNER) {
+      throw new ForbiddenException("Only an Owner can change Series roles");
+    }
+
+    var target =
+        requireParticipant(
+            participants,
+            targetConsultantId,
+            () -> new NotFoundException("Series participant not found"));
+    if (target.getRole() == ParticipantRole.OWNER && newRole != ParticipantRole.OWNER) {
+      long ownerCount = ownerCount(participants);
+      if (ownerCount <= 1) {
+        throw new ConflictException("The last Series Owner cannot be demoted");
+      }
+    }
+
+    target.setRole(newRole);
+    participantRepository.save(target);
+  }
+
+  @Transactional
+  public void transferPrimaryOwnership(
+      Long seriesId, String actingOwnerId, String targetConsultantId) {
+    var participants = participantRepository.findBySeriesIdForUpdate(seriesId);
+    var actor =
+        requireParticipant(
+            participants,
+            actingOwnerId,
+            () -> new ForbiddenException("Actor is not a member of this Series"));
+    if (actor.getRole() != ParticipantRole.OWNER) {
+      throw new ForbiddenException("Only an Owner can transfer primary ownership");
+    }
+    var target =
+        requireParticipant(
+            participants,
+            targetConsultantId,
+            () -> new NotFoundException("Series participant not found"));
+    var series =
+        chatRepository
+            .findById(seriesId)
+            .orElseThrow(() -> new NotFoundException("Chat Series not found"));
+    var newPrimaryOwner =
+        consultantRepository
+            .findById(targetConsultantId)
+            .orElseThrow(() -> new NotFoundException("Consultant not found"));
+
+    actor.setRole(ParticipantRole.CO_MODERATOR);
+    target.setRole(ParticipantRole.OWNER);
+    series.setChatOwner(newPrimaryOwner);
+    participantRepository.save(actor);
+    participantRepository.save(target);
+    chatRepository.save(series);
+  }
+
+  @Transactional
+  public void removeParticipant(
+      Long seriesId, String actingConsultantId, String targetConsultantId) {
+    var participants = participantRepository.findBySeriesIdForUpdate(seriesId);
+    var actor =
+        requireParticipant(
+            participants,
+            actingConsultantId,
+            () -> new ForbiddenException("Actor is not a member of this Series"));
+    if (actor.getRole() != ParticipantRole.OWNER) {
+      throw new ForbiddenException("Only an Owner can remove Series participants");
+    }
+
+    var target =
+        requireParticipant(
+            participants,
+            targetConsultantId,
+            () -> new NotFoundException("Series participant not found"));
+    if (target.getRole() == ParticipantRole.OWNER) {
+      throw new ConflictException("An Owner must transfer or relinquish ownership before removal");
+    }
+
+    var series =
+        chatRepository
+            .findById(seriesId)
+            .orElseThrow(() -> new NotFoundException("Chat Series not found"));
+    var targetConsultant =
+        consultantRepository
+            .findById(targetConsultantId)
+            .orElseThrow(() -> new NotFoundException("Consultant not found"));
+
+    participantRepository.delete(target);
+    groupChatMembershipService.removeLeavingMemberFromRoom(
+        series, targetConsultant.getMatrixUserId());
+  }
+
+  @Transactional
+  public void leaveSeries(Chat series, Consultant consultant) {
+    if (series == null
+        || series.getId() == null
+        || consultant == null
+        || consultant.getId() == null) {
+      return;
+    }
+
+    var participants = participantRepository.findBySeriesIdForUpdate(series.getId());
+    var participation =
+        participants.stream()
+            .filter(participant -> consultant.getId().equals(participant.getConsultantId()))
+            .findFirst();
+    if (participation.isPresent()) {
+      var leavingParticipant = participation.get();
+      if (leavingParticipant.getRole() == ParticipantRole.OWNER) {
+        long ownerCount = ownerCount(participants);
+        if (ownerCount <= 1) {
+          throw new ConflictException(
+              "The last Series Owner cannot leave before transferring ownership");
+        }
+      }
+      participantRepository.delete(leavingParticipant);
+    }
+
+    groupChatMembershipService.removeLeavingMemberFromRoom(series, consultant.getMatrixUserId());
+  }
+
+  private GroupChatParticipant requireParticipant(
+      List<GroupChatParticipant> participants,
+      String consultantId,
+      Supplier<? extends RuntimeException> exceptionSupplier) {
+    return participants.stream()
+        .filter(participant -> consultantId.equals(participant.getConsultantId()))
+        .findFirst()
+        .orElseThrow(exceptionSupplier);
+  }
+
+  private long ownerCount(List<GroupChatParticipant> participants) {
+    return participants.stream()
+        .filter(participant -> participant.getRole() == ParticipantRole.OWNER)
+        .count();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.service.matrix;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -57,6 +58,52 @@ public class GroupChatMembershipService {
   public void removeLeavingMemberFromRoom(Chat chat, String leavingMatrixUserId) {
     var matrixRoomId = resolveMatrixRoomId(chat);
     removeMemberFromRoom(matrixRoomId, leavingMatrixUserId);
+  }
+
+  /**
+   * Invites a member to a group chat's Matrix room and accepts the invitation on their behalf.
+   *
+   * @return {@code true} only when the member is joined (or was already joined)
+   */
+  public boolean addMemberToRoom(Chat chat, String memberMatrixUserId) {
+    var matrixRoomId = resolveMatrixRoomId(chat);
+    var ownerMatrixUserId =
+        chat == null || chat.getChatOwner() == null ? null : chat.getChatOwner().getMatrixUserId();
+    if (isBlank(matrixRoomId) || isBlank(memberMatrixUserId) || isBlank(ownerMatrixUserId)) {
+      return false;
+    }
+
+    try {
+      var ownerToken = matrixSynapseService.loginAsUserAccessToken(ownerMatrixUserId);
+      if (isBlank(ownerToken)) {
+        return false;
+      }
+
+      try {
+        matrixSynapseService.inviteUserToRoom(matrixRoomId, memberMatrixUserId, ownerToken);
+      } catch (MatrixInviteUserException e) {
+        var message = e.getMessage();
+        if (message == null
+            || (!message.contains("already in the room") && !message.contains("already invited"))) {
+          log.warn(
+              "Could not invite member {} to Matrix room {}: {}",
+              memberMatrixUserId,
+              matrixRoomId,
+              message);
+          return false;
+        }
+      }
+
+      var memberToken = matrixSynapseService.loginAsUserAccessToken(memberMatrixUserId);
+      return !isBlank(memberToken) && matrixSynapseService.joinRoom(matrixRoomId, memberToken);
+    } catch (Exception e) {
+      log.warn(
+          "Could not join member {} to Matrix room {}: {}",
+          memberMatrixUserId,
+          matrixRoomId,
+          e.getMessage());
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationDeduplicationWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationDeduplicationWriter.java
@@ -1,0 +1,22 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import de.caritas.cob.userservice.api.model.EventNotification;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Isolates unique-key races so a duplicate cannot mark the caller's transaction rollback-only. */
+@Service
+@RequiredArgsConstructor
+public class EventNotificationDeduplicationWriter {
+
+  private final @NonNull EventNotificationRepository eventNotificationRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void persistInNewTransaction(EventNotification eventNotification) {
+    eventNotificationRepository.saveAndFlush(eventNotification);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -27,6 +27,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +39,7 @@ public class EventNotificationService {
 
   public static final String CATEGORY_SYSTEM = "system";
   public static final String CATEGORY_MESSAGE = "message";
+
   private static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
   private static final String REDACTED_PREVIEW = "[content hidden]";
 
@@ -46,6 +48,7 @@ public class EventNotificationService {
   private final @NonNull UserRepository userRepository;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull IdentityTombstoneService identityTombstoneService;
+  private final @NonNull EventNotificationDeduplicationWriter deduplicationWriter;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
   private final ObjectMapper paramsObjectMapper = new ObjectMapper();
 
@@ -587,21 +590,87 @@ public class EventNotificationService {
     if (recipientUserId == null || recipientUserId.isBlank()) {
       return;
     }
-    var event =
-        EventNotification.builder()
-            .recipientUserId(recipientUserId)
-            .eventType(eventType)
-            .category(nonNull(category) ? category : CATEGORY_SYSTEM)
-            .title(nonNull(title) ? title : "Notification")
-            .text(nonNull(text) ? text : "")
-            .params(params)
-            .actionPath(actionPath)
-            .sourceSessionId(sourceSessionId)
-            .readDate(null)
-            .createDate(LocalDateTime.now())
-            .tenantId(tenantId)
-            .build();
-    eventNotificationRepository.save(event);
+    eventNotificationRepository.save(
+        buildEvent(
+            recipientUserId,
+            eventType,
+            category,
+            title,
+            text,
+            params,
+            actionPath,
+            sourceSessionId,
+            tenantId,
+            null));
+  }
+
+  /** Persists an event at most once for a producer-owned key and recipient. */
+  @Transactional
+  public void createEventOnce(
+      String deduplicationKey,
+      String recipientUserId,
+      String eventType,
+      String category,
+      String title,
+      String text,
+      String params,
+      String actionPath,
+      Long sourceSessionId,
+      Long tenantId) {
+    if (recipientUserId == null
+        || recipientUserId.isBlank()
+        || deduplicationKey == null
+        || deduplicationKey.isBlank()
+        || eventNotificationRepository.existsByRecipientUserIdAndDeduplicationKey(
+            recipientUserId, deduplicationKey)) {
+      return;
+    }
+
+    try {
+      deduplicationWriter.persistInNewTransaction(
+          buildEvent(
+              recipientUserId,
+              eventType,
+              category,
+              title,
+              text,
+              params,
+              actionPath,
+              sourceSessionId,
+              tenantId,
+              deduplicationKey));
+    } catch (DataIntegrityViolationException duplicate) {
+      // Another scheduler replica won the unique-key race. The desired event already exists.
+      log.debug(
+          "Notification {} already persisted for recipient {}", deduplicationKey, recipientUserId);
+    }
+  }
+
+  private EventNotification buildEvent(
+      String recipientUserId,
+      String eventType,
+      String category,
+      String title,
+      String text,
+      String params,
+      String actionPath,
+      Long sourceSessionId,
+      Long tenantId,
+      String deduplicationKey) {
+    return EventNotification.builder()
+        .recipientUserId(recipientUserId)
+        .eventType(eventType)
+        .category(nonNull(category) ? category : CATEGORY_SYSTEM)
+        .title(nonNull(title) ? title : "Notification")
+        .text(nonNull(text) ? text : "")
+        .params(params)
+        .actionPath(actionPath)
+        .sourceSessionId(sourceSessionId)
+        .deduplicationKey(deduplicationKey)
+        .readDate(null)
+        .createDate(LocalDateTime.now())
+        .tenantId(tenantId)
+        .build();
   }
 
   private NotificationItem toItem(EventNotification item) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatLifecycleNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatLifecycleNotificationService.java
@@ -1,0 +1,205 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/** Publishes privacy-safe timeline events for self-help group occurrences. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupChatLifecycleNotificationService {
+
+  public static final String EVENT_GROUP_CHAT_OPENED = "group_chat.opened";
+  public static final String EVENT_GROUP_CHAT_REMINDER = "group_chat.reminder";
+  public static final String EVENT_GROUP_CHAT_CANCELLED = "group_chat.cancelled";
+
+  private final @NonNull EventNotificationService eventNotificationService;
+  private final @NonNull ObjectMapper objectMapper;
+
+  public void createOpenedNotifications(
+      Long seriesId,
+      Integer occurrenceIndex,
+      LocalDateTime occurrenceStart,
+      String roomRef,
+      String callRoomId,
+      Boolean isVideo,
+      Collection<String> recipientUserIds) {
+    createNotifications(
+        LifecycleEvent.OPENED,
+        seriesId,
+        occurrenceIndex,
+        occurrenceStart,
+        roomRef,
+        callRoomId,
+        isVideo,
+        recipientUserIds);
+  }
+
+  public void createReminderNotifications(
+      Long seriesId,
+      Integer occurrenceIndex,
+      LocalDateTime occurrenceStart,
+      String roomRef,
+      String callRoomId,
+      Boolean isVideo,
+      Collection<String> recipientUserIds) {
+    createNotifications(
+        LifecycleEvent.REMINDER,
+        seriesId,
+        occurrenceIndex,
+        occurrenceStart,
+        roomRef,
+        callRoomId,
+        isVideo,
+        recipientUserIds);
+  }
+
+  public void createCancelledNotifications(
+      Long seriesId,
+      Integer occurrenceIndex,
+      LocalDateTime occurrenceStart,
+      String roomRef,
+      String callRoomId,
+      Boolean isVideo,
+      Collection<String> recipientUserIds) {
+    createNotifications(
+        LifecycleEvent.CANCELLED,
+        seriesId,
+        occurrenceIndex,
+        occurrenceStart,
+        roomRef,
+        callRoomId,
+        isVideo,
+        recipientUserIds);
+  }
+
+  private void createNotifications(
+      LifecycleEvent event,
+      Long seriesId,
+      Integer occurrenceIndex,
+      LocalDateTime occurrenceStart,
+      String roomRef,
+      String callRoomId,
+      Boolean isVideo,
+      Collection<String> recipientUserIds) {
+    if (seriesId == null || recipientUserIds == null || recipientUserIds.isEmpty()) {
+      return;
+    }
+
+    String params =
+        serializeParams(
+            buildParams(seriesId, occurrenceIndex, occurrenceStart, roomRef, callRoomId, isVideo));
+    String deduplicationKey =
+        buildDeduplicationKey(event, seriesId, occurrenceIndex, occurrenceStart);
+    recipientUserIds.stream()
+        .filter(id -> id != null && !id.isBlank())
+        .distinct()
+        .forEach(
+            recipientUserId ->
+                createForRecipient(event, seriesId, params, deduplicationKey, recipientUserId));
+  }
+
+  private void createForRecipient(
+      LifecycleEvent event,
+      Long seriesId,
+      String params,
+      String deduplicationKey,
+      String recipientUserId) {
+    try {
+      eventNotificationService.createEventOnce(
+          deduplicationKey,
+          recipientUserId,
+          event.eventType,
+          EventNotificationService.CATEGORY_SYSTEM,
+          event.title,
+          event.text,
+          params,
+          null,
+          seriesId,
+          null);
+    } catch (RuntimeException ex) {
+      // Each call crosses the EventNotificationService transaction boundary independently, so one
+      // failed recipient cannot roll back notifications already written for other recipients.
+      log.warn(
+          "Could not persist {} notification for recipient {} (series {})",
+          event.eventType,
+          recipientUserId,
+          seriesId,
+          ex);
+    }
+  }
+
+  private String buildDeduplicationKey(
+      LifecycleEvent event, Long seriesId, Integer occurrenceIndex, LocalDateTime occurrenceStart) {
+    String occurrenceKey =
+        occurrenceIndex != null
+            ? occurrenceIndex.toString()
+            : occurrenceStart != null ? occurrenceStart.toString() : "series";
+    return "group-chat:" + event.eventType + ":" + seriesId + ":" + occurrenceKey;
+  }
+
+  private Map<String, Object> buildParams(
+      Long seriesId,
+      Integer occurrenceIndex,
+      LocalDateTime occurrenceStart,
+      String roomRef,
+      String callRoomId,
+      Boolean isVideo) {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("seriesId", seriesId);
+    if (occurrenceIndex != null) {
+      params.put("occurrenceIndex", occurrenceIndex);
+    }
+    if (occurrenceStart != null) {
+      params.put("start", occurrenceStart.toString());
+      params.put("occurrenceStart", occurrenceStart.toString());
+    }
+    putIfPresent(params, "roomRef", roomRef);
+    putIfPresent(params, "callRoomId", callRoomId);
+    if (isVideo != null) {
+      params.put("isVideo", isVideo);
+    }
+    return params;
+  }
+
+  private void putIfPresent(Map<String, Object> params, String key, String value) {
+    if (value != null && !value.isBlank()) {
+      params.put(key, value);
+    }
+  }
+
+  private String serializeParams(Map<String, Object> params) {
+    try {
+      return objectMapper.writeValueAsString(params);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("Could not serialize group chat lifecycle parameters", ex);
+    }
+  }
+
+  private enum LifecycleEvent {
+    OPENED(EVENT_GROUP_CHAT_OPENED, "Group chat available", "A group chat is now available."),
+    REMINDER(EVENT_GROUP_CHAT_REMINDER, "Group chat reminder", "A group chat is scheduled soon."),
+    CANCELLED(
+        EVENT_GROUP_CHAT_CANCELLED,
+        "Group chat cancelled",
+        "A group chat occurrence was cancelled.");
+
+    private final String eventType;
+    private final String title;
+    private final String text;
+
+    LifecycleEvent(String eventType, String title, String text) {
+      this.eventType = eventType;
+      this.title = title;
+      this.text = text;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatNotificationRecipientService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatNotificationRecipientService.java
@@ -1,0 +1,40 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.UserChatRepository;
+import java.util.LinkedHashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Resolves every identity already participating in a self-help group Series. */
+@Service
+@RequiredArgsConstructor
+public class GroupChatNotificationRecipientService {
+
+  private final GroupChatParticipantRepository participantRepository;
+  private final UserChatRepository userChatRepository;
+
+  public List<String> resolveRecipientIds(Chat series) {
+    if (series == null || series.getId() == null) {
+      return List.of();
+    }
+
+    var recipientIds = new LinkedHashSet<String>();
+    participantRepository.findBySeriesId(series.getId()).stream()
+        .map(participant -> participant.getConsultantId())
+        .filter(GroupChatNotificationRecipientService::isPresent)
+        .forEach(recipientIds::add);
+    userChatRepository.findByChat(series).stream()
+        .filter(relation -> relation.getUser() != null)
+        .map(relation -> relation.getUser().getUserId())
+        .filter(GroupChatNotificationRecipientService::isPresent)
+        .forEach(recipientIds::add);
+    return List.copyOf(recipientIds);
+  }
+
+  private static boolean isPresent(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatReminderService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/GroupChatReminderService.java
@@ -1,0 +1,43 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Selects upcoming inactive Series occurrences and publishes durable in-app reminders. */
+@Service
+@RequiredArgsConstructor
+public class GroupChatReminderService {
+
+  private final ChatRepository chatRepository;
+  private final GroupChatNotificationRecipientService notificationRecipientService;
+  private final GroupChatLifecycleNotificationService lifecycleNotificationService;
+
+  @Value("${group.chat.reminder.leadMinutes:60}")
+  private long leadMinutes;
+
+  @Value("${group.chat.reminder.windowMinutes:5}")
+  private long windowMinutes;
+
+  public void publishUpcomingReminders(LocalDateTime nowUtc) {
+    var reminderAt = nowUtc.plusMinutes(leadMinutes);
+    var windowStart = reminderAt.minusMinutes(windowMinutes);
+    chatRepository.findAllByActiveIsFalseAndStartDateBetween(windowStart, reminderAt).stream()
+        .filter(series -> series.getId() != null)
+        .filter(series -> series.getCurrentOccurrenceIndex() < series.getRepeatCount())
+        .forEach(
+            series -> {
+              lifecycleNotificationService.createReminderNotifications(
+                  series.getId(),
+                  series.getCurrentOccurrenceIndex(),
+                  series.getStartDate(),
+                  series.getMatrixRoomId() != null ? series.getMatrixRoomId() : series.getGroupId(),
+                  null,
+                  series.getChatModality() == ChatModality.VIDEO,
+                  notificationRecipientService.resolveRecipientIds(series));
+            });
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
@@ -61,6 +61,7 @@ public class UserSessionListService {
   private void enrichSessionsWithTopics(List<UserSessionResponseDTO> mergedSessions) {
     mergedSessions.stream()
         .map(UserSessionResponseDTO::getSession)
+        .filter(java.util.Objects::nonNull)
         .forEach(sessionTopicEnrichmentService::enrichSessionWithTopicData);
   }
 
@@ -80,8 +81,19 @@ public class UserSessionListService {
       Set<String> roles) {
 
     var groupIds = new HashSet<>(rcGroupIds);
-    var sessions = sessionService.getSessionsByUserAndGroupIds(userId, groupIds, roles);
     var chats = chatService.getChatSessionsByGroupIds(groupIds);
+    var chatGroupIds =
+        chats.stream()
+            .map(UserSessionResponseDTO::getChat)
+            .filter(java.util.Objects::nonNull)
+            .map(UserChatDTO::getGroupId)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toSet());
+    groupIds.removeAll(chatGroupIds);
+    var sessions =
+        groupIds.isEmpty()
+            ? List.<UserSessionResponseDTO>of()
+            : sessionService.getSessionsByUserAndGroupIds(userId, groupIds, roles);
 
     return mergeUserSessionsAndChats(sessions, chats, rocketChatCredentials);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatService.java
@@ -33,7 +33,11 @@ public class DeactivateGroupChatService {
   }
 
   private Predicate<Chat> isChatOutsideOfDeactivationTime(LocalDateTime deactivationTime) {
-    return chat -> chat.getUpdateDate().isBefore(deactivationTime.minusMinutes(chat.getDuration()));
+    return chat -> {
+      var plannedStart = chat.getStartDate() != null ? chat.getStartDate() : chat.getUpdateDate();
+      var plannedEnd = plannedStart.plusMinutes(chat.getDuration());
+      return !plannedEnd.isAfter(deactivationTime);
+    };
   }
 
   private void deactivateStaleActiveChat(Chat staleChat) {

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/groupchatreminder/scheduler/GroupChatReminderScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/groupchatreminder/scheduler/GroupChatReminderScheduler.java
@@ -1,0 +1,37 @@
+package de.caritas.cob.userservice.api.workflow.groupchatreminder.scheduler;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
+
+import de.caritas.cob.userservice.api.service.notification.GroupChatReminderService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Periodically publishes the privacy-safe in-app reminder for upcoming group-chat occurrences. */
+@Component
+@RequiredArgsConstructor
+public class GroupChatReminderScheduler {
+
+  private final GroupChatReminderService reminderService;
+  private final TenantContextProvider tenantContextProvider;
+
+  @Value("${group.chat.reminder.enabled:true}")
+  private Boolean enabled;
+
+  @Scheduled(cron = "${group.chat.reminder.cron:0 */5 * * * ?}")
+  public void publishUpcomingReminders() {
+    if (!isTrue(enabled)) {
+      return;
+    }
+    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+    try {
+      reminderService.publishUpcomingReminders(nowInUtc());
+    } finally {
+      TenantContext.clear();
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,8 +67,8 @@ deletion.pause.defaultMonths=${DELETION_PAUSE_DEFAULT_MONTHS:3}
 deletion.pause.maxMonths=${DELETION_PAUSE_MAX_MONTHS:12}
 user.anonymous.deactivateworkflow.cron=0 0 * * * ?
 user.anonymous.deactivateworkflow.periodMinutes=360
-group.chat.deactivateworkflow.cron=0 0 * * * ?
-group.chat.deactivateworkflow.periodMinutes=360
+group.chat.deactivateworkflow.cron=0 * * * * ?
+group.chat.deactivateworkflow.periodMinutes=0
 
 session.inactive.deleteWorkflow.enabled=false
 session.inactive.deleteWorkflow.cron=0 0 2 * * ?
@@ -82,6 +82,11 @@ user.registeredonly.deleteWorkflow.afterSessionPurge.enabled=false
 enquiry.open.notification.enabled=false
 enquiry.open.notification.cron=0 7 * * * ?
 enquiry.open.notification.check.hours=12
+
+group.chat.reminder.enabled=${GROUP_CHAT_REMINDER_ENABLED:true}
+group.chat.reminder.cron=${GROUP_CHAT_REMINDER_CRON:0 */5 * * * ?}
+group.chat.reminder.leadMinutes=${GROUP_CHAT_REMINDER_LEAD_MINUTES:60}
+group.chat.reminder.windowMinutes=${GROUP_CHAT_REMINDER_WINDOW_MINUTES:5}
 
 inactive.account.notification.enabled=false
 inactive.account.notification.cron=0 30 2 * * ?
@@ -322,6 +327,7 @@ matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
 # Derive consultant live-chat availability from real-time Matrix presence.
 # Set to false to fall back to the legacy RocketChat / best-effort signal.
 matrix.presenceEnabled=${MATRIX_PRESENCE_ENABLED:true}
+matrix.encryptionEnabled=${MATRIX_ENCRYPTION_ENABLED:false}
 # A consultant counts as available only if their last Matrix activity is within this window (ms).
 # Avoids counting consultants who closed the app but linger as "online"/"unavailable" in Synapse.
 matrix.presenceActiveThresholdMs=${MATRIX_PRESENCE_ACTIVE_THRESHOLD_MS:300000}

--- a/src/main/resources/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml
@@ -63,4 +63,48 @@
     <sql>UPDATE chat SET repeat_count = 12 WHERE is_repetitive = TRUE AND repeat_count = 1</sql>
     <rollback><sql>UPDATE chat SET repeat_count = 1 WHERE is_repetitive = TRUE AND repeat_count = 12</sql></rollback>
   </changeSet>
+
+  <changeSet id="0060_align_legacy_repeating_chat_occurrence" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <columnExists tableName="chat" columnName="is_repetitive"/>
+        <columnExists tableName="chat" columnName="initial_start_date"/>
+        <columnExists tableName="chat" columnName="start_date"/>
+        <columnExists tableName="chat" columnName="chat_interval"/>
+        <columnExists tableName="chat" columnName="current_occurrence_index"/>
+        <columnExists tableName="chat" columnName="repeat_count"/>
+      </and>
+    </preConditions>
+    <sql>
+      UPDATE chat
+      SET current_occurrence_index = GREATEST(
+        0,
+        TIMESTAMPDIFF(WEEK, initial_start_date, start_date)
+      )
+      WHERE is_repetitive = TRUE
+        AND chat_interval = 'WEEKLY'
+        AND current_occurrence_index = 0;
+
+      UPDATE chat
+      SET repeat_count = current_occurrence_index + 12
+      WHERE is_repetitive = TRUE
+        AND chat_interval = 'WEEKLY'
+        AND repeat_count = 12
+        AND current_occurrence_index &gt; 0;
+    </sql>
+    <rollback>
+      <sql>
+        UPDATE chat
+        SET repeat_count = 12
+        WHERE is_repetitive = TRUE
+          AND chat_interval = 'WEEKLY'
+          AND repeat_count = current_occurrence_index + 12;
+
+        UPDATE chat
+        SET current_occurrence_index = 0
+        WHERE is_repetitive = TRUE
+          AND chat_interval = 'WEEKLY';
+      </sql>
+    </rollback>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+  <changeSet id="0060_chat_repeat_count" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="chat" columnName="repeat_count"/></not>
+    </preConditions>
+    <addColumn tableName="chat">
+      <column name="repeat_count" type="INT" defaultValueNumeric="1">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <rollback><dropColumn tableName="chat" columnName="repeat_count"/></rollback>
+  </changeSet>
+
+  <changeSet id="0060_chat_current_occurrence_index" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="chat" columnName="current_occurrence_index"/></not>
+    </preConditions>
+    <addColumn tableName="chat">
+      <column name="current_occurrence_index" type="INT" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <rollback><dropColumn tableName="chat" columnName="current_occurrence_index"/></rollback>
+  </changeSet>
+
+  <changeSet id="0060_chat_timezone" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="chat" columnName="timezone"/></not>
+    </preConditions>
+    <addColumn tableName="chat">
+      <column name="timezone" type="VARCHAR(100)" defaultValue="UTC">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <rollback><dropColumn tableName="chat" columnName="timezone"/></rollback>
+  </changeSet>
+
+  <changeSet id="0060_chat_modality" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="chat" columnName="modality"/></not>
+    </preConditions>
+    <addColumn tableName="chat">
+      <column name="modality" type="VARCHAR(16)" defaultValue="TEXT">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <rollback><dropColumn tableName="chat" columnName="modality"/></rollback>
+  </changeSet>
+
+  <changeSet id="0060_backfill_legacy_repeating_chats" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <columnExists tableName="chat" columnName="repeat_count"/>
+        <columnExists tableName="chat" columnName="is_repetitive"/>
+      </and>
+    </preConditions>
+    <sql>UPDATE chat SET repeat_count = 12 WHERE is_repetitive = TRUE AND repeat_count = 1</sql>
+    <rollback><sql>UPDATE chat SET repeat_count = 1 WHERE is_repetitive = TRUE AND repeat_count = 12</sql></rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0061_chat_occurrence_exception/0061_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0061_chat_occurrence_exception/0061_changeSet.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+  <changeSet id="0061_chat_occurrence_exception_sequence" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><sequenceExists sequenceName="sequence_chat_occurrence_exception"/></not>
+    </preConditions>
+    <createSequence sequenceName="sequence_chat_occurrence_exception" startValue="1" incrementBy="1"/>
+    <rollback><dropSequence sequenceName="sequence_chat_occurrence_exception"/></rollback>
+  </changeSet>
+
+  <changeSet id="0061_chat_occurrence_exception_table" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><tableExists tableName="chat_occurrence_exception"/></not>
+    </preConditions>
+    <createTable tableName="chat_occurrence_exception">
+      <column name="id" type="BIGINT">
+        <constraints nullable="false" primaryKey="true"/>
+      </column>
+      <column name="series_id" type="BIGINT UNSIGNED">
+        <constraints nullable="false"/>
+      </column>
+      <column name="original_occurrence_start_utc" type="DATETIME(6)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="exception_type" type="VARCHAR(16)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="override_start_utc" type="DATETIME(6)"/>
+      <column name="override_duration" type="INT"/>
+      <column name="override_capacity" type="INT"/>
+      <column name="override_modality" type="VARCHAR(16)"/>
+    </createTable>
+    <rollback><dropTable tableName="chat_occurrence_exception"/></rollback>
+  </changeSet>
+
+  <changeSet id="0061_chat_occurrence_exception_fk" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><foreignKeyConstraintExists foreignKeyName="fk_chat_occurrence_exception_series"/></not>
+    </preConditions>
+    <addForeignKeyConstraint
+      baseTableName="chat_occurrence_exception"
+      baseColumnNames="series_id"
+      referencedTableName="chat"
+      referencedColumnNames="id"
+      constraintName="fk_chat_occurrence_exception_series"/>
+    <rollback>
+      <dropForeignKeyConstraint
+        baseTableName="chat_occurrence_exception"
+        constraintName="fk_chat_occurrence_exception_series"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="0061_chat_occurrence_exception_unique" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'chat_occurrence_exception'
+        AND CONSTRAINT_NAME = 'uk_chat_occurrence_exception_series_start'
+      </sqlCheck>
+    </preConditions>
+    <addUniqueConstraint
+      tableName="chat_occurrence_exception"
+      columnNames="series_id, original_occurrence_start_utc"
+      constraintName="uk_chat_occurrence_exception_series_start"/>
+    <rollback>
+      <dropUniqueConstraint
+        tableName="chat_occurrence_exception"
+        constraintName="uk_chat_occurrence_exception_series_start"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0062_group_chat_participant_series_roles/0062_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0062_group_chat_participant_series_roles/0062_changeSet.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+  <changeSet id="0062_group_chat_participant_series" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="group_chat_participant" columnName="series_id"/></not>
+    </preConditions>
+    <addColumn tableName="group_chat_participant">
+      <column name="series_id" type="BIGINT UNSIGNED"/>
+    </addColumn>
+    <rollback><dropColumn tableName="group_chat_participant" columnName="series_id"/></rollback>
+  </changeSet>
+
+  <changeSet id="0062_group_chat_participant_role" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><columnExists tableName="group_chat_participant" columnName="participant_role"/></not>
+    </preConditions>
+    <addColumn tableName="group_chat_participant">
+      <column name="participant_role" type="VARCHAR(16)" defaultValue="PARTICIPANT">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <rollback><dropColumn tableName="group_chat_participant" columnName="participant_role"/></rollback>
+  </changeSet>
+
+  <changeSet id="0062_backfill_group_chat_participant_series_roles" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <columnExists tableName="group_chat_participant" columnName="series_id"/>
+        <columnExists tableName="group_chat_participant" columnName="participant_role"/>
+        <columnExists tableName="session" columnName="rc_group_id"/>
+        <columnExists tableName="chat" columnName="rc_group_id"/>
+      </and>
+    </preConditions>
+    <sql><![CDATA[
+      UPDATE group_chat_participant gcp
+      JOIN session s ON s.id = gcp.chat_id
+      JOIN chat c ON c.rc_group_id = s.rc_group_id
+      SET gcp.series_id = c.id,
+          gcp.participant_role = CASE
+            WHEN gcp.consultant_id = c.consultant_id_owner THEN 'OWNER'
+            ELSE 'CO_MODERATOR'
+          END
+      WHERE gcp.series_id IS NULL
+        AND s.rc_group_id IS NOT NULL
+    ]]></sql>
+    <rollback>
+      <sql><![CDATA[
+        UPDATE group_chat_participant gcp
+        JOIN session s ON s.id = gcp.chat_id
+        JOIN chat c ON c.id = gcp.series_id AND c.rc_group_id = s.rc_group_id
+        SET gcp.series_id = NULL,
+            gcp.participant_role = 'PARTICIPANT'
+      ]]></sql>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="0062_group_chat_participant_series_fk" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not><foreignKeyConstraintExists foreignKeyName="fk_group_chat_participant_series"/></not>
+    </preConditions>
+    <addForeignKeyConstraint
+      baseTableName="group_chat_participant"
+      baseColumnNames="series_id"
+      referencedTableName="chat"
+      referencedColumnNames="id"
+      constraintName="fk_group_chat_participant_series"/>
+    <rollback>
+      <dropForeignKeyConstraint
+        baseTableName="group_chat_participant"
+        constraintName="fk_group_chat_participant_series"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="0062_group_chat_participant_series_user_unique" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'group_chat_participant'
+        AND CONSTRAINT_NAME = 'uk_group_chat_participant_series_consultant'
+      </sqlCheck>
+    </preConditions>
+    <addUniqueConstraint
+      tableName="group_chat_participant"
+      columnNames="series_id, consultant_id"
+      constraintName="uk_group_chat_participant_series_consultant"/>
+    <rollback>
+      <dropUniqueConstraint
+        tableName="group_chat_participant"
+        constraintName="uk_group_chat_participant_series_consultant"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0063_event_notification_deduplication/0063_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0063_event_notification_deduplication/0063_changeSet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
+
+  <changeSet id="0063-event-notification-deduplication" author="codex">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="event_notification" />
+      <not>
+        <columnExists tableName="event_notification" columnName="deduplication_key" />
+      </not>
+    </preConditions>
+    <sqlFile
+      path="db/changelog/changeset/0063_event_notification_deduplication/addEventNotificationDeduplication.sql"
+      relativeToChangelogFile="false" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0063_event_notification_deduplication/addEventNotificationDeduplication.sql
+++ b/src/main/resources/db/changelog/changeset/0063_event_notification_deduplication/addEventNotificationDeduplication.sql
@@ -1,0 +1,5 @@
+ALTER TABLE event_notification
+  ADD COLUMN deduplication_key VARCHAR(191) NULL;
+
+CREATE UNIQUE INDEX uk_event_notification_recipient_deduplication
+  ON event_notification (recipient_user_id, deduplication_key);

--- a/src/main/resources/db/changelog/changeset/0064_group_chat_author_content/0064_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0064_group_chat_author_content/0064_changeSet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
+
+  <changeSet id="0064-group-chat-author-content" author="codex">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="chat" />
+      <not>
+        <columnExists tableName="chat" columnName="source_language" />
+      </not>
+    </preConditions>
+    <sqlFile
+      path="db/changelog/changeset/0064_group_chat_author_content/addGroupChatAuthorContent.sql"
+      relativeToChangelogFile="false" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0064_group_chat_author_content/addGroupChatAuthorContent.sql
+++ b/src/main/resources/db/changelog/changeset/0064_group_chat_author_content/addGroupChatAuthorContent.sql
@@ -1,0 +1,4 @@
+ALTER TABLE chat
+  ADD COLUMN source_language VARCHAR(10) NULL,
+  ADD COLUMN hint_message_translations JSON NULL,
+  ADD COLUMN group_chat_rules_translations JSON NULL;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -92,6 +92,16 @@
   <include file="db/changelog/changeset/0057_case_handover_request/0057_changeSet.xml" />
   <include
     file="db/changelog/changeset/0058_adr008_supervision_sideroom_migration/0058_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0061_chat_occurrence_exception/0061_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0062_group_chat_participant_series_roles/0062_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0063_event_notification_deduplication/0063_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0064_group_chat_author_content/0064_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/SelfHelpGroupContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/SelfHelpGroupContractTest.java
@@ -71,6 +71,31 @@ class SelfHelpGroupContractTest {
   }
 
   @Test
+  void legacySeriesMigrationShouldAlignCurrentOccurrenceWithTheAdvancedStartDate()
+      throws IOException {
+    String changelog =
+        new String(
+            getClass()
+                .getResourceAsStream(
+                    "/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml")
+                .readAllBytes());
+
+    assertThat(changelog)
+        .contains(
+            "TIMESTAMPDIFF(WEEK, initial_start_date, start_date)",
+            "repeat_count = current_occurrence_index + 12");
+    assertThat(changelog.indexOf("TIMESTAMPDIFF(WEEK, initial_start_date, start_date)"))
+        .isLessThan(changelog.indexOf("repeat_count = current_occurrence_index + 12"));
+
+    int alignmentChangeSetStart =
+        changelog.indexOf("<changeSet id=\"0060_align_legacy_repeating_chat_occurrence\"");
+    String alignmentChangeSet =
+        changelog.substring(
+            alignmentChangeSetStart, changelog.indexOf("</changeSet>", alignmentChangeSetStart));
+    assertThat(alignmentChangeSet).contains("columnName=\"is_repetitive\"");
+  }
+
+  @Test
   void ownerMutationsShouldUseAPessimisticSeriesLock() throws IOException {
     String repository =
         Files.readString(

--- a/src/test/java/de/caritas/cob/userservice/api/SelfHelpGroupContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/SelfHelpGroupContractTest.java
@@ -1,0 +1,107 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+class SelfHelpGroupContractTest {
+
+  private static final List<String> AUTHENTICATED_OPERATIONS =
+      List.of(
+          "/users/chat-series/{seriesId}/occurrences:get",
+          "/users/chat-series/{seriesId}/occurrences/skip:post",
+          "/users/chat-series/{seriesId}/occurrences/override:put",
+          "/users/chat-series/{seriesId}/participants/{consultantId}/role:put",
+          "/users/chat-series/consultants:get",
+          "/users/chat-series/{seriesId}/participants/{consultantId}:delete",
+          "/users/chat-series/{seriesId}/transfer-ownership:post");
+
+  @Test
+  void everyChatSeriesOperationShouldDeclareBearerSecurityAndUnauthorizedResponse()
+      throws IOException {
+    Map<String, Object> specification =
+        new Yaml().load(Files.readString(Path.of("api/userservice.yaml")));
+    Map<String, Object> paths = map(specification.get("paths"));
+
+    for (String operationReference : AUTHENTICATED_OPERATIONS) {
+      String[] parts = operationReference.split(":");
+      Map<String, Object> operation = map(map(paths.get(parts[0])).get(parts[1]));
+
+      assertThat(operation.get("security")).as(operationReference + " security").isNotNull();
+      assertThat(map(operation.get("responses")))
+          .as(operationReference + " responses")
+          .containsKey("401");
+    }
+  }
+
+  @Test
+  void participantSeriesMigrationShouldBackfillLegacyRowsBeforeAddingTheForeignKey()
+      throws IOException {
+    String changelog =
+        new String(
+            getClass()
+                .getResourceAsStream(
+                    "/db/changelog/changeset/0062_group_chat_participant_series_roles/0062_changeSet.xml")
+                .readAllBytes());
+
+    assertThat(changelog).contains("UPDATE group_chat_participant");
+    assertThat(changelog.indexOf("UPDATE group_chat_participant"))
+        .isLessThan(changelog.indexOf("addForeignKeyConstraint"));
+    assertThat(changelog).contains("participant_role", "consultant_id_owner", "rc_group_id");
+  }
+
+  @Test
+  void legacyRepeatCountRollbackShouldOnlyTouchRepeatingChats() throws IOException {
+    String changelog =
+        new String(
+            getClass()
+                .getResourceAsStream(
+                    "/db/changelog/changeset/0060_self_help_group_series/0060_changeSet.xml")
+                .readAllBytes());
+
+    assertThat(changelog)
+        .contains(
+            "UPDATE chat SET repeat_count = 1 WHERE is_repetitive = TRUE AND repeat_count = 12");
+  }
+
+  @Test
+  void ownerMutationsShouldUseAPessimisticSeriesLock() throws IOException {
+    String repository =
+        Files.readString(
+            Path.of(
+                "src/main/java/de/caritas/cob/userservice/api/port/out/GroupChatParticipantRepository.java"));
+    String service =
+        Files.readString(
+            Path.of(
+                "src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatRoleService.java"));
+
+    assertThat(repository).contains("LockModeType.PESSIMISTIC_WRITE", "findBySeriesIdForUpdate");
+    assertThat(service).contains("findBySeriesIdForUpdate");
+  }
+
+  @Test
+  void deduplicatedNotificationWritesShouldUseANewTransactionBoundary() throws IOException {
+    String service =
+        Files.readString(
+            Path.of(
+                "src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java"));
+    Path writerPath =
+        Path.of(
+            "src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationDeduplicationWriter.java");
+
+    assertThat(service).contains("deduplicationWriter.persistInNewTransaction");
+    assertThat(writerPath).exists();
+    assertThat(Files.readString(writerPath)).contains("Propagation.REQUIRES_NEW", "saveAndFlush");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> map(Object value) {
+    return (Map<String, Object>) value;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreatorTest.java
@@ -110,6 +110,7 @@ class ChatReCreatorTest {
     assertEquals(NEW_MATRIX_ROOM_ID, chat.getGroupId());
     assertEquals(NEW_MATRIX_ROOM_ID, chat.getMatrixRoomId());
     assertEquals(START_DATE.plusWeeks(1), chat.getStartDate());
+    assertEquals(1, chat.getCurrentOccurrenceIndex());
     assertFalse(chat.isActive());
     assertNotNull(chat.getUpdateDate());
     verify(chatService).saveChat(chat);
@@ -134,6 +135,7 @@ class ChatReCreatorTest {
             .startDate(START_DATE)
             .duration(60)
             .repetitive(true)
+            .repeatCount(2)
             .chatInterval(ChatInterval.WEEKLY)
             .chatOwner(owner)
             .build();

--- a/src/test/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommandTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommandTest.java
@@ -7,6 +7,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.IS_REPETIT
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.RC_GROUP_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -124,12 +125,12 @@ class StopChatActionCommandTest {
   }
 
   @Test
-  void stopChat_Should_NotDeleteGroup_When_ChatIntervallIsNullOnRepetitiveChats() {
+  void stopChat_ShouldRejectInvalidFiniteSeriesBeforeDeletingItsRoom() {
     when(chat.isActive()).thenReturn(true);
     when(chat.getGroupId()).thenReturn(RC_GROUP_ID);
     when(chat.isRepetitive()).thenReturn(true);
 
-    stopChatActionCommand.execute(chat);
+    assertThrows(InternalServerErrorException.class, () -> stopChatActionCommand.execute(chat));
 
     verify(rocketChatService, times(0)).deleteGroupAsSystemUser(Mockito.any());
   }
@@ -144,6 +145,7 @@ class StopChatActionCommandTest {
             .startDate(CHAT_START_DATETIME)
             .duration(1)
             .repetitive(IS_REPETITIVE)
+            .repeatCount(2)
             .chatInterval(CHAT_INTERVAL_WEEKLY)
             .chatOwner(CONSULTANT)
             .build();
@@ -217,6 +219,37 @@ class StopChatActionCommandTest {
 
     stopChatActionCommand.execute(chat);
 
+    verify(rocketChatService).deleteGroupAsSystemUser(RC_GROUP_ID);
+    verify(matrixSynapseService).purgeRoom(MATRIX_ROOM_ID);
+    verify(chatService).deleteChat(chat);
+  }
+
+  @Test
+  void stopChatShouldUseMatrixGroupIdAndNotCallRocketChatWhenDedicatedRoomIdIsMissing() {
+    when(chat.isActive()).thenReturn(true);
+    when(chat.isRepetitive()).thenReturn(false);
+    when(chat.getGroupId()).thenReturn(MATRIX_ROOM_ID);
+    when(chat.getMatrixRoomId()).thenReturn(null);
+    when(matrixSynapseService.purgeRoom(MATRIX_ROOM_ID)).thenReturn(true);
+
+    stopChatActionCommand.execute(chat);
+
+    verifyNoInteractions(rocketChatService);
+    verify(matrixSynapseService).purgeRoom(MATRIX_ROOM_ID);
+    verify(chatService).deleteChat(chat);
+  }
+
+  @Test
+  void stopChatShouldAllowMatrixRoomIdWhenLegacyGroupIdIsMissing() {
+    when(chat.isActive()).thenReturn(true);
+    when(chat.isRepetitive()).thenReturn(false);
+    when(chat.getGroupId()).thenReturn(null);
+    when(chat.getMatrixRoomId()).thenReturn(MATRIX_ROOM_ID);
+    when(matrixSynapseService.purgeRoom(MATRIX_ROOM_ID)).thenReturn(true);
+
+    stopChatActionCommand.execute(chat);
+
+    verifyNoInteractions(rocketChatService);
     verify(matrixSynapseService).purgeRoom(MATRIX_ROOM_ID);
     verify(chatService).deleteChat(chat);
   }
@@ -338,6 +371,32 @@ class StopChatActionCommandTest {
     assertEquals(CHAT_START_DATETIME, repetitiveChat.getStartDate());
   }
 
+  @Test
+  void stopFiniteSeriesShouldShutDownAndPersistItsLastOccurrence() {
+    var disabledRocketChatService =
+        new DisabledRocketChatService(
+            mock(RocketChatCredentialsProvider.class),
+            mock(RocketChatConfig.class),
+            mock(RocketChatMapper.class));
+    var command =
+        new StopChatActionCommand(
+            chatService,
+            disabledRocketChatService,
+            chatReCreator,
+            new MatrixChatShutdownService(matrixSynapseService));
+    var series = buildRepetitiveChatWithMatrixRoom();
+    series.setCurrentOccurrenceIndex(1);
+    when(matrixSynapseService.purgeRoom(MATRIX_ROOM_ID)).thenReturn(true);
+
+    command.execute(series);
+
+    assertFalse(series.isActive());
+    verify(matrixSynapseService).purgeRoom(MATRIX_ROOM_ID);
+    verify(chatService).saveChat(series);
+    verify(chatService, never()).deleteChat(series);
+    verifyNoInteractions(chatReCreator);
+  }
+
   private Chat buildRepetitiveChatWithMatrixRoom() {
     var owner =
         Consultant.builder()
@@ -357,6 +416,7 @@ class StopChatActionCommandTest {
             .startDate(CHAT_START_DATETIME)
             .duration(1)
             .repetitive(IS_REPETITIVE)
+            .repeatCount(2)
             .chatInterval(CHAT_INTERVAL_WEEKLY)
             .chatOwner(owner)
             .build();

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -86,6 +86,26 @@ class MatrixRoomClientTest {
   }
 
   @Test
+  void createRoom_WhenEncryptionEnabled_ShouldSendMegolmInitialState() throws Exception {
+    var responseBody = new MatrixCreateRoomResponseDTO();
+    responseBody.setRoomId(ROOM_ID);
+    when(restTemplate.postForEntity(
+            eq(uri(API_URL + "/_matrix/client/r0/createRoom")),
+            createRoomRequestCaptor.capture(),
+            eq(MatrixCreateRoomResponseDTO.class)))
+        .thenReturn(ResponseEntity.ok(responseBody));
+
+    matrixRoomClient.createRoom("Room name", "room-alias", ACCESS_TOKEN, true);
+
+    var initialState = createRoomRequestCaptor.getValue().getBody().getInitialState();
+    assertThat(initialState).hasSize(1);
+    var event = initialState.getFirst();
+    assertThat(event.getType()).isEqualTo("m.room.encryption");
+    assertThat(event.getStateKey()).isEmpty();
+    assertThat(event.getContent()).isEqualTo(Map.of("algorithm", "m.megolm.v1.aes-sha2"));
+  }
+
+  @Test
   void createRoom_ShouldThrowMatrixCreateRoomException_WhenMatrixRejectsRequest() {
     when(restTemplate.postForEntity(
             eq(uri(API_URL + "/_matrix/client/r0/createRoom")),

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
@@ -18,6 +19,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +35,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -319,6 +325,19 @@ class MatrixSynapseServiceTest {
 
     assertThat(service.unbanUserFromRoom(MATRIX_ROOM_ID, MATRIX_USER_ID, ACCESS_TOKEN)).isTrue();
     verify(matrixRoomClient).unbanUserFromRoom(MATRIX_ROOM_ID, MATRIX_USER_ID, ACCESS_TOKEN);
+  }
+
+  @Test
+  void createRoomShouldPassConfiguredEncryptionFlagToRoomClient() throws Exception {
+    matrixConfig.setEncryptionEnabled(true);
+    var expected = ResponseEntity.ok(new MatrixCreateRoomResponseDTO());
+    when(matrixRoomClient.createRoom("Room name", "room-alias", ACCESS_TOKEN, true))
+        .thenReturn(expected);
+
+    var result = matrixSynapseService().createRoom("Room name", "room-alias", ACCESS_TOKEN);
+
+    assertThat(result).isSameAs(expected);
+    verify(matrixRoomClient).createRoom("Room name", "room-alias", ACCESS_TOKEN, true);
   }
 
   @Test
@@ -643,6 +662,123 @@ class MatrixSynapseServiceTest {
         .thenReturn(ResponseEntity.ok(Map.of("user_id", "@alice:example.org")));
 
     assertThat(matrixSynapseService().loginAsUserAccessToken("@alice:example.org")).isNull();
+  }
+
+  @Test
+  void loginBrowserDevice_rotatesTransientPasswordWithoutLoggingOutExistingDevices() {
+    // Browser E2EE requires a normal Matrix login whose access token is bound to a real device.
+    // The transient password must never become an application credential or invalidate another
+    // browser's encryption keys.
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    matrixConfig.setAdminUsername("admin");
+    matrixConfig.setAdminPassword("admin-password");
+    var updateUri = URI.create(MATRIX_BASE_URL + "/_synapse/admin/v2/users/%40alice%3Aexample.org");
+    when(restTemplate.exchange(
+            eq(updateUri), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()));
+    when(restTemplate.postForEntity(
+            eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", MATRIX_ADMIN_TOKEN)))
+        .thenReturn(
+            ResponseEntity.ok(
+                Map.of(
+                    "access_token", "browser-token",
+                    "user_id", "@alice:example.org",
+                    "device_id", "ORISO_WEB_DEVICE_ONE")));
+    var updateRequest = ArgumentCaptor.forClass(HttpEntity.class);
+    var loginRequest = ArgumentCaptor.forClass(HttpEntity.class);
+
+    var result =
+        matrixSynapseService().loginBrowserDevice("@alice:example.org", "ORISO_WEB_DEVICE_ONE");
+
+    assertThat(result)
+        .containsEntry("access_token", "browser-token")
+        .containsEntry("device_id", "ORISO_WEB_DEVICE_ONE");
+    verify(restTemplate)
+        .exchange(eq(updateUri), eq(HttpMethod.PUT), updateRequest.capture(), eq(Map.class));
+    @SuppressWarnings("unchecked")
+    var updateBody = (Map<String, Object>) updateRequest.getValue().getBody();
+    assertThat(updateBody).containsEntry("logout_devices", false).containsKey("password");
+    assertThat(String.valueOf(updateBody.get("password"))).hasSizeGreaterThanOrEqualTo(32);
+
+    verify(restTemplate, times(2))
+        .postForEntity(
+            eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"),
+            loginRequest.capture(),
+            eq(Map.class));
+    @SuppressWarnings("unchecked")
+    var browserLoginBody = (Map<String, Object>) loginRequest.getAllValues().get(1).getBody();
+    assertThat(browserLoginBody)
+        .containsEntry("type", "m.login.password")
+        .containsEntry("user", "@alice:example.org")
+        .containsEntry("device_id", "ORISO_WEB_DEVICE_ONE")
+        .containsEntry("initial_device_display_name", "ORISO Web");
+    assertThat(browserLoginBody.get("password")).isEqualTo(updateBody.get("password"));
+  }
+
+  @Test
+  void loginBrowserDevice_rejectsUnsafeDeviceIdWithoutCallingSynapse() {
+    assertThat(matrixSynapseService().loginBrowserDevice("@alice:example.org", "bad/device"))
+        .isNull();
+
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void loginBrowserDevice_serializesPasswordRotationAndLoginForTheSameUser() throws Exception {
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    var service = matrixSynapseService();
+    ReflectionTestUtils.setField(service, "cachedAdminToken", MATRIX_ADMIN_TOKEN);
+    ReflectionTestUtils.setField(service, "adminTokenExpiry", Long.MAX_VALUE);
+    var updateUri = URI.create(MATRIX_BASE_URL + "/_synapse/admin/v2/users/%40alice%3Aexample.org");
+    var updateCalls = new AtomicInteger();
+    var firstLoginEntered = new CountDownLatch(1);
+    var releaseFirstLogin = new CountDownLatch(1);
+    var secondUpdateEntered = new CountDownLatch(1);
+    when(restTemplate.exchange(
+            eq(updateUri), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+        .thenAnswer(
+            invocation -> {
+              if (updateCalls.incrementAndGet() == 2) {
+                secondUpdateEntered.countDown();
+              }
+              return ResponseEntity.ok(Map.of());
+            });
+    when(restTemplate.postForEntity(
+            eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"), any(HttpEntity.class), eq(Map.class)))
+        .thenAnswer(
+            invocation -> {
+              if (firstLoginEntered.getCount() > 0) {
+                firstLoginEntered.countDown();
+                releaseFirstLogin.await(2, TimeUnit.SECONDS);
+              }
+              return ResponseEntity.ok(
+                  Map.of(
+                      "access_token", "browser-token",
+                      "device_id", "ORISO_WEB_DEVICE"));
+            });
+
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var first =
+          executor.submit(
+              () -> service.loginBrowserDevice("@alice:example.org", "ORISO_WEB_DEVICE_ONE"));
+      assertThat(firstLoginEntered.await(2, TimeUnit.SECONDS)).isTrue();
+      var second =
+          executor.submit(
+              () -> service.loginBrowserDevice("@alice:example.org", "ORISO_WEB_DEVICE_TWO"));
+
+      assertThat(secondUpdateEntered.await(200, TimeUnit.MILLISECONDS))
+          .as("the second password rotation must wait until the first login completes")
+          .isFalse();
+
+      releaseFirstLogin.countDown();
+      assertThat(first.get(2, TimeUnit.SECONDS)).isNotNull();
+      assertThat(second.get(2, TimeUnit.SECONDS)).isNotNull();
+    } finally {
+      releaseFirstLogin.countDown();
+      executor.shutdownNow();
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixEncryptionConfigPropertiesTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/config/MatrixEncryptionConfigPropertiesTest.java
@@ -1,0 +1,28 @@
+package de.caritas.cob.userservice.api.adapters.matrix.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class MatrixEncryptionConfigPropertiesTest {
+
+  private static final Path APPLICATION_PROPERTIES =
+      Path.of("src/main/resources/application.properties");
+
+  @Test
+  void matrixEncryptionShouldBeDisabledUnlessExplicitlyEnabledByEnvironment() throws IOException {
+    assertThat(new MatrixConfig().isEncryptionEnabled()).isFalse();
+
+    var properties = new Properties();
+    try (var input = Files.newInputStream(APPLICATION_PROPERTIES)) {
+      properties.load(input);
+    }
+
+    assertThat(properties.getProperty("matrix.encryptionEnabled"))
+        .isEqualTo("${MATRIX_ENCRYPTION_ENABLED:false}");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ChatSeriesControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ChatSeriesControllerAuthorizationIT.java
@@ -1,0 +1,109 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.adapters.web.dto.GetChatSeriesOccurrences200ResponseInner;
+import de.caritas.cob.userservice.api.adapters.web.dto.OccurrenceOverrideRequest;
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("testing")
+class ChatSeriesControllerAuthorizationIT {
+
+  private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", "test");
+
+  @Autowired private MockMvc mvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("requestMappingHandlerMapping")
+  private RequestMappingHandlerMapping handlerMapping;
+
+  @Test
+  void consultantCanReadSeriesOccurrences() throws Exception {
+    mvc.perform(
+            get("/users/chat-series/999999/occurrences")
+                .with(
+                    jwt()
+                        .authorities(new SimpleGrantedAuthority(AuthorityValue.CONSULTANT_DEFAULT))
+                        .jwt(token -> token.claim("userId", "consultant-1")))
+                .cookie(CSRF_COOKIE)
+                .header("csrfHeader", "test")
+                .queryParam("from", "2026-07-01T00:00:00Z")
+                .queryParam("to", "2026-08-01T00:00:00Z")
+                .queryParam("limit", "50"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void consultantWriteRouteReachesSeriesAuthorizationInsteadOfGeneratedStub() throws Exception {
+    mvc.perform(
+            post("/users/chat-series/999999/occurrences/skip")
+                .with(
+                    jwt()
+                        .authorities(new SimpleGrantedAuthority(AuthorityValue.CONSULTANT_DEFAULT))
+                        .jwt(token -> token.claim("userId", "consultant-1")))
+                .cookie(CSRF_COOKIE)
+                .header("csrfHeader", "test")
+                .queryParam("originalStartUtc", "2026-07-20T16:00:00Z"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void seriesSkipHasExactlyOneConcreteHandler() {
+    var handlers =
+        handlerMapping.getHandlerMethods().entrySet().stream()
+            .filter(
+                entry ->
+                    entry
+                        .getKey()
+                        .getPatternValues()
+                        .contains("/users/chat-series/{seriesId}/occurrences/skip"))
+            .filter(
+                entry ->
+                    entry.getKey().getMethodsCondition().getMethods().contains(RequestMethod.POST))
+            .map(java.util.Map.Entry::getValue)
+            .toList();
+
+    assertThat(handlers).hasSize(1);
+    assertThat(handlers.getFirst().getBeanType()).isEqualTo(UserController.class);
+    assertThat(handlers.getFirst().getMethod().getName()).isEqualTo("skipChatSeriesOccurrence");
+  }
+
+  @Test
+  void occurrenceOverrideUsesOrdinaryNullableJsonFields() {
+    assertThatCode(
+            () ->
+                objectMapper.readValue(
+                    """
+                    {"originalStartUtc":"2026-09-20T16:00:00Z","capacity":14}
+                    """,
+                    OccurrenceOverrideRequest.class))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void occurrenceCapacitySerializesAsANumber() throws Exception {
+    var occurrence = new GetChatSeriesOccurrences200ResponseInner().capacity(14);
+
+    assertThat(objectMapper.writeValueAsString(occurrence)).contains("\"capacity\":14");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
@@ -140,6 +140,14 @@ class MatrixMessageControllerTest {
   }
 
   @Test
+  void getCurrentUserMatrixToken_ShouldReturnBadRequest_WhenDeviceIdIsInvalid() {
+    var response = controller.getCurrentUserMatrixToken("bad/device");
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    verifyNoInteractions(matrixSynapseService, consultantService, userService);
+  }
+
+  @Test
   void getCurrentUserMatrixToken_ShouldReturnOk_WhenTokenMintingSucceeds() {
     // Business reason: authenticated users need short-lived Matrix browser tokens for messaging
     // features.

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
@@ -134,7 +134,7 @@ class MatrixMessageControllerTest {
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(userService.getUser(USER_ID)).thenReturn(Optional.of(userWithMatrixId("")));
 
-    var response = controller.getCurrentUserMatrixToken();
+    var response = controller.getCurrentUserMatrixToken("ORISO_WEB_DEVICE_ONE");
 
     assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
   }
@@ -146,14 +146,15 @@ class MatrixMessageControllerTest {
     when(authenticatedUser.getUserId()).thenReturn(USER_ID);
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(userService.getUser(USER_ID)).thenReturn(Optional.of(userWithMatrixId()));
-    when(matrixSynapseService.loginAsUser(MATRIX_USER_ID, 55 * 60 * 1000L))
+    when(matrixSynapseService.loginBrowserDevice(MATRIX_USER_ID, "ORISO_WEB_DEVICE_ONE"))
         .thenReturn(Map.of("access_token", "abc", "user_id", MATRIX_USER_ID, "device_id", "dev1"));
 
-    var response = controller.getCurrentUserMatrixToken();
+    var response = controller.getCurrentUserMatrixToken("ORISO_WEB_DEVICE_ONE");
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     var body = assertInstanceOf(Map.class, response.getBody());
     assertEquals("abc", body.get("accessToken"));
+    assertEquals("dev1", body.get("deviceId"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
@@ -155,6 +155,15 @@ class UserChatControllerDelegateTest {
   }
 
   @Test
+  void assignChatShouldDelegateNumericSeriesIdToCanonicalJoinFlow() {
+    var response = delegate.assignChat("1013");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(joinAndLeaveChatFacade).joinChat(1013L, authenticatedUser);
+    verify(assignChatFacade, never()).assignChat(any(), any());
+  }
+
+  @Test
   void joinChatShouldDelegateAndReturnOk() {
     var response = delegate.joinChat(1L);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatFeatureGate;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -58,6 +59,7 @@ class UserChatControllerDelegateTest {
   @Mock private Messaging messenger;
   @Mock private UserDtoMapper userDtoMapper;
   @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private GroupChatFeatureGate groupChatFeatureGate;
 
   @InjectMocks private UserChatControllerDelegate delegate;
 
@@ -87,6 +89,7 @@ class UserChatControllerDelegateTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(response.getBody()).isSameAs(createChatResponseDTO);
+    verify(groupChatFeatureGate).requireEnabled(consultant);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
@@ -155,12 +155,12 @@ class UserChatControllerDelegateTest {
   }
 
   @Test
-  void assignChatShouldDelegateNumericSeriesIdToCanonicalJoinFlow() {
+  void assignChatShouldDelegateNumericSeriesIdToV2AssignmentFlow() {
     var response = delegate.assignChat("1013");
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    verify(joinAndLeaveChatFacade).joinChat(1013L, authenticatedUser);
-    verify(assignChatFacade, never()).assignChat(any(), any());
+    verify(assignChatFacade).assignChat(1013L, authenticatedUser);
+    verify(joinAndLeaveChatFacade, never()).joinChat(any(), any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserChatControllerDelegateTest.java
@@ -164,6 +164,22 @@ class UserChatControllerDelegateTest {
   }
 
   @Test
+  void assignChatShouldRejectNumericSeriesIdAboveLongRange() {
+    assertThatThrownBy(() -> delegate.assignChat("9223372036854775808"))
+        .isInstanceOf(BadRequestException.class);
+
+    verify(assignChatFacade, never()).assignChat(anyLong(), any());
+  }
+
+  @Test
+  void assignChatShouldAcceptLongMaxValue() {
+    var response = delegate.assignChat(String.valueOf(Long.MAX_VALUE));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(assignChatFacade).assignChat(Long.MAX_VALUE, authenticatedUser);
+  }
+
+  @Test
   void joinChatShouldDelegateAndReturnOk() {
     var response = delegate.joinChat(1L);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
@@ -85,6 +85,29 @@ class UserConsultantControllerDelegateTest {
   }
 
   @Test
+  void getTenantConsultantsUsesTheAuthenticatedTenantBoundary() {
+    var consultant = org.mockito.Mockito.mock(Consultant.class);
+    when(authenticatedUser.getTenantId()).thenReturn(7L);
+    when(consultant.getId()).thenReturn("consultant-1");
+    when(consultant.getFirstName()).thenReturn("Ada");
+    when(consultant.getLastName()).thenReturn("Lovelace");
+    when(consultant.getUsername()).thenReturn("ada");
+    when(consultant.getDisplayName()).thenReturn("Ada L.");
+    when(consultantService.findActiveConsultantsForTenant(7L)).thenReturn(List.of(consultant));
+
+    var response = delegate.getTenantConsultants();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody())
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.getConsultantId()).isEqualTo("consultant-1");
+              assertThat(item.getDisplayName()).isEqualTo("Ada L.");
+            });
+  }
+
+  @Test
   void searchConsultantsShouldFilterAgenciesForRestrictedAdmin() {
     var resultMap = Map.<String, Object>of("consultants", List.of(), "totalElements", 1);
     var searchResult =

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -69,6 +70,7 @@ import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.model.UserChat;
 import de.caritas.cob.userservice.api.port.out.ChatAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
@@ -108,6 +110,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -124,9 +127,9 @@ import org.springframework.web.client.RestTemplate;
 class UserControllerChatE2EIT {
 
   private static final EasyRandom easyRandom = new EasyRandom();
-  private static final String CSRF_HEADER = "csrfHeader";
+  private static final String CSRF_HEADER = "X-CSRF-Token";
   private static final String CSRF_VALUE = "test";
-  private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", CSRF_VALUE);
+  private static final Cookie CSRF_COOKIE = new Cookie("CSRF-TOKEN", CSRF_VALUE);
 
   @Autowired private MockMvc mockMvc;
 
@@ -135,6 +138,8 @@ class UserControllerChatE2EIT {
   @Autowired private UsernameTranscoder usernameTranscoder;
 
   @Autowired private ConsultantRepository consultantRepository;
+
+  @Autowired private ConsultantAgencyRepository consultantAgencyRepository;
 
   @Autowired private UserRepository userRepository;
 
@@ -540,6 +545,28 @@ class UserControllerChatE2EIT {
     assertEquals(storedChatUser.getChat(), chat);
     assertEquals(storedChatUser.getUser(), user);
 
+    chatUserRepository.delete(storedChatUser);
+  }
+
+  @Test
+  @WithMockUser(authorities = AuthorityValue.USER_DEFAULT)
+  @Transactional
+  void assignChat_Should_ReturnOK_When_GroupIdIsAMatrixRoomId() throws Exception {
+    givenAValidUser(true);
+    givenAValidConsultant();
+    var matrixRoomId = "!OxvwFBFfkXNNhHUBOk:matrix.localhost";
+    givenAValidChat(false, matrixRoomId);
+
+    mockMvc
+        .perform(
+            put("/users/chat/{groupId}/assign", matrixRoomId)
+                .with(jwt().authorities(new SimpleGrantedAuthority(AuthorityValue.USER_DEFAULT)))
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    var storedChatUser = chatUserRepository.findByChatAndUser(chat, user).orElseThrow();
     chatUserRepository.delete(storedChatUser);
   }
 
@@ -1435,11 +1462,17 @@ class UserControllerChatE2EIT {
   }
 
   private void givenAValidChat(boolean isRepetitive) {
+    givenAValidChat(isRepetitive, RC_GROUP_ID);
+  }
+
+  private void givenAValidChat(boolean isRepetitive, String groupId) {
     chat = easyRandom.nextObject(Chat.class);
     chat.setId(null);
-    chat.setGroupId(RC_GROUP_ID);
+    chat.setGroupId(groupId);
+    chat.setMatrixRoomId(groupId.startsWith("!") ? groupId : null);
     chat.setActive(true);
     chat.setRepetitive(isRepetitive);
+    chat.setSourceLanguage("de");
     chat.setChatOwner(consultant);
     chat.setConsultingTypeId(easyRandom.nextInt(128));
     chat.setDuration(easyRandom.nextInt(32768));
@@ -1447,7 +1480,8 @@ class UserControllerChatE2EIT {
     chat.setUpdateDate(CustomLocalDateTime.nowInUtc());
     chatRepository.save(chat);
 
-    var agencyId = consultant.getConsultantAgencies().iterator().next().getAgencyId();
+    var agencyId =
+        consultantAgencyRepository.findByConsultantId(consultant.getId()).getFirst().getAgencyId();
     chatAgency = new ChatAgency();
     chatAgency.setChat(chat);
     chatAgency.setAgencyId(agencyId);
@@ -1457,7 +1491,6 @@ class UserControllerChatE2EIT {
       userAgency = new UserAgency();
       userAgency.setUser(user);
       userAgency.setAgencyId(agencyId);
-      user.getUserAgencies().add(userAgency);
       userAgencyRepository.save(userAgency);
     }
   }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/AssignChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/AssignChatFacadeTest.java
@@ -72,4 +72,15 @@ class AssignChatFacadeTest {
     verify(chatService)
         .saveUserChatRelation(UserChat.builder().user(USER).chat(ACTIVE_CHAT).build());
   }
+
+  @Test
+  void assignChatBySeriesId_Should_AddUserToChat() {
+    when(chatService.getChat(ACTIVE_CHAT.getId())).thenReturn(Optional.of(ACTIVE_CHAT));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(USER));
+
+    assignChatFacade.assignChat(ACTIVE_CHAT.getId(), authenticatedUser);
+
+    verify(chatService)
+        .saveUserChatRelation(UserChat.builder().user(USER).chat(ACTIVE_CHAT).build());
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/ChatConverterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/ChatConverterTest.java
@@ -2,18 +2,48 @@ package de.caritas.cob.userservice.api.facade;
 
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_HINT_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import de.caritas.cob.userservice.api.model.Consultant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ChatConverterTest {
+
+  @Test
+  void convertToEntityPreservesMultilingualGroupChatAuthorContent() {
+    var request =
+        ChatDTO.builder()
+            .topic("topic")
+            .startDate(LocalDate.of(2022, 8, 12))
+            .startTime(LocalTime.of(12, 5))
+            .duration(120)
+            .repetitive(false)
+            .sourceLanguage("de")
+            .hintMessageTranslations(Map.of("de", "Willkommen", "en", "Welcome"))
+            .groupChatRulesTranslations(
+                Map.of(
+                    "de", List.of("Respektvoll bleiben"),
+                    "en", List.of("Be respectful")))
+            .build();
+
+    var chat = new ChatConverter().convertToEntity(request, givenConsultant(), givenAgencyDTO());
+
+    assertThat(chat.getSourceLanguage()).isEqualTo("de");
+    assertThat(chat.getHintMessageTranslations()).containsEntry("en", "Welcome");
+    assertThat(chat.getGroupChatRulesTranslations())
+        .containsEntry("de", List.of("Respektvoll bleiben"));
+  }
 
   @Test
   void convertToEntity_Should_setConsultingTypeId_When_agencyIsNotNull() {
@@ -153,6 +183,59 @@ class ChatConverterTest {
 
     // then
     assertThat(chat.getHintMessage()).isEqualTo(CHAT_HINT_MESSAGE);
+  }
+
+  @Test
+  void convertToEntityShouldDefaultAnOldNonRepeatingRequestToOneTextOccurrence() {
+    var chat =
+        new ChatConverter()
+            .convertToEntity(givenChatDTO(false), givenConsultant(), givenAgencyDTO());
+
+    assertThat(chat.getRepeatCount()).isEqualTo(1);
+    assertThat(chat.getCurrentOccurrenceIndex()).isZero();
+    assertThat(chat.getChatModality()).isEqualTo(ChatModality.TEXT);
+    assertThat(chat.getTimezone()).isEqualTo("UTC");
+  }
+
+  @Test
+  void convertToEntityShouldMapExplicitFiniteSeriesSettings() {
+    var request =
+        ChatDTO.builder()
+            .topic("topic")
+            .startDate(LocalDate.of(2022, 8, 12))
+            .startTime(LocalTime.of(12, 5))
+            .duration(120)
+            .repetitive(true)
+            .repeatCount(4)
+            .chatInterval(ChatInterval.BIWEEKLY)
+            .modality(ChatModality.AUDIO)
+            .timezone("Europe/Berlin")
+            .hintMessage(CHAT_HINT_MESSAGE)
+            .build();
+
+    var chat = new ChatConverter().convertToEntity(request, givenConsultant(), givenAgencyDTO());
+
+    assertThat(chat.getRepeatCount()).isEqualTo(4);
+    assertThat(chat.getChatInterval()).isEqualTo(ChatInterval.BIWEEKLY);
+    assertThat(chat.getChatModality()).isEqualTo(ChatModality.AUDIO);
+    assertThat(chat.getTimezone()).isEqualTo("Europe/Berlin");
+    assertThat(chat.isRepetitive()).isTrue();
+  }
+
+  @Test
+  void convertToEntityShouldRejectAnInvalidTimezone() {
+    var request =
+        ChatDTO.builder()
+            .topic("topic")
+            .startDate(LocalDate.of(2026, 8, 12))
+            .startTime(LocalTime.of(12, 5))
+            .timezone("Not/A-Timezone")
+            .build();
+
+    assertThatThrownBy(
+            () -> new ChatConverter().convertToEntity(request, givenConsultant(), givenAgencyDTO()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("timezone");
   }
 
   private ChatDTO givenChatDTO() {

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
@@ -193,6 +194,21 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     verify(sessionService, times(2)).saveSession(any());
     // chatService.saveChat called twice: initial save + update with matrixRoomId
     verify(chatService, times(2)).saveChat(any());
+  }
+
+  @Test
+  void createSimplifiedGroupChat_Should_RemainInactiveUntilCounsellorOpensOccurrence()
+      throws Exception {
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
+        .thenReturn(matrixRoomResponse("!room:matrix.org"));
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
+    Chat unsavedChat = mock(Chat.class);
+    doReturn(unsavedChat).when(chatConverter).convertToEntity(any(), any(), any());
+
+    createChatFacade.createChatV1(chatDto, consultant);
+
+    verify(unsavedChat).setActive(false);
   }
 
   // ---------------------------------------------------------------------------
@@ -401,7 +417,8 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
-  void createSimplifiedGroupChat_Should_PersistCreatorWithSessionId_NotChatId() throws Exception {
+  void createSimplifiedGroupChatShouldPersistCreatorAsSeriesOwnerAndKeepLegacySessionId()
+      throws Exception {
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
@@ -415,5 +432,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     verify(groupChatParticipantRepository, times(1)).save(captor.capture());
     // creator participant must use sessionId (200L), not chatId (CHAT_ID=1L)
     assertThat(captor.getValue().getChatId()).isEqualTo(200L);
+    assertThat(captor.getValue().getSeriesId()).isEqualTo(CHAT_ID);
+    assertThat(captor.getValue().getRole()).isEqualTo(ParticipantRole.OWNER);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
@@ -468,6 +468,7 @@ class JoinAndLeaveChatFacadeTest {
     Chat repetitiveChat = mock(Chat.class);
     when(repetitiveChat.isActive()).thenReturn(true);
     when(repetitiveChat.isRepetitive()).thenReturn(true);
+    when(repetitiveChat.nextStart()).thenReturn(LocalDateTime.now().plusWeeks(1));
     when(repetitiveChat.getGroupId()).thenReturn("groupId");
     when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(repetitiveChat));
     when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
@@ -482,6 +483,30 @@ class JoinAndLeaveChatFacadeTest {
 
     verify(chatReCreator, times(1)).updateAsNextChat(repetitiveChat, "newGroupId");
     verify(chatService, never()).deleteChat(any());
+  }
+
+  @Test
+  void leaveChat_Should_CompleteFiniteSeries_When_NoNextOccurrenceRemains() {
+    Chat repetitiveChat = mock(Chat.class);
+    when(repetitiveChat.isActive()).thenReturn(true);
+    when(repetitiveChat.isRepetitive()).thenReturn(true);
+    when(repetitiveChat.nextStart()).thenReturn(null);
+    when(repetitiveChat.getGroupId()).thenReturn("groupId");
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(repetitiveChat));
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getRcUserId()).thenReturn(RC_USER_ID);
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(repetitiveChat, MATRIX_USER_ID))
+        .thenReturn(false);
+    when(rocketChatService.deleteGroupAsSystemUser("groupId")).thenReturn(true);
+
+    joinAndLeaveChatFacade.leaveChat(CHAT_ID, authenticatedUser);
+
+    verify(chatReCreator, never()).recreateMessengerChat(any());
+    verify(chatReCreator, never()).updateAsNextChat(any(), any());
+    verify(matrixChatShutdownService).shutdownRoom(repetitiveChat);
+    verify(repetitiveChat).setActive(false);
+    verify(chatService).saveChat(repetitiveChat);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/JoinAndLeaveChatFacadeTest.java
@@ -35,6 +35,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatRoleService;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.time.LocalDateTime;
@@ -73,6 +74,8 @@ class JoinAndLeaveChatFacadeTest {
   @Mock private GroupChatMembershipService groupChatMembershipService;
 
   @Mock private MatrixChatShutdownService matrixChatShutdownService;
+
+  @Mock private GroupChatRoleService groupChatRoleService;
 
   @Test
   void joinChat_Should_ThrowNotFoundException_WhenChatDoesNotExist() {
@@ -200,6 +203,24 @@ class JoinAndLeaveChatFacadeTest {
     joinAndLeaveChatFacade.joinChat(ACTIVE_CHAT.getId(), authenticatedUser);
 
     verify(rocketChatService, times(1)).addUserToGroup(RC_USER_ID, ACTIVE_CHAT.getGroupId());
+  }
+
+  @Test
+  void joinChat_Should_JoinMatrixUser_WhenRocketChatIdIsMissing()
+      throws RocketChatAddUserToGroupException {
+    Chat matrixChat = mock(Chat.class);
+    when(matrixChat.isActive()).thenReturn(true);
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(matrixChat));
+    when(groupChatMembershipService.resolveMatrixRoomId(matrixChat))
+        .thenReturn("!room:matrix.oriso.org");
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.addMemberToRoom(matrixChat, MATRIX_USER_ID)).thenReturn(true);
+
+    joinAndLeaveChatFacade.joinChat(CHAT_ID, authenticatedUser);
+
+    verify(groupChatMembershipService).addMemberToRoom(matrixChat, MATRIX_USER_ID);
+    verify(rocketChatService, never()).addUserToGroup(anyString(), anyString());
   }
 
   @Test
@@ -403,6 +424,27 @@ class JoinAndLeaveChatFacadeTest {
   }
 
   @Test
+  void leaveChat_Should_UseMatrixIdentityWithoutRocketChatCredentials()
+      throws RocketChatRemoveUserFromGroupException {
+    Chat matrixChat = mock(Chat.class);
+    when(matrixChat.isActive()).thenReturn(true);
+    when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(matrixChat));
+    when(groupChatMembershipService.resolveMatrixRoomId(matrixChat))
+        .thenReturn("!room:matrix.oriso.org");
+    when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
+    when(user.getMatrixUserId()).thenReturn(MATRIX_USER_ID);
+    when(groupChatMembershipService.hasRemainingHumanMembers(matrixChat, MATRIX_USER_ID))
+        .thenReturn(true);
+
+    joinAndLeaveChatFacade.leaveChat(CHAT_ID, authenticatedUser);
+
+    verify(chatPermissionVerifier).verifyPermissionForChat(matrixChat);
+    verify(groupChatMembershipService).removeLeavingMemberFromRoom(matrixChat, MATRIX_USER_ID);
+    verify(chatService).deleteUserChatRelation(matrixChat, user);
+    verify(rocketChatService, never()).removeUserFromGroup(any(), any());
+  }
+
+  @Test
   void leaveChat_Should_DeleteChat_When_NoHumanMembersRemain() {
     Chat singleChat = mock(Chat.class);
     when(singleChat.isActive()).thenReturn(true);
@@ -477,7 +519,8 @@ class JoinAndLeaveChatFacadeTest {
             disabledRocketChatService,
             chatReCreator,
             groupChatMembershipService,
-            matrixChatShutdownService);
+            matrixChatShutdownService,
+            groupChatRoleService);
     when(chatService.getChat(CHAT_ID)).thenReturn(Optional.of(ACTIVE_CHAT));
     when(userService.getUserViaAuthenticatedUser(authenticatedUser)).thenReturn(Optional.of(user));
     when(user.getRcUserId()).thenReturn(RC_USER_ID);

--- a/src/test/java/de/caritas/cob/userservice/api/facade/StartChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/StartChatFacadeTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
@@ -16,9 +17,11 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatAddUserToGroupException;
-import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatPermissionService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatNotificationRecipientService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,18 +33,24 @@ public class StartChatFacadeTest {
 
   @InjectMocks private StartChatFacade startChatFacade;
 
-  @Mock private ChatPermissionVerifier chatPermissionVerifier;
+  @Mock private GroupChatPermissionService groupChatPermissionService;
 
   @Mock private RocketChatService rocketChatService;
 
   @Mock private ChatService chatService;
+
+  @Mock private GroupChatLifecycleNotificationService groupChatLifecycleNotificationService;
+
+  @Mock private GroupChatNotificationRecipientService notificationRecipientService;
 
   @Mock private Chat chat;
 
   @Test
   public void
       startChat_Should_ThrowRequestForbiddenException_WhenConsultantHasNoPermissionForChat() {
-    when(chatPermissionVerifier.hasSameAgencyAssigned(ACTIVE_CHAT, CONSULTANT)).thenReturn(false);
+    doThrow(new ForbiddenException("forbidden"))
+        .when(groupChatPermissionService)
+        .requireCanModerate(ACTIVE_CHAT, CONSULTANT);
 
     try {
       startChatFacade.startChat(ACTIVE_CHAT, CONSULTANT);
@@ -53,8 +62,6 @@ public class StartChatFacadeTest {
 
   @Test
   public void startChat_Should_ThrowConflictException_WhenChatIsAlreadyStarted() {
-    when(chatPermissionVerifier.hasSameAgencyAssigned(ACTIVE_CHAT, CONSULTANT)).thenReturn(true);
-
     try {
       startChatFacade.startChat(ACTIVE_CHAT, CONSULTANT);
       fail("Expected exception: ConflictException");
@@ -68,8 +75,6 @@ public class StartChatFacadeTest {
     when(chat.isActive()).thenReturn(false);
     when(chat.getGroupId()).thenReturn(null);
 
-    when(chatPermissionVerifier.hasSameAgencyAssigned(chat, CONSULTANT)).thenReturn(true);
-
     try {
       startChatFacade.startChat(chat, CONSULTANT);
       fail("Expected exception: InternalServerErrorException");
@@ -81,8 +86,6 @@ public class StartChatFacadeTest {
   @Test
   public void startChat_Should_AddConsultantToRocketChatGroup()
       throws RocketChatAddUserToGroupException {
-    when(chatPermissionVerifier.hasSameAgencyAssigned(INACTIVE_CHAT, CONSULTANT)).thenReturn(true);
-
     startChatFacade.startChat(INACTIVE_CHAT, CONSULTANT);
 
     verify(rocketChatService, times(1))
@@ -92,12 +95,77 @@ public class StartChatFacadeTest {
   @Test
   public void startChat_Should_SetChatActiveAndSaveChat() {
     when(chat.getGroupId()).thenReturn(RC_GROUP_ID);
-    when(chatPermissionVerifier.hasSameAgencyAssigned(chat, CONSULTANT)).thenReturn(true);
-
     startChatFacade.startChat(chat, CONSULTANT);
 
     verify(chat, times(1)).setActive(true);
     verify(chatService, times(1)).saveChat(chat);
+  }
+
+  @Test
+  public void startChat_Should_NotCallRocketChat_WhenGroupIdIsMatrixRoom() {
+    when(chat.isActive()).thenReturn(false);
+    when(chat.getGroupId()).thenReturn("!room:matrix.local");
+    startChatFacade.startChat(chat, CONSULTANT);
+
+    verifyNoInteractions(rocketChatService);
+    verify(chat).setActive(true);
+    verify(chatService).saveChat(chat);
+  }
+
+  @Test
+  public void startChat_Should_AllowMatrixRoomIdWithoutLegacyGroupId() {
+    when(chat.isActive()).thenReturn(false);
+    when(chat.getGroupId()).thenReturn(null);
+    when(chat.getMatrixRoomId()).thenReturn("!room:matrix.local");
+    startChatFacade.startChat(chat, CONSULTANT);
+
+    verifyNoInteractions(rocketChatService);
+    verify(chat).setActive(true);
+    verify(chatService).saveChat(chat);
+  }
+
+  @Test
+  public void startChat_Should_PublishOpenedEventForMatrixSeriesParticipants() {
+    when(chat.isActive()).thenReturn(false);
+    when(chat.getId()).thenReturn(42L);
+    when(chat.getGroupId()).thenReturn("!room:matrix.local");
+    when(chat.getMatrixRoomId()).thenReturn("!room:matrix.local");
+    when(chat.getCurrentOccurrenceIndex()).thenReturn(0);
+    when(chat.getStartDate()).thenReturn(java.time.LocalDateTime.parse("2026-08-03T18:00:00"));
+    when(chat.getChatModality()).thenReturn(Chat.ChatModality.TEXT);
+    when(notificationRecipientService.resolveRecipientIds(chat))
+        .thenReturn(java.util.List.of("consultant-1", "asker-1"));
+
+    startChatFacade.startChat(chat, CONSULTANT);
+
+    verify(groupChatLifecycleNotificationService)
+        .createOpenedNotifications(
+            42L,
+            0,
+            java.time.LocalDateTime.parse("2026-08-03T18:00:00"),
+            "!room:matrix.local",
+            null,
+            false,
+            java.util.List.of("consultant-1", "asker-1"));
+  }
+
+  @Test
+  void startChatShouldRemainSuccessfulWhenOpenedNotificationFails() {
+    when(chat.isActive()).thenReturn(false);
+    when(chat.getId()).thenReturn(42L);
+    when(chat.getGroupId()).thenReturn("!room:matrix.local");
+    when(chat.getMatrixRoomId()).thenReturn("!room:matrix.local");
+    when(chat.getChatModality()).thenReturn(Chat.ChatModality.TEXT);
+    when(notificationRecipientService.resolveRecipientIds(chat))
+        .thenReturn(java.util.List.of("consultant-1"));
+    doThrow(new IllegalStateException("notification storage unavailable"))
+        .when(groupChatLifecycleNotificationService)
+        .createOpenedNotifications(any(), any(), any(), any(), any(), any(), any());
+
+    assertDoesNotThrow(() -> startChatFacade.startChat(chat, CONSULTANT));
+
+    verify(chat).setActive(true);
+    verify(chatService).saveChat(chat);
   }
 
   @Test
@@ -108,7 +176,6 @@ public class StartChatFacadeTest {
         InternalServerErrorException.class,
         () -> {
           when(chat.getGroupId()).thenReturn(RC_GROUP_ID);
-          when(chatPermissionVerifier.hasSameAgencyAssigned(chat, CONSULTANT)).thenReturn(true);
           doThrow(new RocketChatAddUserToGroupException(""))
               .when(rocketChatService)
               .addUserToGroup(any(), any());

--- a/src/test/java/de/caritas/cob/userservice/api/facade/StopChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/StopChatFacadeTest.java
@@ -4,6 +4,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.ACTIVE_CHA
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTANT;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,8 +13,8 @@ import de.caritas.cob.userservice.api.actions.ActionCommandMockProvider;
 import de.caritas.cob.userservice.api.actions.chat.StopChatActionCommand;
 import de.caritas.cob.userservice.api.actions.registry.ActionsRegistry;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
-import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.service.chat.GroupChatPermissionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,7 @@ class StopChatFacadeTest {
 
   @InjectMocks private StopChatFacade stopChatFacade;
 
-  @Mock private ChatPermissionVerifier chatPermissionVerifier;
+  @Mock private GroupChatPermissionService groupChatPermissionService;
 
   @Mock private ActionsRegistry actionsRegistry;
 
@@ -43,7 +44,9 @@ class StopChatFacadeTest {
 
   @Test
   void stopChat_Should_ThrowRequestForbiddenException_When_ConsultantHasNoPermissionToStopChat() {
-    when(chatPermissionVerifier.hasSameAgencyAssigned(ACTIVE_CHAT, CONSULTANT)).thenReturn(false);
+    doThrow(new ForbiddenException("forbidden"))
+        .when(groupChatPermissionService)
+        .requireCanModerate(ACTIVE_CHAT, CONSULTANT);
 
     try {
       stopChatFacade.stopChat(ACTIVE_CHAT, CONSULTANT);
@@ -55,8 +58,6 @@ class StopChatFacadeTest {
 
   @Test
   void stopChat_Should_executeExpectedAction_When_ConsultantHasPermissionToStopChat() {
-    when(chatPermissionVerifier.hasSameAgencyAssigned(ACTIVE_CHAT, CONSULTANT)).thenReturn(true);
-
     stopChatFacade.stopChat(ACTIVE_CHAT, CONSULTANT);
 
     verify(this.mockProvider.getActionMock(StopChatActionCommand.class), times(1))

--- a/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/RocketChatRoomInformationProviderTest.java
@@ -14,10 +14,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.room.RoomsUpdateDTO;
 import de.caritas.cob.userservice.api.container.RocketChatRoomInformation;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Objects;
@@ -38,6 +40,8 @@ class RocketChatRoomInformationProviderTest {
   @Mock private MatrixSynapseService matrixSynapseService;
 
   @Mock private ConsultantRepository consultantRepository;
+
+  @Mock private UserRepository userRepository;
 
   @org.junit.jupiter.api.BeforeEach
   void enableRocketChat() {
@@ -97,6 +101,22 @@ class RocketChatRoomInformationProviderTest {
     assertTrue(CollectionUtils.sizeIsEmpty(rocketChatRoomInformation.getReadMessages()));
     assertTrue(CollectionUtils.sizeIsEmpty(rocketChatRoomInformation.getLastMessagesRoom()));
     assertTrue(CollectionUtils.sizeIsEmpty(rocketChatRoomInformation.getRoomsForUpdate()));
+  }
+
+  @Test
+  void retrieveRocketChatInformation_Should_ResolveAskerMatrixRoomsFromLegacyCredentials() {
+    var credentials =
+        RocketChatCredentials.builder()
+            .rocketChatUserId("@asker:matrix.localhost")
+            .rocketChatToken("dummy-token")
+            .build();
+    when(matrixSynapseService.getJoinedRoomsForMatrixUser("@asker:matrix.localhost"))
+        .thenReturn(java.util.List.of("!room:matrix.localhost"));
+
+    var roomInformation =
+        rocketChatRoomInformationProvider.retrieveRocketChatInformation(credentials);
+
+    assertEquals(java.util.List.of("!room:matrix.localhost"), roomInformation.getUserRooms());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/model/ChatTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/model/ChatTest.java
@@ -6,8 +6,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import java.time.LocalDateTime;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class ChatTest {
 
@@ -60,6 +64,8 @@ public class ChatTest {
         () -> {
           var chat = new Chat();
           chat.setRepetitive(true);
+          chat.setRepeatCount(2);
+          chat.setChatInterval(ChatInterval.WEEKLY);
 
           chat.nextStart();
         });
@@ -69,7 +75,70 @@ public class ChatTest {
   public void nextDateShouldReturnCorrectNextStartDateWhenChatIsRepetitive() {
     var chat = easyRandom.nextObject(Chat.class);
     chat.setRepetitive(true);
+    chat.setRepeatCount(2);
+    chat.setCurrentOccurrenceIndex(0);
+    chat.setChatInterval(ChatInterval.WEEKLY);
 
     assertThat(chat.nextStart(), is(notNullValue()));
+  }
+
+  @Test
+  void occurrenceStartShouldUseTheSeriesAnchorForMonthlyEndOfMonthDates() {
+    var chat = new Chat();
+    chat.setInitialStartDate(LocalDateTime.of(2026, 1, 31, 18, 0));
+    chat.setChatInterval(ChatInterval.MONTHLY);
+
+    assertThat(chat.occurrenceStart(1), is(LocalDateTime.of(2026, 2, 28, 18, 0)));
+    assertThat(chat.occurrenceStart(2), is(LocalDateTime.of(2026, 3, 31, 18, 0)));
+  }
+
+  @Test
+  void nextStartShouldReturnNullAfterTheFiniteSeriesLastOccurrence() {
+    var chat = new Chat();
+    chat.setInitialStartDate(LocalDateTime.of(2026, 7, 10, 18, 0));
+    chat.setStartDate(LocalDateTime.of(2026, 7, 17, 18, 0));
+    chat.setChatInterval(ChatInterval.WEEKLY);
+    chat.setRepeatCount(2);
+    chat.setCurrentOccurrenceIndex(1);
+
+    assertThat(chat.nextStart(), is((LocalDateTime) null));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "DAILY, 2026-01-02T18:00:00",
+    "WEEKLY, 2026-01-08T18:00:00",
+    "BIWEEKLY, 2026-01-15T18:00:00",
+    "MONTHLY, 2026-02-01T18:00:00",
+    "QUARTERLY, 2026-04-01T18:00:00",
+    "YEARLY, 2027-01-01T18:00:00"
+  })
+  void occurrenceStartShouldSupportEverySeriesInterval(
+      ChatInterval interval, LocalDateTime expected) {
+    var chat = new Chat();
+    chat.setInitialStartDate(LocalDateTime.of(2026, 1, 1, 18, 0));
+    chat.setChatInterval(interval);
+
+    assertThat(chat.occurrenceStart(1), is(expected));
+  }
+
+  @Test
+  void occurrenceStartShouldPreserveLocalWallClockTimeAcrossDst() {
+    var chat = new Chat();
+    chat.setInitialStartDate(LocalDateTime.of(2026, 3, 22, 17, 0));
+    chat.setTimezone("Europe/Berlin");
+    chat.setChatInterval(ChatInterval.WEEKLY);
+
+    assertThat(chat.occurrenceStart(1), is(LocalDateTime.of(2026, 3, 29, 16, 0)));
+  }
+
+  @Test
+  void occurrenceStartShouldFallBackToUtcForAnInvalidPersistedTimezone() {
+    var chat = new Chat();
+    chat.setInitialStartDate(LocalDateTime.of(2026, 7, 10, 18, 0));
+    chat.setTimezone("Invalid/Persisted-Timezone");
+    chat.setChatInterval(ChatInterval.WEEKLY);
+
+    assertThat(chat.occurrenceStart(1), is(LocalDateTime.of(2026, 7, 17, 18, 0)));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/UserRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/UserRepositoryTest.java
@@ -1,0 +1,20 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.EntityGraph;
+
+class UserRepositoryTest {
+
+  @Test
+  void findByUserIdAndDeleteDateIsNullShouldFetchAgencyAssignments() throws Exception {
+    var method = UserRepository.class.getMethod("findByUserIdAndDeleteDateIsNull", String.class);
+
+    var entityGraph = method.getAnnotation(EntityGraph.class);
+
+    assertNotNull(entityGraph);
+    assertArrayEquals(new String[] {"userAgencies"}, entityGraph.attributePaths());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,9 +34,12 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
 import de.caritas.cob.userservice.api.model.UserChat;
 import de.caritas.cob.userservice.api.port.out.ChatAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDate;
@@ -65,6 +69,8 @@ class ChatServiceTest {
   @Mock private UserChatRepository chatUserRepository;
 
   @Mock private ConsultantService consultantService;
+
+  @Mock private GroupChatParticipantRepository groupChatParticipantRepository;
 
   @Mock private AgencyService agencyService;
 
@@ -155,6 +161,18 @@ class ChatServiceTest {
   }
 
   @Test
+  void getChatsForUserId_Should_NotExposeNewSeriesBeforeExplicitDeepLinkJoin() {
+    Chat series = activeChatWithAgency();
+    when(chatRepository.findByUserId(USER_ID)).thenReturn(List.of(series));
+    when(groupChatParticipantRepository.findBySeriesId(series.getId()))
+        .thenReturn(List.of(GroupChatParticipant.builder().consultantId("owner").build()));
+
+    List<UserSessionResponseDTO> result = chatService.getChatsForUserId(USER_ID);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
   void getChatsForUserId_Should_ReturnListOfUserSessionResponseDTOWithChats() {
     when(chatRepository.findByUserId(USER_ID)).thenReturn(singletonList(activeChatWithAgency()));
     when(consultantService.findConsultantsByAgencyIds(Mockito.any()))
@@ -183,9 +201,64 @@ class ChatServiceTest {
     assertEquals(ACTIVE_CHAT.isRepetitive(), resultList.get(0).getChat().isRepetitive());
     assertEquals(ACTIVE_CHAT.isActive(), resultList.get(0).getChat().isActive());
     assertEquals(ACTIVE_CHAT.getGroupId(), resultList.get(0).getChat().getGroupId());
+    assertEquals(ACTIVE_CHAT.getRepeatCount(), resultList.get(0).getChat().getRepeatCount());
+    assertEquals(
+        ACTIVE_CHAT.getCurrentOccurrenceIndex(),
+        resultList.get(0).getChat().getCurrentOccurrenceIndex());
+    assertEquals(ACTIVE_CHAT.getChatInterval(), resultList.get(0).getChat().getChatInterval());
+    assertEquals(ACTIVE_CHAT.getChatModality(), resultList.get(0).getChat().getModality());
+    assertEquals(ACTIVE_CHAT.getTimezone(), resultList.get(0).getChat().getTimezone());
     assertNotNull(resultList.get(0).getChat().getModerators());
     assertEquals(1, resultList.get(0).getChat().getModerators().length);
     assertEquals(CONSULTANT.getRocketChatId(), resultList.get(0).getChat().getModerators()[0]);
+  }
+
+  @Test
+  void getChatsForUserId_Should_ExposeOnlyExplicitSeriesModeratorsForNewSeries() {
+    Chat series = activeChatWithAgency();
+    when(chatRepository.findAssignedByUserId(USER_ID)).thenReturn(List.of(series));
+    when(groupChatParticipantRepository.findBySeriesId(series.getId()))
+        .thenReturn(
+            List.of(
+                GroupChatParticipant.builder()
+                    .consultantId("owner")
+                    .role(ParticipantRole.OWNER)
+                    .build(),
+                GroupChatParticipant.builder()
+                    .consultantId("co-mod")
+                    .role(ParticipantRole.CO_MODERATOR)
+                    .build(),
+                GroupChatParticipant.builder()
+                    .consultantId("participant")
+                    .role(ParticipantRole.PARTICIPANT)
+                    .build()));
+
+    List<UserSessionResponseDTO> result = chatService.getChatsForUserId(USER_ID);
+
+    assertArrayEquals(new String[] {"owner", "co-mod"}, result.get(0).getChat().getModerators());
+  }
+
+  @Test
+  void getChatsForUserId_Should_ExposeExplicitParticipantRolesAndDisplayNames() {
+    Chat series = activeChatWithAgency();
+    when(chatRepository.findAssignedByUserId(USER_ID)).thenReturn(List.of(series));
+    when(groupChatParticipantRepository.findBySeriesId(series.getId()))
+        .thenReturn(
+            List.of(
+                GroupChatParticipant.builder()
+                    .consultantId("owner")
+                    .role(ParticipantRole.OWNER)
+                    .build()));
+    Consultant owner = Mockito.mock(Consultant.class);
+    when(owner.getDisplayName()).thenReturn("Alice Owner");
+    when(consultantService.getConsultant("owner")).thenReturn(Optional.of(owner));
+
+    List<UserSessionResponseDTO> result = chatService.getChatsForUserId(USER_ID);
+
+    assertThat(result.get(0).getChat().getParticipants(), hasSize(1));
+    assertEquals("owner", result.get(0).getChat().getParticipants().get(0).getConsultantId());
+    assertEquals("OWNER", result.get(0).getChat().getParticipants().get(0).getRole().getValue());
+    assertEquals("Alice Owner", result.get(0).getChat().getParticipants().get(0).getDisplayName());
   }
 
   @Test
@@ -279,6 +352,21 @@ class ChatServiceTest {
     List<ConsultantSessionResponseDTO> resultList = chatService.getChatsForConsultant(consultant);
 
     assertThat(resultList, hasSize(0));
+  }
+
+  @Test
+  void getChatsForConsultant_Should_NotExposeNewSeriesToUninvitedAgencyConsultants() {
+    Consultant consultant = Mockito.mock(Consultant.class);
+    when(consultant.getId()).thenReturn("uninvited");
+    Chat series = activeChatWithAgency();
+    when(chatRepository.findByAgencyIds(Mockito.any())).thenReturn(List.of(series));
+    when(groupChatParticipantRepository.findBySeriesId(series.getId()))
+        .thenReturn(
+            List.of(GroupChatParticipant.builder().consultantId("explicit-member").build()));
+
+    List<ConsultantSessionResponseDTO> result = chatService.getChatsForConsultant(consultant);
+
+    assertThat(result, hasSize(0));
   }
 
   @Test
@@ -382,9 +470,13 @@ class ChatServiceTest {
   @Test
   void deleteChat_Should_deleteChatInRepository() {
     Chat chat = new Chat();
+    chat.setId(CHAT_ID);
 
     chatService.deleteChat(chat);
 
+    var deletionOrder = inOrder(groupChatParticipantRepository, chatRepository);
+    deletionOrder.verify(groupChatParticipantRepository).deleteBySeriesId(CHAT_ID);
+    deletionOrder.verify(chatRepository).delete(chat);
     verify(chatRepository).delete(chat);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
@@ -1,217 +1,101 @@
 package de.caritas.cob.userservice.api.service.agency;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.httpheader.HttpHeadersResolver;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-@ExtendWith(MockitoExtension.class)
 class AgencyMatrixCredentialClientTest {
 
-  private static final String AGENCY_SERVICE_BASE_URL = "http://agency-service";
   private static final Long AGENCY_ID = 42L;
-  private static final String MATRIX_USER_ID = "@agency:matrix.example.com";
-  private static final String MATRIX_PASSWORD = "matrix-password";
+  private static final String AGENCY_SERVICE_URL = "https://agency.example/service";
 
-  @InjectMocks private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
-
-  @Mock private RestTemplate restTemplate;
-  @Mock private SecurityHeaderSupplier securityHeaderSupplier;
-  @Mock private TenantHeaderSupplier tenantHeaderSupplier;
+  private RestTemplate restTemplate;
+  private MockRestServiceServer mockServer;
+  private IdentityClient identityClient;
+  private IdentityClientConfig identityClientConfig;
+  private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
 
   @BeforeEach
   void setUp() {
+    restTemplate = new RestTemplate();
+    mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+    identityClient = mock(IdentityClient.class);
+    identityClientConfig = mock(IdentityClientConfig.class);
+
+    var securityHeaderSupplier = new SecurityHeaderSupplier(new AuthenticatedUser());
+    ReflectionTestUtils.setField(securityHeaderSupplier, "csrfHeaderProperty", "csrfHeader");
+    ReflectionTestUtils.setField(securityHeaderSupplier, "csrfCookieProperty", "csrfCookie");
+
+    var tenantHeaderSupplier = new TenantHeaderSupplier(new HttpHeadersResolver());
+    ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", false);
+
+    agencyMatrixCredentialClient =
+        new AgencyMatrixCredentialClient(
+            restTemplate,
+            securityHeaderSupplier,
+            tenantHeaderSupplier,
+            identityClient,
+            identityClientConfig);
     ReflectionTestUtils.setField(
-        agencyMatrixCredentialClient, "agencyServiceBaseUrl", AGENCY_SERVICE_BASE_URL);
+        agencyMatrixCredentialClient, "agencyServiceBaseUrl", AGENCY_SERVICE_URL);
   }
 
   @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_agencyIdIsNull() {
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(null);
+  void fetchMatrixCredentialsShouldAuthenticateAsTechnicalUser() throws Exception {
+    var technicalUser = new TechnicalUserConfig();
+    technicalUser.setUsername("technical");
+    technicalUser.setPassword("secret");
 
-    assertThat(result).isEmpty();
-    verifyNoInteractions(restTemplate, securityHeaderSupplier, tenantHeaderSupplier);
-  }
+    var loginResponse = new KeycloakLoginResponseDTO();
+    loginResponse.setAccessToken("technical-access-token");
 
-  @Test
-  void fetchMatrixCredentials_Should_returnCredentials_When_requestSucceeds() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
-    AgencyMatrixCredentialsDTO credentials = credentials();
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenReturn(ResponseEntity.ok(credentials));
+    var credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId("@agency:matrix");
+    credentials.setMatrixPassword("matrix-password");
 
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
+    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
+    when(identityClient.loginUser("technical", "secret")).thenReturn(loginResponse);
+
+    mockServer
+        .expect(requestTo(AGENCY_SERVICE_URL + "/internal/agencies/42/matrix-service-account"))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer technical-access-token"))
+        .andExpect(header("agencyId", "42"))
+        .andRespond(
+            withSuccess(
+                new ObjectMapper().writeValueAsString(credentials), MediaType.APPLICATION_JSON));
+
+    var result = agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
 
     assertThat(result).contains(credentials);
-    verify(tenantHeaderSupplier).addTenantHeader(headers);
-
-    ArgumentCaptor<HttpEntity<?>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-    verify(restTemplate)
-        .exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            requestCaptor.capture(),
-            eq(AgencyMatrixCredentialsDTO.class));
-    assertThat(requestCaptor.getValue().getHeaders().getFirst("agencyId"))
-        .isEqualTo(String.valueOf(AGENCY_ID));
+    mockServer.verify();
   }
 
   @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_responseIsNotSuccessful() {
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenReturn(ResponseEntity.status(HttpStatus.NO_CONTENT).build());
-
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_responseIsErrorWithBody() {
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(credentials()));
-
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_responseBodyIsNull() {
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenReturn(ResponseEntity.ok(null));
-
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_agencyHasNoCredentials() {
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenThrow(
-            HttpClientErrorException.create(
-                HttpStatus.NOT_FOUND,
-                "Not Found",
-                HttpHeaders.EMPTY,
-                new byte[0],
-                StandardCharsets.UTF_8));
-
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void fetchMatrixCredentials_Should_returnEmpty_When_requestFails() {
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenThrow(new RestClientException("connection failed"));
-
-    Optional<AgencyMatrixCredentialsDTO> result =
-        agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void fetchMatrixCredentials_Should_forwardTenantHeader_When_tenantSupplierAddsHeader() {
-    HttpHeaders headers = new HttpHeaders();
-    when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
-    doAnswer(
-            invocation -> {
-              headers.add("tenantId", "7");
-              return null;
-            })
-        .when(tenantHeaderSupplier)
-        .addTenantHeader(headers);
-    when(restTemplate.exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(AgencyMatrixCredentialsDTO.class)))
-        .thenReturn(ResponseEntity.ok(credentials()));
-
-    agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID);
-
-    ArgumentCaptor<HttpEntity<?>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-    verify(restTemplate)
-        .exchange(
-            eq(expectedUrl()),
-            eq(HttpMethod.GET),
-            requestCaptor.capture(),
-            eq(AgencyMatrixCredentialsDTO.class));
-    assertThat(requestCaptor.getValue().getHeaders().getFirst("tenantId")).isEqualTo("7");
-  }
-
-  private static String expectedUrl() {
-    return AGENCY_SERVICE_BASE_URL + "/internal/agencies/" + AGENCY_ID + "/matrix-service-account";
-  }
-
-  private static AgencyMatrixCredentialsDTO credentials() {
-    AgencyMatrixCredentialsDTO credentials = new AgencyMatrixCredentialsDTO();
-    credentials.setMatrixUserId(MATRIX_USER_ID);
-    credentials.setMatrixPassword(MATRIX_PASSWORD);
-    return credentials;
+  void fetchMatrixCredentialsShouldReturnEmptyWhenAgencyIdIsNull() {
+    assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(null)).isEmpty();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
@@ -6,11 +6,13 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -65,19 +68,11 @@ class AgencyMatrixCredentialClientTest {
 
   @Test
   void fetchMatrixCredentialsShouldAuthenticateAsTechnicalUser() throws Exception {
-    var technicalUser = new TechnicalUserConfig();
-    technicalUser.setUsername("technical");
-    technicalUser.setPassword("secret");
-
-    var loginResponse = new KeycloakLoginResponseDTO();
-    loginResponse.setAccessToken("technical-access-token");
+    stubTechnicalUserLogin("technical-access-token");
 
     var credentials = new AgencyMatrixCredentialsDTO();
     credentials.setMatrixUserId("@agency:matrix");
     credentials.setMatrixPassword("matrix-password");
-
-    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    when(identityClient.loginUser("technical", "secret")).thenReturn(loginResponse);
 
     mockServer
         .expect(requestTo(AGENCY_SERVICE_URL + "/internal/agencies/42/matrix-service-account"))
@@ -97,5 +92,57 @@ class AgencyMatrixCredentialClientTest {
   @Test
   void fetchMatrixCredentialsShouldReturnEmptyWhenAgencyIdIsNull() {
     assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(null)).isEmpty();
+  }
+
+  @Test
+  void fetchMatrixCredentialsShouldReturnEmptyWhenTechnicalUserLoginFails() {
+    var technicalUser = new TechnicalUserConfig();
+    technicalUser.setUsername("technical");
+    technicalUser.setPassword("secret");
+
+    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
+    when(identityClient.loginUser("technical", "secret"))
+        .thenThrow(new BadRequestException("Keycloak unavailable"));
+
+    assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  void fetchMatrixCredentialsShouldReturnEmptyWhenAgencyHasNoMatrixCredentials() {
+    stubTechnicalUserLogin("technical-access-token");
+
+    mockServer
+        .expect(requestTo(AGENCY_SERVICE_URL + "/internal/agencies/42/matrix-service-account"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  void fetchMatrixCredentialsShouldReturnEmptyWhenAgencyServiceFails() {
+    stubTechnicalUserLogin("technical-access-token");
+
+    mockServer
+        .expect(requestTo(AGENCY_SERVICE_URL + "/internal/agencies/42/matrix-service-account"))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  private void stubTechnicalUserLogin(String accessToken) {
+    var technicalUser = new TechnicalUserConfig();
+    technicalUser.setUsername("technical");
+    technicalUser.setPassword("secret");
+
+    var loginResponse = new KeycloakLoginResponseDTO();
+    loginResponse.setAccessToken(accessToken);
+
+    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
+    when(identityClient.loginUser("technical", "secret")).thenReturn(loginResponse);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceCommandServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceCommandServiceTest.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ChatOccurrenceExceptionRepository;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService;
+import de.caritas.cob.userservice.api.service.notification.GroupChatNotificationRecipientService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatOccurrenceCommandServiceTest {
+
+  @Mock private ChatRepository chatRepository;
+  @Mock private ChatOccurrenceExceptionRepository exceptionRepository;
+  @Mock private GroupChatParticipantRepository participantRepository;
+  @Mock private GroupChatLifecycleNotificationService lifecycleNotificationService;
+  @Mock private GroupChatNotificationRecipientService notificationRecipientService;
+  @InjectMocks private ChatOccurrenceCommandService service;
+
+  @Test
+  void ownerCanSkipExactlyOneOccurrence() {
+    var originalStart = LocalDateTime.parse("2026-08-03T18:00:00");
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer group")
+            .initialStartDate(originalStart)
+            .startDate(originalStart)
+            .repeatCount(2)
+            .currentOccurrenceIndex(0)
+            .chatModality(Chat.ChatModality.TEXT)
+            .matrixRoomId("!room:matrix.example")
+            .build();
+    when(chatRepository.findById(42L)).thenReturn(Optional.of(series));
+    when(participantRepository.findBySeriesIdAndConsultantId(42L, "owner"))
+        .thenReturn(Optional.of(participant(ParticipantRole.OWNER)));
+    when(notificationRecipientService.resolveRecipientIds(series))
+        .thenReturn(java.util.List.of("owner", "co-mod", "asker"));
+
+    service.skip(42L, "owner", originalStart);
+
+    var saved = ArgumentCaptor.forClass(ChatOccurrenceException.class);
+    verify(exceptionRepository).save(saved.capture());
+    org.assertj.core.api.Assertions.assertThat(saved.getValue().getSeries()).isSameAs(series);
+    org.assertj.core.api.Assertions.assertThat(saved.getValue().getOriginalOccurrenceStartUtc())
+        .isEqualTo(originalStart);
+    org.assertj.core.api.Assertions.assertThat(saved.getValue().getExceptionType())
+        .isEqualTo(ChatOccurrenceException.ExceptionType.SKIP);
+    verify(lifecycleNotificationService)
+        .createCancelledNotifications(
+            42L,
+            0,
+            originalStart,
+            "!room:matrix.example",
+            null,
+            false,
+            java.util.List.of("owner", "co-mod", "asker"));
+  }
+
+  @Test
+  void participantCannotChangeAnOccurrence() {
+    when(participantRepository.findBySeriesIdAndConsultantId(42L, "participant"))
+        .thenReturn(Optional.of(participant(ParticipantRole.PARTICIPANT)));
+
+    assertThatThrownBy(
+            () ->
+                service.override(
+                    42L,
+                    "participant",
+                    LocalDateTime.parse("2026-08-03T18:00:00"),
+                    LocalDateTime.parse("2026-08-03T19:00:00"),
+                    90,
+                    12,
+                    Chat.ChatModality.TEXT))
+        .isInstanceOf(ForbiddenException.class);
+    verify(exceptionRepository, org.mockito.Mockito.never()).save(any());
+  }
+
+  private static GroupChatParticipant participant(ParticipantRole role) {
+    return GroupChatParticipant.builder().role(role).build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceProjectorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceProjectorTest.java
@@ -1,0 +1,77 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException;
+import de.caritas.cob.userservice.api.model.ChatOccurrenceException.ExceptionType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChatOccurrenceProjectorTest {
+
+  @Test
+  void projectShouldOmitAnOccurrenceWithASkipException() {
+    var anchor = LocalDateTime.of(2026, 8, 1, 18, 0);
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer support")
+            .initialStartDate(anchor)
+            .startDate(anchor)
+            .duration(60)
+            .repeatCount(3)
+            .repetitive(true)
+            .chatInterval(ChatInterval.DAILY)
+            .build();
+    var skip = ChatOccurrenceException.skip(series, anchor.plusDays(1));
+
+    var occurrences =
+        new ChatOccurrenceProjector()
+            .project(series, List.of(skip), anchor.minusMinutes(1), anchor.plusDays(3), 10);
+
+    assertThat(occurrences)
+        .extracting(ChatOccurrence::start)
+        .containsExactly(anchor, anchor.plusDays(2));
+  }
+
+  @Test
+  void projectShouldApplyASingleOccurrenceOverrideWithoutMovingLaterOccurrences() {
+    var anchor = LocalDateTime.of(2026, 8, 1, 18, 0);
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer support")
+            .initialStartDate(anchor)
+            .startDate(anchor)
+            .duration(60)
+            .maxParticipants(12)
+            .repeatCount(3)
+            .repetitive(true)
+            .chatInterval(ChatInterval.DAILY)
+            .build();
+    var override =
+        ChatOccurrenceException.builder()
+            .series(series)
+            .originalOccurrenceStartUtc(anchor.plusDays(1))
+            .exceptionType(ExceptionType.OVERRIDE)
+            .overrideStartUtc(anchor.plusDays(1).plusHours(2))
+            .overrideDuration(30)
+            .overrideCapacity(5)
+            .overrideModality(ChatModality.VIDEO)
+            .build();
+
+    var occurrences =
+        new ChatOccurrenceProjector()
+            .project(series, List.of(override), anchor, anchor.plusDays(4), 10);
+
+    assertThat(occurrences.get(1).start()).isEqualTo(anchor.plusDays(1).plusHours(2));
+    assertThat(occurrences.get(1).duration()).isEqualTo(30);
+    assertThat(occurrences.get(1).capacity()).isEqualTo(5);
+    assertThat(occurrences.get(1).modality()).isEqualTo(ChatModality.VIDEO);
+    assertThat(occurrences.get(2).start()).isEqualTo(anchor.plusDays(2));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceQueryServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/ChatOccurrenceQueryServiceTest.java
@@ -1,0 +1,41 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.port.out.ChatOccurrenceExceptionRepository;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class ChatOccurrenceQueryServiceTest {
+
+  private final ChatOccurrenceQueryService service =
+      new ChatOccurrenceQueryService(
+          mock(ChatRepository.class), mock(ChatOccurrenceExceptionRepository.class));
+
+  @Test
+  void rejectsUnboundedOrInvalidWindows() {
+    assertThatThrownBy(
+            () ->
+                service.getOccurrences(
+                    1L,
+                    LocalDateTime.parse("2026-08-04T00:00:00"),
+                    LocalDateTime.parse("2026-08-03T00:00:00"),
+                    50))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void rejectsLimitsAboveTheBoundedProjectionMaximum() {
+    assertThatThrownBy(
+            () ->
+                service.getOccurrences(
+                    1L,
+                    LocalDateTime.parse("2026-08-03T00:00:00"),
+                    LocalDateTime.parse("2026-08-04T00:00:00"),
+                    101))
+        .isInstanceOf(BadRequestException.class);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGateTest.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatFeatureGateTest {
+
+  @Mock private TenantService tenantService;
+  @Mock private Consultant consultant;
+  private GroupChatFeatureGate gate;
+
+  @BeforeEach
+  void setUp() {
+    gate = new GroupChatFeatureGate(tenantService);
+  }
+
+  @Test
+  void enabledTenantMayCreateSelfHelpGroupSeries() {
+    when(consultant.getTenantId()).thenReturn(7L);
+    when(tenantService.getRestrictedTenantData(7L))
+        .thenReturn(
+            new RestrictedTenantDTO()
+                .id(7L)
+                .name("Tenant")
+                .settings(new RestrictedTenantSettings().featureGroupChatV2Enabled(true)));
+
+    assertThatCode(() -> gate.requireEnabled(consultant)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void disabledTenantMayNotCreateSelfHelpGroupSeries() {
+    when(consultant.getTenantId()).thenReturn(7L);
+    when(tenantService.getRestrictedTenantData(7L))
+        .thenReturn(
+            new RestrictedTenantDTO()
+                .id(7L)
+                .name("Tenant")
+                .settings(new RestrictedTenantSettings().featureGroupChatV2Enabled(false)));
+
+    assertThatThrownBy(() -> gate.requireEnabled(consultant))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void missingTenantContextFailsClosed() {
+    assertThatThrownBy(() -> gate.requireEnabled(null)).isInstanceOf(ForbiddenException.class);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatPermissionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatPermissionServiceTest.java
@@ -1,0 +1,68 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.ChatPermissionVerifier;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatPermissionServiceTest {
+
+  @Mock private GroupChatParticipantRepository participantRepository;
+  @Mock private ChatPermissionVerifier legacyPermissionVerifier;
+  @Mock private Chat chat;
+  @Mock private Consultant consultant;
+
+  private GroupChatPermissionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new GroupChatPermissionService(participantRepository, legacyPermissionVerifier);
+    when(chat.getId()).thenReturn(42L);
+  }
+
+  @Test
+  void ownerAndCoModeratorCanOpenOrEndAnOccurrence() {
+    when(consultant.getId()).thenReturn("actor");
+    for (ParticipantRole role : List.of(ParticipantRole.OWNER, ParticipantRole.CO_MODERATOR)) {
+      when(participantRepository.findBySeriesId(42L))
+          .thenReturn(List.of(participant("actor", role)));
+
+      assertThatCode(() -> service.requireCanModerate(chat, consultant)).doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  void ordinaryParticipantCannotOpenOrEndAnOccurrenceEvenWithinAgency() {
+    when(consultant.getId()).thenReturn("actor");
+    when(participantRepository.findBySeriesId(42L))
+        .thenReturn(List.of(participant("actor", ParticipantRole.PARTICIPANT)));
+    assertThatThrownBy(() -> service.requireCanModerate(chat, consultant))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void legacyChatWithoutSeriesMembershipKeepsAgencyAuthorization() {
+    when(participantRepository.findBySeriesId(42L)).thenReturn(List.of());
+    when(legacyPermissionVerifier.hasSameAgencyAssigned(chat, consultant)).thenReturn(true);
+
+    assertThatCode(() -> service.requireCanModerate(chat, consultant)).doesNotThrowAnyException();
+  }
+
+  private static GroupChatParticipant participant(String id, ParticipantRole role) {
+    return GroupChatParticipant.builder().consultantId(id).role(role).build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatRoleServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatRoleServiceTest.java
@@ -1,0 +1,144 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatRoleServiceTest {
+
+  @Mock private GroupChatParticipantRepository participantRepository;
+
+  @Mock private ChatRepository chatRepository;
+
+  @Mock private ConsultantRepository consultantRepository;
+
+  @Mock private GroupChatMembershipService groupChatMembershipService;
+
+  @InjectMocks private GroupChatRoleService roleService;
+
+  @Test
+  void changeRoleShouldRejectDemotingTheLastOwner() {
+    var owner = participant(42L, "owner", ParticipantRole.OWNER);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+
+    assertThrows(
+        ConflictException.class,
+        () -> roleService.changeRole(42L, "owner", "owner", ParticipantRole.CO_MODERATOR));
+
+    verify(participantRepository, never()).save(owner);
+  }
+
+  @Test
+  void transferPrimaryOwnershipShouldReplaceTheInitiatingOwnerAndUpdateTheChatProjection() {
+    var actor = participant(42L, "owner", ParticipantRole.OWNER);
+    var target = participant(42L, "target", ParticipantRole.CO_MODERATOR);
+    var oldOwner = org.mockito.Mockito.mock(Consultant.class);
+    var newOwner = org.mockito.Mockito.mock(Consultant.class);
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer support")
+            .initialStartDate(java.time.LocalDateTime.now())
+            .startDate(java.time.LocalDateTime.now())
+            .chatOwner(oldOwner)
+            .build();
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(actor, target));
+    when(chatRepository.findById(42L)).thenReturn(java.util.Optional.of(series));
+    when(consultantRepository.findById("target")).thenReturn(java.util.Optional.of(newOwner));
+
+    roleService.transferPrimaryOwnership(42L, "owner", "target");
+
+    org.junit.jupiter.api.Assertions.assertEquals(ParticipantRole.CO_MODERATOR, actor.getRole());
+    org.junit.jupiter.api.Assertions.assertEquals(ParticipantRole.OWNER, target.getRole());
+    org.junit.jupiter.api.Assertions.assertEquals(newOwner, series.getChatOwner());
+    verify(participantRepository).save(actor);
+    verify(participantRepository).save(target);
+    verify(chatRepository).save(series);
+  }
+
+  @Test
+  void removeParticipantShouldDeleteTheRoleAndRevokeMatrixRoomMembership() {
+    var actor = participant(42L, "owner", ParticipantRole.OWNER);
+    var target = participant(42L, "target", ParticipantRole.CO_MODERATOR);
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer support")
+            .initialStartDate(java.time.LocalDateTime.now())
+            .startDate(java.time.LocalDateTime.now())
+            .matrixRoomId("!room:matrix.example")
+            .build();
+    var targetConsultant = org.mockito.Mockito.mock(Consultant.class);
+    when(targetConsultant.getMatrixUserId()).thenReturn("@target:matrix.example");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(actor, target));
+    when(chatRepository.findById(42L)).thenReturn(java.util.Optional.of(series));
+    when(consultantRepository.findById("target"))
+        .thenReturn(java.util.Optional.of(targetConsultant));
+
+    roleService.removeParticipant(42L, "owner", "target");
+
+    verify(participantRepository).delete(target);
+    verify(groupChatMembershipService)
+        .removeLeavingMemberFromRoom(series, "@target:matrix.example");
+  }
+
+  @Test
+  void leaveSeriesShouldRejectTheLastOwner() {
+    var owner = participant(42L, "owner", ParticipantRole.OWNER);
+    var series = org.mockito.Mockito.mock(Chat.class);
+    var consultant = org.mockito.Mockito.mock(Consultant.class);
+    when(series.getId()).thenReturn(42L);
+    when(consultant.getId()).thenReturn("owner");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+
+    assertThrows(ConflictException.class, () -> roleService.leaveSeries(series, consultant));
+
+    verify(participantRepository, never()).delete(owner);
+    verify(groupChatMembershipService, never()).removeLeavingMemberFromRoom(series, null);
+  }
+
+  @Test
+  void leaveSeriesShouldRemoveACoModeratorFromTheSeriesAndCurrentMatrixRoom() {
+    var coModerator = participant(42L, "co-mod", ParticipantRole.CO_MODERATOR);
+    var series = org.mockito.Mockito.mock(Chat.class);
+    var consultant = org.mockito.Mockito.mock(Consultant.class);
+    when(series.getId()).thenReturn(42L);
+    when(consultant.getId()).thenReturn("co-mod");
+    when(consultant.getMatrixUserId()).thenReturn("@co-mod:matrix.example");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(coModerator));
+    roleService.leaveSeries(series, consultant);
+
+    verify(participantRepository).delete(coModerator);
+    verify(groupChatMembershipService)
+        .removeLeavingMemberFromRoom(series, "@co-mod:matrix.example");
+  }
+
+  private GroupChatParticipant participant(
+      Long seriesId, String consultantId, ParticipantRole role) {
+    return GroupChatParticipant.builder()
+        .id("owner".equals(consultantId) ? 1L : 2L)
+        .seriesId(seriesId)
+        .chatId(200L)
+        .consultantId(consultantId)
+        .role(role)
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipServiceTest.java
@@ -15,6 +15,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
@@ -201,6 +202,22 @@ class GroupChatMembershipServiceTest {
     groupChatMembershipService.removeLeavingMemberFromRoom(chatWithMatrixRoom(), LEAVER_MATRIX_ID);
 
     verify(matrixSynapseService).leaveRoom(MATRIX_ROOM_ID, "token");
+  }
+
+  @Test
+  void addMemberToRoom_Should_InviteAndJoinWithMatrixTokens() throws MatrixInviteUserException {
+    var owner = org.mockito.Mockito.mock(Consultant.class);
+    var chat = chatBuilder().matrixRoomId(MATRIX_ROOM_ID).chatOwner(owner).build();
+    when(owner.getMatrixUserId()).thenReturn(CONSULTANT_MATRIX_ID);
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MATRIX_ID))
+        .thenReturn("owner-token");
+    when(matrixSynapseService.loginAsUserAccessToken(ASKER_MATRIX_ID)).thenReturn("asker-token");
+    when(matrixSynapseService.joinRoom(MATRIX_ROOM_ID, "asker-token")).thenReturn(true);
+
+    assertTrue(groupChatMembershipService.addMemberToRoom(chat, ASKER_MATRIX_ID));
+
+    verify(matrixSynapseService).inviteUserToRoom(MATRIX_ROOM_ID, ASKER_MATRIX_ID, "owner-token");
+    verify(matrixSynapseService).joinRoom(MATRIX_ROOM_ID, "asker-token");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -52,6 +52,7 @@ class EventNotificationServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private ConsultantRepository consultantRepository;
   @Mock private IdentityTombstoneService identityTombstoneService;
+  @Mock private EventNotificationDeduplicationWriter deduplicationWriter;
   @Captor private ArgumentCaptor<EventNotification> eventCaptor;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -664,6 +665,39 @@ class EventNotificationServiceTest {
         "user-1", "message.new", null, "Title", "Text", null, 1L, 1L);
     verify(eventNotificationRepository).save(eventCaptor.capture());
     assertEquals(EventNotificationService.CATEGORY_SYSTEM, eventCaptor.getValue().getCategory());
+  }
+
+  @Test
+  void createEventOnce_persistsTheDeduplicationKeyOnlyOnce() {
+    when(eventNotificationRepository.existsByRecipientUserIdAndDeduplicationKey(
+            "consultant-1", "group-chat:reminder:42:0"))
+        .thenReturn(false, true);
+
+    eventNotificationService.createEventOnce(
+        "group-chat:reminder:42:0",
+        "consultant-1",
+        "group_chat.reminder",
+        EventNotificationService.CATEGORY_SYSTEM,
+        "Reminder",
+        "Soon",
+        "{\"seriesId\":42}",
+        null,
+        42L,
+        null);
+    eventNotificationService.createEventOnce(
+        "group-chat:reminder:42:0",
+        "consultant-1",
+        "group_chat.reminder",
+        EventNotificationService.CATEGORY_SYSTEM,
+        "Reminder",
+        "Soon",
+        "{\"seriesId\":42}",
+        null,
+        42L,
+        null);
+
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getDeduplicationKey()).isEqualTo("group-chat:reminder:42:0");
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatLifecycleNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatLifecycleNotificationServiceTest.java
@@ -1,0 +1,150 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService.EVENT_GROUP_CHAT_CANCELLED;
+import static de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService.EVENT_GROUP_CHAT_OPENED;
+import static de.caritas.cob.userservice.api.service.notification.GroupChatLifecycleNotificationService.EVENT_GROUP_CHAT_REMINDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatLifecycleNotificationServiceTest {
+
+  @Mock private EventNotificationService eventNotificationService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private GroupChatLifecycleNotificationService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new GroupChatLifecycleNotificationService(eventNotificationService, objectMapper);
+  }
+
+  @Test
+  void opened_fansOutDistinctRecipientsWithMetadataOnlyParams() throws Exception {
+    LocalDateTime occurrenceStart = LocalDateTime.of(2026, 7, 10, 18, 30);
+
+    service.createOpenedNotifications(
+        42L,
+        3,
+        occurrenceStart,
+        "!room:matrix.example",
+        "!call:matrix.example",
+        true,
+        Arrays.asList("user-a", "user-a", " ", null, "user-b"));
+
+    ArgumentCaptor<String> paramsCaptor = ArgumentCaptor.forClass(String.class);
+    verify(eventNotificationService)
+        .createEventOnce(
+            eq("group-chat:group_chat.opened:42:3"),
+            eq("user-a"),
+            eq(EVENT_GROUP_CHAT_OPENED),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq("Group chat available"),
+            eq("A group chat is now available."),
+            paramsCaptor.capture(),
+            isNull(),
+            eq(42L),
+            isNull());
+    verify(eventNotificationService)
+        .createEventOnce(
+            eq("group-chat:group_chat.opened:42:3"),
+            eq("user-b"),
+            eq(EVENT_GROUP_CHAT_OPENED),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq("Group chat available"),
+            eq("A group chat is now available."),
+            anyString(),
+            isNull(),
+            eq(42L),
+            isNull());
+
+    JsonNode params = objectMapper.readTree(paramsCaptor.getValue());
+    assertThat(params.get("seriesId").asLong()).isEqualTo(42L);
+    assertThat(params.get("occurrenceIndex").asInt()).isEqualTo(3);
+    assertThat(params.get("start").asText()).isEqualTo(occurrenceStart.toString());
+    assertThat(params.get("occurrenceStart").asText()).isEqualTo(occurrenceStart.toString());
+    assertThat(params.get("roomRef").asText()).isEqualTo("!room:matrix.example");
+    assertThat(params.get("callRoomId").asText()).isEqualTo("!call:matrix.example");
+    assertThat(params.get("isVideo").asBoolean()).isTrue();
+    assertThat(paramsCaptor.getValue()).doesNotContain("topic", "agency", "participant", "message");
+  }
+
+  @Test
+  void reminderAndCancelled_useCanonicalTypesAndNeutralFallbackText() {
+    LocalDateTime occurrenceStart = LocalDateTime.of(2026, 7, 11, 9, 0);
+
+    service.createReminderNotifications(
+        7L, 0, occurrenceStart, null, null, false, List.of("user-a"));
+    service.createCancelledNotifications(
+        7L, 0, occurrenceStart, null, null, false, List.of("user-a"));
+
+    verify(eventNotificationService)
+        .createEventOnce(
+            eq("group-chat:group_chat.reminder:7:0"),
+            eq("user-a"),
+            eq(EVENT_GROUP_CHAT_REMINDER),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq("Group chat reminder"),
+            eq("A group chat is scheduled soon."),
+            anyString(),
+            isNull(),
+            eq(7L),
+            isNull());
+    verify(eventNotificationService)
+        .createEventOnce(
+            eq("group-chat:group_chat.cancelled:7:0"),
+            eq("user-a"),
+            eq(EVENT_GROUP_CHAT_CANCELLED),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq("Group chat cancelled"),
+            eq("A group chat occurrence was cancelled."),
+            anyString(),
+            isNull(),
+            eq(7L),
+            isNull());
+  }
+
+  @Test
+  void invalidSeriesOrRecipients_doesNothing() {
+    service.createOpenedNotifications(
+        null, 0, LocalDateTime.now(), "!room:matrix", null, null, List.of("user-a"));
+    service.createReminderNotifications(
+        1L, 0, LocalDateTime.now(), "!room:matrix", null, null, null);
+
+    verify(eventNotificationService, never())
+        .createEventOnce(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void fanoutContinuesWhenOnePersistenceCallFails() {
+    doThrow(new RuntimeException("DB error"))
+        .doNothing()
+        .when(eventNotificationService)
+        .createEventOnce(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+    service.createCancelledNotifications(
+        9L, 1, LocalDateTime.now(), null, null, null, List.of("user-a", "user-b"));
+
+    verify(eventNotificationService, times(2))
+        .createEventOnce(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatNotificationRecipientServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatNotificationRecipientServiceTest.java
@@ -1,0 +1,66 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.model.UserChat;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.UserChatRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatNotificationRecipientServiceTest {
+
+  @Mock private GroupChatParticipantRepository participantRepository;
+  @Mock private UserChatRepository userChatRepository;
+  @InjectMocks private GroupChatNotificationRecipientService service;
+
+  @Test
+  void returnsDistinctConsultantAndAskerIdentityIdsForTheSeries() {
+    var series = mock(Chat.class);
+    when(series.getId()).thenReturn(42L);
+    var asker = mock(User.class);
+    when(asker.getUserId()).thenReturn("asker-id");
+    var sharedIdentity = mock(User.class);
+    when(sharedIdentity.getUserId()).thenReturn("shared-id");
+    when(participantRepository.findBySeriesId(42L))
+        .thenReturn(
+            List.of(
+                GroupChatParticipant.builder().consultantId("owner-id").build(),
+                GroupChatParticipant.builder().consultantId("shared-id").build()));
+    when(userChatRepository.findByChat(series))
+        .thenReturn(
+            List.of(
+                UserChat.builder().user(asker).chat(series).build(),
+                UserChat.builder().user(sharedIdentity).chat(series).build()));
+
+    assertThat(service.resolveRecipientIds(series))
+        .containsExactly("owner-id", "shared-id", "asker-id");
+  }
+
+  @Test
+  void ignoresIncompleteLegacyRelationsAndUnsavedSeries() {
+    var series = mock(Chat.class);
+    when(series.getId()).thenReturn(42L);
+    when(participantRepository.findBySeriesId(42L))
+        .thenReturn(
+            List.of(
+                GroupChatParticipant.builder().consultantId(null).build(),
+                GroupChatParticipant.builder().consultantId(" ").build()));
+    when(userChatRepository.findByChat(series))
+        .thenReturn(List.of(UserChat.builder().user(null).chat(series).build()));
+
+    assertThat(service.resolveRecipientIds(series)).isEmpty();
+    assertThat(service.resolveRecipientIds(mock(Chat.class))).isEmpty();
+    assertThat(service.resolveRecipientIds(null)).isEmpty();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatReminderServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/GroupChatReminderServiceTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatReminderServiceTest {
+
+  @Mock private ChatRepository chatRepository;
+  @Mock private GroupChatNotificationRecipientService notificationRecipientService;
+  @Mock private GroupChatLifecycleNotificationService lifecycleNotificationService;
+  @InjectMocks private GroupChatReminderService service;
+
+  @Test
+  void publishesOneIdempotentReminderForEachUpcomingSeriesParticipant() {
+    var now = LocalDateTime.parse("2026-08-03T17:00:00");
+    var start = LocalDateTime.parse("2026-08-03T18:00:00");
+    var series =
+        Chat.builder()
+            .id(42L)
+            .topic("Peer group")
+            .startDate(start)
+            .initialStartDate(start)
+            .currentOccurrenceIndex(0)
+            .repeatCount(3)
+            .chatModality(Chat.ChatModality.AUDIO)
+            .matrixRoomId("!room:matrix.example")
+            .build();
+    ReflectionTestUtils.setField(service, "leadMinutes", 60L);
+    ReflectionTestUtils.setField(service, "windowMinutes", 5L);
+    when(chatRepository.findAllByActiveIsFalseAndStartDateBetween(
+            LocalDateTime.parse("2026-08-03T17:55:00"), start))
+        .thenReturn(List.of(series));
+    when(notificationRecipientService.resolveRecipientIds(series))
+        .thenReturn(List.of("owner", "co-mod", "asker"));
+
+    service.publishUpcomingReminders(now);
+
+    verify(lifecycleNotificationService)
+        .createReminderNotifications(
+            42L,
+            0,
+            start,
+            "!room:matrix.example",
+            null,
+            false,
+            List.of("owner", "co-mod", "asker"));
+    verifyNoMoreInteractions(lifecycleNotificationService);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListServiceTest.java
@@ -37,6 +37,7 @@ import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -123,6 +124,52 @@ class UserSessionListServiceTest {
             .get(0)
             .getChat()
             .isMessagesRead());
+  }
+
+  @Test
+  void retrieveSessionsForAuthenticatedUser_Should_NotEnrichNullSessionForGroupChat() {
+    ReflectionTestUtils.setField(userSessionListService, "featureTopicsEnabled", true);
+    userSessionListService.setSessionTopicEnrichmentService(sessionTopicEnrichmentService);
+    when(sessionService.getSessionsForUserId(USER_ID)).thenReturn(Collections.emptyList());
+    when(chatService.getChatsForUserId(USER_ID)).thenReturn(USER_CHAT_RESPONSE_DTO_LIST);
+    var roomInformation =
+        RocketChatRoomInformation.builder()
+            .readMessages(MESSAGES_READ_MAP_WITHOUT_UNREADS)
+            .lastMessagesRoom(emptyMap())
+            .build();
+    when(rocketChatRoomInformationProvider.retrieveRocketChatInformation(RC_CREDENTIALS))
+        .thenReturn(roomInformation);
+
+    var result =
+        assertDoesNotThrow(
+            () ->
+                userSessionListService.retrieveSessionsForAuthenticatedUser(
+                    USER_ID, RC_CREDENTIALS));
+
+    assertEquals(USER_CHAT_RESPONSE_DTO_LIST.size(), result.size());
+    verify(sessionTopicEnrichmentService, Mockito.never()).enrichSessionWithTopicData(null);
+  }
+
+  @Test
+  void retrieveSessionsForGroupIds_Should_NotLoadSystemSessionForKnownChatRoom() {
+    var chatResponse = USER_CHAT_RESPONSE_DTO_LIST.getFirst();
+    when(chatService.getChatSessionsByGroupIds(Set.of(RC_GROUP_ID_4)))
+        .thenReturn(List.of(chatResponse));
+    var roomInformation =
+        RocketChatRoomInformation.builder()
+            .readMessages(MESSAGES_READ_MAP_WITHOUT_UNREADS)
+            .lastMessagesRoom(emptyMap())
+            .build();
+    when(rocketChatRoomInformationProvider.retrieveRocketChatInformation(RC_CREDENTIALS))
+        .thenReturn(roomInformation);
+
+    var result =
+        userSessionListService.retrieveSessionsForAuthenticatedUserAndGroupIds(
+            USER_ID, List.of(RC_GROUP_ID_4), RC_CREDENTIALS, Set.of("user"));
+
+    assertEquals(List.of(chatResponse), result);
+    verify(sessionService, Mockito.never())
+        .getSessionsByUserAndGroupIds(Mockito.anyString(), Mockito.anySet(), Mockito.anySet());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatServiceTest.java
@@ -103,6 +103,23 @@ class DeactivateGroupChatServiceTest {
         .execute(chat);
   }
 
+  @Test
+  void deactivateShouldUseThePlannedEndEvenWhenTheChatWasUpdatedRecently() {
+    setField(deactivateGroupChatService, "deactivatePeriodMinutes", 0L);
+    var chat = new Chat();
+    chat.setDuration(60);
+    chat.setActive(true);
+    chat.setStartDate(LocalDateTime.now().minusMinutes(61));
+    chat.setUpdateDate(LocalDateTime.now());
+    when(this.chatRepository.findAllByActiveIsTrue()).thenReturn(List.of(chat));
+    when(this.actionsRegistry.buildContainerForType(Chat.class))
+        .thenReturn(commandMockProvider.getActionContainer(Chat.class));
+
+    this.deactivateGroupChatService.deactivateStaleGroupChats();
+
+    verify(this.commandMockProvider.getActionMock(StopChatActionCommand.class)).execute(chat);
+  }
+
   private static List<LocalDateTime> createOverdueUpdateDates() {
     LocalDateTime now = LocalDateTime.now();
     LocalDateTime oneDeletionPeriodAgo =

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/groupchatreminder/scheduler/GroupChatReminderSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/groupchatreminder/scheduler/GroupChatReminderSchedulerTest.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.userservice.api.workflow.groupchatreminder.scheduler;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+
+import de.caritas.cob.userservice.api.service.notification.GroupChatReminderService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatReminderSchedulerTest {
+
+  @InjectMocks private GroupChatReminderScheduler scheduler;
+  @Mock private GroupChatReminderService reminderService;
+  @Mock private TenantContextProvider tenantContextProvider;
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void publishUpcomingRemindersShouldClearTechnicalTenantContextAfterSuccess() {
+    enableSchedulerAndSetTechnicalContext();
+
+    scheduler.publishUpcomingReminders();
+
+    assertFalse(TenantContext.contextIsSet());
+  }
+
+  @Test
+  void publishUpcomingRemindersShouldClearTechnicalTenantContextAfterFailure() {
+    enableSchedulerAndSetTechnicalContext();
+    doThrow(new IllegalStateException("notification storage unavailable"))
+        .when(reminderService)
+        .publishUpcomingReminders(org.mockito.ArgumentMatchers.any());
+
+    assertThrows(IllegalStateException.class, scheduler::publishUpcomingReminders);
+    assertFalse(TenantContext.contextIsSet());
+  }
+
+  private void enableSchedulerAndSetTechnicalContext() {
+    ReflectionTestUtils.setField(scheduler, "enabled", true);
+    doAnswer(
+            invocation -> {
+              TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+              return null;
+            })
+        .when(tenantContextProvider)
+        .setTechnicalContextIfMultiTenancyIsEnabled();
+  }
+}

--- a/src/test/resources/database/chatAndRelationData.sql
+++ b/src/test/resources/database/chatAndRelationData.sql
@@ -1,8 +1,8 @@
-INSERT INTO `chat` (`id`, `topic`, `consulting_type`, `initial_start_date`, `start_date`, `duration`, `is_repetitive`, `chat_interval`, `is_active`, `max_participants`, `consultant_id_owner`, `rc_group_id`) VALUES
-    (0,	'TestV2 1',	null, '2022-08-24 10:45:00', '2022-08-24 10:45:00',	60,	0, NULL, 0, NULL, '0b3b1cc6-be98-4787-aa56-212259d811b9', 'x'),
-    (1,	'TestV2 2',	null, '2022-08-25 11:00:00', '2022-08-25 11:00:00',	60,	0, NULL, 0, NULL, '0b3b1cc6-be98-4787-aa56-212259d811b9', 'xx'),
-    (2,	'TestV2 3',	null, '2022-08-26 10:00:00', '2022-08-26 10:00:00',	60,	0, NULL, 0, NULL, '1293c11a-1b3e-47b8-a16e-ce0a8f055689', 'xxx'),
-    (3,	'TestV2 4',	null, '2022-08-26 10:00:00', '2022-08-26 10:00:00',	60,	0, NULL, 0, NULL, '1293c11a-1b3e-47b8-a16e-ce0a8f055689', 'xxxx');
+INSERT INTO `chat` (`id`, `topic`, `consulting_type`, `initial_start_date`, `start_date`, `duration`, `is_repetitive`, `repeat_count`, `current_occurrence_index`, `timezone`, `modality`, `chat_interval`, `is_active`, `max_participants`, `consultant_id_owner`, `rc_group_id`) VALUES
+    (0,	'TestV2 1',	null, '2022-08-24 10:45:00', '2022-08-24 10:45:00',	60,	0, 1, 0, 'UTC', 'TEXT', NULL, 0, NULL, '0b3b1cc6-be98-4787-aa56-212259d811b9', 'x'),
+    (1,	'TestV2 2',	null, '2022-08-25 11:00:00', '2022-08-25 11:00:00',	60,	0, 1, 0, 'UTC', 'TEXT', NULL, 0, NULL, '0b3b1cc6-be98-4787-aa56-212259d811b9', 'xx'),
+    (2,	'TestV2 3',	null, '2022-08-26 10:00:00', '2022-08-26 10:00:00',	60,	0, 1, 0, 'UTC', 'TEXT', NULL, 0, NULL, '1293c11a-1b3e-47b8-a16e-ce0a8f055689', 'xxx'),
+    (3,	'TestV2 4',	null, '2022-08-26 10:00:00', '2022-08-26 10:00:00',	60,	0, 1, 0, 'UTC', 'TEXT', NULL, 0, NULL, '1293c11a-1b3e-47b8-a16e-ce0a8f055689', 'xxxx');
 
 INSERT INTO `chat_agency` (`id`, `chat_id`, `agency_id`) VALUES
     (0, 0, 1731), (1, 0, 1),
@@ -17,6 +17,5 @@ INSERT INTO `user_chat` (`id`, `user_id`, `chat_id`) VALUES
     (0,	'015d013d-95e7-4e91-85b5-12cdb3d317f3',	0),
     (1,	'015d013d-95e7-4e91-85b5-12cdb3d317f3',	1),
     (2,	'017cac2a-2086-47eb-9f8e-40547dfa2fd5',	2);
-
 
 


### PR DESCRIPTION
## Summary

Promotes the UserService self-help group lifecycle already validated on PreDev, including the final fixes for numeric assignment, agency loading, join authorization, and malformed numeric identifiers.

Closes #378. Tracks OpenResilienceInitiative/ORISO-Frontend#396 and OpenResilienceInitiative/ORISO-Frontend#400.

## Included

- self-help group series and occurrence lifecycle
- participant roles and ownership safeguards
- Matrix/Megolm lifecycle and recurrence processing
- numeric `/assign/{seriesId}` compatibility using the correct two-step assignment/join contract
- eager `userAgencies` loading at the permission boundary
- HTTP 400 for digit-only identifiers above `Long.MAX_VALUE`

## Verification

- full Maven package gate passed: 3,061 tests, 0 failures, 0 errors, 7 skipped
- Spotless passed
- linux/amd64 image deployed on PreDev as `docker.io/library/oriso-userservice:26fddb7`
- live assignment and join both returned 200
- advice seeker became a participant and sent a Matrix-encrypted message that a consultant decrypted
- second CodeRabbit review returned no findings

## Release note

This PR does not authorize a direct deployment or merge. Promote only after human approval and green GitHub checks.
