### PR TITLE
fix: correct LocalDate/java.sql.Date projection mismatch in admin statistics dashboard

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepository.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.Session;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
@@ -25,7 +26,16 @@ public interface AdminStatisticsRepository extends Repository<Session, Long> {
   interface DailyCountProjection {
     Long getGroupId();
 
-    java.sql.Date getDay();
+    /**
+     * Backed by a native {@code CAST(... AS DATE)} projection. Declared as {@link LocalDate} rather
+     * than {@link java.sql.Date}: MariaDB's JDBC driver hands Spring's projection proxy a {@link
+     * LocalDate} for this column, and Spring Data has no registered converter from {@link
+     * LocalDate} to the concrete {@link java.sql.Date} class (only the reverse), which used to blow
+     * up with {@code UnsupportedOperationException: Cannot project java.time.LocalDate to
+     * java.sql.Date}. H2 (used by {@code AdminStatisticsRepositoryIT}) converts either type
+     * cleanly, which is why that divergence only surfaced against real MariaDB.
+     */
+    LocalDate getDay();
 
     Long getTotal();
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsService.java
@@ -597,10 +597,7 @@ public class AdminDashboardStatisticsService {
       }
       result
           .computeIfAbsent(row.getGroupId(), key -> new TreeMap<>())
-          .merge(
-              row.getDay().toLocalDate().toString(),
-              row.getTotal() == null ? 0L : row.getTotal(),
-              Long::sum);
+          .merge(row.getDay().toString(), row.getTotal() == null ? 0L : row.getTotal(), Long::sum);
     }
     return result;
   }

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepositoryMariaDbIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepositoryMariaDbIT.java
@@ -1,0 +1,113 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Regression test for the Pre-Dev incident (correlationId 2cbc3e28-de31-4772-89fa-06e1b24a5318):
+ * {@code GET /useradmin/statistics/dashboard} threw {@code UnsupportedOperationException: Cannot
+ * project java.time.LocalDate to java.sql.Date} against real MariaDB.
+ *
+ * <p>The plain H2 {@code @DataJpaTest} ({@link AdminStatisticsRepositoryIT}) cannot catch this: it
+ * asserts against an empty {@code session} table, so the {@code CAST(... AS DATE)} projection
+ * getter is never actually invoked, and even with rows H2's JDBC driver hands Spring's projection
+ * proxy a value that converts cleanly to the (previously) declared {@code java.sql.Date} getter.
+ * MariaDB's JDBC driver returns a {@code java.time.LocalDate} for the same native cast, and Spring
+ * Data has no registered converter from {@code LocalDate} to the concrete {@code java.sql.Date}
+ * class, so the projection proxy blows up.
+ *
+ * <p>This test runs {@link AdminStatisticsRepository#countDailyNewSessionsByTenant} against a real
+ * MariaDB instance, on a fully Liquibase-built {@code userservice} schema, with an actual {@code
+ * session} row so the {@code day} projection getter is genuinely exercised end-to-end.
+ *
+ * <p>Follows the same env-var-provided-database pattern as {@link
+ * de.caritas.cob.userservice.api.DatabaseChangelogDriftIT} (this project's Testcontainers 1.17.6
+ * dependency predates current Docker Desktop API versions and cannot bootstrap containers).
+ *
+ * <pre>
+ *   docker run -d --name stats-mariadb-it -p 3314:3306 -e MARIADB_ROOT_PASSWORD=root \
+ *     -e MARIADB_DATABASE=userservice mariadb:11.0.6
+ *   LIQUIBASE_IT_DB_URL=jdbc:mariadb://127.0.0.1:3314/userservice \
+ *     ./mvnw test -Dtest=AdminStatisticsRepositoryMariaDbIT -DfailIfNoTests=true
+ * </pre>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class AdminStatisticsRepositoryMariaDbIT {
+
+  private static final long TENANT_ID = 4242L;
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.liquibase.contexts", () -> "dev,seed");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+  }
+
+  @Autowired private AdminStatisticsRepository underTest;
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  void countDailyNewSessionsByTenantShouldProjectDayWithoutConversionError() {
+    var today = LocalDate.now();
+    seedSingleSession(today);
+
+    // Before the fix, this line threw:
+    // java.lang.UnsupportedOperationException: Cannot project java.time.LocalDate to
+    // java.sql.Date; Target type is not an interface and no matching Converter found
+    var rows = underTest.countDailyNewSessionsByTenant(today.atStartOfDay().minusDays(1));
+
+    assertThat(rows).hasSize(1);
+    var row = rows.get(0);
+    assertThat(row.getGroupId()).isEqualTo(TENANT_ID);
+    assertThat(row.getTotal()).isEqualTo(1L);
+    assertThat(row.getDay()).isEqualTo(today);
+  }
+
+  private void seedSingleSession(LocalDate day) {
+    var userId = "stats-it-user-" + TENANT_ID;
+    entityManager
+        .createNativeQuery(
+            "INSERT INTO `user` (`user_id`, `tenant_id`, `username`, `email`) "
+                + "VALUES (:userId, :tenantId, :username, :email)")
+        .setParameter("userId", userId)
+        .setParameter("tenantId", TENANT_ID)
+        .setParameter("username", "stats-it-user")
+        .setParameter("email", "stats-it-user@example.test")
+        .executeUpdate();
+
+    entityManager
+        .createNativeQuery(
+            "INSERT INTO `session` "
+                + "(`id`, `tenant_id`, `user_id`, `consulting_type`, `postcode`, `status`, "
+                + "`create_date`, `update_date`) "
+                + "VALUES (:id, :tenantId, :userId, 0, '12345', 1, :createDate, :createDate)")
+        .setParameter("id", 999_000_001L)
+        .setParameter("tenantId", TENANT_ID)
+        .setParameter("userId", userId)
+        .setParameter("createDate", LocalDateTime.of(day, java.time.LocalTime.of(9, 0)))
+        .executeUpdate();
+
+    entityManager.flush();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/statistics/AdminDashboardStatisticsServiceTest.java
@@ -18,9 +18,9 @@ import de.caritas.cob.userservice.api.port.out.AdminStatisticsRepository.TopicCo
 import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.DashboardScope;
 import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.TargetType;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
-import java.sql.Date;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -102,8 +102,8 @@ class AdminDashboardStatisticsServiceTest {
       }
 
       @Override
-      public Date getDay() {
-        return Date.valueOf(day);
+      public LocalDate getDay() {
+        return LocalDate.parse(day);
       }
 
       @Override


### PR DESCRIPTION
## Summary

Fixes a live Pre-Dev bug found via SigNoz logs (correlationId `2cbc3e28-de31-4772-89fa-06e1b24a5318`): `GET /useradmin/statistics/dashboard` returned `500 INTERNAL_SERVER_ERROR`:

```
java.lang.UnsupportedOperationException: Cannot project java.time.LocalDate to java.sql.Date; Target type is not an interface and no matching Converter found
	at org.springframework.data.projection.ProjectingMethodInterceptor.potentiallyConvertResult(...)
```

- **Root cause**: `AdminStatisticsRepository.DailyCountProjection#getDay()` (in `src/main/java/de/caritas/cob/userservice/api/port/out/AdminStatisticsRepository.java`) declared its native `CAST(s.create_date AS DATE)` column projection as `java.sql.Date`. MariaDB's JDBC driver hands Spring's interface-projection proxy a `java.time.LocalDate` for that column, and Spring Data has a registered converter from `java.sql.Date`/`java.util.Date` → `LocalDate`, but **not** the reverse (to the concrete `java.sql.Date` class) — so the proxy throws. H2 (used by the existing `AdminStatisticsRepositoryIT`) converts either type cleanly, which is why this only ever surfaced against real MariaDB.
- **Fix**: declare the getter as `LocalDate` (matching what the driver actually returns) and drop the now-redundant `.toLocalDate()` call at the single call site in `AdminDashboardStatisticsService#toDailyMap`. The controller/DTO response shape (`DailyCount(String date, long count)`) is unchanged, so the frontend (Admin PR #293/#295) is unaffected.
- Same fix pattern applies to both `countDailyNewSessionsByTenant` and `countDailyNewSessionsByAgency`, which share the `DailyCountProjection` interface.

## Why the existing tests didn't catch this

The 8 Mockito unit tests hand-build `DailyCountProjection` as a plain anonymous class — they never go through Spring's projection proxy, so they can't exercise this conversion path at all. The existing `AdminStatisticsRepositoryIT` (`@DataJpaTest` on H2) asserts against an **empty** `session` table, so the `day` getter is never actually invoked, and even with rows H2 doesn't reproduce the divergence.

## Regression test

Added `AdminStatisticsRepositoryMariaDbIT`, following the existing `DatabaseChangelogDriftIT` env-var-provided-MariaDB pattern (this project's Testcontainers 1.17.6 dependency predates current Docker Desktop APIs and can't bootstrap containers). It builds the full schema via Liquibase against a real MariaDB, inserts one actual `session` row, and calls `countDailyNewSessionsByTenant` so the projection getter is genuinely exercised.

Verified true red → green locally against MariaDB 11.0.6:
- **Before the fix**: reproduced the exact production exception (`UnsupportedOperationException: Cannot project java.time.LocalDate to java.sql.Date`) at `row.getDay()`.
- **After the fix**: green.

This test is `@EnabledIfEnvironmentVariable(LIQUIBASE_IT_DB_URL)`-gated (same as `DatabaseChangelogDriftIT`), so it's a no-op in CI until that harness is wired up, but is available for any dev to reproduce with:

```
docker run -d --name stats-mariadb-it -p 3314:3306 -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABASE=userservice mariadb:11.0.6
LIQUIBASE_IT_DB_URL=jdbc:mariadb://127.0.0.1:3314/userservice ./mvnw test -Dtest=AdminStatisticsRepositoryMariaDbIT -DfailIfNoTests=true
```

## Test plan

- [x] `AdminDashboardStatisticsServiceTest` (10 unit tests) green
- [x] `AdminStatisticsRepositoryIT` (H2, 2 tests) green
- [x] `AdminStatisticsRepositoryMariaDbIT` (new): red before fix (reproduced prod exception), green after fix
- [x] `mvn compile` green
- [x] `spotless:check` clean (via JDK 21, per project convention)
- [ ] Cherry-pick/hot-deploy to Pre-Dev and confirm `GET /useradmin/statistics/dashboard` returns 200 (blocking the live E2E verification loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)