### PR TITLE
Fix stale tenant feature gate for group chats

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
@@ -32,4 +32,11 @@ public class TenantService {
         .createControllerApi()
         .getRestrictedTenantDataByTenantId(tenantId);
   }
+
+  public RestrictedTenantDTO getRestrictedTenantDataFresh(Long tenantId) {
+    log.info("Calling tenant service for current tenant data for tenantId {}", tenantId);
+    return tenantServiceApiControllerFactory
+        .createControllerApi()
+        .getRestrictedTenantDataByTenantId(tenantId);
+  }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGate.java
@@ -19,7 +19,7 @@ public class GroupChatFeatureGate {
       throw disabled();
     }
 
-    var tenant = tenantService.getRestrictedTenantData(consultant.getTenantId());
+    var tenant = tenantService.getRestrictedTenantDataFresh(consultant.getTenantId());
     if (tenant == null
         || tenant.getSettings() == null
         || !Boolean.TRUE.equals(tenant.getSettings().getFeatureGroupChatV2Enabled())) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
@@ -148,6 +148,20 @@ class TenantServiceTest {
       assertThat(tenantControllerApi.tenantIdCalls.get()).isEqualTo(1);
     }
 
+    @Test
+    void getRestrictedTenantDataFresh_afterCachedLookup_returnsCurrentApiValue() {
+      var disabled = new RestrictedTenantDTO().id(TENANT_ID).name("Disabled");
+      var enabled = new RestrictedTenantDTO().id(TENANT_ID).name("Enabled");
+      tenantControllerApi.tenantIdResult = disabled;
+
+      assertThat(cachedTenantService.getRestrictedTenantData(TENANT_ID)).isSameAs(disabled);
+
+      tenantControllerApi.tenantIdResult = enabled;
+
+      assertThat(cachedTenantService.getRestrictedTenantDataFresh(TENANT_ID)).isSameAs(enabled);
+      assertThat(tenantControllerApi.tenantIdCalls.get()).isEqualTo(2);
+    }
+
     // Each subdomain is a distinct cache entry for multitenancy routing.
     @Test
     void getRestrictedTenantData_differentSubdomains_callsApiForEach() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatFeatureGateTest.java
@@ -30,7 +30,7 @@ class GroupChatFeatureGateTest {
   @Test
   void enabledTenantMayCreateSelfHelpGroupSeries() {
     when(consultant.getTenantId()).thenReturn(7L);
-    when(tenantService.getRestrictedTenantData(7L))
+    when(tenantService.getRestrictedTenantDataFresh(7L))
         .thenReturn(
             new RestrictedTenantDTO()
                 .id(7L)
@@ -43,7 +43,7 @@ class GroupChatFeatureGateTest {
   @Test
   void disabledTenantMayNotCreateSelfHelpGroupSeries() {
     when(consultant.getTenantId()).thenReturn(7L);
-    when(tenantService.getRestrictedTenantData(7L))
+    when(tenantService.getRestrictedTenantDataFresh(7L))
         .thenReturn(
             new RestrictedTenantDTO()
                 .id(7L)


### PR DESCRIPTION
## Summary

- bypass the 24-hour tenant cache only for the group-chat feature gate
- preserve all existing cached tenant lookups
- add regression coverage proving a cached disabled value does not mask a freshly enabled tenant

## Verification

- TDD red: `getRestrictedTenantDataFresh` did not exist and the regression tests failed to compile
- focused: 15 tests, 0 failures/errors
- full UserService: 3,407 tests, 0 failures/errors, 7 skipped
- Spotless and compilation green
- CodeRabbit CLI: 0 findings across 4 files

Closes #405

Base and deployment target: `pre-dev` only. No dev merge or deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)