### PR TITLE
fix: run tenant filter only after authentication

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/TenantFilterRegistrationConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/TenantFilterRegistrationConfig.java
@@ -1,0 +1,20 @@
+package de.caritas.cob.userservice.api.config.auth;
+
+import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.HttpTenantFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnExpression("${multitenancy.enabled:true}")
+class TenantFilterRegistrationConfig {
+
+  @Bean
+  FilterRegistrationBean<HttpTenantFilter> disableHttpTenantFilterContainerRegistration(
+      HttpTenantFilter tenantFilter) {
+    var registration = new FilterRegistrationBean<>(tenantFilter);
+    registration.setEnabled(false);
+    return registration;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterRegistrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterRegistrationIT.java
@@ -1,0 +1,44 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.ServletContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = UserServiceApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"spring.profiles.active=testing", "multitenancy.enabled=true"})
+class HttpTenantFilterRegistrationIT {
+
+  @Autowired private ServletContext servletContext;
+
+  @Autowired private FilterChainProxy securityFilterChain;
+
+  @Test
+  void httpTenantFilter_ShouldOnlyRunInsideSpringSecurityFilterChain() {
+    assertThat(servletContext.getFilterRegistrations().values())
+        .extracting(FilterRegistration::getClassName)
+        .doesNotContain(HttpTenantFilter.class.getName());
+  }
+
+  @Test
+  void httpTenantFilter_ShouldRunAfterBearerAuthentication() {
+    List<Class<?>> securityFilterTypes =
+        securityFilterChain.getFilterChains().stream()
+            .flatMap(filterChain -> filterChain.getFilters().stream())
+            .map(Object::getClass)
+            .toList();
+
+    assertThat(securityFilterTypes).containsOnlyOnce(HttpTenantFilter.class);
+    assertThat(securityFilterTypes.indexOf(HttpTenantFilter.class))
+        .isGreaterThan(securityFilterTypes.indexOf(BearerTokenAuthenticationFilter.class));
+  }
+}


### PR DESCRIPTION
## Summary

- disable the automatic servlet-container registration of `HttpTenantFilter`
- retain its explicit Spring Security registration after `BearerTokenAuthenticationFilter`
- add an embedded-server integration test for both registration boundaries

## Why

The first #401 repair correctly reset a retained Hibernate filter, but the real PreDev Admin retest still failed. Live diagnostics proved that the active platform-admin session claims tenant `0` while UserService resolved the same authenticated request as tenant `1`.

`HttpTenantFilter` was registered twice: automatically as a servlet filter because it is a Spring component, and explicitly inside Spring Security after bearer authentication. The servlet-container invocation ran before authentication and marked the `OncePerRequestFilter` as already processed, so the correctly ordered security-chain invocation was skipped.

## Verification

- RED: embedded servlet context contained `HttpTenantFilter` as a container filter
- GREEN: no container registration; exactly one security-chain occurrence after bearer authentication
- targeted filter/security/tenant suite: 19 tests, 0 failures, 0 errors, 0 skipped
- full Java 21 package: 3,428 tests, 0 failures, 0 errors, 7 skipped
- final acceptance remains the real PreDev Admin create-and-assign flow after deployment

Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)