### PR TITLE
fix: resolve tenant after request principal is available

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -31,9 +31,9 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
-import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
 /** Provides the Keycloak/Spring Security configuration. */
@@ -382,7 +382,7 @@ public class SecurityConfig {
    */
   private void enableTenantFilterIfMultitenancyEnabled(HttpSecurity http) {
     if (multitenancy && tenantFilter != null) {
-      http.addFilterAfter(tenantFilter, BearerTokenAuthenticationFilter.class);
+      http.addFilterAfter(tenantFilter, SecurityContextHolderAwareRequestFilter.class);
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterRegistrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterRegistrationIT.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(classes = UserServiceApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -30,7 +30,7 @@ class HttpTenantFilterRegistrationIT {
   }
 
   @Test
-  void httpTenantFilter_ShouldRunAfterBearerAuthentication() {
+  void httpTenantFilter_ShouldRunAfterRequestPrincipalIsAvailable() {
     List<Class<?>> securityFilterTypes =
         securityFilterChain.getFilterChains().stream()
             .flatMap(filterChain -> filterChain.getFilters().stream())
@@ -39,6 +39,6 @@ class HttpTenantFilterRegistrationIT {
 
     assertThat(securityFilterTypes).containsOnlyOnce(HttpTenantFilter.class);
     assertThat(securityFilterTypes.indexOf(HttpTenantFilter.class))
-        .isGreaterThan(securityFilterTypes.indexOf(BearerTokenAuthenticationFilter.class));
+        .isGreaterThan(securityFilterTypes.indexOf(SecurityContextHolderAwareRequestFilter.class));
   }
 }


### PR DESCRIPTION
## Summary

- move `HttpTenantFilter` behind `SecurityContextHolderAwareRequestFilter`
- keep the single security-chain registration introduced by #403
- tighten the embedded-server filter-order regression to the actual request-principal contract

## Why

Live PreDev TRACE after #403 proved this sequence:

1. `BearerTokenAuthenticationFilter` at 9/17
2. `HttpTenantFilter` at 10/17
3. request-principal wrapping later in the chain

The exact Admin consultant-search request carried a bearer JWT with tenant `0`, but the tenant resolver reads `request.getUserPrincipal()`. At filter position 10 that principal was not yet exposed on the servlet request, so the resolver treated the request as unauthenticated and fell back to the single-domain main tenant `1`.

## Verification

- RED: TenantFilter index 9 was not greater than principal-wrapper index 12
- GREEN: TenantFilter runs exactly once after `SecurityContextHolderAwareRequestFilter`
- targeted filter/security/tenant suite: 19 tests, 0 failures, 0 errors, 0 skipped
- full Java 21 package: 3,428 tests, 0 failures, 0 errors, 7 skipped
- final acceptance remains live tenant resolution `0` plus agency assignment through the PreDev Admin UI

Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)