### PR TITLE
fix: skip Rocket.Chat cleanup without members

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/UnauthorizedMembersProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/UnauthorizedMembersProvider.java
@@ -47,6 +47,9 @@ public class UnauthorizedMembersProvider {
       Consultant consultant,
       List<GroupMemberDTO> memberList,
       Consultant consultantToKeep) {
+    if (memberList.isEmpty()) {
+      return List.of();
+    }
     var authorizedMembers = obtainAuthorizedMembers(rcGroupId, session, consultant);
     if (nonNull(consultantToKeep)) {
       authorizedMembers.add(consultantToKeep.getRocketChatId());

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/UnauthorizedMembersProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/UnauthorizedMembersProviderTest.java
@@ -8,6 +8,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.TEAM_SESSI
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.when;
@@ -113,6 +114,17 @@ class UnauthorizedMembersProviderTest {
           assertNotEquals(consultantToRemove.getId(), consultant.getId());
           assertNotEquals(consultantToRemove.getRocketChatId(), consultant.getRocketChatId());
         });
+  }
+
+  @Test
+  void obtainConsultantsToRemoveShouldReturnEmptyWhenGroupHasNoMembers() {
+    var consultant = easyRandom.nextObject(Consultant.class);
+
+    var consultantsToRemove =
+        unauthorizedMembersProvider.obtainConsultantsToRemove(
+            RC_GROUP_ID, SESSION_WITH_ASKER_AND_CONSULTANT, consultant, List.of());
+
+    assertThat(consultantsToRemove, is(empty()));
   }
 
   @Test


### PR DESCRIPTION
Continues #383

## Deployed reproduction
After #384 removed the incorrect 403, accepting registered session 103139 reached assignment logic but returned HTTP 500. The deployed stack trace points to `UnauthorizedMembersProvider.addTechnicalUsers`: with Rocket.Chat disabled, the adapter returns an empty member list, yet the provider still requires the absent Rocket.Chat technical user.

## Minimal fix
When the group contains no Rocket.Chat members, return an empty removal list before resolving any Rocket.Chat technical identity. There is nobody to remove, and the Matrix-only path no longer depends on removed Rocket.Chat credentials.

## TDD evidence
- RED: empty-member regression test failed while resolving the technical user
- GREEN: provider + assignment-facade tests pass
- full required suite: 3,062 tests, 0 failures/errors, 7 skipped
- package build: passed

## PreDev QA
Deploy the regular image and retry session 103139 acceptance, then prove encrypted asker/consultant two-way messaging and reload.