### PR TITLE
Fix tenant resolution for public asker registration

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -358,7 +358,7 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring().requestMatchers("/actuator/**", "/users/askers/new");
+    return web -> web.ignoring().requestMatchers("/actuator/**");
   }
 
   @Bean

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/SecurityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/SecurityConfigTest.java
@@ -1,0 +1,30 @@
+package de.caritas.cob.userservice.api.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.config.CsrfSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+
+class SecurityConfigTest {
+
+  @Test
+  void publicAskerRegistrationShouldPassThroughSecurityFilterChain() {
+    var securityConfig = new SecurityConfig(mock(CsrfSecurityProperties.class), null, null);
+    var webSecurity = mock(WebSecurity.class);
+    var ignoredRequests = mock(WebSecurity.IgnoredRequestConfigurer.class);
+    when(webSecurity.ignoring()).thenReturn(ignoredRequests);
+
+    securityConfig.webSecurityCustomizer().customize(webSecurity);
+
+    var ignoredPaths = ArgumentCaptor.forClass(String[].class);
+    verify(ignoredRequests).requestMatchers(ignoredPaths.capture());
+    assertThat(ignoredPaths.getValue())
+        .containsExactly("/actuator/**")
+        .doesNotContain("/users/askers/new");
+  }
+}


### PR DESCRIPTION
## Summary

- keep public asker registration inside the Spring Security filter chain
- allow `HttpTenantFilter` to resolve the selected agency tenant from the existing `agencyId` header
- add focused regression coverage for the web-security bypass

## Root cause

`/users/askers/new` was both `permitAll` and excluded via `WebSecurityCustomizer`. The full exclusion bypassed `HttpTenantFilter`, so fresh registrations were persisted without tenant scope and every authenticated bootstrap request returned HTTP 403.

## Verification

- TDD red: regression test observed ignored paths `[/actuator/**, /users/askers/new]`
- TDD green: focused security and CSRF tests pass
- full suite: 3,382 tests, 0 failures, 0 errors, 7 skipped
- Spotless check passes
- CodeRabbit CLI: no findings

Closes #407

PreDev only; no merge or deployment to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)