### PR TITLE
Fix anonymous Matrix token bootstrap

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -56,17 +56,21 @@ public class AnonymousUserCreatorService {
     // subsequent login fails with 401 (breaking invite-link redeem). The anonymous chat endpoints
     // in SecurityConfig all accept USER_DEFAULT, matching how /users/askers/new already registers
     // anonymous chat users (see CreateUserFacade).
-    createUserFacade.updateIdentityAndCreateAccount(response.getUserId(), userDto, UserRole.USER);
-
     KeycloakLoginResponseDTO kcLoginResponseDTO;
     ResponseEntity<LoginResponseDTO> rcLoginResponseDto = null;
     try {
+      var user =
+          createUserFacade.updateIdentityAndCreateAccount(
+              response.getUserId(), userDto, UserRole.USER);
+      if (!rocketChatEnabled) {
+        createUserFacade.provisionMatrixUser(user, userDto.getUsername());
+      }
       kcLoginResponseDTO = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
       if (rocketChatEnabled) {
         ensureRocketChatUserExists(userDto, response.getUserId());
         rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());
       }
-    } catch (RocketChatLoginException | BadRequestException e) {
+    } catch (RocketChatLoginException | BadRequestException | InternalServerErrorException e) {
       rollBackAnonymousUserAccount(response.getUserId());
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -4,7 +4,6 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
@@ -108,33 +107,8 @@ public class CreateUserFacade {
       plainUsername = null;
     }
     try {
-      if (isNotBlank(plainUsername)) {
-        String matrixPassword = java.util.UUID.randomUUID() + "-" + java.util.UUID.randomUUID();
-        var matrixResponse =
-            matrixSynapseService.createUser(plainUsername, matrixPassword, plainUsername);
-
-        log.info(
-            "Matrix user creation response for plain username '{}': statusCode={}, hasBody={}",
-            plainUsername,
-            matrixResponse.getStatusCode(),
-            matrixResponse.getBody() != null);
-
-        if (matrixResponse.getBody() != null && matrixResponse.getBody().getUserId() != null) {
-          user.setMatrixUserId(matrixResponse.getBody().getUserId());
-          userService.saveUser(user);
-          log.info(
-              "Successfully created Matrix user with plain username '{}' → Matrix ID: {}",
-              plainUsername,
-              matrixResponse.getBody().getUserId());
-        } else {
-          log.warn(
-              "Matrix user creation response body is null or missing user_id for plain username: {}",
-              plainUsername);
-        }
-      } else {
-        log.warn("Plain username not resolvable, skipping Matrix user creation");
-      }
-    } catch (Exception e) {
+      provisionMatrixUser(user, plainUsername);
+    } catch (InternalServerErrorException e) {
       log.error(
           "Matrix user creation failed for plain username: {}, but continuing with registration",
           plainUsername,
@@ -177,6 +151,38 @@ public class CreateUserFacade {
     }
 
     return registration.getSessionId();
+  }
+
+  /** Provisions and persists the Matrix identity needed by browser token bootstrap. */
+  public void provisionMatrixUser(User user, String plainUsername) {
+    try {
+      if (user == null || isBlank(plainUsername)) {
+        throw new IllegalArgumentException("Plain username or user not resolvable");
+      }
+
+      String matrixPassword = java.util.UUID.randomUUID() + "-" + java.util.UUID.randomUUID();
+      var matrixResponse =
+          matrixSynapseService.createUser(plainUsername, matrixPassword, plainUsername);
+
+      log.info(
+          "Matrix user creation response for plain username '{}': statusCode={}, hasBody={}",
+          plainUsername,
+          matrixResponse.getStatusCode(),
+          matrixResponse.getBody() != null);
+
+      if (matrixResponse.getBody() != null && matrixResponse.getBody().getUserId() != null) {
+        user.setMatrixUserId(matrixResponse.getBody().getUserId());
+        userService.saveUser(user);
+        log.info(
+            "Successfully created Matrix user with plain username '{}' → Matrix ID: {}",
+            plainUsername,
+            matrixResponse.getBody().getUserId());
+      } else {
+        throw new IllegalStateException("Matrix user creation response is missing user_id");
+      }
+    } catch (Exception e) {
+      throw new InternalServerErrorException("Could not provision Matrix user " + plainUsername, e);
+    }
   }
 
   private String getTenantName() {

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,12 +71,15 @@ class AnonymousUserCreatorServiceTest {
   @Test
   void createAnonymousUser_Should_ReturnKeycloakCredentials_When_RocketChatIsDisabled() {
     ReflectionTestUtils.setField(anonymousUserCreatorService, "rocketChatEnabled", false);
+    User user = mock(User.class);
     KeycloakCreateUserResponseDTO responseDTO =
         easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
     KeycloakLoginResponseDTO keycloakLoginResponseDTO =
         easyRandom.nextObject(KeycloakLoginResponseDTO.class);
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
     when(keycloakService.loginUser(anyString(), anyString())).thenReturn(keycloakLoginResponseDTO);
+    when(createUserFacade.updateIdentityAndCreateAccount(anyString(), any(), any()))
+        .thenReturn(user);
 
     AnonymousUserCredentials credentials =
         anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
@@ -83,6 +87,7 @@ class AnonymousUserCreatorServiceTest {
     assertThat(credentials.getAccessToken(), is(keycloakLoginResponseDTO.getAccessToken()));
     assertThat(credentials.getRefreshToken(), is(keycloakLoginResponseDTO.getRefreshToken()));
     assertThat(credentials.getRocketChatCredentials(), is((Object) null));
+    verify(createUserFacade).provisionMatrixUser(user, USER_DTO_SUCHT.getUsername());
     verifyNoInteractions(rocketChatService);
     verifyNoInteractions(userService);
   }
@@ -104,6 +109,27 @@ class AnonymousUserCreatorServiceTest {
           verifyNoInteractions(rollbackFacade);
           verifyNoInteractions(rocketChatService);
         });
+  }
+
+  @Test
+  void createAnonymousUser_Should_RollBack_When_MatrixProvisioningFails() {
+    ReflectionTestUtils.setField(anonymousUserCreatorService, "rocketChatEnabled", false);
+    User user = mock(User.class);
+    KeycloakCreateUserResponseDTO responseDTO =
+        easyRandom.nextObject(KeycloakCreateUserResponseDTO.class);
+    when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
+    when(createUserFacade.updateIdentityAndCreateAccount(anyString(), any(), any()))
+        .thenReturn(user);
+    doThrow(new InternalServerErrorException("Matrix provisioning failed"))
+        .when(createUserFacade)
+        .provisionMatrixUser(user, USER_DTO_SUCHT.getUsername());
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT));
+
+    verify(rollbackFacade).rollBackUserAccount(any());
+    verifyNoInteractions(rocketChatService);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- provision and persist the anonymous Matrix identity before the redeem response in Matrix-only mode
- reuse the existing registration provisioning logic instead of duplicating Synapse calls
- roll back the partially created anonymous account when Matrix provisioning fails
- preserve best-effort Matrix provisioning for normal registrations

## Verification

- TDD red: `AnonymousUserCreatorServiceTest` failed because early Matrix provisioning did not exist
- Green: `AnonymousUserCreatorServiceTest,CreateUserFacadeTest` — 32 tests passed
- Spotless passed under the project JDK 21
- local CodeRabbit review: 0 remaining findings

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)