### PR TITLE
fix: bypass security for username availability

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -366,7 +366,7 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring().requestMatchers("/actuator/**");
+    return web -> web.ignoring().requestMatchers("/actuator/**", "/users/availability/**");
   }
 
   @Bean

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/SecurityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/SecurityConfigTest.java
@@ -13,7 +13,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 class SecurityConfigTest {
 
   @Test
-  void publicAskerRegistrationShouldPassThroughSecurityFilterChain() {
+  void usernameAvailabilityShouldPassThroughSecurityFilterChain() {
     var securityConfig = new SecurityConfig(mock(CsrfSecurityProperties.class), null, null);
     var webSecurity = mock(WebSecurity.class);
     var ignoredRequests = mock(WebSecurity.IgnoredRequestConfigurer.class);
@@ -24,7 +24,7 @@ class SecurityConfigTest {
     var ignoredPaths = ArgumentCaptor.forClass(String[].class);
     verify(ignoredRequests).requestMatchers(ignoredPaths.capture());
     assertThat(ignoredPaths.getValue())
-        .containsExactly("/actuator/**")
+        .containsExactly("/actuator/**", "/users/availability/**")
         .doesNotContain("/users/askers/new");
   }
 }


### PR DESCRIPTION
## Summary
- bypass the Spring Security filter chain for username availability checks
- keep the existing authenticated matcher list unchanged
- update the security config unit test for the ignored path list

Fixes #430

## Test
- ./mvnw -Dtest=SecurityConfigTest test