### PR TITLE
feat: tenant-scoped admin dashboard statistics endpoint (pre-dev)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AdminStatisticsController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AdminStatisticsController.java
@@ -1,0 +1,30 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService;
+import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.DashboardStatistics;
+import io.swagger.annotations.Api;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Serves aggregated counselling statistics for the admin dashboard.
+ *
+ * <p>Data source is exclusively the application-layer database (KDG compliance). The response is
+ * scoped to the caller: platform admins receive per-tenant rows, tenant admins receive their tenant
+ * plus per-agency rows, agency admins receive only their own agencies.
+ */
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "admin-statistics-controller")
+public class AdminStatisticsController {
+
+  private final @NonNull AdminDashboardStatisticsService adminDashboardStatisticsService;
+
+  @GetMapping({"/useradmin/statistics/dashboard", "/service/useradmin/statistics/dashboard"})
+  public ResponseEntity<DashboardStatistics> getDashboardStatistics() {
+    return ResponseEntity.ok(adminDashboardStatisticsService.buildDashboard());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -298,6 +298,12 @@ public class SecurityConfig {
                     "/useradmin/users/{userId:" + UUID_PATTERN + "}/identities",
                     "/service/useradmin/users/{userId:" + UUID_PATTERN + "}/identities")
                 .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT)
+                .requestMatchers(
+                    HttpMethod.GET,
+                    "/useradmin/statistics/dashboard",
+                    "/service/useradmin/statistics/dashboard")
+                .hasAnyAuthority(
+                    USER_ADMIN, TENANT_ADMIN, SINGLE_TENANT_ADMIN, RESTRICTED_AGENCY_ADMIN)
                 .requestMatchers("/useradmin", "/useradmin/**")
                 .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT)
                 .requestMatchers("/users/consultants/search")

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepository.java
@@ -1,0 +1,213 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.Session;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Read-only aggregate queries for the admin statistics dashboard.
+ *
+ * <p>All statistics are computed from the application-layer database only (KDG compliance). Native
+ * queries are used because Hibernate tenant filters do not apply to aggregations; therefore every
+ * query carries an explicit tenant restriction.
+ */
+public interface AdminStatisticsRepository extends Repository<Session, Long> {
+
+  interface GroupCountProjection {
+    Long getGroupId();
+
+    Long getTotal();
+  }
+
+  interface DailyCountProjection {
+    Long getGroupId();
+
+    java.sql.Date getDay();
+
+    Long getTotal();
+  }
+
+  interface TopicCountProjection {
+    Long getGroupId();
+
+    Long getTopicId();
+
+    Long getTotal();
+  }
+
+  /* ---------- tenant scope: grouped by agency ---------- */
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.agency_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id = :tenantId "
+              + "AND s.create_date >= :fromDate AND s.create_date < :toDate "
+              + "GROUP BY s.agency_id")
+  List<GroupCountProjection> countNewSessionsByAgency(
+      @Param("tenantId") Long tenantId,
+      @Param("fromDate") LocalDateTime fromDate,
+      @Param("toDate") LocalDateTime toDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.agency_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id = :tenantId AND s.status = 2 "
+              + "GROUP BY s.agency_id")
+  List<GroupCountProjection> countActiveCasesByAgency(@Param("tenantId") Long tenantId);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.agency_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id = :tenantId AND s.status = 2 "
+              + "AND s.update_date >= :since "
+              + "GROUP BY s.agency_id")
+  List<GroupCountProjection> countActiveSessionsSinceByAgency(
+      @Param("tenantId") Long tenantId, @Param("since") LocalDateTime since);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.agency_id AS groupId, CAST(s.create_date AS DATE) AS day, COUNT(*) AS total "
+              + "FROM session s "
+              + "WHERE s.tenant_id = :tenantId AND s.create_date >= :fromDate "
+              + "GROUP BY s.agency_id, CAST(s.create_date AS DATE)")
+  List<DailyCountProjection> countDailyNewSessionsByAgency(
+      @Param("tenantId") Long tenantId, @Param("fromDate") LocalDateTime fromDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.agency_id AS groupId, s.main_topic_id AS topicId, COUNT(*) AS total "
+              + "FROM session s "
+              + "WHERE s.tenant_id = :tenantId AND s.main_topic_id IS NOT NULL "
+              + "AND s.create_date >= :fromDate AND s.create_date < :toDate "
+              + "GROUP BY s.agency_id, s.main_topic_id")
+  List<TopicCountProjection> countSessionTopicsByAgency(
+      @Param("tenantId") Long tenantId,
+      @Param("fromDate") LocalDateTime fromDate,
+      @Param("toDate") LocalDateTime toDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT ca.agency_id AS groupId, COUNT(DISTINCT ca.consultant_id) AS total "
+              + "FROM consultant_agency ca "
+              + "JOIN consultant c ON c.consultant_id = ca.consultant_id "
+              + "WHERE ca.tenant_id = :tenantId "
+              + "AND ca.delete_date IS NULL AND c.delete_date IS NULL "
+              + "GROUP BY ca.agency_id")
+  List<GroupCountProjection> countConsultantsByAgency(@Param("tenantId") Long tenantId);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT COUNT(*) FROM consultant c "
+              + "WHERE c.tenant_id = :tenantId AND c.delete_date IS NULL")
+  long countConsultantsForTenant(@Param("tenantId") Long tenantId);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT ca.agency_id AS groupId, COUNT(DISTINCT c.id) AS total "
+              + "FROM chat c "
+              + "JOIN chat_agency ca ON ca.chat_id = c.id "
+              + "JOIN consultant co ON co.consultant_id = c.consultant_id_owner "
+              + "WHERE co.tenant_id = :tenantId "
+              + "AND COALESCE(c.create_date, c.initial_start_date) >= :fromDate "
+              + "AND COALESCE(c.create_date, c.initial_start_date) < :toDate "
+              + "GROUP BY ca.agency_id")
+  List<GroupCountProjection> countGroupChatsByAgency(
+      @Param("tenantId") Long tenantId,
+      @Param("fromDate") LocalDateTime fromDate,
+      @Param("toDate") LocalDateTime toDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT COUNT(DISTINCT c.id) FROM chat c "
+              + "JOIN consultant co ON co.consultant_id = c.consultant_id_owner "
+              + "WHERE co.tenant_id = :tenantId "
+              + "AND COALESCE(c.create_date, c.initial_start_date) >= :fromDate "
+              + "AND COALESCE(c.create_date, c.initial_start_date) < :toDate")
+  long countGroupChatsForTenant(
+      @Param("tenantId") Long tenantId,
+      @Param("fromDate") LocalDateTime fromDate,
+      @Param("toDate") LocalDateTime toDate);
+
+  /* ---------- platform scope: grouped by tenant ---------- */
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.tenant_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id IS NOT NULL "
+              + "AND s.create_date >= :fromDate AND s.create_date < :toDate "
+              + "GROUP BY s.tenant_id")
+  List<GroupCountProjection> countNewSessionsByTenant(
+      @Param("fromDate") LocalDateTime fromDate, @Param("toDate") LocalDateTime toDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.tenant_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id IS NOT NULL AND s.status = 2 "
+              + "GROUP BY s.tenant_id")
+  List<GroupCountProjection> countActiveCasesByTenant();
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.tenant_id AS groupId, COUNT(*) AS total FROM session s "
+              + "WHERE s.tenant_id IS NOT NULL AND s.status = 2 "
+              + "AND s.update_date >= :since "
+              + "GROUP BY s.tenant_id")
+  List<GroupCountProjection> countActiveSessionsSinceByTenant(@Param("since") LocalDateTime since);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.tenant_id AS groupId, CAST(s.create_date AS DATE) AS day, COUNT(*) AS total "
+              + "FROM session s "
+              + "WHERE s.tenant_id IS NOT NULL AND s.create_date >= :fromDate "
+              + "GROUP BY s.tenant_id, CAST(s.create_date AS DATE)")
+  List<DailyCountProjection> countDailyNewSessionsByTenant(
+      @Param("fromDate") LocalDateTime fromDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT s.tenant_id AS groupId, s.main_topic_id AS topicId, COUNT(*) AS total "
+              + "FROM session s "
+              + "WHERE s.tenant_id IS NOT NULL AND s.main_topic_id IS NOT NULL "
+              + "AND s.create_date >= :fromDate AND s.create_date < :toDate "
+              + "GROUP BY s.tenant_id, s.main_topic_id")
+  List<TopicCountProjection> countSessionTopicsByTenant(
+      @Param("fromDate") LocalDateTime fromDate, @Param("toDate") LocalDateTime toDate);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT c.tenant_id AS groupId, COUNT(*) AS total FROM consultant c "
+              + "WHERE c.tenant_id IS NOT NULL AND c.delete_date IS NULL "
+              + "GROUP BY c.tenant_id")
+  List<GroupCountProjection> countConsultantsByTenant();
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT co.tenant_id AS groupId, COUNT(DISTINCT c.id) AS total "
+              + "FROM chat c "
+              + "JOIN consultant co ON co.consultant_id = c.consultant_id_owner "
+              + "WHERE co.tenant_id IS NOT NULL "
+              + "AND COALESCE(c.create_date, c.initial_start_date) >= :fromDate "
+              + "AND COALESCE(c.create_date, c.initial_start_date) < :toDate "
+              + "GROUP BY co.tenant_id")
+  List<GroupCountProjection> countGroupChatsByTenant(
+      @Param("fromDate") LocalDateTime fromDate, @Param("toDate") LocalDateTime toDate);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsService.java
@@ -1,0 +1,611 @@
+package de.caritas.cob.userservice.api.service.statistics;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.DailyCountProjection;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.GroupCountProjection;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.TopicCountProjection;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Service;
+
+/**
+ * Builds the admin statistics dashboard from the application-layer database only (KDG compliance:
+ * no monitoring data, no message content, no per-client drill-down).
+ *
+ * <p>Re-identification protection (small-cell suppression): counselling statistics of a target
+ * (tenant or agency) are only returned when they aggregate over at least {@link
+ * #SMALL_CELL_MINIMUM_COUNSELORS} counsellor accounts. Otherwise the target is marked {@code
+ * suppressed} and all counselling metrics are omitted.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminDashboardStatisticsService {
+
+  public static final int SMALL_CELL_MINIMUM_COUNSELORS = 2;
+
+  private static final int CHART_WEEKS = 5;
+  private static final int TOPIC_MONTHS = 4;
+  private static final LocalDateTime EPOCH = LocalDateTime.of(1970, 1, 1, 0, 0);
+
+  private final @NonNull AdminStatisticsRepository adminStatisticsRepository;
+  private final @NonNull AdminAgencyRepository adminAgencyRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull Clock clock;
+  private final @NonNull Environment environment;
+
+  /**
+   * Dev-only escape hatch for end-to-end testing with small test datasets. Fail-closed: when the
+   * prod profile is active, suppression stays enforced regardless of this property.
+   */
+  @Value("${statistics.small-cell-suppression.enabled:true}")
+  private boolean smallCellSuppressionEnabled = true;
+
+  public enum TargetType {
+    TENANT,
+    AGENCY
+  }
+
+  public enum DashboardScope {
+    PLATFORM,
+    TENANT,
+    AGENCY
+  }
+
+  public record DashboardStatistics(
+      String generatedAt,
+      DashboardScope scope,
+      boolean suppressionDisabled,
+      List<TargetStatistics> targets) {}
+
+  public record TargetStatistics(
+      TargetType targetType,
+      Long tenantId,
+      Long agencyId,
+      long counselorCount,
+      boolean suppressed,
+      Metrics metrics,
+      List<DailyCount> dailyNewSessions,
+      List<MonthlyTopic> monthlyTopTopics,
+      PeriodCounts sessionCountsByPeriod,
+      PeriodCounts groupChatCountsByPeriod) {}
+
+  public record Metrics(
+      long enquiriesCurrentMonth,
+      long enquiriesPreviousMonth,
+      long activeCases,
+      long activeConversationsToday,
+      long groupChatsTotal) {}
+
+  public record DailyCount(String date, long count) {}
+
+  public record MonthlyTopic(String month, Long topicId, long sessionCount, int sharePercent) {}
+
+  public record PeriodCounts(
+      long today, long yesterday, long thisWeek, long total, long thisYear, long lastYear) {}
+
+  private record DateRanges(
+      LocalDateTime todayStart,
+      LocalDateTime tomorrowStart,
+      LocalDateTime yesterdayStart,
+      LocalDateTime weekStart,
+      LocalDateTime chartStart,
+      LocalDateTime currentMonthStart,
+      LocalDateTime nextMonthStart,
+      LocalDateTime previousMonthStart,
+      LocalDateTime yearStart,
+      LocalDateTime lastYearStart,
+      List<YearMonth> topicMonths) {}
+
+  /** Aggregated raw counts for one group (agency or tenant), before suppression. */
+  private record GroupData(
+      long counselorCount,
+      long enquiriesCurrentMonth,
+      long enquiriesPreviousMonth,
+      long activeCases,
+      long activeConversationsToday,
+      Map<String, Long> dailyNewSessions,
+      Map<String, Map<Long, Long>> topicCountsByMonth,
+      PeriodCounts sessionCountsByPeriod,
+      PeriodCounts groupChatCountsByPeriod) {}
+
+  public DashboardStatistics buildDashboard() {
+    var ranges = buildDateRanges();
+    var suppressionActive = resolveSuppressionActive();
+
+    if (authenticatedUser.isPlatformAdmin()) {
+      return buildPlatformDashboard(ranges, suppressionActive);
+    }
+    if (authenticatedUser.isTenantSuperAdmin() || authenticatedUser.isSingleTenantAdmin()) {
+      return buildTenantDashboard(ranges, resolveTenantId(), suppressionActive);
+    }
+    if (authenticatedUser.isRestrictedAgencyAdmin() || authenticatedUser.isAgencySuperAdmin()) {
+      return buildAgencyDashboard(ranges, resolveTenantId(), suppressionActive);
+    }
+    throw new ForbiddenException(
+        "User %s is not authorized to access admin statistics"
+            .formatted(authenticatedUser.getUserId()));
+  }
+
+  /**
+   * Small-cell suppression may only be switched off outside production. If the prod profile is
+   * active, the property is ignored and suppression stays enforced (fail-closed).
+   */
+  private boolean resolveSuppressionActive() {
+    if (smallCellSuppressionEnabled) {
+      return true;
+    }
+    if (environment.acceptsProfiles(Profiles.of("prod"))) {
+      log.warn(
+          "statistics.small-cell-suppression.enabled=false was requested, but the prod profile "
+              + "is active - small-cell suppression stays enforced (fail-closed)");
+      return true;
+    }
+    log.info("Small-cell suppression is DISABLED for admin statistics (non-production profile)");
+    return false;
+  }
+
+  private Long resolveTenantId() {
+    var contextTenant = TenantContext.getCurrentTenant();
+    if (contextTenant != null && !TenantContext.TECHNICAL_TENANT_ID.equals(contextTenant)) {
+      return contextTenant;
+    }
+    return authenticatedUser.getTenantId();
+  }
+
+  /* ---------- platform scope ---------- */
+
+  private DashboardStatistics buildPlatformDashboard(DateRanges ranges, boolean suppressionActive) {
+    var groups =
+        collectGroups(
+            ranges,
+            adminStatisticsRepository::countConsultantsByTenant,
+            adminStatisticsRepository::countNewSessionsByTenant,
+            adminStatisticsRepository::countActiveCasesByTenant,
+            adminStatisticsRepository::countActiveSessionsSinceByTenant,
+            adminStatisticsRepository::countDailyNewSessionsByTenant,
+            adminStatisticsRepository::countSessionTopicsByTenant,
+            adminStatisticsRepository::countGroupChatsByTenant);
+
+    var targets =
+        groups.entrySet().stream()
+            .filter(entry -> entry.getKey() != null)
+            .map(
+                entry ->
+                    toTargetStatistics(
+                        TargetType.TENANT,
+                        entry.getKey(),
+                        null,
+                        entry.getValue(),
+                        suppressionActive))
+            .toList();
+
+    return new DashboardStatistics(
+        OffsetDateTime.now(clock).toString(), DashboardScope.PLATFORM, !suppressionActive, targets);
+  }
+
+  /* ---------- tenant scope ---------- */
+
+  private DashboardStatistics buildTenantDashboard(
+      DateRanges ranges, Long tenantId, boolean suppressionActive) {
+    requireTenant(tenantId);
+    var groups = collectAgencyGroups(ranges, tenantId);
+    var targets = new ArrayList<TargetStatistics>();
+
+    targets.add(buildTenantTotalTarget(ranges, tenantId, groups, suppressionActive));
+    groups.entrySet().stream()
+        .filter(entry -> entry.getKey() != null)
+        .forEach(
+            entry ->
+                targets.add(
+                    toTargetStatistics(
+                        TargetType.AGENCY,
+                        tenantId,
+                        entry.getKey(),
+                        entry.getValue(),
+                        suppressionActive)));
+
+    return new DashboardStatistics(
+        OffsetDateTime.now(clock).toString(), DashboardScope.TENANT, !suppressionActive, targets);
+  }
+
+  /* ---------- agency scope ---------- */
+
+  private DashboardStatistics buildAgencyDashboard(
+      DateRanges ranges, Long tenantId, boolean suppressionActive) {
+    requireTenant(tenantId);
+    var allowedAgencyIds =
+        adminAgencyRepository.findByAdminId(authenticatedUser.getUserId()).stream()
+            .map(adminAgency -> adminAgency.getAgencyId())
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    var groups = collectAgencyGroups(ranges, tenantId);
+    var targets =
+        groups.entrySet().stream()
+            .filter(entry -> entry.getKey() != null && allowedAgencyIds.contains(entry.getKey()))
+            .map(
+                entry ->
+                    toTargetStatistics(
+                        TargetType.AGENCY,
+                        tenantId,
+                        entry.getKey(),
+                        entry.getValue(),
+                        suppressionActive))
+            .toList();
+
+    return new DashboardStatistics(
+        OffsetDateTime.now(clock).toString(), DashboardScope.AGENCY, !suppressionActive, targets);
+  }
+
+  private static void requireTenant(Long tenantId) {
+    if (tenantId == null) {
+      throw new ForbiddenException("No tenant context available for admin statistics");
+    }
+  }
+
+  /* ---------- group collection ---------- */
+
+  private Map<Long, GroupData> collectAgencyGroups(DateRanges ranges, Long tenantId) {
+    return collectGroups(
+        ranges,
+        () -> adminStatisticsRepository.countConsultantsByAgency(tenantId),
+        (from, to) -> adminStatisticsRepository.countNewSessionsByAgency(tenantId, from, to),
+        () -> adminStatisticsRepository.countActiveCasesByAgency(tenantId),
+        since -> adminStatisticsRepository.countActiveSessionsSinceByAgency(tenantId, since),
+        from -> adminStatisticsRepository.countDailyNewSessionsByAgency(tenantId, from),
+        (from, to) -> adminStatisticsRepository.countSessionTopicsByAgency(tenantId, from, to),
+        (from, to) -> adminStatisticsRepository.countGroupChatsByAgency(tenantId, from, to));
+  }
+
+  private interface RangeQuery {
+    List<GroupCountProjection> query(LocalDateTime from, LocalDateTime to);
+  }
+
+  private interface SinceQuery {
+    List<GroupCountProjection> query(LocalDateTime since);
+  }
+
+  private interface DailyQuery {
+    List<DailyCountProjection> query(LocalDateTime from);
+  }
+
+  private interface TopicQuery {
+    List<TopicCountProjection> query(LocalDateTime from, LocalDateTime to);
+  }
+
+  private interface PlainQuery {
+    List<GroupCountProjection> query();
+  }
+
+  @SuppressWarnings("java:S107")
+  private Map<Long, GroupData> collectGroups(
+      DateRanges ranges,
+      PlainQuery counselors,
+      RangeQuery newSessions,
+      PlainQuery activeCases,
+      SinceQuery activeSince,
+      DailyQuery daily,
+      TopicQuery topics,
+      RangeQuery groupChats) {
+
+    var counselorCounts = toCountMap(counselors.query());
+    var enquiriesCurrent =
+        toCountMap(newSessions.query(ranges.currentMonthStart(), ranges.nextMonthStart()));
+    var enquiriesPrevious =
+        toCountMap(newSessions.query(ranges.previousMonthStart(), ranges.currentMonthStart()));
+    var activeCaseCounts = toCountMap(activeCases.query());
+    var activeTodayCounts = toCountMap(activeSince.query(ranges.todayStart()));
+    var sessionPeriods = collectPeriodCounts(ranges, newSessions);
+    var chatPeriods = collectPeriodCounts(ranges, groupChats);
+    var dailyCounts = toDailyMap(daily.query(ranges.chartStart()));
+    var topicDistributions = collectTopicDistributions(ranges, topics);
+
+    var groupIds = new HashSet<Long>();
+    groupIds.addAll(counselorCounts.keySet());
+    groupIds.addAll(enquiriesCurrent.keySet());
+    groupIds.addAll(enquiriesPrevious.keySet());
+    groupIds.addAll(activeCaseCounts.keySet());
+    groupIds.addAll(sessionPeriods.keySet());
+    groupIds.addAll(chatPeriods.keySet());
+    groupIds.addAll(dailyCounts.keySet());
+    groupIds.addAll(topicDistributions.keySet());
+
+    var groups = new LinkedHashMap<Long, GroupData>();
+    for (var groupId : groupIds) {
+      groups.put(
+          groupId,
+          new GroupData(
+              counselorCounts.getOrDefault(groupId, 0L),
+              enquiriesCurrent.getOrDefault(groupId, 0L),
+              enquiriesPrevious.getOrDefault(groupId, 0L),
+              activeCaseCounts.getOrDefault(groupId, 0L),
+              activeTodayCounts.getOrDefault(groupId, 0L),
+              dailyCounts.getOrDefault(groupId, Map.of()),
+              topicDistributions.getOrDefault(groupId, Map.of()),
+              sessionPeriods.getOrDefault(groupId, zeroPeriods()),
+              chatPeriods.getOrDefault(groupId, zeroPeriods())));
+    }
+    return groups;
+  }
+
+  private Map<Long, PeriodCounts> collectPeriodCounts(DateRanges ranges, RangeQuery query) {
+    var today = toCountMap(query.query(ranges.todayStart(), ranges.tomorrowStart()));
+    var yesterday = toCountMap(query.query(ranges.yesterdayStart(), ranges.todayStart()));
+    var thisWeek = toCountMap(query.query(ranges.weekStart(), ranges.tomorrowStart()));
+    var total = toCountMap(query.query(EPOCH, ranges.tomorrowStart()));
+    var thisYear = toCountMap(query.query(ranges.yearStart(), ranges.tomorrowStart()));
+    var lastYear = toCountMap(query.query(ranges.lastYearStart(), ranges.yearStart()));
+
+    var groupIds = new HashSet<Long>();
+    groupIds.addAll(today.keySet());
+    groupIds.addAll(yesterday.keySet());
+    groupIds.addAll(thisWeek.keySet());
+    groupIds.addAll(total.keySet());
+    groupIds.addAll(thisYear.keySet());
+    groupIds.addAll(lastYear.keySet());
+
+    var result = new HashMap<Long, PeriodCounts>();
+    for (var groupId : groupIds) {
+      result.put(
+          groupId,
+          new PeriodCounts(
+              today.getOrDefault(groupId, 0L),
+              yesterday.getOrDefault(groupId, 0L),
+              thisWeek.getOrDefault(groupId, 0L),
+              total.getOrDefault(groupId, 0L),
+              thisYear.getOrDefault(groupId, 0L),
+              lastYear.getOrDefault(groupId, 0L)));
+    }
+    return result;
+  }
+
+  /** Returns groupId → (month → (topicId → session count)). */
+  private Map<Long, Map<String, Map<Long, Long>>> collectTopicDistributions(
+      DateRanges ranges, TopicQuery query) {
+    var result = new HashMap<Long, Map<String, Map<Long, Long>>>();
+    for (var month : ranges.topicMonths()) {
+      var from = month.atDay(1).atStartOfDay();
+      var to = month.plusMonths(1).atDay(1).atStartOfDay();
+      for (var row : query.query(from, to)) {
+        if (row.getTopicId() == null) {
+          continue;
+        }
+        result
+            .computeIfAbsent(row.getGroupId(), key -> new HashMap<>())
+            .computeIfAbsent(month.toString(), key -> new HashMap<>())
+            .merge(row.getTopicId(), row.getTotal() == null ? 0L : row.getTotal(), Long::sum);
+      }
+    }
+    return result;
+  }
+
+  /* ---------- target building ---------- */
+
+  private TargetStatistics buildTenantTotalTarget(
+      DateRanges ranges,
+      Long tenantId,
+      Map<Long, GroupData> agencyGroups,
+      boolean suppressionActive) {
+    var counselorCount = adminStatisticsRepository.countConsultantsForTenant(tenantId);
+    var chatPeriods =
+        new PeriodCounts(
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, ranges.todayStart(), ranges.tomorrowStart()),
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, ranges.yesterdayStart(), ranges.todayStart()),
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, ranges.weekStart(), ranges.tomorrowStart()),
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, EPOCH, ranges.tomorrowStart()),
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, ranges.yearStart(), ranges.tomorrowStart()),
+            adminStatisticsRepository.countGroupChatsForTenant(
+                tenantId, ranges.lastYearStart(), ranges.yearStart()));
+
+    var total = sumGroups(agencyGroups.values(), counselorCount, chatPeriods);
+    return toTargetStatistics(TargetType.TENANT, tenantId, null, total, suppressionActive);
+  }
+
+  private GroupData sumGroups(
+      Iterable<GroupData> groups, long counselorCount, PeriodCounts chatPeriods) {
+    long enquiriesCurrent = 0;
+    long enquiriesPrevious = 0;
+    long activeCases = 0;
+    long activeToday = 0;
+    long sessionsToday = 0;
+    long sessionsYesterday = 0;
+    long sessionsThisWeek = 0;
+    long sessionsTotal = 0;
+    long sessionsThisYear = 0;
+    long sessionsLastYear = 0;
+    var daily = new TreeMap<String, Long>();
+    var topicCountsByMonth = new HashMap<String, Map<Long, Long>>();
+
+    for (var group : groups) {
+      enquiriesCurrent += group.enquiriesCurrentMonth();
+      enquiriesPrevious += group.enquiriesPreviousMonth();
+      activeCases += group.activeCases();
+      activeToday += group.activeConversationsToday();
+      sessionsToday += group.sessionCountsByPeriod().today();
+      sessionsYesterday += group.sessionCountsByPeriod().yesterday();
+      sessionsThisWeek += group.sessionCountsByPeriod().thisWeek();
+      sessionsTotal += group.sessionCountsByPeriod().total();
+      sessionsThisYear += group.sessionCountsByPeriod().thisYear();
+      sessionsLastYear += group.sessionCountsByPeriod().lastYear();
+      group.dailyNewSessions().forEach((day, count) -> daily.merge(day, count, Long::sum));
+      group
+          .topicCountsByMonth()
+          .forEach(
+              (month, topicCounts) ->
+                  topicCounts.forEach(
+                      (topicId, count) ->
+                          topicCountsByMonth
+                              .computeIfAbsent(month, key -> new HashMap<>())
+                              .merge(topicId, count, Long::sum)));
+    }
+
+    return new GroupData(
+        counselorCount,
+        enquiriesCurrent,
+        enquiriesPrevious,
+        activeCases,
+        activeToday,
+        daily,
+        topicCountsByMonth,
+        new PeriodCounts(
+            sessionsToday,
+            sessionsYesterday,
+            sessionsThisWeek,
+            sessionsTotal,
+            sessionsThisYear,
+            sessionsLastYear),
+        chatPeriods);
+  }
+
+  private TargetStatistics toTargetStatistics(
+      TargetType targetType,
+      Long tenantId,
+      Long agencyId,
+      GroupData data,
+      boolean suppressionActive) {
+    var suppressed = suppressionActive && data.counselorCount() < SMALL_CELL_MINIMUM_COUNSELORS;
+
+    if (suppressed) {
+      return new TargetStatistics(
+          targetType,
+          tenantId,
+          agencyId,
+          data.counselorCount(),
+          true,
+          null,
+          List.of(),
+          List.of(),
+          null,
+          null);
+    }
+
+    var metrics =
+        new Metrics(
+            data.enquiriesCurrentMonth(),
+            data.enquiriesPreviousMonth(),
+            data.activeCases(),
+            data.activeConversationsToday(),
+            data.groupChatCountsByPeriod().total());
+    var daily =
+        data.dailyNewSessions().entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> new DailyCount(entry.getKey(), entry.getValue()))
+            .toList();
+
+    return new TargetStatistics(
+        targetType,
+        tenantId,
+        agencyId,
+        data.counselorCount(),
+        false,
+        metrics,
+        daily,
+        buildMonthlyTopTopics(data.topicCountsByMonth()),
+        data.sessionCountsByPeriod(),
+        data.groupChatCountsByPeriod());
+  }
+
+  private List<MonthlyTopic> buildMonthlyTopTopics(
+      Map<String, Map<Long, Long>> topicCountsByMonth) {
+    var monthlyTopics = new ArrayList<MonthlyTopic>();
+    for (var entry : new TreeMap<>(topicCountsByMonth).descendingMap().entrySet()) {
+      var counts = entry.getValue();
+      var monthTotal = counts.values().stream().mapToLong(Long::longValue).sum();
+      counts.entrySet().stream()
+          .max(Map.Entry.comparingByValue())
+          .ifPresent(
+              top ->
+                  monthlyTopics.add(
+                      new MonthlyTopic(
+                          entry.getKey(),
+                          top.getKey(),
+                          top.getValue(),
+                          monthTotal > 0
+                              ? Math.toIntExact(Math.round(top.getValue() * 100.0 / monthTotal))
+                              : 0)));
+    }
+    return monthlyTopics;
+  }
+
+  /* ---------- helpers ---------- */
+
+  private DateRanges buildDateRanges() {
+    var today = LocalDate.now(clock);
+    var weekStart = today.with(DayOfWeek.MONDAY);
+    var currentMonth = YearMonth.from(today);
+    var topicMonths = new ArrayList<YearMonth>();
+    for (int i = 0; i < TOPIC_MONTHS; i++) {
+      topicMonths.add(currentMonth.minusMonths(i));
+    }
+
+    return new DateRanges(
+        today.atStartOfDay(),
+        today.plusDays(1).atStartOfDay(),
+        today.minusDays(1).atStartOfDay(),
+        weekStart.atStartOfDay(),
+        weekStart.minusWeeks(CHART_WEEKS - 1L).atStartOfDay(),
+        currentMonth.atDay(1).atStartOfDay(),
+        currentMonth.plusMonths(1).atDay(1).atStartOfDay(),
+        currentMonth.minusMonths(1).atDay(1).atStartOfDay(),
+        today.withDayOfYear(1).atStartOfDay(),
+        today.withDayOfYear(1).minusYears(1).atStartOfDay(),
+        topicMonths);
+  }
+
+  private static Map<Long, Long> toCountMap(List<GroupCountProjection> rows) {
+    var result = new HashMap<Long, Long>();
+    for (var row : rows) {
+      result.merge(row.getGroupId(), row.getTotal() == null ? 0L : row.getTotal(), Long::sum);
+    }
+    return result;
+  }
+
+  private static Map<Long, Map<String, Long>> toDailyMap(List<DailyCountProjection> rows) {
+    var result = new HashMap<Long, Map<String, Long>>();
+    for (var row : rows) {
+      if (row.getDay() == null) {
+        continue;
+      }
+      result
+          .computeIfAbsent(row.getGroupId(), key -> new TreeMap<>())
+          .merge(
+              row.getDay().toLocalDate().toString(),
+              row.getTotal() == null ? 0L : row.getTotal(),
+              Long::sum);
+    }
+    return result;
+  }
+
+  private static PeriodCounts zeroPeriods() {
+    return new PeriodCounts(0, 0, 0, 0, 0, 0);
+  }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -103,3 +103,7 @@ spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}
 spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:}
 keycloak.ssl-required=none
+
+# KDG: small-cell suppression is always enforced in production (code additionally
+# fail-closes on the prod profile even if this value were flipped)
+statistics.small-cell-suppression.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -247,6 +247,10 @@ spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}
 spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:}
 statistics.enabled=false
 statistics.rabbitmq.exchange.name=statistics.topic
+# Small-cell suppression for the admin statistics dashboard (KDG re-identification
+# protection). May only be disabled in non-production environments for E2E testing;
+# the prod profile enforces suppression regardless of this value (fail-closed).
+statistics.small-cell-suppression.enabled=${STATISTICS_SMALL_CELL_SUPPRESSION_ENABLED:true}
 
 # ---------------- Video Chat ----------------
 videochat.e2e-encryption-enabled=false

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepositoryIT.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Executes every native query of {@link AdminStatisticsRepository} against the H2 testing schema.
+ * The goal is SQL syntax and projection-mapping validation; result correctness is covered by the
+ * service unit tests.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+class AdminStatisticsRepositoryIT {
+
+  private static final long TENANT_ID = 1L;
+  private static final LocalDateTime FROM = LocalDateTime.of(2026, 6, 1, 0, 0);
+  private static final LocalDateTime TO = LocalDateTime.of(2026, 8, 1, 0, 0);
+
+  @Autowired private AdminStatisticsRepository underTest;
+
+  @Test
+  void allTenantScopedQueriesShouldExecute() {
+    assertThat(underTest.countNewSessionsByAgency(TENANT_ID, FROM, TO)).isEmpty();
+    assertThat(underTest.countActiveCasesByAgency(TENANT_ID)).isEmpty();
+    assertThat(underTest.countActiveSessionsSinceByAgency(TENANT_ID, FROM)).isEmpty();
+    assertThat(underTest.countDailyNewSessionsByAgency(TENANT_ID, FROM)).isEmpty();
+    assertThat(underTest.countSessionTopicsByAgency(TENANT_ID, FROM, TO)).isEmpty();
+    assertThat(underTest.countConsultantsByAgency(TENANT_ID)).isEmpty();
+    assertThat(underTest.countConsultantsForTenant(TENANT_ID)).isZero();
+    assertThat(underTest.countGroupChatsByAgency(TENANT_ID, FROM, TO)).isEmpty();
+    assertThat(underTest.countGroupChatsForTenant(TENANT_ID, FROM, TO)).isZero();
+  }
+
+  @Test
+  void allPlatformScopedQueriesShouldExecute() {
+    assertThat(underTest.countNewSessionsByTenant(FROM, TO)).isEmpty();
+    assertThat(underTest.countActiveCasesByTenant()).isEmpty();
+    assertThat(underTest.countActiveSessionsSinceByTenant(FROM)).isEmpty();
+    assertThat(underTest.countDailyNewSessionsByTenant(FROM)).isEmpty();
+    assertThat(underTest.countSessionTopicsByTenant(FROM, TO)).isEmpty();
+    assertThat(underTest.countConsultantsByTenant()).isEmpty();
+    assertThat(underTest.countGroupChatsByTenant(FROM, TO)).isEmpty();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsServiceTest.java
@@ -1,0 +1,421 @@
+package de.caritas.cob.userservice.api.service.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AdminAgency;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.GroupCountProjection;
+import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.TopicCountProjection;
+import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.DashboardScope;
+import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.TargetType;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.sql.Date;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminDashboardStatisticsServiceTest {
+
+  private static final long TENANT_ID = 5L;
+  private static final long AGENCY_WITH_TEAM = 11L;
+  private static final long AGENCY_WITH_SINGLE_COUNSELOR = 12L;
+  private static final String ADMIN_USER_ID = "admin-user-id";
+
+  // Fixed clock: Saturday, 2026-07-11 in Europe/Berlin
+  private final Clock clock =
+      Clock.fixed(Instant.parse("2026-07-11T10:00:00Z"), ZoneId.of("Europe/Berlin"));
+
+  @Mock private AdminStatisticsRepository adminStatisticsRepository;
+  @Mock private AdminAgencyRepository adminAgencyRepository;
+
+  private AuthenticatedUser authenticatedUser;
+  private MockEnvironment mockEnvironment;
+  private AdminDashboardStatisticsService service;
+
+  @BeforeEach
+  void setUp() {
+    authenticatedUser = new AuthenticatedUser();
+    authenticatedUser.setUserId(ADMIN_USER_ID);
+    authenticatedUser.setUsername("admin");
+    authenticatedUser.setAccessToken("token");
+    authenticatedUser.setTenantId(TENANT_ID);
+    mockEnvironment = new MockEnvironment();
+    service =
+        new AdminDashboardStatisticsService(
+            adminStatisticsRepository,
+            adminAgencyRepository,
+            authenticatedUser,
+            clock,
+            mockEnvironment);
+    TenantContext.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  private static GroupCountProjection groupCount(Long groupId, long total) {
+    return new GroupCountProjection() {
+      @Override
+      public Long getGroupId() {
+        return groupId;
+      }
+
+      @Override
+      public Long getTotal() {
+        return total;
+      }
+    };
+  }
+
+  private static AdminStatisticsRepository.DailyCountProjection dailyCount(
+      Long groupId, String day, long total) {
+    return new AdminStatisticsRepository.DailyCountProjection() {
+      @Override
+      public Long getGroupId() {
+        return groupId;
+      }
+
+      @Override
+      public Date getDay() {
+        return Date.valueOf(day);
+      }
+
+      @Override
+      public Long getTotal() {
+        return total;
+      }
+    };
+  }
+
+  private static TopicCountProjection topicCount(Long groupId, Long topicId, long total) {
+    return new TopicCountProjection() {
+      @Override
+      public Long getGroupId() {
+        return groupId;
+      }
+
+      @Override
+      public Long getTopicId() {
+        return topicId;
+      }
+
+      @Override
+      public Long getTotal() {
+        return total;
+      }
+    };
+  }
+
+  private void givenEmptyTenantScopedQueries() {
+    lenient()
+        .when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countNewSessionsByAgency(any(), any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countActiveCasesByAgency(TENANT_ID))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countActiveSessionsSinceByAgency(any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countDailyNewSessionsByAgency(any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countSessionTopicsByAgency(any(), any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countGroupChatsByAgency(any(), any(), any()))
+        .thenReturn(List.of());
+    lenient().when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(0L);
+    lenient()
+        .when(adminStatisticsRepository.countGroupChatsForTenant(any(), any(), any()))
+        .thenReturn(0L);
+  }
+
+  private void givenTenantAdmin() {
+    authenticatedUser.setRoles(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    TenantContext.setCurrentTenant(TENANT_ID);
+  }
+
+  @Test
+  void buildDashboard_Should_ThrowForbidden_When_UserHasNoAdminRole() {
+    authenticatedUser.setRoles(Set.of(UserRole.CONSULTANT.getValue()));
+
+    assertThatThrownBy(() -> service.buildDashboard()).isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void buildDashboard_Should_ThrowForbidden_When_TenantAdminHasNoTenantContext() {
+    authenticatedUser.setRoles(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    authenticatedUser.setTenantId(null);
+
+    assertThatThrownBy(() -> service.buildDashboard()).isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void buildDashboard_Should_ReturnTenantScope_WithTenantTotalAndAgencyRows() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(
+            List.of(groupCount(AGENCY_WITH_TEAM, 3), groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 1)));
+    when(adminStatisticsRepository.countActiveCasesByAgency(TENANT_ID))
+        .thenReturn(
+            List.of(groupCount(AGENCY_WITH_TEAM, 7), groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 2)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(4L);
+
+    var dashboard = service.buildDashboard();
+
+    assertThat(dashboard.scope()).isEqualTo(DashboardScope.TENANT);
+    assertThat(dashboard.targets()).hasSize(3);
+
+    var tenantRow = dashboard.targets().get(0);
+    assertThat(tenantRow.targetType()).isEqualTo(TargetType.TENANT);
+    assertThat(tenantRow.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(tenantRow.agencyId()).isNull();
+    assertThat(tenantRow.counselorCount()).isEqualTo(4);
+    assertThat(tenantRow.suppressed()).isFalse();
+    // tenant total aggregates over ALL agencies, including individually suppressed ones
+    assertThat(tenantRow.metrics().activeCases()).isEqualTo(9);
+  }
+
+  @Test
+  void buildDashboard_Should_SuppressSmallCellAgencies_When_LessThanTwoCounselors() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(
+            List.of(groupCount(AGENCY_WITH_TEAM, 3), groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 1)));
+    when(adminStatisticsRepository.countActiveCasesByAgency(TENANT_ID))
+        .thenReturn(
+            List.of(groupCount(AGENCY_WITH_TEAM, 7), groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 2)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(4L);
+
+    var dashboard = service.buildDashboard();
+
+    var teamAgency =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(AGENCY_WITH_TEAM).equals(target.agencyId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(teamAgency.suppressed()).isFalse();
+    assertThat(teamAgency.metrics().activeCases()).isEqualTo(7);
+
+    var singleCounselorAgency =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(AGENCY_WITH_SINGLE_COUNSELOR).equals(target.agencyId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(singleCounselorAgency.suppressed()).isTrue();
+    assertThat(singleCounselorAgency.metrics()).isNull();
+    assertThat(singleCounselorAgency.sessionCountsByPeriod()).isNull();
+    assertThat(singleCounselorAgency.dailyNewSessions()).isEmpty();
+    assertThat(singleCounselorAgency.monthlyTopTopics()).isEmpty();
+  }
+
+  @Test
+  void buildDashboard_Should_ComputeTopTopicShares_ForTenantTotal() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_TEAM, 3)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(3L);
+    // current month: topic 100 has 3 sessions, topic 200 has 1 → top topic 100 with 75%
+    when(adminStatisticsRepository.countSessionTopicsByAgency(
+            any(), any(LocalDateTime.class), any(LocalDateTime.class)))
+        .thenAnswer(
+            invocation -> {
+              LocalDateTime from = invocation.getArgument(1);
+              if (from.getMonthValue() == 7) {
+                return List.of(
+                    topicCount(AGENCY_WITH_TEAM, 100L, 3), topicCount(AGENCY_WITH_TEAM, 200L, 1));
+              }
+              return List.of();
+            });
+
+    var dashboard = service.buildDashboard();
+
+    var tenantRow = dashboard.targets().get(0);
+    assertThat(tenantRow.monthlyTopTopics()).hasSize(1);
+    var topTopic = tenantRow.monthlyTopTopics().get(0);
+    assertThat(topTopic.month()).isEqualTo("2026-07");
+    assertThat(topTopic.topicId()).isEqualTo(100L);
+    assertThat(topTopic.sessionCount()).isEqualTo(3);
+    assertThat(topTopic.sharePercent()).isEqualTo(75);
+  }
+
+  @Test
+  void buildDashboard_Should_MapDailySessionCounts_ToSortedSeries() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_TEAM, 2)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(2L);
+    when(adminStatisticsRepository.countDailyNewSessionsByAgency(any(), any()))
+        .thenReturn(
+            List.of(
+                dailyCount(AGENCY_WITH_TEAM, "2026-07-10", 2),
+                dailyCount(AGENCY_WITH_TEAM, "2026-07-08", 1)));
+
+    var dashboard = service.buildDashboard();
+
+    var agencyRow =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(AGENCY_WITH_TEAM).equals(target.agencyId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(agencyRow.dailyNewSessions())
+        .extracting(AdminDashboardStatisticsService.DailyCount::date)
+        .containsExactly("2026-07-08", "2026-07-10");
+  }
+
+  @Test
+  void buildDashboard_Should_ReturnOnlyAssignedAgencies_ForRestrictedAgencyAdmin() {
+    authenticatedUser.setRoles(Set.of(UserRole.RESTRICTED_AGENCY_ADMIN.getValue()));
+    TenantContext.setCurrentTenant(TENANT_ID);
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_TEAM, 2), groupCount(99L, 5)));
+
+    var assignedAgency = new AdminAgency();
+    assignedAgency.setAgencyId(AGENCY_WITH_TEAM);
+    when(adminAgencyRepository.findByAdminId(anyString())).thenReturn(List.of(assignedAgency));
+
+    var dashboard = service.buildDashboard();
+
+    assertThat(dashboard.scope()).isEqualTo(DashboardScope.AGENCY);
+    assertThat(dashboard.targets())
+        .extracting(AdminDashboardStatisticsService.TargetStatistics::agencyId)
+        .containsExactly(AGENCY_WITH_TEAM);
+  }
+
+  @Test
+  void buildDashboard_Should_SkipSuppression_When_DisabledOutsideProduction() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 1)));
+    when(adminStatisticsRepository.countActiveCasesByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 2)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(1L);
+    ReflectionTestUtils.setField(service, "smallCellSuppressionEnabled", false);
+
+    var dashboard = service.buildDashboard();
+
+    assertThat(dashboard.suppressionDisabled()).isTrue();
+    var singleCounselorAgency =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(AGENCY_WITH_SINGLE_COUNSELOR).equals(target.agencyId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(singleCounselorAgency.suppressed()).isFalse();
+    assertThat(singleCounselorAgency.metrics()).isNotNull();
+    assertThat(singleCounselorAgency.metrics().activeCases()).isEqualTo(2);
+  }
+
+  @Test
+  void buildDashboard_Should_EnforceSuppression_When_DisabledButProdProfileActive() {
+    givenTenantAdmin();
+    givenEmptyTenantScopedQueries();
+    when(adminStatisticsRepository.countConsultantsByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 1)));
+    when(adminStatisticsRepository.countActiveCasesByAgency(TENANT_ID))
+        .thenReturn(List.of(groupCount(AGENCY_WITH_SINGLE_COUNSELOR, 2)));
+    when(adminStatisticsRepository.countConsultantsForTenant(TENANT_ID)).thenReturn(1L);
+    ReflectionTestUtils.setField(service, "smallCellSuppressionEnabled", false);
+    mockEnvironment.setActiveProfiles("prod");
+
+    var dashboard = service.buildDashboard();
+
+    // fail-closed: prod ignores the disable switch
+    assertThat(dashboard.suppressionDisabled()).isFalse();
+    var singleCounselorAgency =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(AGENCY_WITH_SINGLE_COUNSELOR).equals(target.agencyId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(singleCounselorAgency.suppressed()).isTrue();
+    assertThat(singleCounselorAgency.metrics()).isNull();
+  }
+
+  @Test
+  void buildDashboard_Should_ReturnPlatformScope_ForPlatformAdmin() {
+    authenticatedUser.setRoles(
+        Set.of(UserRole.TENANT_ADMIN.getValue(), UserRole.AGENCY_ADMIN.getValue()));
+    authenticatedUser.setTenantId(0L);
+    TenantContext.setCurrentTenant(0L);
+
+    lenient()
+        .when(adminStatisticsRepository.countConsultantsByTenant())
+        .thenReturn(List.of(groupCount(1L, 4), groupCount(2L, 1)));
+    lenient()
+        .when(adminStatisticsRepository.countNewSessionsByTenant(any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countActiveCasesByTenant())
+        .thenReturn(List.of(groupCount(1L, 10), groupCount(2L, 3)));
+    lenient()
+        .when(adminStatisticsRepository.countActiveSessionsSinceByTenant(any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countDailyNewSessionsByTenant(any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countSessionTopicsByTenant(any(), any()))
+        .thenReturn(List.of());
+    lenient()
+        .when(adminStatisticsRepository.countGroupChatsByTenant(any(), any()))
+        .thenReturn(List.of());
+
+    var dashboard = service.buildDashboard();
+
+    assertThat(dashboard.scope()).isEqualTo(DashboardScope.PLATFORM);
+    assertThat(dashboard.targets()).hasSize(2);
+
+    var tenantOne =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(1L).equals(target.tenantId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(tenantOne.targetType()).isEqualTo(TargetType.TENANT);
+    assertThat(tenantOne.suppressed()).isFalse();
+    assertThat(tenantOne.metrics().activeCases()).isEqualTo(10);
+
+    // tenant 2 has a single counselor and must be suppressed platform-wide as well
+    var tenantTwo =
+        dashboard.targets().stream()
+            .filter(target -> Long.valueOf(2L).equals(target.tenantId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(tenantTwo.suppressed()).isTrue();
+    assertThat(tenantTwo.metrics()).isNull();
+  }
+}


### PR DESCRIPTION
Cherry-pick of #390 (merged to dev) onto pre-dev — pre-dev is the integration branch actually deployed on the Pre-Dev cluster; the endpoint was missing there, causing authenticated 404 on /useradmin/statistics/dashboard.

Clean cherry-pick, no conflicts. Original review: #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)