### PR TITLE
fix: topic-only anonymous live-chat queue (remove unauthenticated AgencyService lookup)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -3,18 +3,14 @@ package de.caritas.cob.userservice.api.conversation.provider;
 import static de.caritas.cob.userservice.api.conversation.model.ConversationListType.ANONYMOUS_ENQUIRY;
 import static de.caritas.cob.userservice.api.model.Session.RegistrationType.ANONYMOUS;
 
-import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
 import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
-import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
-import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
@@ -22,7 +18,6 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +34,6 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
 
   private final @NonNull UserAccountService userAccountProvider;
   private final @NonNull SessionRepository sessionRepository;
-  private final @NonNull AgencyService agencyService;
   private final @NonNull ConsultantSessionEnricher consultantSessionEnricher;
   private final @NonNull ConsultantTopicRepository consultantTopicRepository;
 
@@ -52,12 +46,11 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
   public ConsultantSessionListResponseDTO buildConversations(
       PageableListRequest pageableListRequest) {
     var consultant = this.userAccountProvider.retrieveValidatedConsultant();
-    Set<Integer> relatedConsultingTypes = retrieveRelatedConsultingTypes(consultant);
     List<Long> consultantTopicIds =
         consultantTopicRepository.findTopicIdsByConsultantId(consultant.getId());
 
     Page<Session> anonymousSessionsOfConsultant =
-        queryForRelevantSessions(pageableListRequest, relatedConsultingTypes, consultantTopicIds);
+        queryForRelevantSessions(pageableListRequest, consultantTopicIds);
 
     List<ConsultantSessionResponseDTO> sessions =
         anonymousSessionsOfConsultant.stream()
@@ -74,45 +67,38 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
         .total((int) anonymousSessionsOfConsultant.getTotalElements());
   }
 
-  private Set<Integer> retrieveRelatedConsultingTypes(Consultant consultant) {
-    List<Long> consultantAgencyIds =
-        consultant.getConsultantAgencies().stream()
-            .map(ConsultantAgency::getAgencyId)
-            .collect(Collectors.toList());
-    return this.agencyService.getAgencies(consultantAgencyIds).stream()
-        .map(AgencyDTO::getConsultingType)
-        .collect(Collectors.toSet());
-  }
-
   private Page<Session> queryForRelevantSessions(
-      PageableListRequest pageableListRequest,
-      Set<Integer> relatedConsultingTypes,
-      List<Long> consultantTopicIds) {
+      PageableListRequest pageableListRequest, List<Long> consultantTopicIds) {
     var requestedPage = obtainPageByOffsetAndCount(pageableListRequest);
     var pageable = PageRequest.of(requestedPage, pageableListRequest.getCount());
+
+    // The anonymous Live Chat queue is topic-bound: a consultant sees anonymous enquiries for the
+    // topics they are assigned to. A consultant with no topic assignment cannot serve the topic
+    // queue, so return nothing without any cross-service lookup. This deliberately does NOT resolve
+    // the consultant's consulting types via AgencyService — the queue is topic-only, which also
+    // avoids an authenticated AgencyService call from this list path.
+    if (consultantTopicIds == null || consultantTopicIds.isEmpty()) {
+      return Page.empty(pageable);
+    }
+
     var minUpdateDate = LocalDateTime.now().minusMinutes(liveChatQueueActivePeriodMinutes);
 
-    // The anonymous Live Chat queue is deliberately cross-agency AND cross-tenant: a consultant who
-    // is live for a topic/consulting type must see anonymous enquiries for that topic regardless of
-    // the asker's tenant. The consultant's own consulting types and topics were already resolved in
-    // the caller's tenant context; only the visibility query itself must bypass the tenant filter.
-    // Running it in technical context makes TenantAspect disable the Hibernate tenantFilter; the
-    // caller's tenant is restored afterwards so no other query in this request leaks. Registered
-    // (non-anonymous) session queries are unaffected and stay strictly tenant-isolated.
+    // The queue is deliberately cross-agency AND cross-tenant: a consultant who is live for a topic
+    // must see anonymous enquiries for that topic regardless of the asker's tenant. The
+    // consultant's
+    // own topics were resolved in the caller's tenant context; only the visibility query itself
+    // must
+    // bypass the tenant filter. Running it in technical context makes TenantAspect disable the
+    // Hibernate tenantFilter; the caller's tenant is restored afterwards so no other query in this
+    // request leaks. Registered (non-anonymous) session queries stay strictly tenant-isolated.
     return runCrossTenant(
-        () -> {
-          if (consultantTopicIds == null || consultantTopicIds.isEmpty()) {
-            return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsWithoutTopic(
-                relatedConsultingTypes, SessionStatus.NEW, minUpdateDate, ANONYMOUS, pageable);
-          }
-          return this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopics(
-              relatedConsultingTypes,
-              new HashSet<>(consultantTopicIds),
-              SessionStatus.NEW,
-              minUpdateDate,
-              ANONYMOUS,
-              pageable);
-        });
+        () ->
+            this.sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+                new HashSet<>(consultantTopicIds),
+                SessionStatus.NEW,
+                minUpdateDate,
+                ANONYMOUS,
+                pageable));
   }
 
   private Page<Session> runCrossTenant(java.util.function.Supplier<Page<Session>> query) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -266,6 +266,31 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
       Pageable pageable);
 
   /**
+   * Topic-only visibility for the anonymous Live Chat queue. A live consultant sees anonymous
+   * enquiries for the topics they are assigned to, independent of consulting type — the queue is
+   * topic-bound and deliberately cross-agency/cross-tenant. Used instead of the consulting-type
+   * variant so the queue never needs an authenticated AgencyService lookup to resolve the
+   * consultant's consulting types.
+   */
+  @Query(
+      "SELECT s FROM Session s "
+          + "JOIN s.user u "
+          + "WHERE s.mainTopicId IN :topicIds "
+          + "AND s.status = :sessionStatus "
+          + "AND s.consultant IS NULL "
+          + "AND u.dataPrivacyConfirmation IS NOT NULL "
+          + "AND s.updateDate >= :minUpdateDate "
+          + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
+          + "     OR u.username LIKE 'Anonymous-%') "
+          + "ORDER BY s.createDate DESC")
+  Page<Session> findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+      @Param("topicIds") Set<Long> topicIds,
+      @Param("sessionStatus") SessionStatus sessionStatus,
+      @Param("minUpdateDate") LocalDateTime minUpdateDate,
+      @Param("anonymousRegistrationType") RegistrationType anonymousRegistrationType,
+      Pageable pageable);
+
+  /**
    * Count live-chat enquiries that are visible in the consultant queue and were created before the
    * reference session — i.e. people genuinely ahead of the asker. Matches the same visibility rules
    * as {@code SessionService#isVisibleRegisteredEnquiryForConsultant}: anonymous-style session,

--- a/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
@@ -62,7 +62,11 @@ public class LiveEventNotificationService {
       LiveEventMessage liveEventMessage, Supplier<String> errorMessageSupplier) {
     try {
       this.liveServiceApiControllerFactory.createControllerApi().sendLiveEvent(liveEventMessage);
-    } catch (ApiException e) {
+    } catch (ApiException | RuntimeException e) {
+      // Live events are best-effort. Besides the declared ApiException, a transport failure (e.g.
+      // the live service host is unreachable → UnresolvedAddressException/ConnectException wrapped
+      // in a RuntimeException by the java.net.http client) must never break the enquiry/session
+      // flow that fired the event — online consultants reconcile via the next queue poll anyway.
       log.error("Internal Server Error: {}", errorMessageSupplier.get(), e);
     }
   }

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
@@ -4,21 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
-import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,12 +28,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * The anonymous Live Chat queue is deliberately cross-agency AND cross-tenant: any consultant who
- * is live for a topic/consulting type must see anonymous enquiries for that topic regardless of the
- * asker's tenant. Tenant isolation on Session queries is enforced by {@code TenantAspect}, which
- * enables the Hibernate {@code tenantFilter} for the current tenant and disables it only in
- * technical context. This test pins that the two queue queries run in technical context (filter
- * off), and that the caller's tenant context is restored afterwards so no other query leaks.
+ * The anonymous Live Chat queue is topic-bound and deliberately cross-agency AND cross-tenant: any
+ * consultant assigned to a topic sees anonymous enquiries for that topic regardless of the asker's
+ * tenant. Tenant isolation on Session queries is enforced by {@code TenantAspect}, which enables
+ * the Hibernate {@code tenantFilter} for the current tenant and disables it only in technical
+ * context. These tests pin that the topic-only queue query runs in technical context (filter off)
+ * and that the caller's tenant is restored afterwards — and that no AgencyService lookup happens.
  */
 @ExtendWith(MockitoExtension.class)
 class AnonymousEnquiryConversationListProviderCrossTenantTest {
@@ -44,7 +42,6 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
 
   @Mock private UserAccountService userAccountProvider;
   @Mock private SessionRepository sessionRepository;
-  @Mock private AgencyService agencyService;
   @Mock private ConsultantSessionEnricher consultantSessionEnricher;
   @Mock private ConsultantTopicRepository consultantTopicRepository;
 
@@ -58,34 +55,29 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
         new AnonymousEnquiryConversationListProvider(
             userAccountProvider,
             sessionRepository,
-            agencyService,
             consultantSessionEnricher,
             consultantTopicRepository);
     ReflectionTestUtils.setField(provider, "liveChatQueueActivePeriodMinutes", 60L);
     return provider;
   }
 
-  private Consultant consultantWithAgency() {
+  private Consultant consultant() {
     var consultant = org.mockito.Mockito.mock(Consultant.class);
-    var agency = org.mockito.Mockito.mock(ConsultantAgency.class);
-    lenient().when(agency.getAgencyId()).thenReturn(1L);
     lenient().when(consultant.getId()).thenReturn("consultant-83");
-    lenient().when(consultant.getConsultantAgencies()).thenReturn(Set.of(agency));
     return consultant;
   }
 
   @Test
   void buildConversations_Should_runTopicQueueQueryCrossTenant_And_restoreTenant() {
     TenantContext.setCurrentTenant(CONSULTANT_TENANT);
-    var consultant = consultantWithAgency();
+    var consultant = consultant();
     when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
-    when(agencyService.getAgencies(any())).thenReturn(List.of(new AgencyDTO().consultingType(1)));
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-83"))
         .thenReturn(List.of(11L));
 
     var tenantDuringQuery = new AtomicReference<Long>();
-    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopics(
-            anySet(), anySet(), any(), any(), any(), any(Pageable.class)))
+    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+            anySet(), any(), any(), any(), any(Pageable.class)))
         .thenAnswer(
             invocation -> {
               tenantDuringQuery.set(TenantContext.getCurrentTenant());
@@ -99,26 +91,21 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
   }
 
   @Test
-  void buildConversations_Should_runNoTopicQueueQueryCrossTenant_And_restoreTenant() {
+  void buildConversations_Should_returnEmpty_When_consultantHasNoTopics() {
     TenantContext.setCurrentTenant(CONSULTANT_TENANT);
-    var consultant = consultantWithAgency();
+    var consultant = consultant();
     when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
-    when(agencyService.getAgencies(any())).thenReturn(List.of(new AgencyDTO().consultingType(1)));
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-83"))
         .thenReturn(List.of());
 
-    var tenantDuringQuery = new AtomicReference<Long>();
-    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsWithoutTopic(
-            anySet(), any(), any(), any(), any(Pageable.class)))
-        .thenAnswer(
-            invocation -> {
-              tenantDuringQuery.set(TenantContext.getCurrentTenant());
-              return new PageImpl<Session>(List.of());
-            });
+    var response =
+        newProvider().buildConversations(PageableListRequest.builder().count(5).offset(0).build());
 
-    newProvider().buildConversations(PageableListRequest.builder().count(5).offset(0).build());
-
-    assertThat(tenantDuringQuery.get()).isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+    assertThat(response.getSessions()).isEmpty();
+    // A consultant without a topic assignment triggers no visibility query at all.
+    verify(sessionRepository, never())
+        .findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+            anySet(), any(), any(), any(), any(Pageable.class));
     assertThat(TenantContext.getCurrentTenant()).isEqualTo(CONSULTANT_TENANT);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderIT.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -64,6 +65,8 @@ class AnonymousEnquiryConversationListProviderIT {
 
   @MockitoBean private UserAccountService userAccountProvider;
 
+  @MockitoBean private ConsultantTopicRepository consultantTopicRepository;
+
   @BeforeEach
   void setup() {
     Consultant consultant = mock(Consultant.class);
@@ -73,6 +76,8 @@ class AnonymousEnquiryConversationListProviderIT {
     when(this.userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
     AgencyDTO agencyDTO = new AgencyDTO().consultingType(CONSULTING_TYPE_ID_OFFENDER);
     when(this.agencyService.getAgencies(any())).thenReturn(singletonList(agencyDTO));
+    when(this.consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
+        .thenReturn(java.util.List.of(11L));
   }
 
   @AfterEach
@@ -151,7 +156,7 @@ class AnonymousEnquiryConversationListProviderIT {
           session.setPostcode("12345");
           session.setConsultingTypeId(CONSULTING_TYPE_ID_OFFENDER);
           session.setStatus(SessionStatus.NEW);
-          session.setMainTopicId(null);
+          session.setMainTopicId(11L);
           session.setSessionTopics(Lists.newArrayList());
           session.setUpdateDate(LocalDateTime.now());
         });

--- a/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
@@ -108,6 +108,25 @@ public class LiveEventNotificationServiceTest {
   }
 
   @Test
+  public void
+      sendLiveNewAnonymousEnquiryEventToUsers_Should_notPropagate_When_liveServiceUnreachable()
+          throws ApiException {
+    // A live event is best-effort: a transport failure (e.g. the live service host is unreachable,
+    // surfacing as an UnresolvedAddressException/ConnectException — NOT an ApiException) must never
+    // break the enquiry/session flow that fired it.
+    doThrow(new RuntimeException(new java.net.ConnectException("unreachable")))
+        .when(this.liveControllerApi)
+        .sendLiveEvent(any());
+
+    try (var logCaptor = LogbackCaptor.forClass(LiveEventNotificationService.class)) {
+      this.liveEventNotificationService.sendLiveNewAnonymousEnquiryEventToUsers(
+          asList("consultant-1"), 4711L);
+
+      assertThat(logCaptor.contains(Level.ERROR, "Internal Server Error")).isTrue();
+    }
+  }
+
+  @Test
   public void sendLiveDirectMessageEventToUsers_Should_sendEventToAllUsersInsteadOfInitiatingUser()
       throws ApiException {
     List<String> userIds = asList("id1", "id2", "id3", "id4");


### PR DESCRIPTION
## Why

Completes the anonymous cross-tenant Live Chat topic queue (#413). With redeem now creating true ANONYMOUS sessions and the FE consuming `/enquiries/anonymous`, that endpoint was found to reliably 500 on PreDev.

Root cause: `AnonymousEnquiryConversationListProvider` resolved the consultant's consulting types via `agencyService.getAgencies(consultantAgencyIds)`. That call goes out **unauthenticated** — `SecurityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders()` only adds a bearer token when the request context already carries one — so AgencyService's `GET /agencies/{ids}` returned 401 and the provider 500'd. Latent for a long time: this provider is the only caller of `getAgencies`, and the FE never hit `/enquiries/anonymous` until it started merging that feed.

## What

Product model (Frank): the anonymous Live Chat queue is **topic-bound** — a live consultant sees anonymous enquiries for the topics they are assigned to, independent of consulting type, deliberately cross-agency and cross-tenant.

- New `SessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly` — matches `mainTopicId IN :topicIds` (no consulting-type filter).
- `AnonymousEnquiryConversationListProvider` now resolves only the consultant's assigned topics (local `ConsultantTopicRepository`) and queries topic-only. A consultant with no topic assignment returns empty **without any cross-service call**. The `AgencyService` dependency is removed from this provider entirely, eliminating the unauthenticated agency lookup.
- The cross-tenant behaviour (running the visibility query in technical context so `TenantAspect` disables the Hibernate `tenantFilter`, then restoring the caller's tenant) is retained and unit-pinned.
- Also included: `LiveEventNotificationService` best-effort delivery — a live-service transport failure (RuntimeException, not just ApiException) must not break the enquiry/session flow.

## Tests

- `AnonymousEnquiryConversationListProviderCrossTenantTest`: the topic-only query runs in technical context (tenant 0 = filter off) and the caller's tenant is restored; a consultant with no topics returns empty and triggers no query.
- `AnonymousEnquiryConversationListProviderIT`: updated to the topic-only path.
- `LiveEventNotificationServiceTest`: RuntimeException swallowed.
- Full Java 21 unit gate: 3,431 tests, 0 failures, 0 errors, 7 skipped; Spotless applied. (Pre-existing flaky `…IT#returnElementsInExpectedOrder` — EasyRandom dates — is unrelated and not run in the CI unit phase.)

Refs #413. PreDev only; no merge or deployment to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
