### PR TITLE
fix: reset retained tenant filter for platform admins

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/tenant/TenantAspect.java
+++ b/src/main/java/de/caritas/cob/userservice/api/tenant/TenantAspect.java
@@ -20,12 +20,14 @@ public class TenantAspect {
 
   @Before("execution(* de.caritas.cob.userservice.api.port..*(..)))")
   public void beforeQueryAspect() {
+    var session = entityManager.unwrap(Session.class);
 
     if (TenantContext.isTechnicalOrSuperAdminContext()) {
+      session.disableFilter("tenantFilter");
       return;
     }
 
-    var filter = entityManager.unwrap(Session.class).enableFilter("tenantFilter");
+    var filter = session.enableFilter("tenantFilter");
     filter.setParameter("tenantId", TenantContext.getCurrentTenant());
     filter.validate();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/tenant/TenantAspectTenantFilterIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/tenant/TenantAspectTenantFilterIT.java
@@ -1,0 +1,72 @@
+package de.caritas.cob.userservice.api.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Admin.AdminType;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = {"spring.profiles.active=testing", "multitenancy.enabled=true"})
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+@Transactional
+class TenantAspectTenantFilterIT {
+
+  @Autowired private AdminRepository adminRepository;
+
+  @Autowired private EntityManager entityManager;
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void technicalContext_ShouldSeeAllTenants_AfterTenantScopedQueryOnSamePersistenceContext() {
+    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+    Admin tenantOneAdmin = admin("tenant-one-admin", 1L);
+    Admin tenantEightyThreeAdmin = admin("tenant-eighty-three-admin", 83L);
+    adminRepository.saveAll(Set.of(tenantOneAdmin, tenantEightyThreeAdmin));
+    entityManager.flush();
+    entityManager.clear();
+
+    TenantContext.setCurrentTenant(1L);
+    assertThat(
+            adminRepository.findAllByIdIn(
+                Set.of(tenantOneAdmin.getId(), tenantEightyThreeAdmin.getId())))
+        .extracting(Admin::getTenantId)
+        .containsExactly(1L);
+
+    entityManager.clear();
+    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+
+    assertThat(
+            adminRepository.findAllByIdIn(
+                Set.of(tenantOneAdmin.getId(), tenantEightyThreeAdmin.getId())))
+        .extracting(Admin::getTenantId)
+        .containsExactlyInAnyOrder(1L, 83L);
+  }
+
+  private Admin admin(String id, Long tenantId) {
+    return Admin.builder()
+        .id(id)
+        .tenantId(tenantId)
+        .username(id)
+        .firstName("E2E")
+        .lastName(id)
+        .email(id + "@synthetic.oriso.test")
+        .type(AdminType.TENANT)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

- disable a retained Hibernate tenant filter when repository access enters technical/platform-admin context
- keep normal tenant-scoped filtering unchanged
- add a same-persistence-context regression test that switches from tenant 1 to the technical tenant and proves cross-tenant visibility

## Why

The real PreDev Admin flow could create a consultant in tenant 83 but fail the immediate agency assignment with HTTP 400 because the platform-admin lookup inherited a tenant-1 filter from an earlier repository query.

## Verification

- RED: regression test returned only tenant 1 and missed tenant 83
- GREEN: focused regression test passes
- targeted tenant/consultant integration suite: 36 tests, 0 failures, 0 errors, 0 skipped
- full Java 21 package: 3,426 tests, 0 failures, 0 errors, 7 skipped
- final acceptance remains the real Admin UI create-and-assign flow after deployment to PreDev

Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)