### PR TITLE
fix: finalize persisted consultant agency relation

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -86,11 +86,11 @@ public class ConsultantAgencyRelationCreatorService {
 
   private void createNewConsultantAgency(
       ConsultantAgencyCreationInput input, Consumer<String> logMethod) {
-    prepareConsultantAgencyRelation(input);
-    completeConsultantAgencyAssigment(input, logMethod);
+    var persistedRelation = prepareConsultantAgencyRelation(input);
+    completeConsultantAgencyAssigment(input, logMethod, persistedRelation);
   }
 
-  public void prepareConsultantAgencyRelation(ConsultantAgencyCreationInput input) {
+  public ConsultantAgency prepareConsultantAgencyRelation(ConsultantAgencyCreationInput input) {
     var consultant = this.retrieveConsultant(input.getConsultantId());
 
     var agency = retrieveAgency(input.getAgencyId());
@@ -103,11 +103,19 @@ public class ConsultantAgencyRelationCreatorService {
             consultant.getId(), input.getAdditionalAgencyIds(), consultant.getTenantId());
 
     ensureConsultingTypeRoles(input, agency);
-    consultantAgencyService.saveConsultantAgency(buildConsultantAgency(consultant, agency.getId()));
+    return consultantAgencyService.saveConsultantAgency(
+        buildConsultantAgency(consultant, agency.getId()));
   }
 
   public void completeConsultantAgencyAssigment(
       ConsultantAgencyCreationInput input, Consumer<String> logMethod) {
+    completeConsultantAgencyAssigment(input, logMethod, null);
+  }
+
+  private void completeConsultantAgencyAssigment(
+      ConsultantAgencyCreationInput input,
+      Consumer<String> logMethod,
+      ConsultantAgency persistedRelation) {
 
     var consultant = this.retrieveConsultant(input.getConsultantId());
     var agency = retrieveAgency(input.getAgencyId());
@@ -121,9 +129,14 @@ public class ConsultantAgencyRelationCreatorService {
       rocketChatAsyncHelper.addConsultantToSessions(
           consultant, agency, logMethod, TenantContext.getCurrentTenant());
     } else {
-      // Matrix-only: no Rocket.Chat group assignments exist, so finalize synchronously in this
-      // transaction — the async variant cannot see the uncommitted consultant_agency row.
-      rocketChatAsyncHelper.finalizeConsultantAgencyRelation(consultant, agency);
+      if (persistedRelation == null) {
+        // Legacy two-step callers do not carry the prepared relation across requests.
+        rocketChatAsyncHelper.finalizeConsultantAgencyRelation(consultant, agency);
+      } else {
+        // The atomic create path already owns the persisted row. Carry it forward instead of
+        // relying on an immediate read-after-write query that may not see the row yet.
+        rocketChatAsyncHelper.finalizeConsultantAgencyRelation(consultant, persistedRelation);
+      }
     }
 
     if (isTeamAgencyButNotTeamConsultant(agency, consultant)) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/RocketChatAsyncHelper.java
@@ -90,6 +90,13 @@ public class RocketChatAsyncHelper {
     updateConsultantStatus(consultant, agency);
   }
 
+  /** Finalizes a relation that the caller has just persisted without an immediate re-query. */
+  @Transactional
+  public void finalizeConsultantAgencyRelation(
+      Consultant consultant, ConsultantAgency persistedRelation) {
+    updateConsultantStatus(consultant, persistedRelation);
+  }
+
   private void updateConsultantStatus(Consultant consultant, AgencyDTO agencyDTO) {
     ConsultantAgency consultantAgency =
         consultantAgencyRepository.findByConsultantIdAndAgencyIdAndStatusAndDeleteDateIsNull(
@@ -104,6 +111,10 @@ public class RocketChatAsyncHelper {
       return;
     }
 
+    updateConsultantStatus(consultant, consultantAgency);
+  }
+
+  private void updateConsultantStatus(Consultant consultant, ConsultantAgency consultantAgency) {
     consultantAgency.setStatus(ConsultantAgencyStatus.CREATED);
     consultantAgencyRepository.save(consultantAgency);
     List<ConsultantAgency> consultantAgencies =

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -19,6 +19,8 @@ import de.caritas.cob.userservice.api.facade.RocketChatFacade;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.ConsultantAgencyStatus;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.model.Language;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
@@ -48,6 +50,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,6 +98,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
   void
       createNewConsultantAgency_Should_addConsultantToEnquiriesRocketChatGroups_When_ParamsAreValidAndMultitenancyEnabled() {
 
+    ReflectionTestUtils.setField(consultantAgencyRelationCreatorService, "rocketChatEnabled", true);
+
     Consultant consultant = createConsultantWithoutAgencyAndSession();
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO = new CreateConsultantAgencyDTO();
@@ -135,6 +140,41 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     assertEquals(1, agenciesForConsultant.get(0).getTenantId());
   }
 
+  @Test
+  void
+      createNewConsultantAgency_ShouldFinalizePersistedRelation_WhenMatrixOnlyAndMultitenancyEnabled() {
+    ReflectionTestUtils.setField(
+        consultantAgencyRelationCreatorService, "rocketChatEnabled", false);
+    TenantContext.setCurrentTenant(0L);
+    Consultant consultant = createConsultantWithoutAgencyAndSession();
+    consultant.setTenantId(83L);
+    consultant.setStatus(ConsultantStatus.CREATED);
+    consultantRepository.save(consultant);
+
+    CreateConsultantAgencyDTO createConsultantAgencyDTO =
+        new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("valid-role-set");
+    when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
+    AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0);
+    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+
+    consultantAgencyRelationCreatorService.createNewConsultantAgency(
+        consultant.getId(), createConsultantAgencyDTO);
+
+    ConsultantAgency relation =
+        consultantAgencyRepository
+            .findByConsultantIdAndAgencyIdAndDeleteDateIsNull(consultant.getId(), 15L)
+            .getFirst();
+    assertEquals(ConsultantAgencyStatus.CREATED, relation.getStatus());
+    assertEquals(
+        ConsultantStatus.CREATED,
+        consultantRepository
+            .findByIdAndDeleteDateIsNull(consultant.getId())
+            .orElseThrow()
+            .getStatus());
+  }
+
   private Consultant createConsultantWithoutAgencyAndSession() {
     Consultant consultant = easyRandom.nextObject(Consultant.class);
     consultant.setAppointments(null);
@@ -142,6 +182,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     consultant.setConsultantAgencies(null);
     consultant.setSessions(null);
     consultant.setConsultantMobileTokens(null);
+    consultant.setConsultantTopics(null);
     consultant.setRocketChatId("RocketChatId");
     consultant.setDeleteDate(null);
     Set<Language> language = new HashSet<>();
@@ -176,6 +217,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     session.setSessionTopics(Lists.newArrayList());
     session.setLanguageCode(LanguageCode.de);
     session.setIsConsultantDirectlySet(false);
+    session.setTenantId(1L);
 
     return this.sessionRepository.save(session);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -36,6 +36,7 @@ import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -149,6 +150,32 @@ public class ConsultantAgencyRelationCreatorServiceTest {
   }
 
   @Test
+  void createNewConsultantAgency_Should_finalizeThePersistedRelationWithoutRequeryingIt() {
+    ReflectionTestUtils.setField(
+        consultantAgencyRelationCreatorService, "rocketChatEnabled", false);
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(83L);
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgencyWithoutCaching(280L)).thenReturn(agency);
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+    when(consultantAgencyService.saveConsultantAgency(any(ConsultantAgency.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    consultantAgencyRelationCreatorService.createNewConsultantAgency(
+        "consultant Id", new CreateConsultantAgencyDTO().agencyId(280L));
+
+    var persistedRelation = ArgumentCaptor.forClass(ConsultantAgency.class);
+    verify(consultantAgencyService).saveConsultantAgency(persistedRelation.capture());
+    verify(rocketChatAsyncHelper)
+        .finalizeConsultantAgencyRelation(consultant, persistedRelation.getValue());
+  }
+
+  @Test
   public void createNewConsultantAgency_Should_throwBadRequest_When_consultantDoesNotExist() {
     when(consultantRepository.findByIdAndDeleteDateIsNull("missing")).thenReturn(Optional.empty());
 
@@ -254,7 +281,10 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     verify(rocketChatAsyncHelper)
         .addConsultantToSessions(eq(consultant), eq(agencyDTO), any(), eq(4L));
-    verify(rocketChatAsyncHelper, never()).finalizeConsultantAgencyRelation(any(), any());
+    verify(rocketChatAsyncHelper, never())
+        .finalizeConsultantAgencyRelation(any(Consultant.class), any(AgencyDTO.class));
+    verify(rocketChatAsyncHelper, never())
+        .finalizeConsultantAgencyRelation(any(Consultant.class), any(ConsultantAgency.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- carry the newly persisted consultant-agency relation into synchronous Matrix-only finalization
- avoid the failing immediate read-after-write lookup in the atomic Admin create flow
- preserve the legacy two-step prepare/complete fallback
- add unit and tenant-aware platform-admin regression coverage

## PreDev evidence

The real Admin flow created both relation rows for tenant 83 and Agency 280, but the immediate finalization lookup returned no row. Both relations and consultants therefore remained `IN_PROGRESS`, blocking agency visibility. Liquibase 0065 is healthy and the rows contain the correct tenant IDs.

## Verification

- targeted unit and tenant-aware integration tests: pass
- full Java 21 package gate: 3,388 tests, 0 failures, 0 errors, 7 skipped
- `git diff --check`: pass

## Deployment gate

After human review and merge into `pre-dev`, publish and deploy the immutable UserService image digest, then repeat the real Admin flow with two consultants before continuing the four-modality E2E gate.

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consultant–agency assignment finalization by consistently using the saved relationship record.
  * Ensured consultant and agency statuses are updated correctly across tenant-aware and Rocket.Chat-enabled workflows.

* **Tests**
  * Added coverage for persisted relationship handling and tenant-specific assignment scenarios.
  * Strengthened verification of Rocket.Chat finalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->