### PR TITLE
fix: route new enquiries through Matrix assignment

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.adapters.web.mapping.UserDtoMapper;
 import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
 import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
@@ -50,6 +51,7 @@ class UserSessionControllerDelegate {
   private final @NonNull SessionService sessionService;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull SessionListFacade sessionListFacade;
+  private final @NonNull AssignEnquiryFacade assignEnquiryFacade;
   private final @NonNull AssignSessionFacade assignSessionFacade;
   private final @NonNull ConsultantDataFacade consultantDataFacade;
   private final @NonNull SessionArchiveService sessionArchiveService;
@@ -209,7 +211,8 @@ class UserSessionControllerDelegate {
     }
 
     var userId = authenticatedUser.getUserId();
-    if (session.get().getStatus().equals(SessionStatus.NEW)
+    var isNewEnquiry = session.get().getStatus().equals(SessionStatus.NEW);
+    if (isNewEnquiry
         && !authenticatedUser
             .getGrantedAuthorities()
             .contains(AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY)) {
@@ -222,6 +225,11 @@ class UserSessionControllerDelegate {
     }
 
     var consultantToAssign = userAccountProvider.retrieveValidatedConsultantById(consultantId);
+    if (isNewEnquiry) {
+      assignEnquiryFacade.assignRegisteredEnquiry(session.get(), consultantToAssign);
+      return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     var consultantToKeep = consultantService.getConsultant(userId).orElse(null);
     assignSessionFacade.assignSession(session.get(), consultantToAssign, consultantToKeep);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
 import de.caritas.cob.userservice.api.facade.sessionlist.SessionListFacade;
 import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataFacade;
@@ -56,6 +57,7 @@ class UserSessionControllerDelegateTest {
   @Mock private SessionService sessionService;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private SessionListFacade sessionListFacade;
+  @Mock private AssignEnquiryFacade assignEnquiryFacade;
   @Mock private AssignSessionFacade assignSessionFacade;
   @Mock private ConsultantDataFacade consultantDataFacade;
   @Mock private SessionArchiveService sessionArchiveService;
@@ -562,20 +564,17 @@ class UserSessionControllerDelegateTest {
     // New enquiries may be assigned when the caller holds enquiry assignment authority.
     var session = newSession();
     var consultantToAssign = consultant("assigned-consultant-id");
-    var consultantToKeep = consultant("consultant-id");
     when(sessionService.getSession(1L)).thenReturn(Optional.of(session));
     when(authenticatedUser.getUserId()).thenReturn("consultant-id");
     when(authenticatedUser.getGrantedAuthorities())
         .thenReturn(Set.of(AuthorityValue.ASSIGN_CONSULTANT_TO_ENQUIRY));
     when(userAccountProvider.retrieveValidatedConsultantById("assigned-consultant-id"))
         .thenReturn(consultantToAssign);
-    when(consultantService.getConsultant("consultant-id"))
-        .thenReturn(Optional.of(consultantToKeep));
-
     var response = delegate.assignSession(1L, "assigned-consultant-id");
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    verify(assignSessionFacade).assignSession(session, consultantToAssign, consultantToKeep);
+    verify(assignEnquiryFacade).assignRegisteredEnquiry(session, consultantToAssign);
+    verifyNoInteractions(assignSessionFacade, consultantService);
   }
 
   @Test


### PR DESCRIPTION
Continues #383

## Deployed reproduction
On regular PreDev digest `sha256:dc9ea04e...`, a clean NEW registered enquiry is accepted with HTTP 200, but the assigned consultant remains outside the Matrix room. The asker can send to the room with 200 while the consultant receives Matrix 403 for that room.

## Root cause
`PUT /service/users/sessions/{id}/consultant/{consultantId}` routes every status through `AssignSessionFacade`, the legacy/reassignment path. For NEW enquiries the existing `AssignEnquiryFacade` is the intended path and already implements agency-room reuse, consultant invite, power level, token minting, join, rollback, and notifications.

## Minimal fix
- NEW enquiry: enforce `ASSIGN_CONSULTANT_TO_ENQUIRY`, then call `AssignEnquiryFacade.assignRegisteredEnquiry`
- existing/in-progress session: preserve `AssignSessionFacade` behavior

## TDD evidence
- RED: controller test required the Matrix enquiry facade and observed zero calls
- GREEN: 30 controller + 26 Matrix enquiry-facade tests pass
- full required suite: 3,062 tests, 0 failures/errors, 7 skipped
- package build: passed

## PreDev QA
Deploy the regular image, accept a still-NEW registered session, then prove Matrix membership, encrypted asker/consultant messages, and reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session assignment for new enquiries with enquiry authority.
  * New enquiries are now assigned through the dedicated enquiry assignment flow.
  * Prevented unnecessary consultant and session assignment processing in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->