### PR TITLE
fix: Matrix-migrate the anonymous live-chat path (RC-disabled)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Service to create anonymous user conversations (sessions). */
@@ -38,6 +39,10 @@ public class AnonymousConversationCreatorService {
   private final @NonNull ConsultantAgencyService consultantAgencyService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
+
+  /** ADR-004: with Rocket.Chat disabled no Rocket.Chat room is created for the waiting session. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
 
   /**
    * Creates a new anonymous conversation session with the corresponding Rocket.Chat room.
@@ -59,10 +64,16 @@ public class AnonymousConversationCreatorService {
               user, userDTO, false, RegistrationType.ANONYMOUS, SessionStatus.NEW);
       session.setConversationType(ConversationType.LIVE_CHAT);
       consultantAgencies = obtainConsultants(session);
-      String rcGroupId =
-          createEnquiryMessageFacade.createRocketChatRoomAndAddUsers(
-              session, consultantAgencies, credentials.getRocketChatCredentials());
-      session.setGroupId(rcGroupId);
+      if (rocketChatEnabled) {
+        String rcGroupId =
+            createEnquiryMessageFacade.createRocketChatRoomAndAddUsers(
+                session, consultantAgencies, credentials.getRocketChatCredentials());
+        session.setGroupId(rcGroupId);
+      }
+      // ADR-004 Matrix-only: the waiting session has no agency and needs no room yet. The Matrix
+      // room is created when a live consultant accepts
+      // (AssignEnquiryFacade.assignAnonymousEnquiry),
+      // which is also when the agency/tenant binding and that agency's DSE apply.
       sessionService.saveSession(session);
 
     } catch (Exception ex) {

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -31,12 +32,24 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AnonymousUserCreatorService {
 
+  /**
+   * Matrix migration placeholder — mirrors {@code CreateEnquiryMessageFacade}. Downstream room
+   * creation skips all Rocket.Chat operations when it sees this dummy user id.
+   */
+  private static final String MATRIX_MIGRATION_DUMMY_RC_USER_ID = "matrix-migration-dummy-user";
+
+  private static final String MATRIX_MIGRATION_DUMMY_RC_TOKEN = "matrix-migration-dummy-token";
+
   private final @NonNull CreateUserFacade createUserFacade;
   private final @NonNull IdentityClient identityClient;
   private final @NonNull RocketChatService rocketChatService;
   private final @NonNull RollbackFacade rollbackFacade;
   private final @NonNull UserService userService;
   private final @NonNull UserHelper userHelper;
+
+  /** ADR-004: with Rocket.Chat disabled no Rocket.Chat account is created or logged in. */
+  @Value("${rocket-chat.enabled:false}")
+  private boolean rocketChatEnabled;
 
   /**
    * Creates an anonymous user account in Keycloak, MariaDB and Rocket.Chat.
@@ -52,14 +65,26 @@ public class AnonymousUserCreatorService {
     // subsequent login fails with 401 (breaking invite-link redeem). The anonymous chat endpoints
     // in SecurityConfig all accept USER_DEFAULT, matching how /users/askers/new already registers
     // anonymous chat users (see CreateUserFacade).
-    createUserFacade.updateIdentityAndCreateAccount(response.getUserId(), userDto, UserRole.USER);
+    var createdUser =
+        createUserFacade.updateIdentityAndCreateAccount(
+            response.getUserId(), userDto, UserRole.USER);
+
+    // ADR-004 Matrix-only: anonymous askers need a Matrix account too, otherwise their first
+    // enquiry fails with "has no Matrix account". The registered path provisions Matrix inside
+    // createUserAccountWithInitializedConsultingType; the anonymous path calls only the inner
+    // account creation, so provision Matrix explicitly here when Rocket.Chat is disabled.
+    if (!rocketChatEnabled) {
+      createUserFacade.ensureMatrixUser(createdUser, userDto.getUsername());
+    }
 
     KeycloakLoginResponseDTO kcLoginResponseDTO;
-    ResponseEntity<LoginResponseDTO> rcLoginResponseDto;
+    ResponseEntity<LoginResponseDTO> rcLoginResponseDto = null;
     try {
       kcLoginResponseDTO = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
-      ensureRocketChatUserExists(userDto, response.getUserId());
-      rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
+      if (rocketChatEnabled) {
+        ensureRocketChatUserExists(userDto, response.getUserId());
+        rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
+      }
     } catch (RocketChatLoginException | BadRequestException e) {
       rollBackAnonymousUserAccount(response.getUserId());
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
@@ -72,12 +97,24 @@ public class AnonymousUserCreatorService {
             .expiresIn(kcLoginResponseDTO.getExpiresIn())
             .refreshToken(kcLoginResponseDTO.getRefreshToken())
             .refreshExpiresIn(kcLoginResponseDTO.getRefreshExpiresIn())
-            .rocketChatCredentials(obtainRocketChatCredentials(rcLoginResponseDto))
+            .rocketChatCredentials(
+                rocketChatEnabled
+                    ? obtainRocketChatCredentials(rcLoginResponseDto)
+                    : matrixMigrationDummyCredentials())
             .build();
 
-    updateRocketChatUserIdInDatabase(anonymousUserCredentials);
+    if (rocketChatEnabled) {
+      updateRocketChatUserIdInDatabase(anonymousUserCredentials);
+    }
 
     return anonymousUserCredentials;
+  }
+
+  private RocketChatCredentials matrixMigrationDummyCredentials() {
+    return RocketChatCredentials.builder()
+        .rocketChatUserId(MATRIX_MIGRATION_DUMMY_RC_USER_ID)
+        .rocketChatToken(MATRIX_MIGRATION_DUMMY_RC_TOKEN)
+        .build();
   }
 
   private void ensureRocketChatUserExists(UserDTO userDto, String keycloakUserId)

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -95,50 +95,11 @@ public class CreateUserFacade {
 
     // Create Matrix user with a random local Matrix password that is never persisted.
     // The plain username is needed for the Matrix localpart. Prefer the value captured during
-    // request deserialization, but fall back to deriving it from the persisted username. The
-    // ThreadLocal is populated by a Jackson deserializer and is not always available by the time
-    // we get here; relying on it alone left some askers without a Matrix account, which later
-    // makes their first enquiry fail with "Could not create Matrix room".
-    String plainUsername;
-    if (plainCreds != null && plainCreds.getUsername() != null) {
-      plainUsername = plainCreds.getUsername();
-    } else if (user != null && user.getUsername() != null) {
-      plainUsername = new UsernameTranscoder().decodeUsername(user.getUsername());
-    } else {
-      plainUsername = null;
-    }
+    // request deserialization, but fall back to deriving it from the persisted username.
+    String plainUsername =
+        plainCreds != null && plainCreds.getUsername() != null ? plainCreds.getUsername() : null;
     try {
-      if (isNotBlank(plainUsername)) {
-        String matrixPassword = java.util.UUID.randomUUID() + "-" + java.util.UUID.randomUUID();
-        var matrixResponse =
-            matrixSynapseService.createUser(plainUsername, matrixPassword, plainUsername);
-
-        log.info(
-            "Matrix user creation response for plain username '{}': statusCode={}, hasBody={}",
-            plainUsername,
-            matrixResponse.getStatusCode(),
-            matrixResponse.getBody() != null);
-
-        if (matrixResponse.getBody() != null && matrixResponse.getBody().getUserId() != null) {
-          user.setMatrixUserId(matrixResponse.getBody().getUserId());
-          userService.saveUser(user);
-          log.info(
-              "Successfully created Matrix user with plain username '{}' → Matrix ID: {}",
-              plainUsername,
-              matrixResponse.getBody().getUserId());
-        } else {
-          log.warn(
-              "Matrix user creation response body is null or missing user_id for plain username: {}",
-              plainUsername);
-        }
-      } else {
-        log.warn("Plain username not resolvable, skipping Matrix user creation");
-      }
-    } catch (Exception e) {
-      log.error(
-          "Matrix user creation failed for plain username: {}, but continuing with registration",
-          plainUsername,
-          e);
+      user = ensureMatrixUser(user, plainUsername);
     } finally {
       // Clean up ThreadLocal to prevent memory leaks
       de.caritas.cob.userservice.api.helper.PlainCredentialsHolder.clear();
@@ -199,6 +160,60 @@ public class CreateUserFacade {
           "AgencyId is null for user during registration. Will not send agency name to statistics");
       return StringUtils.EMPTY;
     }
+  }
+
+  /**
+   * Ensures the given account has a Matrix user, creating one with a random, never-persisted local
+   * password when missing. The plain username is the Matrix localpart: prefer {@code
+   * plainUsername}, otherwise decode it from the persisted username. Failures are logged and
+   * swallowed so account creation is never blocked; a persisted {@code matrixUserId} is set on
+   * success. Shared by registered and anonymous account creation so both paths provision Matrix
+   * identically.
+   *
+   * @param user the persisted user
+   * @param plainUsername the plain (decoded) username, or {@code null} to derive it
+   * @return the user, with {@code matrixUserId} set when creation succeeded
+   */
+  public User ensureMatrixUser(User user, String plainUsername) {
+    String resolvedPlainUsername = plainUsername;
+    if (isBlank(resolvedPlainUsername) && user != null && user.getUsername() != null) {
+      resolvedPlainUsername = new UsernameTranscoder().decodeUsername(user.getUsername());
+    }
+    try {
+      if (isNotBlank(resolvedPlainUsername)) {
+        String matrixPassword = java.util.UUID.randomUUID() + "-" + java.util.UUID.randomUUID();
+        var matrixResponse =
+            matrixSynapseService.createUser(
+                resolvedPlainUsername, matrixPassword, resolvedPlainUsername);
+
+        log.info(
+            "Matrix user creation response for plain username '{}': statusCode={}, hasBody={}",
+            resolvedPlainUsername,
+            matrixResponse.getStatusCode(),
+            matrixResponse.getBody() != null);
+
+        if (matrixResponse.getBody() != null && matrixResponse.getBody().getUserId() != null) {
+          user.setMatrixUserId(matrixResponse.getBody().getUserId());
+          userService.saveUser(user);
+          log.info(
+              "Successfully created Matrix user with plain username '{}' → Matrix ID: {}",
+              resolvedPlainUsername,
+              matrixResponse.getBody().getUserId());
+        } else {
+          log.warn(
+              "Matrix user creation response body is null or missing user_id for plain username: {}",
+              resolvedPlainUsername);
+        }
+      } else {
+        log.warn("Plain username not resolvable, skipping Matrix user creation");
+      }
+    } catch (Exception e) {
+      log.error(
+          "Matrix user creation failed for plain username: {}, but continuing",
+          resolvedPlainUsername,
+          e);
+    }
+    return user;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
@@ -62,7 +62,11 @@ public class LiveEventNotificationService {
       LiveEventMessage liveEventMessage, Supplier<String> errorMessageSupplier) {
     try {
       this.liveServiceApiControllerFactory.createControllerApi().sendLiveEvent(liveEventMessage);
-    } catch (ApiException e) {
+    } catch (ApiException | RuntimeException e) {
+      // Live events are best-effort. Besides the declared ApiException, a transport failure (e.g.
+      // the live service host is unreachable → UnresolvedAddressException/ConnectException wrapped
+      // in a RuntimeException by the java.net.http client) must never break the enquiry/session
+      // flow that fired the event — online consultants reconcile via the next queue poll anyway.
       log.error("Internal Server Error: {}", errorMessageSupplier.get(), e);
     }
   }

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -60,9 +61,36 @@ class AnonymousUserCreatorServiceTest {
 
   EasyRandom easyRandom = new EasyRandom();
 
+  private void enableRocketChat() {
+    ReflectionTestUtils.setField(anonymousUserCreatorService, "rocketChatEnabled", true);
+  }
+
+  @Test
+  void createAnonymousUser_Should_SkipRocketChat_When_RocketChatDisabled() {
+    // ADR-004 Matrix-only: with rocket-chat.enabled=false no Rocket.Chat account is created or
+    // logged in for anonymous live-chat askers; creation must still succeed.
+    KeycloakCreateUserResponseDTO responseDTO =
+        easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
+    when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
+    KeycloakLoginResponseDTO keycloakLoginResponseDTO =
+        easyRandom.nextObject(KeycloakLoginResponseDTO.class);
+    when(keycloakService.loginUser(anyString(), anyString())).thenReturn(keycloakLoginResponseDTO);
+
+    AnonymousUserCredentials credentials =
+        anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
+
+    assertThat(credentials, instanceOf(AnonymousUserCredentials.class));
+    assertThat(credentials.getAccessToken(), is(keycloakLoginResponseDTO.getAccessToken()));
+    assertThat(credentials.getRocketChatCredentials(), is(org.hamcrest.Matchers.notNullValue()));
+    verifyNoInteractions(rocketChatService);
+    verify(userService, times(0)).updateRocketChatIdInDatabase(any(), any());
+    verifyNoInteractions(rollbackFacade);
+  }
+
   @Test
   void
       createAnonymousUser_Should_ThrowInternalServerErrorExceptionAndPerformRollback_When_KeycloakLoginFails() {
+    enableRocketChat();
     assertThrows(
         InternalServerErrorException.class,
         () -> {
@@ -83,6 +111,7 @@ class AnonymousUserCreatorServiceTest {
   void
       createAnonymousUser_Should_ThrowInternalServerErrorExceptionAndPerformRollback_When_RocketChatLoginFails()
           throws RocketChatLoginException {
+    enableRocketChat();
     assertThrows(
         InternalServerErrorException.class,
         () -> {
@@ -110,6 +139,7 @@ class AnonymousUserCreatorServiceTest {
 
   @Test
   void createAnonymousUser_Should_ReturnAnonymousUserCredentials() throws RocketChatLoginException {
+    enableRocketChat();
     KeycloakCreateUserResponseDTO responseDTO =
         easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
@@ -145,6 +175,7 @@ class AnonymousUserCreatorServiceTest {
   void
       createAnonymousUser_Should_throwInternalServerError_When_userToUpdateRocketChatIdDoesNotExist()
           throws RocketChatLoginException {
+    enableRocketChat();
     KeycloakCreateUserResponseDTO responseDTO =
         easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);

--- a/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AnonymousConversationCreatorServiceTest {
@@ -55,6 +56,10 @@ class AnonymousConversationCreatorServiceTest {
   @Mock TopicConsultantRoutingService topicConsultantRoutingService;
 
   EasyRandom easyRandom = new EasyRandom();
+
+  private void enableRocketChat() {
+    ReflectionTestUtils.setField(anonymousConversationCreatorService, "rocketChatEnabled", true);
+  }
 
   @Test
   void
@@ -110,6 +115,7 @@ class AnonymousConversationCreatorServiceTest {
   void
       createAnonymousConversation_Should_ThrowInternalServerErrorExceptionAndPerformRollback_When_CreateRcRoomFails()
           throws CreateEnquiryException {
+    enableRocketChat();
     assertThrows(
         InternalServerErrorException.class,
         () -> {
@@ -142,6 +148,7 @@ class AnonymousConversationCreatorServiceTest {
   @Test
   void createAnonymousConversation_Should_ReturnSessionAndTriggerLiveEvent()
       throws CreateEnquiryException {
+    enableRocketChat();
     when(userService.getUser(anyString())).thenReturn(Optional.of(USER));
     when(sessionService.initializeSession(
             any(User.class),
@@ -165,6 +172,7 @@ class AnonymousConversationCreatorServiceTest {
 
   @Test
   void createAnonymousConversationShouldStampLiveChatBeforeSaving() throws CreateEnquiryException {
+    enableRocketChat();
     Session session = easyRandom.nextObject(Session.class);
     session.setConversationType(null);
     when(userService.getUser(anyString())).thenReturn(Optional.of(USER));
@@ -182,5 +190,30 @@ class AnonymousConversationCreatorServiceTest {
         USER_DTO_SUCHT, easyRandom.nextObject(AnonymousUserCredentials.class));
 
     assertThat(session.getConversationType(), org.hamcrest.Matchers.is(ConversationType.LIVE_CHAT));
+  }
+
+  @Test
+  void createAnonymousConversation_Should_SkipRocketChatRoom_When_RocketChatDisabled()
+      throws CreateEnquiryException {
+    // ADR-004 Matrix-only: the waiting anonymous session needs no room; it is created on accept.
+    when(userService.getUser(anyString())).thenReturn(Optional.of(USER));
+    when(sessionService.initializeSession(
+            any(User.class),
+            any(UserDTO.class),
+            anyBoolean(),
+            any(RegistrationType.class),
+            any(SessionStatus.class)))
+        .thenReturn(SESSION);
+
+    Session session =
+        anonymousConversationCreatorService.createAnonymousConversation(
+            USER_DTO_SUCHT, easyRandom.nextObject(AnonymousUserCredentials.class));
+
+    assertThat(session, instanceOf(Session.class));
+    verify(createEnquiryMessageFacade, times(0))
+        .createRocketChatRoomAndAddUsers(any(), any(), any());
+    verify(sessionService, times(1)).saveSession(any());
+    verify(liveEventNotificationService, times(1))
+        .sendLiveNewAnonymousEnquiryEventToUsers(any(), any());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
@@ -108,6 +108,25 @@ public class LiveEventNotificationServiceTest {
   }
 
   @Test
+  public void
+      sendLiveNewAnonymousEnquiryEventToUsers_Should_notPropagate_When_liveServiceUnreachable()
+          throws ApiException {
+    // A live event is best-effort: a transport failure (e.g. the live service host is unreachable,
+    // surfacing as an UnresolvedAddressException/ConnectException — NOT an ApiException) must never
+    // break the enquiry/session flow that fired it.
+    doThrow(new RuntimeException(new java.net.ConnectException("unreachable")))
+        .when(this.liveControllerApi)
+        .sendLiveEvent(any());
+
+    try (var logCaptor = LogbackCaptor.forClass(LiveEventNotificationService.class)) {
+      this.liveEventNotificationService.sendLiveNewAnonymousEnquiryEventToUsers(
+          asList("consultant-1"), 4711L);
+
+      assertThat(logCaptor.contains(Level.ERROR, "Internal Server Error")).isTrue();
+    }
+  }
+
+  @Test
   public void sendLiveDirectMessageEventToUsers_Should_sendEventToAllUsersInsteadOfInitiatingUser()
       throws ApiException {
     List<String> userIds = asList("id1", "id2", "id3", "id4");


### PR DESCRIPTION
## Why

Follow-up to #417. Deploying the anonymous topic-queue flow to PreDev (Gate B of E2E run `e2e-20260711-1357`) surfaced that the **entire anonymous live-chat backend path was never Matrix-migrated** — it hard-required Rocket.Chat and broke under `rocket-chat.enabled=false` (ADR-004). Each fix below is a live-RED → TDD repair.

## What

1. **`AnonymousUserCreatorService` — Matrix-only account.** Gated the Rocket.Chat user create/login behind `rocket-chat.enabled`; when disabled, carry Matrix-migration dummy RC credentials. Also provision a Matrix account for the anonymous asker (the path called only `updateIdentityAndCreateAccount`, which does not create a Matrix user, so the first enquiry failed "has no Matrix account"). Extracted the Matrix-user provisioning from the registered path into a reusable **`CreateUserFacade.ensureMatrixUser`** (registered-path refactor is behavior-preserving — 26 tests green) and call it from the anonymous path in Matrix-only mode.
2. **`AnonymousConversationCreatorService` — no room while waiting.** It always created a Rocket.Chat room. A waiting live-chat session has no agency and needs no room yet: the Matrix room is created on **accept** (`AssignEnquiryFacade.assignAnonymousEnquiry`, which reuses or creates a room), which is also when the agency/tenant binding + that agency's DSE apply. Gated room creation behind `rocket-chat.enabled`.
3. **`LiveEventNotificationService` — best-effort delivery.** Only the declared `ApiException` was caught; a transport failure to the live service (host unreachable → `UnresolvedAddressException`/`ConnectException` wrapped in a `RuntimeException` by the java.net.http client) escaped and broke the enquiry/session flow. Broadened the catch — live events are best-effort; consultants reconcile via the next queue poll.

## Tests

- `AnonymousUserCreatorServiceTest` (RC-disabled skip path + existing RC-enabled cases), `AnonymousConversationCreatorServiceTest` (RC-disabled room-skip), `LiveEventNotificationServiceTest` (RuntimeException swallowed), `CreateUserFacadeTest` (26, behavior-preserving).
- Full Java 21 unit gate: 3,431 tests, 0 failures, 0 errors, 7 skipped; Spotless applied.

## Separate config finding (ORISO-Helm, not code)

PreDev `userservice-configmap-env` had `LIVE_SERVICE_API_URL=http://liveservice.caritas:8080` but the `liveservice` Service listens on **8086** (short host also didn't resolve from the pod). Hot-patched the live ConfigMap to `http://liveservice.caritas.svc.cluster.local:8086` for the E2E run; needs a durable ORISO-Helm fix.

Refs #413. PreDev only; no merge or deployment to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
