### PR TITLE
fix: keep invite-link agency fallback tenant and topic scoped

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -214,7 +214,19 @@ public class AgencyInviteLinkService {
       throw new BadRequestException(
           "No agency available for this invite link — set agencyId on the link or configure a topic fallback agency");
     }
-    return agencies.get(0).getId();
+    return agencies.stream()
+        .filter(agency -> Objects.equals(agency.getTenantId(), link.getTenantId()))
+        .filter(
+            agency ->
+                link.getTopicId() == null
+                    || (agency.getTopicIds() != null
+                        && agency.getTopicIds().contains(link.getTopicId())))
+        .map(AgencyDTO::getId)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new BadRequestException(
+                    "No agency in the invite link tenant serves the configured consulting type and topic"));
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.service.agencyinvitelink.AgencyInviteLinkS
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -347,6 +348,7 @@ class AgencyInviteLinkServiceTest {
             .build();
     AgencyDTO fallbackAgency = new AgencyDTO();
     fallbackAgency.setId(42L);
+    fallbackAgency.setTenantId(1L);
     when(repository.findByTokenAndStatus("tok2", InviteLinkStatus.ACTIVE.name()))
         .thenReturn(Optional.of(link));
     when(agencyService.getAgenciesByConsultingType(5))
@@ -355,6 +357,29 @@ class AgencyInviteLinkServiceTest {
     var ctx = service.redeem("tok2");
 
     assertThat(ctx.getAgencyId()).isEqualTo(42L);
+  }
+
+  @Test
+  void redeem_Should_SelectAgencyFromInviteTenantAndTopic() {
+    AgencyInviteLink link =
+        AgencyInviteLink.builder()
+            .token("tenant-topic-link")
+            .status(InviteLinkStatus.ACTIVE.name())
+            .tenantId(83L)
+            .consultingTypeId(1)
+            .topicId(11L)
+            .build();
+    AgencyDTO crossTenantAgency = new AgencyDTO().id(237L).tenantId(1L).topicIds(List.of(11L));
+    AgencyDTO wrongTopicAgency = new AgencyDTO().id(279L).tenantId(83L).topicIds(List.of(12L));
+    AgencyDTO matchingAgency = new AgencyDTO().id(280L).tenantId(83L).topicIds(List.of(11L));
+    when(repository.findByTokenAndStatus("tenant-topic-link", InviteLinkStatus.ACTIVE.name()))
+        .thenReturn(Optional.of(link));
+    when(agencyService.getAgenciesByConsultingType(1))
+        .thenReturn(List.of(crossTenantAgency, wrongTopicAgency, matchingAgency));
+
+    var ctx = service.redeem("tenant-topic-link");
+
+    assertThat(ctx.getAgencyId()).isEqualTo(280L);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
@@ -383,6 +383,26 @@ class AgencyInviteLinkServiceTest {
   }
 
   @Test
+  void redeem_Should_ThrowBadRequest_When_NoAgencyMatchesInviteTenantAndTopic() {
+    AgencyInviteLink link =
+        AgencyInviteLink.builder()
+            .token("no-match-link")
+            .status(InviteLinkStatus.ACTIVE.name())
+            .tenantId(83L)
+            .consultingTypeId(1)
+            .topicId(11L)
+            .build();
+    AgencyDTO crossTenantAgency = new AgencyDTO().id(237L).tenantId(1L).topicIds(List.of(11L));
+    when(repository.findByTokenAndStatus("no-match-link", InviteLinkStatus.ACTIVE.name()))
+        .thenReturn(Optional.of(link));
+    when(agencyService.getAgenciesByConsultingType(1)).thenReturn(List.of(crossTenantAgency));
+
+    assertThatThrownBy(() -> service.redeem("no-match-link"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("No agency in the invite link tenant");
+  }
+
+  @Test
   void redeem_Should_ThrowBadRequest_When_LinkIsNotActive() {
     AgencyInviteLink inactiveLink =
         AgencyInviteLink.builder()


### PR DESCRIPTION
## Problem

Topic-bound External Inbound invite links without an explicit agency selected the first agency returned for a consulting type, even when that agency belonged to another tenant.

## Actual behavior

A tenant 83 / topic 11 link could resolve Agency 237 from tenant 1. The anonymous asker was then registered in the wrong tenant and never appeared in the intended Live Chat queue.

## Expected behavior

The fallback selects only an agency that belongs to the invite link tenant and serves the configured topic. If none exists, redemption fails closed instead of crossing tenant boundaries.

## Evidence

- RED regression: expected Agency 280 but the previous implementation returned cross-tenant Agency 237.
- Focused test gate: 26 tests, 0 failures, 0 errors.
- Full Java 21 package gate: 3,423 tests, 0 failures, 0 errors, 7 skipped.
- Spotless and package build passed.
- CodeRabbit CLI reviewed both changed files with 0 findings.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invite link registration now selects the agency matching the link’s tenant and topic.
  * Registration now shows a clear error when no eligible agency matches the invite link.
  * Added coverage for tenant- and topic-specific agency selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->