### PR TITLE
fix: retry Keycloak admin delete once after forcing a fresh token on 401

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakClient.java
@@ -89,6 +89,18 @@ public class KeycloakClient {
     return keycloak.tokenManager().getAccessTokenString();
   }
 
+  /**
+   * Forces a fresh admin token grant, bypassing the cached access token.
+   *
+   * <p>The keycloak-admin-client only refreshes its cached token when the token's own {@code exp}
+   * claim is close to expiry. It does not know that the underlying Keycloak session can be
+   * invalidated server-side earlier (e.g. by session-idle timeout), so a cached token can look
+   * valid locally while the admin REST API already rejects it with 401.
+   */
+  public void refreshAdminSession() {
+    keycloak.tokenManager().grantToken();
+  }
+
   @NonNull
   private HttpHeaders headersWithBearerToken(String bearerToken) {
     var httpHeaders = new HttpHeaders();

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -27,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -725,6 +726,13 @@ public class KeycloakService implements IdentityClient {
       keycloakClient.getUsersResource().get(userId).remove();
     } catch (NotFoundException e) {
       log.warn("User {} not found in Keycloak, skipping deletion.", userId);
+    } catch (NotAuthorizedException e) {
+      log.warn(
+          "Keycloak admin session was unauthorized for deleting user {}, forcing token refresh"
+              + " and retrying once",
+          userId);
+      keycloakClient.refreshAdminSession();
+      keycloakClient.getUsersResource().get(userId).remove();
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1405,6 +1405,23 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void deleteUser_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
+    UsersResource usersResource = mock(UsersResource.class);
+    UserResource userResource = mock(UserResource.class);
+    org.mockito.Mockito.doThrow(mock(jakarta.ws.rs.NotAuthorizedException.class))
+        .doNothing()
+        .when(userResource)
+        .remove();
+    when(usersResource.get(any())).thenReturn(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.deleteUser(USER_ID);
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(userResource, times(2)).remove();
+  }
+
+  @Test
   public void ensureRole_Should_SkipUpdate_When_UserAlreadyHasRole() {
     UserResource userResource = givenUserResourceWithRealmRoles("consultant");
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);


### PR DESCRIPTION
## Summary
- `DeleteKeycloakAskerAction` was failing hourly with `jakarta.ws.rs.NotAuthorizedException: HTTP 401` when `KeycloakService.deleteUser()` called Keycloak's admin REST API, triggering the SigNoz "Elevated error/exception log rate" alert.
- Root cause (confirmed live on Pre-Dev): the admin `Keycloak` client's cached access token has a 5h lifespan (`expires_in=18000`), but the Keycloak session backing it only lives 30 minutes (`refresh_expires_in=1800`). `TokenManager` only re-authenticates based on the token's own (long) expiry claim, not session-idle state, so after any 30+ minute gap between admin-client calls — which the hourly scheduler always exceeds — the cached token looks valid client-side while the server has already invalidated the session. The next admin call then gets a flat 401. Verified the credentials themselves are correct: a fresh token grant with the same technical-user creds succeeds immediately (HTTP 200).
- `KeycloakService.deleteUser()` now catches `NotAuthorizedException`, forces a fresh token grant via the new `KeycloakClient.refreshAdminSession()`, and retries the delete once.

## Test plan
- [x] `KeycloakServiceTest` — added `deleteUser_Should_RefreshAdminSessionAndRetry_When_Unauthorized`, all 89 tests pass (JDK21, `-Dspotless.check.skip=true` due to known JDK25 spotless incompatibility)
- [x] `mvn spotless:apply` — no formatting changes needed
- [ ] Deploying to Pre-Dev to confirm the hourly `scheduling-1` 401 stops recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)