### PR TITLE
fix: allow consultants to accept registered enquiries

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.config.auth;
 
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.ANONYMOUS_DEFAULT;
+import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.ASSIGN_CONSULTANT_TO_SESSION;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.CONSULTANT_CREATE;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.CONSULTANT_DEFAULT;
@@ -31,6 +32,7 @@ public enum Authority {
       UserRole.CONSULTANT,
       List.of(
           CONSULTANT_DEFAULT,
+          ASSIGN_CONSULTANT_TO_ENQUIRY,
           ASSIGN_CONSULTANT_TO_SESSION,
           VIEW_AGENCY_CONSULTANTS,
           CREATE_NEW_CHAT,

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/AuthorityTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/AuthorityTest.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.config.auth;
 
+import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.ASSIGN_CONSULTANT_TO_SESSION;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.CONSULTANT_DEFAULT;
 import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.CREATE_NEW_CHAT;
@@ -32,13 +33,14 @@ class AuthorityTest {
         result,
         containsInAnyOrder(
             CONSULTANT_DEFAULT,
+            ASSIGN_CONSULTANT_TO_ENQUIRY,
             ASSIGN_CONSULTANT_TO_SESSION,
             VIEW_AGENCY_CONSULTANTS,
             CREATE_NEW_CHAT,
             START_CHAT,
             STOP_CHAT,
             UPDATE_CHAT));
-    assertEquals(7, result.size());
+    assertEquals(8, result.size());
   }
 
   @Test


### PR DESCRIPTION
Closes #383

## Problem
A consultant could list registered enquiries but received HTTP 403 when accepting a NEW enquiry. The CONSULTANT role had `ASSIGN_CONSULTANT_TO_SESSION`, while the NEW-enquiry delegate correctly checks `ASSIGN_CONSULTANT_TO_ENQUIRY`.

## Change
- grant `ASSIGN_CONSULTANT_TO_ENQUIRY` to the CONSULTANT role
- extend the authority mapping regression test

## TDD evidence
- RED: `AuthorityTest` failed on the missing enquiry authority
- GREEN: focused authority/delegate tests: 37/37 passed
- required test suite: 3,061 tests passed, 0 failures/errors, 7 skipped
- package build: passed

## Known non-blocking burn-in
`mvn verify` reproduces the repository-wide integration-test baseline (911 ITs; 240 failures, 266 errors). This job is explicitly `continue-on-error` in the verify burn-in action and the failures span unrelated 401/application-context/lazy-loading/locking scenarios; the required `mvn test` gate and package build are green.

## PreDev QA after approval
Deploy the regular UserService image, then accept registered session 103139 as a real consultant and prove encrypted two-way messaging plus reload.