### PR TITLE
OBS-P5: Remove Sentry SDK (SigNoz has full parity)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
 		<springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
 		<ehcache.version>2.10.9.2</ehcache.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
-		<sentry.version>8.46.0</sentry.version>
 		<lombok.version>1.18.42</lombok.version>
 	</properties>
 
@@ -111,11 +110,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.sentry</groupId>
-			<artifactId>sentry-spring-boot-4-starter</artifactId>
-			<version>${sentry.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -336,11 +330,6 @@
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
 			<version>7.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>io.sentry</groupId>
-			<artifactId>sentry-logback</artifactId>
-			<version>${sentry.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,15 +23,6 @@ spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD:${SPRING_REDIS_PASSWORD:
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration
 
-# ---------------- Sentry ----------------
-sentry.dsn=${SENTRY_DSN:}
-sentry.environment=${SENTRY_ENVIRONMENT:dev}
-sentry.release=${SENTRY_RELEASE:oriso-userservice@local}
-sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
-sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
-sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
-sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
-
 # ---------------- Server ----------------
 server.port=8082
 server.host=http://localhost
@@ -314,8 +305,8 @@ management.endpoint.loggers.enabled=true
 
 # ---------------- OpenTelemetry / SigNoz (traces + metrics) ----------------
 # Traces and metrics ship via OTLP to the SigNoz gateway collector (logs already
-# flow separately via stdout JSON). Endpoints are env-driven, mirroring the
-# sentry.dsn pattern.
+# flow separately via stdout JSON). Endpoints are env-driven, each with its own
+# explicit *_ENABLED flag (see below).
 #
 # Property names verified against the actual Spring Boot 4.0.1 tagged source /
 # spring-configuration-metadata.json (not docs): Boot 4 renamed the tracing OTLP


### PR DESCRIPTION
## Summary
- Removes the dormant Sentry SDK now that SigNoz has full traces/metrics/logs/RUM/error-intake parity (OBS-P1 through P4/P6/P8/P9 all done and deployed). Sentry has had zero events since 2026-06-22.
- `pom.xml`: removed `io.sentry:sentry-spring-boot-4-starter`, `io.sentry:sentry-logback`, and the `sentry.version` property.
- `application.properties`: removed the `sentry.dsn` / `sentry.environment` / `sentry.release` / `sentry.traces-sample-rate` / `sentry.send-default-pii` / `sentry.logging.*` block, and updated a stale comment in the OpenTelemetry section that referenced the now-removed `sentry.dsn` pattern.
- Searched `src/main/java` and `src/test/java` for any `Sentry.*` API usage (captureException, init, annotations, etc.) — none exist. This is a config/dependency-only removal, no source code changes were needed.

Part of the observability rollout tracked in OpenResilienceInitiative/ORISO-Helm#62 (OBS-P5).

**Helm follow-up needed (separate repo, not touched here):** `application.properties` read `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_SEND_DEFAULT_PII`, `SENTRY_LOGGING_MINIMUM_EVENT_LEVEL`, and `SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL` as env vars with defaults, so they never hard-failed without ORISO-Helm wiring — but if any of these are actually set in ORISO-Helm's UserService values/deployment, they're now unused and a human should clean them up there.

## Test plan
- [x] `mvn spotless:apply` (JDK 21) — 1154 files already clean, no changes needed.
- [x] `mvn clean verify -Dskip.integration-tests=true` (JDK 21) — BUILD SUCCESS, all unit tests pass. This matches how CI actually runs this repo (per prior audits, no `*IT` integration tests run in CI here).
- [x] Full `mvn clean verify` (including `*IT` integration tests) was also run for completeness. It has 240 failures / 265 errors, but I verified these are **pre-existing on unmodified `origin/pre-dev`** (reproduced the identical root-cause stack trace — a Spring HATEOAS/`spring-plugin-core` `PluginRegistryFactoryBean` bean-creation failure, unrelated to Sentry — on a stash of this change). Not introduced by this PR.
- [x] Repo-wide case-insensitive grep for `sentry`/`Sentry`/`SENTRY` confirms no remaining references anywhere (Dockerfile, CI workflow files, Java source, test source) other than incidental false positives like `containsEntry`/`hasEntry` method names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)