### PR TITLE
fix: create anonymous live chat in Matrix-only mode

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/facade/CreateAnonymousEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/facade/CreateAnonymousEnquiryFacade.java
@@ -58,6 +58,7 @@ public class CreateAnonymousEnquiryFacade {
     AnonymousUserCredentials credentials = anonymousUserCreatorService.createAnonymousUser(userDto);
     var session =
         anonymousConversationCreatorService.createAnonymousConversation(userDto, credentials);
+    var rocketChatCredentials = credentials.getRocketChatCredentials();
 
     return new CreateAnonymousEnquiryResponseDTO()
         .userName(userDto.getUsername())
@@ -65,8 +66,9 @@ public class CreateAnonymousEnquiryFacade {
         .refreshToken(credentials.getRefreshToken())
         .expiresIn(credentials.getExpiresIn())
         .refreshExpiresIn(credentials.getRefreshExpiresIn())
-        .rcUserId(credentials.getRocketChatCredentials().getRocketChatUserId())
-        .rcToken(credentials.getRocketChatCredentials().getRocketChatToken())
+        .rcUserId(
+            rocketChatCredentials != null ? rocketChatCredentials.getRocketChatUserId() : null)
+        .rcToken(rocketChatCredentials != null ? rocketChatCredentials.getRocketChatToken() : null)
         .rcGroupId(session.getGroupId())
         .sessionId(session.getId());
   }

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
@@ -23,12 +23,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Service to create anonymous user conversations (sessions). */
 @Service
 @RequiredArgsConstructor
 public class AnonymousConversationCreatorService {
+
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
 
   private final @NonNull UserService userService;
   private final @NonNull SessionService sessionService;
@@ -40,7 +44,7 @@ public class AnonymousConversationCreatorService {
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
 
   /**
-   * Creates a new anonymous conversation session with the corresponding Rocket.Chat room.
+   * Creates a new anonymous waiting session and a Rocket.Chat room when that transport is enabled.
    *
    * @param userDTO {@link UserDTO}
    * @param credentials {@link AnonymousUserCredentials}
@@ -59,10 +63,12 @@ public class AnonymousConversationCreatorService {
               user, userDTO, false, RegistrationType.ANONYMOUS, SessionStatus.NEW);
       session.setConversationType(ConversationType.LIVE_CHAT);
       consultantAgencies = obtainConsultants(session);
-      String rcGroupId =
-          createEnquiryMessageFacade.createRocketChatRoomAndAddUsers(
-              session, consultantAgencies, credentials.getRocketChatCredentials());
-      session.setGroupId(rcGroupId);
+      if (rocketChatEnabled) {
+        String rcGroupId =
+            createEnquiryMessageFacade.createRocketChatRoomAndAddUsers(
+                session, consultantAgencies, credentials.getRocketChatCredentials());
+        session.setGroupId(rcGroupId);
+      }
       sessionService.saveSession(session);
 
     } catch (Exception ex) {

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -31,6 +32,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AnonymousUserCreatorService {
 
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
+
   private final @NonNull CreateUserFacade createUserFacade;
   private final @NonNull IdentityClient identityClient;
   private final @NonNull RocketChatService rocketChatService;
@@ -39,7 +43,7 @@ public class AnonymousUserCreatorService {
   private final @NonNull UserHelper userHelper;
 
   /**
-   * Creates an anonymous user account in Keycloak, MariaDB and Rocket.Chat.
+   * Creates an anonymous user account in Keycloak and MariaDB, plus Rocket.Chat when enabled.
    *
    * @param userDto {@link UserDTO}
    * @return {@link AnonymousUserCredentials}
@@ -55,27 +59,35 @@ public class AnonymousUserCreatorService {
     createUserFacade.updateIdentityAndCreateAccount(response.getUserId(), userDto, UserRole.USER);
 
     KeycloakLoginResponseDTO kcLoginResponseDTO;
-    ResponseEntity<LoginResponseDTO> rcLoginResponseDto;
+    ResponseEntity<LoginResponseDTO> rcLoginResponseDto = null;
     try {
       kcLoginResponseDTO = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
-      ensureRocketChatUserExists(userDto, response.getUserId());
-      rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
+      if (rocketChatEnabled) {
+        ensureRocketChatUserExists(userDto, response.getUserId());
+        rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
+      }
     } catch (RocketChatLoginException | BadRequestException e) {
       rollBackAnonymousUserAccount(response.getUserId());
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
     }
 
-    var anonymousUserCredentials =
+    var credentialsBuilder =
         AnonymousUserCredentials.builder()
             .userId(response.getUserId())
             .accessToken(kcLoginResponseDTO.getAccessToken())
             .expiresIn(kcLoginResponseDTO.getExpiresIn())
             .refreshToken(kcLoginResponseDTO.getRefreshToken())
-            .refreshExpiresIn(kcLoginResponseDTO.getRefreshExpiresIn())
-            .rocketChatCredentials(obtainRocketChatCredentials(rcLoginResponseDto))
-            .build();
+            .refreshExpiresIn(kcLoginResponseDTO.getRefreshExpiresIn());
 
-    updateRocketChatUserIdInDatabase(anonymousUserCredentials);
+    if (rocketChatEnabled) {
+      credentialsBuilder.rocketChatCredentials(obtainRocketChatCredentials(rcLoginResponseDto));
+    }
+
+    var anonymousUserCredentials = credentialsBuilder.build();
+
+    if (rocketChatEnabled) {
+      updateRocketChatUserIdInDatabase(anonymousUserCredentials);
+    }
 
     return anonymousUserCredentials;
   }

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -32,6 +32,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.Optional;
 import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -41,6 +42,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -59,6 +61,31 @@ class AnonymousUserCreatorServiceTest {
   @Mock private UserHelper userHelper;
 
   EasyRandom easyRandom = new EasyRandom();
+
+  @BeforeEach
+  void enableRocketChatForLegacyTests() {
+    ReflectionTestUtils.setField(anonymousUserCreatorService, "rocketChatEnabled", true);
+  }
+
+  @Test
+  void createAnonymousUser_Should_ReturnKeycloakCredentials_When_RocketChatIsDisabled() {
+    ReflectionTestUtils.setField(anonymousUserCreatorService, "rocketChatEnabled", false);
+    KeycloakCreateUserResponseDTO responseDTO =
+        easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
+    KeycloakLoginResponseDTO keycloakLoginResponseDTO =
+        easyRandom.nextObject(KeycloakLoginResponseDTO.class);
+    when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
+    when(keycloakService.loginUser(anyString(), anyString())).thenReturn(keycloakLoginResponseDTO);
+
+    AnonymousUserCredentials credentials =
+        anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
+
+    assertThat(credentials.getAccessToken(), is(keycloakLoginResponseDTO.getAccessToken()));
+    assertThat(credentials.getRefreshToken(), is(keycloakLoginResponseDTO.getRefreshToken()));
+    assertThat(credentials.getRocketChatCredentials(), is((Object) null));
+    verifyNoInteractions(rocketChatService);
+    verifyNoInteractions(userService);
+  }
 
   @Test
   void

--- a/src/test/java/de/caritas/cob/userservice/api/facade/conversation/CreateAnonymousEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/conversation/CreateAnonymousEnquiryFacadeTest.java
@@ -2,6 +2,8 @@ package de.caritas.cob.userservice.api.facade.conversation;
 
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTING_TYPE_ID_KREUZBUND;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTING_TYPE_ID_SUCHT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -38,6 +40,32 @@ public class CreateAnonymousEnquiryFacadeTest {
   @Mock private ConsultingTypeManager consultingTypeManager;
 
   EasyRandom easyRandom = new EasyRandom();
+
+  @Test
+  void createAnonymousEnquiry_Should_ReturnMatrixOnlyResponse_WithoutRocketChatCredentials() {
+    CreateAnonymousEnquiryDTO request = new CreateAnonymousEnquiryDTO(CONSULTING_TYPE_ID_SUCHT);
+    AnonymousUserCredentials credentials =
+        AnonymousUserCredentials.builder()
+            .userId("user-id")
+            .accessToken("access-token")
+            .refreshToken("refresh-token")
+            .expiresIn(300)
+            .refreshExpiresIn(600)
+            .build();
+    Session session = easyRandom.nextObject(Session.class);
+    session.setGroupId(null);
+    when(anonymousUserCreatorService.createAnonymousUser(any())).thenReturn(credentials);
+    when(anonymousConversationCreatorService.createAnonymousConversation(any(), any()))
+        .thenReturn(session);
+
+    var response = createAnonymousEnquiryFacade.createAnonymousEnquiry(request, true);
+
+    assertEquals("access-token", response.getAccessToken());
+    assertEquals(session.getId(), response.getSessionId());
+    assertNull(response.getRcUserId());
+    assertNull(response.getRcToken());
+    assertNull(response.getRcGroupId());
+  }
 
   @Test
   public void

--- a/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
@@ -6,6 +6,7 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER_DTO_SUCHT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -33,13 +34,16 @@ import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRout
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import java.util.List;
 import java.util.Optional;
 import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AnonymousConversationCreatorServiceTest {
@@ -55,6 +59,46 @@ class AnonymousConversationCreatorServiceTest {
   @Mock TopicConsultantRoutingService topicConsultantRoutingService;
 
   EasyRandom easyRandom = new EasyRandom();
+
+  @BeforeEach
+  void enableRocketChatForLegacyTests() {
+    ReflectionTestUtils.setField(anonymousConversationCreatorService, "rocketChatEnabled", true);
+  }
+
+  @Test
+  void createAnonymousConversation_Should_CreateWaitingSession_When_RocketChatIsDisabled() {
+    ReflectionTestUtils.setField(anonymousConversationCreatorService, "rocketChatEnabled", false);
+    Session session = easyRandom.nextObject(Session.class);
+    session.setGroupId(null);
+    session.setMainTopicId(11L);
+    AnonymousUserCredentials credentials =
+        AnonymousUserCredentials.builder().userId(USER.getUserId()).build();
+    when(userService.getUser(credentials.getUserId())).thenReturn(Optional.of(USER));
+    when(sessionService.initializeSession(
+            any(User.class),
+            any(UserDTO.class),
+            anyBoolean(),
+            any(RegistrationType.class),
+            any(SessionStatus.class)))
+        .thenReturn(session);
+    when(topicConsultantRoutingService.findEligibleConsultantIds(
+            session.getMainTopicId(), session.getConsultingTypeId()))
+        .thenReturn(List.of("consultant-id"));
+    when(consultantAgencyService.getConsultantAgenciesByConsultantIds(List.of("consultant-id")))
+        .thenReturn(List.of());
+
+    Session created =
+        anonymousConversationCreatorService.createAnonymousConversation(
+            USER_DTO_SUCHT, credentials);
+
+    assertThat(created, is(session));
+    assertThat(created.getConversationType(), is(ConversationType.LIVE_CHAT));
+    assertThat(created.getGroupId(), is((Object) null));
+    verify(sessionService).saveSession(session);
+    verifyNoInteractions(createEnquiryMessageFacade);
+    verify(liveEventNotificationService)
+        .sendLiveNewAnonymousEnquiryEventToUsers(List.of("consultant-id"), session.getId());
+  }
 
   @Test
   void


### PR DESCRIPTION
## Summary

- create anonymous Keycloak/UserService identities without Rocket.Chat when `rocket-chat.enabled=false`
- save the `ANONYMOUS` / `LIVE_CHAT` waiting session without an RC room in Matrix-only mode
- return nullable legacy RC fields while preserving the Keycloak session credentials
- keep the existing Rocket.Chat-enabled path unchanged

## Why

The anonymous topic-queue increment in #417 correctly moved Live Chat invite redeem to server-side session creation. PreDev is Matrix-only by ADR-004, but the reused creation path still required a Rocket.Chat login and room. Live redeem therefore failed before a waiting session could enter the cross-tenant topic queue.

Matrix provisioning already belongs to the accept boundary: `AssignEnquiryFacade` ensures both Matrix users and creates the Matrix room when a consultant accepts the session. Waiting-room creation should remain transport-neutral.

## TDD evidence

- RED: RC account creation failed with Rocket.Chat disabled
- RED: waiting-session creation still invoked RC room creation
- RED: redeem response dereferenced absent RC credentials
- GREEN targeted gate: 14 tests, 0 failures/errors
- Full Java 21 gate: 3,404 tests, 0 failures/errors, 7 skipped; Spotless and package build green
- Local CodeRabbit CLI: 0 findings across all six changed files

## Risk and rollback

The new branch is active only when `rocket-chat.enabled=false`. Rocket.Chat-enabled behavior and its existing tests remain unchanged. The Matrix room continues to be created at consultant acceptance. Rollback is the single commit in this PR.

## PreDev verification after merge

- deploy the immutable UserService PreDev image
- prove pod digest, start time, health, effective `MATRIX_ENCRYPTION_ENABLED`, and Liquibase status
- redeem a fresh topic-scoped Live Chat invite
- confirm the anonymous session appears in the consultant queue
- accept it and prove encrypted two-way Matrix messages including reload persistence

Closes #419
Related: #413, #417

PreDev only. No merge or deployment to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to disable Rocket.Chat integration.
  * Anonymous conversations can now be created without Rocket.Chat rooms, users, or credentials.
  * Matrix-only responses now correctly omit Rocket.Chat details.

* **Bug Fixes**
  * Prevented failures when Rocket.Chat credentials are unavailable.
  * Preserved anonymous conversation creation and authentication when Rocket.Chat is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->