### PR TITLE
fix: prevent Matrix credential exposure in HTTP debug logs

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -7,6 +7,8 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomRespon
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixLoginRequestDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixPasswordUpdateRequestDTO;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
@@ -420,8 +422,9 @@ public class MatrixSynapseService {
       String transientPassword = UUID.randomUUID() + "-" + UUID.randomUUID();
       var adminHeaders = getClientHttpHeaders(adminToken);
       adminHeaders.setContentType(MediaType.APPLICATION_JSON);
-      var updateBody =
-          java.util.Map.<String, Object>of("password", transientPassword, "logout_devices", false);
+      var updateBody = new MatrixPasswordUpdateRequestDTO();
+      updateBody.setPassword(transientPassword);
+      updateBody.setLogoutDevices(false);
       var updateUri =
           MatrixUrlBuilder.buildUrl(
               matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
@@ -433,12 +436,12 @@ public class MatrixSynapseService {
 
       var loginHeaders = new HttpHeaders();
       loginHeaders.setContentType(MediaType.APPLICATION_JSON);
-      var loginBody = new java.util.HashMap<String, Object>();
-      loginBody.put("type", "m.login.password");
-      loginBody.put("user", matrixUserId);
-      loginBody.put("password", transientPassword);
-      loginBody.put("device_id", deviceId);
-      loginBody.put("initial_device_display_name", "ORISO Web");
+      var loginBody = new MatrixLoginRequestDTO();
+      loginBody.setType("m.login.password");
+      loginBody.setUser(matrixUserId);
+      loginBody.setPassword(transientPassword);
+      loginBody.setDeviceId(deviceId);
+      loginBody.setInitialDeviceDisplayName("ORISO Web");
 
       var response =
           restTemplate.postForEntity(
@@ -728,12 +731,12 @@ public class MatrixSynapseService {
       var headers = new HttpHeaders();
       headers.setContentType(MediaType.APPLICATION_JSON);
 
-      var loginRequest = new java.util.HashMap<String, Object>();
-      loginRequest.put("type", "m.login.password");
-      loginRequest.put("user", username);
-      loginRequest.put("password", password);
+      var loginRequest = new MatrixLoginRequestDTO();
+      loginRequest.setType("m.login.password");
+      loginRequest.setUser(username);
+      loginRequest.setPassword(password);
 
-      HttpEntity<java.util.Map<String, Object>> request = new HttpEntity<>(loginRequest, headers);
+      HttpEntity<MatrixLoginRequestDTO> request = new HttpEntity<>(loginRequest, headers);
 
       var url = matrixConfig.getApiUrl(ENDPOINT_LOGIN);
       log.info("Logging in Matrix user: {} at URL: {}", username, url);

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixLoginRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixLoginRequestDTO.java
@@ -1,0 +1,26 @@
+package de.caritas.cob.userservice.api.adapters.matrix.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO for Matrix password login requests. Deliberately has no {@code toString} so framework-level
+ * request logging (e.g. RestTemplate DEBUG "Writing [...]") can never expose the password.
+ */
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MatrixLoginRequestDTO {
+
+  private String type;
+  private String user;
+  private String password;
+
+  @JsonProperty("device_id")
+  private String deviceId;
+
+  @JsonProperty("initial_device_display_name")
+  private String initialDeviceDisplayName;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixPasswordUpdateRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixPasswordUpdateRequestDTO.java
@@ -1,0 +1,20 @@
+package de.caritas.cob.userservice.api.adapters.matrix.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO for the Synapse admin password update request. Deliberately has no {@code toString} so
+ * framework-level request logging (e.g. RestTemplate DEBUG "Writing [...]") can never expose the
+ * password.
+ */
+@Getter
+@Setter
+public class MatrixPasswordUpdateRequestDTO {
+
+  private String password;
+
+  @JsonProperty("logout_devices")
+  private boolean logoutDevices;
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceCredentialLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceCredentialLoggingTest.java
@@ -1,0 +1,154 @@
+package de.caritas.cob.userservice.api.adapters.matrix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Regression for the PreDev finding that Spring's {@link RestTemplate} DEBUG logging serialized
+ * outbound Matrix credential bodies ("Writing [...]"), leaking the service-account password into
+ * pod logs. The wire request must keep carrying the credential while no log line may contain it,
+ * regardless of the configured log level.
+ */
+class MatrixSynapseServiceCredentialLoggingTest {
+
+  private static final String MATRIX_BASE_URL = "https://matrix.example.com";
+  private static final String LOGIN_URL = MATRIX_BASE_URL + "/_matrix/client/r0/login";
+  private static final String ADMIN_USERNAME = "matrix-admin";
+  private static final String ADMIN_PASSWORD = "super-secret-matrix-password";
+  private static final String MATRIX_USER_ID = "@consultant:matrix.example.com";
+  private static final String DEVICE_ID = "ORISOWEBDEVICE01";
+
+  private RestTemplate restTemplate;
+  private MockRestServiceServer mockServer;
+  private MatrixSynapseService service;
+
+  private Logger restTemplateLogger;
+  private Level previousLevel;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void setUp() {
+    restTemplate = new RestTemplate();
+    mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+
+    var matrixConfig = new MatrixConfig();
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    matrixConfig.setAdminUsername(ADMIN_USERNAME);
+    matrixConfig.setAdminPassword(ADMIN_PASSWORD);
+
+    service =
+        new MatrixSynapseService(
+            matrixConfig,
+            restTemplate,
+            restTemplate,
+            mock(MatrixRoomClient.class),
+            mock(MatrixMediaClient.class));
+
+    restTemplateLogger = (Logger) LoggerFactory.getLogger(RestTemplate.class);
+    previousLevel = restTemplateLogger.getLevel();
+    restTemplateLogger.setLevel(Level.DEBUG);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    restTemplateLogger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    restTemplateLogger.detachAppender(logAppender);
+    restTemplateLogger.setLevel(previousLevel);
+  }
+
+  @Test
+  void loginUserShouldNotExposePasswordInRestTemplateDebugLogs() {
+    mockServer
+        .expect(requestTo(LOGIN_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(jsonPath("$.type").value("m.login.password"))
+        .andExpect(jsonPath("$.user").value(ADMIN_USERNAME))
+        .andExpect(jsonPath("$.password").value(ADMIN_PASSWORD))
+        .andRespond(withSuccess("{\"access_token\":\"syt_token\"}", MediaType.APPLICATION_JSON));
+
+    var accessToken = service.loginUser(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    mockServer.verify();
+    assertThat(accessToken).isEqualTo("syt_token");
+    assertThat(bodyWriteLogs()).isNotEmpty();
+    assertThat(allLogMessages()).noneMatch(message -> message.contains(ADMIN_PASSWORD));
+  }
+
+  @Test
+  void loginBrowserDeviceShouldNotExposeAnyPasswordInRestTemplateDebugLogs() throws Exception {
+    var sentPasswords = new java.util.ArrayList<String>();
+    var objectMapper = new ObjectMapper();
+
+    mockServer
+        .expect(requestTo(LOGIN_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(jsonPath("$.user").value(ADMIN_USERNAME))
+        .andRespond(withSuccess("{\"access_token\":\"syt_admin\"}", MediaType.APPLICATION_JSON));
+    mockServer
+        .expect(requestTo(Matchers.containsString("/_synapse/admin/v2/users/")))
+        .andExpect(method(HttpMethod.PUT))
+        .andExpect(jsonPath("$.logout_devices").value(false))
+        .andExpect(
+            request ->
+                sentPasswords.add(
+                    objectMapper
+                        .readTree(((MockClientHttpRequest) request).getBodyAsString())
+                        .path("password")
+                        .asText()))
+        .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+    mockServer
+        .expect(requestTo(LOGIN_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(jsonPath("$.user").value(MATRIX_USER_ID))
+        .andExpect(jsonPath("$.device_id").value(DEVICE_ID))
+        .andRespond(
+            withSuccess(
+                "{\"access_token\":\"syt_device\",\"device_id\":\"" + DEVICE_ID + "\"}",
+                MediaType.APPLICATION_JSON));
+
+    var loginResponse = service.loginBrowserDevice(MATRIX_USER_ID, DEVICE_ID);
+
+    mockServer.verify();
+    assertThat(loginResponse).containsEntry("access_token", "syt_device");
+    assertThat(sentPasswords).hasSize(1);
+    var transientPassword = sentPasswords.get(0);
+    assertThat(transientPassword).isNotBlank();
+    assertThat(bodyWriteLogs()).isNotEmpty();
+    assertThat(allLogMessages())
+        .noneMatch(message -> message.contains(ADMIN_PASSWORD))
+        .noneMatch(message -> message.contains(transientPassword));
+  }
+
+  private List<String> allLogMessages() {
+    return logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+  }
+
+  /** Guards against vacuous passes: the body-write DEBUG line must actually be captured. */
+  private List<String> bodyWriteLogs() {
+    return allLogMessages().stream().filter(message -> message.startsWith("Writing [")).toList();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -13,6 +13,8 @@ import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixLoginRequestDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixPasswordUpdateRequestDTO;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -696,24 +698,21 @@ class MatrixSynapseServiceTest {
         .containsEntry("device_id", "ORISO_WEB_DEVICE_ONE");
     verify(restTemplate)
         .exchange(eq(updateUri), eq(HttpMethod.PUT), updateRequest.capture(), eq(Map.class));
-    @SuppressWarnings("unchecked")
-    var updateBody = (Map<String, Object>) updateRequest.getValue().getBody();
-    assertThat(updateBody).containsEntry("logout_devices", false).containsKey("password");
-    assertThat(String.valueOf(updateBody.get("password"))).hasSizeGreaterThanOrEqualTo(32);
+    var updateBody = (MatrixPasswordUpdateRequestDTO) updateRequest.getValue().getBody();
+    assertThat(updateBody.isLogoutDevices()).isFalse();
+    assertThat(updateBody.getPassword()).hasSizeGreaterThanOrEqualTo(32);
 
     verify(restTemplate, times(2))
         .postForEntity(
             eq(MATRIX_BASE_URL + "/_matrix/client/r0/login"),
             loginRequest.capture(),
             eq(Map.class));
-    @SuppressWarnings("unchecked")
-    var browserLoginBody = (Map<String, Object>) loginRequest.getAllValues().get(1).getBody();
-    assertThat(browserLoginBody)
-        .containsEntry("type", "m.login.password")
-        .containsEntry("user", "@alice:example.org")
-        .containsEntry("device_id", "ORISO_WEB_DEVICE_ONE")
-        .containsEntry("initial_device_display_name", "ORISO Web");
-    assertThat(browserLoginBody.get("password")).isEqualTo(updateBody.get("password"));
+    var browserLoginBody = (MatrixLoginRequestDTO) loginRequest.getAllValues().get(1).getBody();
+    assertThat(browserLoginBody.getType()).isEqualTo("m.login.password");
+    assertThat(browserLoginBody.getUser()).isEqualTo("@alice:example.org");
+    assertThat(browserLoginBody.getDeviceId()).isEqualTo("ORISO_WEB_DEVICE_ONE");
+    assertThat(browserLoginBody.getInitialDeviceDisplayName()).isEqualTo("ORISO Web");
+    assertThat(browserLoginBody.getPassword()).isEqualTo(updateBody.getPassword());
   }
 
   @Test


### PR DESCRIPTION
## Why

On live PreDev, `RestTemplate` DEBUG logging serialized outbound Matrix credential bodies into pod logs (`Writing [{password=..., type=m.login.password, user=...}]`) — the Matrix service-account password on every startup sync login, and the transient browser-device passwords during E2EE device login. Recorded as Bug 2 of E2E run `e2e-20260711-1357`. Fixes #410.

## What

- RED: new `MatrixSynapseServiceCredentialLoggingTest` drives a real `RestTemplate` + `MockRestServiceServer` with the RestTemplate logger at DEBUG and a Logback list appender. It reproduced the exact live leak (`Writing [{password=super-secret-…`) for both `loginUser` and `loginBrowserDevice`, while also pinning the wire contract (JSON still carries the credential) and guarding against vacuous passes (a `Writing [` line must be captured).
- GREEN: the three raw map bodies are replaced with `MatrixLoginRequestDTO` and `MatrixPasswordUpdateRequestDTO` — plain `@Getter/@Setter` DTOs with no `toString()` (same convention as the existing `MatrixCreateUserRequestDTO`), so framework body logging can never expose the password at any log level. Jackson field mapping keeps the wire JSON byte-identical (`device_id`, `initial_device_display_name`, `logout_devices`; `NON_NULL` omits absent device fields exactly like the previous plain-login map).
- One existing test that cast the captured bodies to `Map` was adapted to the DTOs; its assertions are unchanged in substance.

## Verification

- Focused: `MatrixSynapseServiceCredentialLoggingTest` 2/2, `MatrixSynapseServiceTest` 52/52.
- Full Java 21 gate: 3,412 tests, 0 failures, 0 errors, 7 skipped; Spotless applied.

## Follow-ups (tracked on #410)

- Rotation of the already-leaked PreDev Matrix service-account password.
- Same `toString()` audit for the Keycloak login form body (`KeycloakAuthClient`).

PreDev only; no merge or deployment to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
