### PR TITLE
feat: anonymous cross-tenant live-chat topic queue from invite links

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -91,18 +92,41 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
     var pageable = PageRequest.of(requestedPage, pageableListRequest.getCount());
     var minUpdateDate = LocalDateTime.now().minusMinutes(liveChatQueueActivePeriodMinutes);
 
-    if (consultantTopicIds == null || consultantTopicIds.isEmpty()) {
-      return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsWithoutTopic(
-          relatedConsultingTypes, SessionStatus.NEW, minUpdateDate, ANONYMOUS, pageable);
-    }
+    // The anonymous Live Chat queue is deliberately cross-agency AND cross-tenant: a consultant who
+    // is live for a topic/consulting type must see anonymous enquiries for that topic regardless of
+    // the asker's tenant. The consultant's own consulting types and topics were already resolved in
+    // the caller's tenant context; only the visibility query itself must bypass the tenant filter.
+    // Running it in technical context makes TenantAspect disable the Hibernate tenantFilter; the
+    // caller's tenant is restored afterwards so no other query in this request leaks. Registered
+    // (non-anonymous) session queries are unaffected and stay strictly tenant-isolated.
+    return runCrossTenant(
+        () -> {
+          if (consultantTopicIds == null || consultantTopicIds.isEmpty()) {
+            return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsWithoutTopic(
+                relatedConsultingTypes, SessionStatus.NEW, minUpdateDate, ANONYMOUS, pageable);
+          }
+          return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopics(
+              relatedConsultingTypes,
+              new HashSet<>(consultantTopicIds),
+              SessionStatus.NEW,
+              minUpdateDate,
+              ANONYMOUS,
+              pageable);
+        });
+  }
 
-    return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopics(
-        relatedConsultingTypes,
-        new HashSet<>(consultantTopicIds),
-        SessionStatus.NEW,
-        minUpdateDate,
-        ANONYMOUS,
-        pageable);
+  private Page<Session> runCrossTenant(java.util.function.Supplier<Page<Session>> query) {
+    var callerTenant = TenantContext.getCurrentTenant();
+    try {
+      TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+      return query.get();
+    } finally {
+      if (callerTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenant(callerTenant);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -1,7 +1,9 @@
 package de.caritas.cob.userservice.api.service.agencyinvitelink;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAnonymousEnquiryDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateAnonymousEnquiryResponseDTO;
+import de.caritas.cob.userservice.api.conversation.facade.CreateAnonymousEnquiryFacade;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
@@ -50,6 +52,7 @@ public class AgencyInviteLinkService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull ConsultingTypeService consultingTypeService;
   private final @NonNull AgencyService agencyService;
+  private final @NonNull CreateAnonymousEnquiryFacade createAnonymousEnquiryFacade;
 
   /** Create a new invite link. All classification fields are optional — defaults are applied. */
   public AgencyInviteLink create(CreateInviteLinkCommand cmd) {
@@ -190,6 +193,20 @@ public class AgencyInviteLinkService {
       TenantContext.setCurrentTenant(link.getTenantId());
 
       Integer consultingTypeId = pickConsultingTypeId(link);
+
+      // A Live Chat link binds only to a topic. Redeem creates a real anonymous session for the
+      // link's topic and returns it directly — no agency/tenant binding at entry. The client
+      // enters the cross-agency/cross-tenant topic queue; binding to a concrete agency/tenant and
+      // that agency's data-protection declaration happen only when a live consultant accepts.
+      if (InviteLinkChatType.LIVE_CHAT.name().equals(link.getChatType())) {
+        var dto = new CreateAnonymousEnquiryDTO(consultingTypeId).mainTopicId(link.getTopicId());
+        var session = createAnonymousEnquiryFacade.createAnonymousEnquiry(dto, true);
+        // Link is reusable until expiry date — stay ACTIVE, do not mark USED.
+        return new RedeemContext(
+            session, link.getTenantId(), null, consultingTypeId, link.getTopicId());
+      }
+
+      // Registered (non-live-chat) links keep the legacy client-side registration path.
       Long agencyId = resolveAgencyIdForRegistration(link, consultingTypeId);
 
       // Link is reusable until expiry date — stay ACTIVE, do not mark USED.

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
@@ -1,0 +1,124 @@
+package de.caritas.cob.userservice.api.conversation.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
+import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The anonymous Live Chat queue is deliberately cross-agency AND cross-tenant: any consultant who
+ * is live for a topic/consulting type must see anonymous enquiries for that topic regardless of the
+ * asker's tenant. Tenant isolation on Session queries is enforced by {@code TenantAspect}, which
+ * enables the Hibernate {@code tenantFilter} for the current tenant and disables it only in
+ * technical context. This test pins that the two queue queries run in technical context (filter
+ * off), and that the caller's tenant context is restored afterwards so no other query leaks.
+ */
+@ExtendWith(MockitoExtension.class)
+class AnonymousEnquiryConversationListProviderCrossTenantTest {
+
+  private static final Long CONSULTANT_TENANT = 83L;
+
+  @Mock private UserAccountService userAccountProvider;
+  @Mock private SessionRepository sessionRepository;
+  @Mock private AgencyService agencyService;
+  @Mock private ConsultantSessionEnricher consultantSessionEnricher;
+  @Mock private ConsultantTopicRepository consultantTopicRepository;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  private AnonymousEnquiryConversationListProvider newProvider() {
+    var provider =
+        new AnonymousEnquiryConversationListProvider(
+            userAccountProvider,
+            sessionRepository,
+            agencyService,
+            consultantSessionEnricher,
+            consultantTopicRepository);
+    ReflectionTestUtils.setField(provider, "liveChatQueueActivePeriodMinutes", 60L);
+    return provider;
+  }
+
+  private Consultant consultantWithAgency() {
+    var consultant = org.mockito.Mockito.mock(Consultant.class);
+    var agency = org.mockito.Mockito.mock(ConsultantAgency.class);
+    lenient().when(agency.getAgencyId()).thenReturn(1L);
+    lenient().when(consultant.getId()).thenReturn("consultant-83");
+    lenient().when(consultant.getConsultantAgencies()).thenReturn(Set.of(agency));
+    return consultant;
+  }
+
+  @Test
+  void buildConversations_Should_runTopicQueueQueryCrossTenant_And_restoreTenant() {
+    TenantContext.setCurrentTenant(CONSULTANT_TENANT);
+    var consultant = consultantWithAgency();
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(agencyService.getAgencies(any())).thenReturn(List.of(new AgencyDTO().consultingType(1)));
+    when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-83"))
+        .thenReturn(List.of(11L));
+
+    var tenantDuringQuery = new AtomicReference<Long>();
+    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopics(
+            anySet(), anySet(), any(), any(), any(), any(Pageable.class)))
+        .thenAnswer(
+            invocation -> {
+              tenantDuringQuery.set(TenantContext.getCurrentTenant());
+              return new PageImpl<Session>(List.of());
+            });
+
+    newProvider().buildConversations(PageableListRequest.builder().count(5).offset(0).build());
+
+    assertThat(tenantDuringQuery.get()).isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo(CONSULTANT_TENANT);
+  }
+
+  @Test
+  void buildConversations_Should_runNoTopicQueueQueryCrossTenant_And_restoreTenant() {
+    TenantContext.setCurrentTenant(CONSULTANT_TENANT);
+    var consultant = consultantWithAgency();
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(agencyService.getAgencies(any())).thenReturn(List.of(new AgencyDTO().consultingType(1)));
+    when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-83"))
+        .thenReturn(List.of());
+
+    var tenantDuringQuery = new AtomicReference<Long>();
+    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsWithoutTopic(
+            anySet(), any(), any(), any(), any(Pageable.class)))
+        .thenAnswer(
+            invocation -> {
+              tenantDuringQuery.set(TenantContext.getCurrentTenant());
+              return new PageImpl<Session>(List.of());
+            });
+
+    newProvider().buildConversations(PageableListRequest.builder().count(5).offset(0).build());
+
+    assertThat(tenantDuringQuery.get()).isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo(CONSULTANT_TENANT);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
@@ -3,10 +3,15 @@ package de.caritas.cob.userservice.api.service.agencyinvitelink;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAnonymousEnquiryDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAnonymousEnquiryResponseDTO;
+import de.caritas.cob.userservice.api.conversation.facade.CreateAnonymousEnquiryFacade;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
@@ -44,6 +49,7 @@ class AgencyInviteLinkServiceTest {
   @Mock private ConsultantRepository consultantRepository;
   @Mock private ConsultingTypeService consultingTypeService;
   @Mock private AgencyService agencyService;
+  @Mock private CreateAnonymousEnquiryFacade createAnonymousEnquiryFacade;
 
   @InjectMocks private AgencyInviteLinkService service;
 
@@ -249,6 +255,65 @@ class AgencyInviteLinkServiceTest {
     assertThat(ctx.getTenantId()).isEqualTo(1L);
     assertThat(ctx.getAgencyId()).isEqualTo(5L);
     assertThat(ctx.getConsultingTypeId()).isEqualTo(2);
+  }
+
+  @Test
+  void redeem_Should_CreateAnonymousTopicSession_When_LinkIsLiveChat() {
+    // A Live Chat link binds only to a topic. Redeem must create a real anonymous session for
+    // the link's topic — no agency/tenant binding at entry — and return it in the context.
+    AgencyInviteLink link =
+        AgencyInviteLink.builder()
+            .token("live")
+            .status(InviteLinkStatus.ACTIVE.name())
+            .tenantId(83L)
+            .topicId(11L)
+            .consultingTypeId(1)
+            .chatType(InviteLinkChatType.LIVE_CHAT.name())
+            .anonymity(InviteLinkAnonymity.FULL.name())
+            .build();
+    when(repository.findByTokenAndStatus("live", InviteLinkStatus.ACTIVE.name()))
+        .thenReturn(Optional.of(link));
+    var createdSession =
+        new CreateAnonymousEnquiryResponseDTO().sessionId(9001L).userName("Anonymous-1");
+    when(createAnonymousEnquiryFacade.createAnonymousEnquiry(any(), eq(true)))
+        .thenReturn(createdSession);
+
+    RedeemContext ctx = service.redeem("live");
+
+    var dtoCaptor = org.mockito.ArgumentCaptor.forClass(CreateAnonymousEnquiryDTO.class);
+    verify(createAnonymousEnquiryFacade).createAnonymousEnquiry(dtoCaptor.capture(), eq(true));
+    assertThat(dtoCaptor.getValue().getMainTopicId()).isEqualTo(11L);
+    assertThat(dtoCaptor.getValue().getConsultingType()).isEqualTo(1);
+    assertThat(ctx.getSession()).isSameAs(createdSession);
+    assertThat(ctx.getSession().getSessionId()).isEqualTo(9001L);
+    assertThat(ctx.getTopicId()).isEqualTo(11L);
+    // No agency resolution at entry for a live-chat link.
+    assertThat(ctx.getAgencyId()).isNull();
+    verify(agencyService, org.mockito.Mockito.never()).getAgenciesByConsultingType(anyInt());
+  }
+
+  @Test
+  void redeem_Should_StayLegacy_When_LinkIsNotLiveChat() {
+    // A non-live-chat (registered) link keeps the legacy agency-resolution path with no session.
+    AgencyInviteLink link =
+        AgencyInviteLink.builder()
+            .token("reg")
+            .status(InviteLinkStatus.ACTIVE.name())
+            .tenantId(1L)
+            .topicId(3L)
+            .agencyId(5L)
+            .consultingTypeId(2)
+            .chatType("REGISTERED")
+            .build();
+    when(repository.findByTokenAndStatus("reg", InviteLinkStatus.ACTIVE.name()))
+        .thenReturn(Optional.of(link));
+
+    RedeemContext ctx = service.redeem("reg");
+
+    assertThat(ctx.getSession()).isNull();
+    assertThat(ctx.getAgencyId()).isEqualTo(5L);
+    verify(createAnonymousEnquiryFacade, org.mockito.Mockito.never())
+        .createAnonymousEnquiry(any(), org.mockito.ArgumentMatchers.anyBoolean());
   }
 
   // --- list ---


### PR DESCRIPTION
## Why

Gate B of E2E run `e2e-20260711-1357` uncovered that a Live Chat invite link scoped to tenant 83 / topic 11 (no agencyId) enrolled the anonymous asker into a **cross-tenant** agency (237, tenant 1) and never reached the tenant-83 queue (issue #413). Product decision (Frank): a Live Chat link binds **only to a topic**; the waiting-room queue is intentionally **cross-agency AND cross-tenant**; the client enters anonymously and is bound to a concrete agency/tenant (and shown that agency's data-protection declaration) only when a live consultant accepts.

## What

**Increment 1 — redeem a LIVE_CHAT link creates a real anonymous topic session.**
`AgencyInviteLinkService.redeem`: for `chatType=LIVE_CHAT`, call `createAnonymousEnquiry(mainTopicId=link.topicId, consultingType)` and return real session credentials instead of the hard-coded `session=null` + legacy agency resolution. No agency/tenant binding at entry. Registered (non-live-chat) links keep the legacy client-side registration path unchanged. The existing FE session branch (`InviteLink.tsx`) lights up automatically once a session is returned.

**Increment 2 — the anonymous live-chat queue is cross-tenant.**
`AnonymousEnquiryConversationListProvider` runs the two visibility queries in technical context so `TenantAspect` disables the Hibernate `tenantFilter`; the consultant's own consulting types and topics are still resolved in the caller's tenant context first, and the caller's tenant is restored in a `finally` so no other query leaks. `TenantAspect` itself is untouched. Registered (non-anonymous) session queries remain strictly tenant-isolated.

## Tests

- `AgencyInviteLinkServiceTest`: RED proved a LIVE_CHAT link failed with "No agency available"; GREEN creates the anonymous session (topic carried, agency null, no agency lookup) and keeps registered links legacy. 27 tests green.
- `AnonymousEnquiryConversationListProviderCrossTenantTest`: RED proved the queue ran in the consultant's tenant (83); GREEN proves both queue paths run in technical context (tenant 0 = filter off) and restore the caller's tenant. 2 tests green.
- Full Java 21 unit gate: 3,416 tests, 0 failures, 0 errors, 7 skipped; Spotless applied.
- Pre-existing note: the `AnonymousEnquiryConversationListProviderIT#returnElementsInExpectedOrder` integration test is flaky on `pre-dev` independently of this change (EasyRandom dates); not addressed here.

Refs #413. PreDev only; no merge or deployment to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
