### PR TITLE
fix(chat): persist interval/repeatCount/modality on series edit (ADR-012)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -28,9 +28,11 @@ import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -456,6 +458,18 @@ public class ChatService {
     }
 
     LocalDateTime startDate = LocalDateTime.of(chatDTO.getStartDate(), chatDTO.getStartTime());
+    // Timezone drives the recurrence math (occurrenceStart: DST/monthly/yearly). Persist a new
+    // one when the client sends it (validated like the create path), and preserve the existing
+    // zone when the DTO omits it rather than silently resetting to UTC.
+    if (chatDTO.getTimezone() != null && !chatDTO.getTimezone().isBlank()) {
+      try {
+        ZoneId.of(chatDTO.getTimezone());
+      } catch (DateTimeException invalidTimezone) {
+        throw new BadRequestException(
+            "Invalid timezone: " + chatDTO.getTimezone(), invalidTimezone);
+      }
+      chat.setTimezone(chatDTO.getTimezone());
+    }
     chat.setTopic(chatDTO.getTopic());
     chat.setDuration(chatDTO.getDuration());
     // Defaulting must match the create path (ChatConverter.convertToEntity) so editing a

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -458,12 +458,19 @@ public class ChatService {
     LocalDateTime startDate = LocalDateTime.of(chatDTO.getStartDate(), chatDTO.getStartTime());
     chat.setTopic(chatDTO.getTopic());
     chat.setDuration(chatDTO.getDuration());
-    chat.setRepetitive(isTrue(chatDTO.getRepetitive()));
+    // Defaulting must match the create path (ChatConverter.convertToEntity) so editing a
+    // repetitive series without re-sending repeatCount does not silently drop it to a single
+    // occurrence: default 12 for repetitive, derive repetitive + interval from repeatCount > 1.
+    int repeatCount =
+        chatDTO.getRepeatCount() != null
+            ? chatDTO.getRepeatCount()
+            : (isTrue(chatDTO.getRepetitive()) ? 12 : 1);
+    chat.setRepeatCount(repeatCount);
+    chat.setRepetitive(repeatCount > 1);
     chat.setChatInterval(
-        isTrue(chatDTO.getRepetitive())
+        repeatCount > 1
             ? (chatDTO.getChatInterval() != null ? chatDTO.getChatInterval() : ChatInterval.WEEKLY)
             : null);
-    chat.setRepeatCount(chatDTO.getRepeatCount() != null ? chatDTO.getRepeatCount() : 1);
     chat.setChatModality(chatDTO.getModality() != null ? chatDTO.getModality() : ChatModality.TEXT);
     chat.setStartDate(startDate);
     chat.setInitialStartDate(startDate);

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
@@ -458,9 +459,17 @@ public class ChatService {
     chat.setTopic(chatDTO.getTopic());
     chat.setDuration(chatDTO.getDuration());
     chat.setRepetitive(isTrue(chatDTO.getRepetitive()));
-    chat.setChatInterval(isTrue(chatDTO.getRepetitive()) ? ChatInterval.WEEKLY : null);
+    chat.setChatInterval(
+        isTrue(chatDTO.getRepetitive())
+            ? (chatDTO.getChatInterval() != null ? chatDTO.getChatInterval() : ChatInterval.WEEKLY)
+            : null);
+    chat.setRepeatCount(chatDTO.getRepeatCount() != null ? chatDTO.getRepeatCount() : 1);
+    chat.setChatModality(chatDTO.getModality() != null ? chatDTO.getModality() : ChatModality.TEXT);
     chat.setStartDate(startDate);
     chat.setInitialStartDate(startDate);
+    // The schedule anchor moved, so virtual occurrences must restart from index 0 —
+    // otherwise nextStart() would skip the first occurrences of the edited series.
+    chat.setCurrentOccurrenceIndex(0);
     chat.setHintMessage(chatDTO.getHintMessage());
     chat.setSourceLanguage(chatDTO.getSourceLanguage());
     chat.setHintMessageTranslations(chatDTO.getHintMessageTranslations());

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerChatE2EIT.java
@@ -51,6 +51,7 @@ import de.caritas.cob.userservice.api.adapters.rocketchat.dto.subscriptions.Subs
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.subscriptions.SubscriptionsUpdateDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.RocketChatUserDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.dto.user.UserInfoResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.E2eKeyDTO;
 import de.caritas.cob.userservice.api.config.VideoChatConfig;
 import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControllerFactory;
@@ -78,6 +79,9 @@ import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import jakarta.servlet.http.Cookie;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -274,6 +278,73 @@ class UserControllerChatE2EIT {
   private String giveValidCreateChatBodyWithAgency(ConsultantAgency consultantAgency) {
     return VALID_CREATE_CHAT_BODY_WITH_AGENCY_PLACEHOLDER.replace(
         "${AGENCY_ID}", consultantAgency.getAgencyId().toString());
+  }
+
+  @Test
+  @WithMockUser(authorities = AuthorityValue.UPDATE_CHAT)
+  void updateChat_Should_PersistScheduleFieldsToDatabase_When_OwnerEditsInactiveSeries()
+      throws Exception {
+    // The owner is the mocked authenticatedUser; updateChat authorizes on chatOwner id.
+    givenAValidConsultant(true);
+
+    // Seed an INACTIVE repetitive series with a known "before" schedule, straight into H2 so
+    // the assertions below reload from the database rather than a mocked service result.
+    var beforeStart = LocalDateTime.of(2026, 1, 5, 18, 0);
+    var seededChat = easyRandom.nextObject(Chat.class);
+    seededChat.setId(null);
+    seededChat.setGroupId(RC_GROUP_ID);
+    seededChat.setMatrixRoomId(null);
+    seededChat.setActive(false); // updateChat rejects active chats with 409
+    seededChat.setChatOwner(consultant);
+    seededChat.setConsultingTypeId(easyRandom.nextInt(128));
+    seededChat.setMaxParticipants(easyRandom.nextInt(128));
+    seededChat.setUpdateDate(CustomLocalDateTime.nowInUtc());
+    seededChat.setSourceLanguage("de");
+    seededChat.setRepetitive(true);
+    seededChat.setRepeatCount(12);
+    seededChat.setChatInterval(Chat.ChatInterval.WEEKLY);
+    seededChat.setChatModality(Chat.ChatModality.TEXT);
+    seededChat.setTimezone("Europe/Berlin");
+    seededChat.setStartDate(beforeStart);
+    seededChat.setInitialStartDate(beforeStart);
+    seededChat.setCurrentOccurrenceIndex(5); // non-zero, must reset to 0 on re-anchor
+    chat = chatRepository.save(seededChat);
+
+    // "After" schedule: every field changed so a no-op update would fail every assertion.
+    var newStartDate = LocalDate.of(2026, 3, 2);
+    var newStartTime = LocalTime.of(20, 30);
+    var body = new ChatDTO();
+    body.setTopic("Edited self-help series");
+    body.setStartDate(newStartDate);
+    body.setStartTime(newStartTime);
+    body.setDuration(90);
+    body.setRepetitive(true);
+    body.setRepeatCount(6); // 12 -> 6
+    body.setChatInterval(Chat.ChatInterval.MONTHLY); // WEEKLY -> MONTHLY
+    body.setModality(Chat.ChatModality.VIDEO); // TEXT -> VIDEO
+    body.setTimezone("UTC"); // Europe/Berlin -> UTC
+
+    mockMvc
+        .perform(
+            put("/users/chat/{chatId}/update", chat.getId())
+                .with(jwt().authorities(new SimpleGrantedAuthority(AuthorityValue.UPDATE_CHAT)))
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("groupId", is(chat.getGroupId())));
+
+    var persisted = chatRepository.findById(chat.getId()).orElseThrow();
+    assertEquals(6, persisted.getRepeatCount());
+    assertTrue(persisted.isRepetitive());
+    assertEquals(Chat.ChatInterval.MONTHLY, persisted.getChatInterval());
+    assertEquals(Chat.ChatModality.VIDEO, persisted.getChatModality());
+    assertEquals("UTC", persisted.getTimezone());
+    assertEquals(LocalDateTime.of(newStartDate, newStartTime), persisted.getStartDate());
+    assertEquals(LocalDateTime.of(newStartDate, newStartTime), persisted.getInitialStartDate());
+    assertEquals(0, persisted.getCurrentOccurrenceIndex());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -521,6 +521,66 @@ class ChatServiceTest {
   }
 
   @Test
+  void updateChat_Should_PersistTimezone_WhenProvided() {
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto = scheduleDtoBuilder().timezone("Europe/Berlin").build();
+
+    chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT);
+
+    ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+    verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
+    // Recurrence (occurrenceStart) computes DST/monthly/yearly offsets in this zone.
+    assertEquals("Europe/Berlin", chatArgumentCaptor.getValue().getTimezone());
+  }
+
+  @Test
+  void updateChat_Should_PreserveExistingTimezone_WhenOmitted() {
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    inactiveChat.setTimezone("Europe/Berlin");
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto = scheduleDtoBuilder().build(); // no timezone
+
+    chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT);
+
+    ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+    verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
+    assertEquals("Europe/Berlin", chatArgumentCaptor.getValue().getTimezone());
+  }
+
+  @Test
+  void updateChat_Should_RejectInvalidTimezone() {
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto = scheduleDtoBuilder().timezone("Not/AZone").build();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT));
+    verify(chatRepository, Mockito.never()).save(Mockito.any(Chat.class));
+  }
+
+  private static ChatDTO.ChatDTOBuilder scheduleDtoBuilder() {
+    return ChatDTO.builder()
+        .topic(CHAT_TOPIC)
+        .startDate(CHAT_START_DATE)
+        .startTime(CHAT_START_TIME)
+        .duration(CHAT_DURATION)
+        .repetitive(true)
+        .chatInterval(ChatInterval.WEEKLY)
+        .repeatCount(4);
+  }
+
+  @Test
   void updateChat_Should_ResetOccurrenceIndex_WhenScheduleReAnchored() {
     // given a series that has already advanced past its first occurrence
     Chat inactiveChat = new Chat();

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -5,9 +5,13 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.AUTHENTICA
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.AUTHENTICATED_USER_3;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.AUTHENTICATED_USER_CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_DTO;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_DURATION;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_HINT_MESSAGE;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_ID_3;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_START_DATE;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_START_TIME;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_TOPIC;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CHAT_V2;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.INACTIVE_CHAT;
@@ -26,12 +30,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
@@ -448,6 +455,67 @@ class ChatServiceTest {
     ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
     verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
     assertEquals(CHAT_HINT_MESSAGE, chatArgumentCaptor.getValue().getHintMessage());
+  }
+
+  @Test
+  void updateChat_Should_PersistIntervalRepeatCountAndModality() {
+    // given
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto =
+        ChatDTO.builder()
+            .topic(CHAT_TOPIC)
+            .startDate(CHAT_START_DATE)
+            .startTime(CHAT_START_TIME)
+            .duration(CHAT_DURATION)
+            .repetitive(true)
+            .chatInterval(ChatInterval.MONTHLY)
+            .repeatCount(5)
+            .modality(ChatModality.VIDEO)
+            .build();
+
+    // when
+    chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT);
+
+    // then
+    ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+    verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
+    Chat saved = chatArgumentCaptor.getValue();
+    assertEquals(ChatInterval.MONTHLY, saved.getChatInterval());
+    assertEquals(5, saved.getRepeatCount());
+    assertEquals(ChatModality.VIDEO, saved.getChatModality());
+  }
+
+  @Test
+  void updateChat_Should_ResetOccurrenceIndex_WhenScheduleReAnchored() {
+    // given a series that has already advanced past its first occurrence
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    inactiveChat.setCurrentOccurrenceIndex(3);
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto =
+        ChatDTO.builder()
+            .topic(CHAT_TOPIC)
+            .startDate(CHAT_START_DATE)
+            .startTime(CHAT_START_TIME)
+            .duration(CHAT_DURATION)
+            .repetitive(true)
+            .chatInterval(ChatInterval.WEEKLY)
+            .repeatCount(4)
+            .build();
+
+    // when the schedule anchor is edited
+    chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT);
+
+    // then the series restarts from the new anchor, not mid-way through
+    ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+    verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
+    assertEquals(0, chatArgumentCaptor.getValue().getCurrentOccurrenceIndex());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -490,6 +490,37 @@ class ChatServiceTest {
   }
 
   @Test
+  void updateChat_Should_ApplyCreatePathDefaults_WhenScheduleFieldsAreNull() {
+    // given a repetitive update that omits repeatCount / interval / modality
+    Chat inactiveChat = new Chat();
+    inactiveChat.setActive(false);
+    inactiveChat.setChatOwner(CONSULTANT);
+    when(chatRepository.findByIdWithPermissionRelations(Mockito.anyLong()))
+        .thenReturn(Optional.of(inactiveChat));
+    ChatDTO scheduleDto =
+        ChatDTO.builder()
+            .topic(CHAT_TOPIC)
+            .startDate(CHAT_START_DATE)
+            .startTime(CHAT_START_TIME)
+            .duration(CHAT_DURATION)
+            .repetitive(true)
+            .build();
+
+    // when
+    chatService.updateChat(CHAT_ID, scheduleDto, AUTHENTICATED_USER_CONSULTANT);
+
+    // then the defaults must match the create path (ChatConverter): 12 / WEEKLY / TEXT,
+    // NOT drop a repetitive series to a single occurrence.
+    ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+    verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
+    Chat saved = chatArgumentCaptor.getValue();
+    assertEquals(12, saved.getRepeatCount());
+    assertEquals(ChatInterval.WEEKLY, saved.getChatInterval());
+    assertEquals(ChatModality.TEXT, saved.getChatModality());
+    assertTrue(saved.isRepetitive());
+  }
+
+  @Test
   void updateChat_Should_ResetOccurrenceIndex_WhenScheduleReAnchored() {
     // given a series that has already advanced past its first occurrence
     Chat inactiveChat = new Chat();


### PR DESCRIPTION
## Backend foundation for editing a group-chat series (ADR-012)

Part of finishing the self-help group chat against **ADR-012** (audit found the feature ~90–95 % built on `pre-dev`). ADR-012 decision Q9 includes an "edit the whole series" mode; `apiUpdateGroupChat` exists on the frontend but the backend `ChatService.updateChat` could not actually apply a schedule edit. This fixes that so the edit UI (separate Frontend PR) has a correct contract.

### Bug + gaps fixed
`ChatService.updateChat`:
- **Hardcoded interval bug**: `setChatInterval(isTrue(repetitive) ? WEEKLY : null)` ignored the DTO — editing a MONTHLY series reset it to WEEKLY.
- **Dropped fields**: `repeatCount` and `modality` from the DTO were never persisted.
- **Stale occurrence index**: re-anchoring `initialStartDate` left `currentOccurrenceIndex` unchanged, so `nextStart()` would skip the first occurrences of the edited series.

### Fix
Take the interval from the DTO (fallback WEEKLY when repetitive but unset), persist `repeatCount` (default 1) and `modality` (default TEXT), and reset `currentOccurrenceIndex` to 0 on re-anchor.

### TDD (red-green, evidence)
Two new tests, each watched fail first:
- `updateChat_Should_PersistIntervalRepeatCountAndModality` — RED `expected <MONTHLY> but was <WEEKLY>` → GREEN.
- `updateChat_Should_ResetOccurrenceIndex_WhenScheduleReAnchored` — RED `expected <0> but was <3>` → GREEN.

`ChatServiceTest` 27→29 green; `ChatServiceTest + UserChatControllerDelegateTest` **50 green**, no regression, and no test asserted the old behaviour. Java 21, spotless clean.

### Deliberately out of scope
Orphaned `ChatOccurrenceException` (skip) rows after a schedule change are left in place — they are harmless no-ops (the projector applies an exception only when a new occurrence lands on that exact date). Clearing them would require injecting the exception repository here; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recurring chat schedule updates with reliable defaults for interval, repeat count, and text modality.
  * Reset recurring schedules to their first occurrence when the schedule anchor is changed.
  * Correctly clear recurring intervals when a chat is no longer repetitive.
* **Tests**
  * Added coverage for schedule settings, default values, and recurring schedule resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->