### PR TITLE
Persist resolved tenant for fresh registrations

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -40,6 +40,7 @@ import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -217,6 +218,7 @@ public class SessionService {
     var session =
         Session.builder()
             .user(user)
+            .tenantId(TenantContext.getCurrentTenant())
             .consultingTypeId(obtainCheckedConsultingTypeId(extendedConsultingTypeResponseDTO))
             .registrationType(registrationType)
             .postcode(userDto.getPostcode())

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserMobileToken;
 import de.caritas.cob.userservice.api.port.out.UserMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import java.util.Optional;
 import lombok.NonNull;
@@ -73,6 +74,7 @@ public class UserService {
       boolean languageFormal,
       String preferredLanguage) {
     var user = new User(userId, oldId, username, email, languageFormal);
+    user.setTenantId(TenantContext.getCurrentTenant());
     auditingHandler.markCreated(user);
     if (nonNull(preferredLanguage)) {
       user.setLanguageCode(LanguageCode.valueOf(preferredLanguage));

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -74,6 +74,7 @@ import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.testHelper.TestConstants;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -289,6 +290,28 @@ class SessionServiceTest {
     assertThat(savedSession.getSessionTopics()).hasSize(2);
     assertThat(savedSession.getSessionTopics())
         .allMatch(topic -> topic.getSession() == savedSession);
+  }
+
+  @Test
+  void initializeSession_Should_PersistCurrentTenant() {
+    TenantContext.setCurrentTenant(83L);
+    when(sessionRepository.save(any(Session.class)))
+        .thenAnswer(
+            invocation -> {
+              Session persistedSession = invocation.getArgument(0);
+              assertEquals(83L, persistedSession.getTenantId());
+              return persistedSession;
+            });
+    when(consultingTypeManager.getConsultingTypeSettings(any()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_SUCHT);
+
+    try {
+      Session savedSession = sessionService.initializeSession(USER, USER_DTO, IS_TEAM_SESSION);
+
+      assertEquals(83L, savedSession.getTenantId());
+    } finally {
+      TenantContext.clear();
+    }
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/UserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/UserServiceTest.java
@@ -29,6 +29,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserMobileToken;
 import de.caritas.cob.userservice.api.port.out.UserMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Optional;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,26 @@ class UserServiceTest {
 
     assertNotNull(result);
     assertEquals(USER, result);
+  }
+
+  @Test
+  void createUser_Should_PersistCurrentTenant() {
+    TenantContext.setCurrentTenant(83L);
+    when(userRepository.save(Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              User persistedUser = invocation.getArgument(0);
+              assertEquals(83L, persistedUser.getTenantId());
+              return persistedUser;
+            });
+
+    try {
+      var result = userService.createUser(USER_ID, USERNAME, EMAIL, IS_LANGUAGE_FORMAL);
+
+      assertEquals(83L, result.getTenantId());
+    } finally {
+      TenantContext.clear();
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- explicitly persist the current tenant on newly created users
- explicitly persist the current tenant on newly created sessions
- cover both repository boundaries with focused TDD regressions

## Live PreDev evidence

#408 restored tenant resolution and changed post-registration bootstrap from HTTP 403 to tenant-83 requests. The subsequent lookup still failed because both persisted rows retained `tenant_id = NULL`. This follow-up satisfies the remaining persistence acceptance criterion in #407.

## Verification

- TDD red: both new tests observed `tenantId == null`
- TDD green: repository mock answers assert tenant 83 at save time
- full suite: 3,383 tests, 0 failures, 0 errors, 7 skipped
- Spotless check passes
- first CodeRabbit pass identified weak post-save assertions; tests were strengthened
- final CodeRabbit pass: no findings

Refs #407

PreDev only; no merge or deployment to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)