### PR TITLE
Fix async new enquiry email header creation

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
@@ -1,11 +1,13 @@
 package de.caritas.cob.userservice.api.service.httpheader;
 
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -66,10 +68,9 @@ public class SecurityHeaderSupplier {
    * fallback token (e.g. technical user token).
    */
   public HttpHeaders getKeycloakAndCsrfHttpHeadersWithFallback(String fallbackAccessToken) {
-    var currentAccessToken = authenticatedUser.getAccessToken();
-    return StringUtils.isNotBlank(currentAccessToken)
-        ? getKeycloakAndCsrfHttpHeaders(currentAccessToken)
-        : getKeycloakAndCsrfHttpHeaders(fallbackAccessToken);
+    return getCurrentAccessTokenIfAvailable()
+        .map(this::getKeycloakAndCsrfHttpHeaders)
+        .orElseGet(() -> getKeycloakAndCsrfHttpHeaders(fallbackAccessToken));
   }
 
   /**
@@ -77,7 +78,19 @@ public class SecurityHeaderSupplier {
    * already has a user token. This keeps public flows unauthenticated.
    */
   public HttpHeaders getOptionalKeycloakAndCsrfHttpHeaders() {
-    return getKeycloakAndCsrfHttpHeaders();
+    var header = getCsrfHttpHeaders();
+    getCurrentAccessTokenIfAvailable()
+        .ifPresent(accessToken -> this.addKeycloakAuthorizationHeader(header, accessToken));
+    return header;
+  }
+
+  private Optional<String> getCurrentAccessTokenIfAvailable() {
+    try {
+      return Optional.ofNullable(authenticatedUser.getAccessToken())
+          .filter(StringUtils::isNotBlank);
+    } catch (ScopeNotActiveException exception) {
+      return Optional.empty();
+    }
   }
 
   private void addKeycloakAuthorizationHeader(HttpHeaders httpHeaders, String accessToken) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplierTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -78,5 +80,45 @@ public class SecurityHeaderSupplierTest {
 
     assertThat(result.get("Authorization").get(0), is("Bearer " + "token"));
     assertNotNull(result.get(CSRF_TOKEN_HEADER_VALUE));
+  }
+
+  @Test
+  public void getOptionalKeycloakAndCsrfHttpHeaders_Should_AddAuthorization_WhenTokenIsAvailable() {
+    when(authenticatedUser.getAccessToken()).thenReturn(BEARER_TOKEN);
+
+    HttpHeaders result = securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders();
+
+    assertThat(result.get("Authorization").get(0), is("Bearer " + BEARER_TOKEN));
+    assertNotNull(result.get(CSRF_TOKEN_HEADER_VALUE));
+  }
+
+  @Test
+  public void
+      getOptionalKeycloakAndCsrfHttpHeaders_Should_ReturnCsrfOnly_WhenRequestScopeIsNotActive() {
+    when(authenticatedUser.getAccessToken()).thenThrow(scopeNotActiveException());
+
+    HttpHeaders result = securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders();
+
+    assertNull(result.get("Authorization"));
+    assertThat(result.get("Cookie").get(0), startsWith(CSRF_TOKEN_COOKIE_VALUE + "="));
+    assertNotNull(result.get(CSRF_TOKEN_HEADER_VALUE));
+  }
+
+  @Test
+  public void getKeycloakAndCsrfHttpHeadersWithFallback_Should_UseFallback_WhenScopeIsNotActive() {
+    when(authenticatedUser.getAccessToken()).thenThrow(scopeNotActiveException());
+
+    HttpHeaders result =
+        securityHeaderSupplier.getKeycloakAndCsrfHttpHeadersWithFallback("technical-token");
+
+    assertThat(result.get("Authorization").get(0), is("Bearer technical-token"));
+    assertNotNull(result.get(CSRF_TOKEN_HEADER_VALUE));
+  }
+
+  private ScopeNotActiveException scopeNotActiveException() {
+    return new ScopeNotActiveException(
+        "scopedTarget.authenticatedUser",
+        "request",
+        new IllegalStateException("No thread-bound request found"));
   }
 }


### PR DESCRIPTION
## Summary

- Make optional UserService auth header creation safe when there is no active HTTP request scope.
- Keep forwarding the current request bearer token when it exists.
- Return CSRF-only optional headers for async/public flows instead of touching the request-scoped `AuthenticatedUser` bean.
- Use the provided fallback token when request scope is unavailable for fallback header creation.
- Add focused `SecurityHeaderSupplierTest` coverage for active-token, missing-request-scope, and fallback-token behavior.

## Root cause

The async new-enquiry email notification path can call AgencyService after the original request has moved to an async thread. `SecurityHeaderSupplier#getOptionalKeycloakAndCsrfHttpHeaders()` always accessed request-scoped `AuthenticatedUser`, which raises `ScopeNotActiveException` outside request scope and breaks the notification.

## Verification

- `./mvnw.cmd -Dtest=SecurityHeaderSupplierTest test`

Target branch: `pre-dev`.

Fixes #210.