### PR TITLE
feat(obs-p10): report CI run health metrics to SigNoz (PoC)

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # OBS-P10 PoC (ORISO-Helm#62): capture job start time so the final step
+    # can report a real elapsed-seconds duration to SigNoz. Placed before
+    # checkout so the reported duration covers the whole job.
+    - name: Record CI health start time (OBS-P10)
+      id: ci_health_start
+      run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
     - name: Checkout repository
       uses: actions/checkout@v6
 
@@ -27,6 +34,97 @@ jobs:
         push_to_ghcr: false
         image_name: oriso-userservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # OBS-P10 PoC (ORISO-Helm#62): CI/test-health visibility. Fires as the
+    # LAST step, always (pass or fail), and POSTs a tiny OTLP/HTTP JSON
+    # metrics payload straight to the SigNoz otel-collector's public ingest
+    # path (OBS-P8 already opened /v1/metrics for browser RUM; CORS is
+    # browser-only and does not block this server-to-server POST). No new
+    # infra, no new dependency: plain curl. Values come only from GitHub
+    # Actions' own context (repo name, workflow name, job status) — no
+    # commit SHA, branch, actor, or PR number, to keep this an aggregate
+    # health signal rather than an audit trail.
+    #
+    # Metric shapes (dashboard will be built against these exact names):
+    #   ci_run_result (Sum, cumulative temporality, isMonotonic: true, value
+    #     always 1) — chosen over delta temporality because it's the simpler
+    #     internally-consistent choice for a fire-once-per-run counter with
+    #     no state carried between runs.
+    #   ci_run_duration_seconds (Gauge, elapsed wall-clock seconds).
+    # Both scoped under scope.name "ci-health", resource service.name
+    # "ci-cd", attributes repo/workflow/conclusion only.
+    - name: Report CI health metrics to SigNoz (OBS-P10, non-blocking)
+      if: always()
+      env:
+        REPO: ${{ github.event.repository.name }}
+        WORKFLOW: ${{ github.workflow }}
+        # job.status is already exactly success | failure | cancelled —
+        # cancelled is kept as its own value, not folded into failure, since
+        # collapsing it would misrepresent the health signal.
+        CONCLUSION: ${{ job.status }}
+        START_EPOCH: ${{ steps.ci_health_start.outputs.start }}
+      run: |
+        set +e
+        end_epoch=$(date +%s)
+        duration=$(( end_epoch - START_EPOCH ))
+        # Real current Unix nanosecond timestamp — a stale/wrong one silently
+        # pushes the point outside any dashboard's default time range and
+        # looks like nothing arrived.
+        now_ns=$(( end_epoch * 1000000000 ))
+
+        payload=$(cat <<EOF
+        {
+          "resourceMetrics": [{
+            "resource": {
+              "attributes": [{"key": "service.name", "value": {"stringValue": "ci-cd"}}]
+            },
+            "scopeMetrics": [{
+              "scope": {"name": "ci-health"},
+              "metrics": [
+                {
+                  "name": "ci_run_result",
+                  "sum": {
+                    "dataPoints": [{
+                      "attributes": [
+                        {"key": "repo", "value": {"stringValue": "${REPO}"}},
+                        {"key": "workflow", "value": {"stringValue": "${WORKFLOW}"}},
+                        {"key": "conclusion", "value": {"stringValue": "${CONCLUSION}"}}
+                      ],
+                      "startTimeUnixNano": "${now_ns}",
+                      "timeUnixNano": "${now_ns}",
+                      "asInt": "1"
+                    }],
+                    "aggregationTemporality": 2,
+                    "isMonotonic": true
+                  }
+                },
+                {
+                  "name": "ci_run_duration_seconds",
+                  "gauge": {
+                    "dataPoints": [{
+                      "attributes": [
+                        {"key": "repo", "value": {"stringValue": "${REPO}"}},
+                        {"key": "workflow", "value": {"stringValue": "${WORKFLOW}"}},
+                        {"key": "conclusion", "value": {"stringValue": "${CONCLUSION}"}}
+                      ],
+                      "timeUnixNano": "${now_ns}",
+                      "asDouble": ${duration}
+                    }]
+                  }
+                }
+              ]
+            }]
+          }]
+        }
+        EOF
+        )
+
+        curl -s -o /dev/null -w 'CI health metrics POST: HTTP %{http_code}\n' \
+          -X POST "https://signoz.oriso-dev.site/v1/metrics" \
+          -H "Content-Type: application/json" \
+          -d "${payload}" \
+          || echo "::warning::Failed to POST CI health metrics to SigNoz (non-blocking, telemetry only)"
+        true
 
   # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
   # Runs `mvnw -B verify`, which reaches the surefire `integration-tests` execution


### PR DESCRIPTION
## Summary
- OBS-P10 proof-of-concept: adds CI/test-health visibility (pass/fail/cancelled, duration) into SigNoz, starting with 2 repos (this + ORISO-Helm) before deciding on wider rollout.
- Adds a final, `if: always()`, non-blocking step to `ci-pull-request.yml`'s `validate` job (fires on every PR against `pre-dev`) that POSTs a minimal OTLP/HTTP JSON metrics payload directly to the SigNoz otel-collector's already-public `/v1/metrics` ingest path (opened for browser Real User Monitoring in OBS-P8). CORS is a browser-only restriction and does not block this server-to-server POST from a GitHub Actions runner — verified directly (see below).
- **No infra changes** in this PR — this is workflow-file-only. Zero new dependencies (plain `curl` in a `run:` step).
- Chose `ci-pull-request.yml` over `ci-main.yml` / `ci-feature-branch.yml` since it's the workflow that fires on every regular PR (this repo's PRs land on `pre-dev`); the pattern can be duplicated to the other two triggers later if it proves useful.

## Metric schema (built exactly as specified, dashboard will query these names)
Resource `service.name = "ci-cd"`, scope `"ci-health"`:
- `ci_run_result` — Counter (`sum`, `aggregationTemporality: 2` cumulative, `isMonotonic: true`, value always `1`)
- `ci_run_duration_seconds` — Gauge, elapsed wall-clock seconds for the job

Both carry only `repo` (short name, e.g. `"ORISO-UserService"`), `workflow` (`github.workflow`), and `conclusion` (`success` / `failure` / `cancelled` — mapped 1:1 from `job.status`, cancelled kept as its own value, not folded into failure). No commit SHA, branch, actor, or PR number — this is aggregate health monitoring, not an audit trail.

## Verification performed (not just "should work")
1. Manually constructed the exact OTLP JSON payload shape the workflow step produces and POSTed it to `https://signoz.oriso-dev.site/v1/metrics` — got `200 {"partialSuccess":{}}`.
2. Queried ClickHouse via `https://signoz.oriso-dev.site/api/v3/query_range` (API key from `~/.oriso/secrets/signoz.env`) ~30-40s later and confirmed both the `ci_run_result` counter and `ci_run_duration_seconds` gauge landed, queryable, grouped by `repo`, with the correct `conclusion` attribute and duration value.
3. Note: the data needs ~30-40s of ingestion delay to become queryable, not the ~10s I initially assumed — the first query attempt came back empty, a false alarm about the pipeline rather than a real problem (checked `docs/observability-prod-pseudonymization.md` and `otel-collector-configmap.yaml`'s metrics pipeline as instructed; no processor/shape issue, just needed a longer wait).

## Ambiguity I resolved
- Placed the "record start time" step first (before checkout) so the reported duration covers the whole job.
- Used `env:` blocks for all `${{ }}` context values interpolated into the `run:` script (repo, workflow, conclusion, start time) per GitHub Actions injection-safety best practice, even though none of these particular values are attacker-controlled.
- This step is only on `ci-pull-request.yml`, not `ci-main.yml`/`ci-feature-branch.yml` — see Summary above.

Refs OpenResilienceInitiative/ORISO-Helm#62

## Test plan
- [x] `validate` job must still pass on this PR (existing maven-build/docker-build steps unchanged; new step is additive and appended last)
- [x] Manual curl + ClickHouse query round-trip verified (see above)
- [ ] Not merging — POC for review first

🤖 Generated with [Claude Code](https://claude.com/claude-code)