### PR TITLE
feat: wire invite two-factor gate to real OTP lifecycle

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.InviteSendResult;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
@@ -141,6 +142,21 @@ public class AccountInviteController {
             accountInviteService.calculateAccessGate(invite)));
   }
 
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/useradmin/account-invites/{inviteId}/waive-two-factor")
+  public ResponseEntity<AccountInviteResponseDTO> waiveTwoFactor(
+      @PathVariable Long inviteId,
+      @RequestBody(required = false) WaiveTwoFactorRequestDTO request) {
+    String reason = request == null ? null : request.reason;
+    AccountInvite invite =
+        accountInviteService.waiveTwoFactor(inviteId, new WaiveTwoFactorCommand(reason));
+    return ResponseEntity.ok(
+        AccountInviteResponseDTO.from(
+            invite,
+            latestDeliveryStatus(invite),
+            accountInviteService.calculateAccessGate(invite)));
+  }
+
   @PostMapping("/users/account-invites/{token}/accept")
   public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
       @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
@@ -239,6 +255,10 @@ public class AccountInviteController {
   public static class SendInviteRequestDTO {
     public Long templateId;
     public String acceptBaseUrl;
+  }
+
+  public static class WaiveTwoFactorRequestDTO {
+    public String reason;
   }
 
   public static class AcceptInviteRequestDTO {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Locale;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ class UserTwoFactorAuthControllerDelegate {
   private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
+  private final @NonNull AccountInviteService accountInviteService;
   private final @NonNull UserDtoMapper userDtoMapper;
   private final @NonNull UsernameTranscoder usernameTranscoder;
 
@@ -57,6 +59,7 @@ class UserTwoFactorAuthControllerDelegate {
     if (Boolean.parseBoolean(validationResult.get("created"))) {
       var patchMap = userDtoMapper.mapOf(validationResult.get("email"), authenticatedUser);
       accountManager.patchUser(patchMap);
+      accountInviteService.markTwoFactorActive(authenticatedUser.getUserId());
       return ResponseEntity.noContent().build();
     }
     if (Boolean.parseBoolean(validationResult.get("attemptsLeft"))) {
@@ -78,12 +81,17 @@ class UserTwoFactorAuthControllerDelegate {
             oneTimePasswordDTO.getOtp(),
             oneTimePasswordDTO.getSecret());
 
-    return isValid ? ResponseEntity.ok().build() : ResponseEntity.badRequest().build();
+    if (isValid) {
+      accountInviteService.markTwoFactorActive(authenticatedUser.getUserId());
+      return ResponseEntity.ok().build();
+    }
+    return ResponseEntity.badRequest().build();
   }
 
   ResponseEntity<Void> deactivateTwoFactorAuthByApp() {
     identityManager.deleteOneTimePassword(
         usernameTranscoder.encodeUsername(authenticatedUser.getUsername()));
+    accountInviteService.markTwoFactorPendingSetup(authenticatedUser.getUserId());
 
     return new ResponseEntity<>(HttpStatus.OK);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -3,7 +3,9 @@ package de.caritas.cob.userservice.api.port.out;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,4 +30,7 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
       @Param("targetRole") AccountInviteTargetRole targetRole,
       @Param("status") AccountInviteStatus status,
       Pageable pageable);
+
+  List<AccountInvite> findAllByAcceptedByUserIdAndTwoFactorStatus(
+      String acceptedByUserId, TwoFactorGateStatus twoFactorStatus);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -191,6 +191,10 @@ public class AccountInviteService {
     return AccountAccessGateStatus.READY;
   }
 
+  public AccountInvite waiveTwoFactor(Long inviteId, WaiveTwoFactorCommand command) {
+    return waiveTwoFactor(findInvite(inviteId), command);
+  }
+
   public AccountInvite waiveTwoFactor(AccountInvite invite, WaiveTwoFactorCommand command) {
     if (invite == null) {
       throw new BadRequestException("Invite is required");
@@ -198,11 +202,44 @@ public class AccountInviteService {
     if (command == null || isBlank(command.reason())) {
       throw new BadRequestException("Waiver reason is required");
     }
+    LocalDateTime now = LocalDateTime.now();
     invite.setTwoFactorStatus(TwoFactorGateStatus.WAIVED);
     invite.setTwoFactorWaivedBy(authenticatedUser.getUserId());
-    invite.setTwoFactorWaivedAt(LocalDateTime.now());
+    invite.setTwoFactorWaivedAt(now);
     invite.setTwoFactorWaiverReason(command.reason());
+    invite.setUpdateDate(now);
+    accountInviteRepository.save(invite);
     return invite;
+  }
+
+  /** Marks pending invite gates as satisfied once the user has an OTP credential. */
+  public void markTwoFactorActive(String userId) {
+    transitionTwoFactorStatus(
+        userId, TwoFactorGateStatus.PENDING_SETUP, TwoFactorGateStatus.ACTIVE);
+  }
+
+  /** Re-opens the gate when the user deletes their OTP credential (waivers stay untouched). */
+  public void markTwoFactorPendingSetup(String userId) {
+    transitionTwoFactorStatus(
+        userId, TwoFactorGateStatus.ACTIVE, TwoFactorGateStatus.PENDING_SETUP);
+  }
+
+  private void transitionTwoFactorStatus(
+      String userId, TwoFactorGateStatus from, TwoFactorGateStatus to) {
+    if (isBlank(userId)) {
+      return;
+    }
+    var invites = accountInviteRepository.findAllByAcceptedByUserIdAndTwoFactorStatus(userId, from);
+    if (invites.isEmpty()) {
+      return;
+    }
+    LocalDateTime now = LocalDateTime.now();
+    invites.forEach(
+        invite -> {
+          invite.setTwoFactorStatus(to);
+          invite.setUpdateDate(now);
+        });
+    accountInviteRepository.saveAll(invites);
   }
 
   private InviteSendResult sendInvite(

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ class UserTwoFactorAuthControllerDelegateTest {
   @Mock private IdentityClientConfig identityClientConfig;
   @Mock private IdentityManaging identityManager;
   @Mock private AccountManaging accountManager;
+  @Mock private AccountInviteService accountInviteService;
   @Mock private UserDtoMapper userDtoMapper;
   @Mock private UsernameTranscoder usernameTranscoder;
 
@@ -104,6 +106,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     verify(accountManager).patchUser(patchMap);
+    verify(accountInviteService).markTwoFactorActive(authenticatedUser.getUserId());
   }
 
   @Test
@@ -186,12 +189,14 @@ class UserTwoFactorAuthControllerDelegateTest {
   void activateTwoFactorAuthByAppShouldReturnOkWhenOtpIsAccepted() {
     allowOtpForCurrentRoles();
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
+    when(authenticatedUser.getUserId()).thenReturn("user-1");
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.setUpOneTimePassword(ENCODED_USERNAME, OTP, SECRET)).thenReturn(true);
 
     var response = delegate.activateTwoFactorAuthByApp(oneTimePassword());
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(accountInviteService).markTwoFactorActive("user-1");
   }
 
   @Test
@@ -204,17 +209,20 @@ class UserTwoFactorAuthControllerDelegateTest {
     var response = delegate.activateTwoFactorAuthByApp(oneTimePassword());
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    verifyNoInteractions(accountInviteService);
   }
 
   @Test
   void deactivateTwoFactorAuthByAppShouldDeleteOtpForAuthenticatedUser() {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
+    when(authenticatedUser.getUserId()).thenReturn("user-1");
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
 
     var response = delegate.deactivateTwoFactorAuthByApp();
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     verify(identityManager).deleteOneTimePassword(ENCODED_USERNAME);
+    verify(accountInviteService).markTwoFactorPendingSetup("user-1");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +22,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -577,11 +579,72 @@ class AccountInviteServiceTest {
     assertThat(service.calculateAccessGate(invite)).isEqualTo(AccountAccessGateStatus.READY);
   }
 
+  // --- two-factor gate transitions ---
+
+  @Test
+  void markTwoFactorActive_Should_transitionPendingInvitesToActive() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .acceptedByUserId("user-1")
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .build();
+    when(accountInviteRepository.findAllByAcceptedByUserIdAndTwoFactorStatus(
+            "user-1", TwoFactorGateStatus.PENDING_SETUP))
+        .thenReturn(List.of(invite));
+
+    service.markTwoFactorActive("user-1");
+
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.ACTIVE);
+    verify(accountInviteRepository).saveAll(List.of(invite));
+  }
+
+  @Test
+  void markTwoFactorPendingSetup_Should_reopenActiveGates() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .acceptedByUserId("user-1")
+            .twoFactorStatus(TwoFactorGateStatus.ACTIVE)
+            .build();
+    when(accountInviteRepository.findAllByAcceptedByUserIdAndTwoFactorStatus(
+            "user-1", TwoFactorGateStatus.ACTIVE))
+        .thenReturn(List.of(invite));
+
+    service.markTwoFactorPendingSetup("user-1");
+
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+    verify(accountInviteRepository).saveAll(List.of(invite));
+  }
+
+  @Test
+  void markTwoFactorActive_Should_doNothing_When_userIdBlankOrNoMatches() {
+    service.markTwoFactorActive(" ");
+    verify(accountInviteRepository, never())
+        .findAllByAcceptedByUserIdAndTwoFactorStatus(any(), any());
+
+    when(accountInviteRepository.findAllByAcceptedByUserIdAndTwoFactorStatus(
+            "user-2", TwoFactorGateStatus.PENDING_SETUP))
+        .thenReturn(List.of());
+    service.markTwoFactorActive("user-2");
+    verify(accountInviteRepository, never()).saveAll(any());
+  }
+
+  @Test
+  void waiveTwoFactor_Should_persistWaivedInvite() {
+    AccountInvite invite =
+        AccountInvite.builder().twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP).build();
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+
+    service.waiveTwoFactor(invite, new WaiveTwoFactorCommand("four-eyes onboarding"));
+
+    verify(accountInviteRepository).save(invite);
+  }
+
   // --- waiveTwoFactor guards ---
 
   @Test
   void waiveTwoFactor_Should_throwBadRequest_When_inviteNull() {
-    assertThatThrownBy(() -> service.waiveTwoFactor(null, new WaiveTwoFactorCommand("reason")))
+    assertThatThrownBy(
+            () -> service.waiveTwoFactor((AccountInvite) null, new WaiveTwoFactorCommand("reason")))
         .isInstanceOf(BadRequestException.class);
   }
 


### PR DESCRIPTION
## Why

The account-invite two-factor gate (`TwoFactorGateStatus`) was scaffolding: counsellor invites default to `PENDING_SETUP`, but nothing ever transitioned the status — no path to `ACTIVE`, and `waiveTwoFactor` had no REST endpoint and never persisted. The gate could block counsellors (`BLOCKED_TWO_FACTOR`) with no way to satisfy it.

This lands together with [ORISO-Helm#55](https://github.com/OpenResilienceInitiative/ORISO-Helm/pull/55), which makes the underlying 2FA endpoints actually work (otp-config SPI in the Keycloak image).

## What

- `PENDING_SETUP → ACTIVE` when the user activates an OTP credential (app **and** email flow), `ACTIVE → PENDING_SETUP` when the credential is deleted. Waived invites stay untouched.
- New endpoint `POST /useradmin/account-invites/{inviteId}/waive-two-factor` (same admin authorities as the other invite admin routes; reason required) persisting `twoFactorWaivedBy/At/Reason`.
- `waiveTwoFactor` now persists; id-based overload for the controller.
- New repository finder `findAllByAcceptedByUserIdAndTwoFactorStatus`.

## Tests

- `AccountInviteServiceTest`: 4 new tests (transitions both ways, blank-user/no-match no-ops, waive persistence) — 50/50 green.
- `UserTwoFactorAuthControllerDelegateTest`: extended for the new wiring — 16/16 green.
- Note: `UserController2faE2EIT` fails on pre-dev with 28×401 **before this change** — the IT auth harness issue also hits other E2EITs (e.g. `UserControllerSessionE2EIT` 19/29 red); tracked by the test-quality audit, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)