### PR TITLE
fix: delete case_handover_request rows before session/consultant deletion

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
@@ -14,4 +14,10 @@ public interface CaseHandoverRequestRepository extends JpaRepository<CaseHandove
       Long sessionId, CaseHandoverRequest.Status status);
 
   Optional<CaseHandoverRequest> findByIdAndSessionId(Long id, Long sessionId);
+
+  List<CaseHandoverRequest> findBySessionId(Long sessionId);
+
+  List<CaseHandoverRequest> findByRequesterConsultantId(String requesterConsultantId);
+
+  List<CaseHandoverRequest> findByPreviousConsultantId(String previousConsultantId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.workflow.delete.action.asker;
 import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
@@ -16,8 +17,10 @@ public class DeleteAskerRoomsAndSessionsAction extends DeleteRoomsAndSessionActi
   public DeleteAskerRoomsAndSessionsAction(
       SessionRepository sessionRepository,
       SessionDataRepository sessionDataRepository,
-      RocketChatService rocketChatService) {
-    super(sessionRepository, sessionDataRepository, rocketChatService);
+      RocketChatService rocketChatService,
+      CaseHandoverRequestRepository caseHandoverRequestRepository) {
+    super(
+        sessionRepository, sessionDataRepository, rocketChatService, caseHandoverRequestRepository);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
@@ -7,6 +7,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatDeleteGroupException;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
@@ -23,6 +24,7 @@ abstract class DeleteRoomsAndSessionAction {
   protected final @NonNull SessionRepository sessionRepository;
   protected final @NonNull SessionDataRepository sessionDataRepository;
   protected final @NonNull RocketChatService rocketChatService;
+  protected final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
 
   void deleteRocketChatGroup(String rcGroupId, List<DeletionWorkflowError> workflowErrors) {
     if (isNotBlank(rcGroupId)) {
@@ -59,6 +61,24 @@ abstract class DeleteRoomsAndSessionAction {
     }
   }
 
+  void deleteCaseHandoverRequests(Session session, List<DeletionWorkflowError> workflowErrors) {
+    try {
+      var caseHandoverRequests =
+          this.caseHandoverRequestRepository.findBySessionId(session.getId());
+      this.caseHandoverRequestRepository.deleteAll(caseHandoverRequests);
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      workflowErrors.add(
+          DeletionWorkflowError.builder()
+              .deletionSourceType(ASKER)
+              .deletionTargetType(DeletionTargetType.DATABASE)
+              .identifier(String.valueOf(session.getId()))
+              .reason("Unable to delete case handover requests for session")
+              .timestamp(nowInUtc())
+              .build());
+    }
+  }
+
   protected void deleteSession(Session session, List<DeletionWorkflowError> workflowErrors) {
     try {
       this.sessionRepository.delete(session);
@@ -79,6 +99,7 @@ abstract class DeleteRoomsAndSessionAction {
 
     deleteRocketChatGroup(session.getGroupId(), workflowErrors);
     deleteSessionData(session, workflowErrors);
+    deleteCaseHandoverRequests(session, workflowErrors);
     deleteSession(session, workflowErrors);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.workflow.delete.action.asker;
 import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.SessionDeletionWorkflowDTO;
@@ -18,12 +19,15 @@ public class DeleteSingleRoomAndSessionAction extends DeleteRoomsAndSessionActio
    * @param sessionRepository a {@link SessionRepository} instance
    * @param sessionDataRepository a {@link SessionDataRepository} instance
    * @param rocketChatService a {@link RocketChatService} instance
+   * @param caseHandoverRequestRepository a {@link CaseHandoverRequestRepository} instance
    */
   public DeleteSingleRoomAndSessionAction(
       SessionRepository sessionRepository,
       SessionDataRepository sessionDataRepository,
-      RocketChatService rocketChatService) {
-    super(sessionRepository, sessionDataRepository, rocketChatService);
+      RocketChatService rocketChatService,
+      CaseHandoverRequestRepository caseHandoverRequestRepository) {
+    super(
+        sessionRepository, sessionDataRepository, rocketChatService, caseHandoverRequestRepository);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteCaseHandoverRequestsForConsultantAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteCaseHandoverRequestsForConsultantAction.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+
+import de.caritas.cob.userservice.api.actions.ActionCommand;
+import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes {@link CaseHandoverRequest}s referencing a {@link Consultant} as requester or previous
+ * consultant.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteCaseHandoverRequestsForConsultantAction
+    implements ActionCommand<ConsultantDeletionWorkflowDTO> {
+
+  private final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  /**
+   * Deletes all {@link CaseHandoverRequest}s referencing the given {@link Consultant} as requester
+   * or previous consultant.
+   *
+   * @param actionTarget the {@link ConsultantDeletionWorkflowDTO} containing the {@link Consultant}
+   */
+  @Override
+  public void execute(ConsultantDeletionWorkflowDTO actionTarget) {
+    try {
+      var consultantId = actionTarget.getConsultant().getId();
+      List<CaseHandoverRequest> caseHandoverRequests =
+          Stream.concat(
+                  this.caseHandoverRequestRepository
+                      .findByRequesterConsultantId(consultantId)
+                      .stream(),
+                  this.caseHandoverRequestRepository
+                      .findByPreviousConsultantId(consultantId)
+                      .stream())
+              .collect(
+                  Collectors.collectingAndThen(
+                      Collectors.toMap(CaseHandoverRequest::getId, r -> r, (a, b) -> a),
+                      map -> List.copyOf(map.values())));
+      this.caseHandoverRequestRepository.deleteAll(caseHandoverRequests);
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      actionTarget
+          .getDeletionWorkflowErrors()
+          .add(
+              DeletionWorkflowError.builder()
+                  .deletionSourceType(CONSULTANT)
+                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .identifier(actionTarget.getConsultant().getId())
+                  .reason("Could not delete case handover requests for consultant")
+                  .timestamp(nowInUtc())
+                  .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteKeycloa
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteMatrixAskerAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteRocketChatAskerAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteAppointmentServiceConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteCaseHandoverRequestsForConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteChatAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAgencyAction;
@@ -105,6 +106,7 @@ public class DeleteUserAccountService {
         .addActionToExecute(DeleteChatAction.class)
         .addActionToExecute(DeleteRocketChatConsultantAction.class)
         .addActionToExecute(DeleteAppointmentServiceConsultantAction.class)
+        .addActionToExecute(DeleteCaseHandoverRequestsForConsultantAction.class)
         .addActionToExecute(DeleteDatabaseConsultantAction.class)
         .executeActions(deletionWorkflowDTO);
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatDeleteGroupException;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
@@ -49,6 +50,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
   @Mock private SessionDataRepository sessionDataRepository;
 
   @Mock private RocketChatService rocketChatService;
+
+  @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
 
   private LogbackCaptor logCaptor;
 
@@ -89,6 +92,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     verify(this.rocketChatService, times(1)).deleteGroupAsTechnicalUser(any());
     verify(this.sessionDataRepository, times(1)).findBySessionId(session.getId());
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
+    verify(this.caseHandoverRequestRepository, times(1)).findBySessionId(session.getId());
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(any());
     verify(this.sessionRepository, times(1)).delete(session);
   }
 
@@ -101,6 +106,7 @@ class DeleteAskerRoomsAndSessionsActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -108,8 +114,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(3));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(3);
+    assertThat(workflowErrors, hasSize(4));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(4);
   }
 
   @Test
@@ -122,6 +128,7 @@ class DeleteAskerRoomsAndSessionsActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -129,8 +136,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(9));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(9);
+    assertThat(workflowErrors, hasSize(12));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(12);
   }
 
   @Test
@@ -173,6 +180,28 @@ class DeleteAskerRoomsAndSessionsActionTest {
     assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
     assertThat(workflowErrors.get(0).getIdentifier(), is(session.getId().toString()));
     assertThat(workflowErrors.get(0).getReason(), is("Unable to delete session data from session"));
+    assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
+  }
+
+  @Test
+  void execute_Should_returnExpectedWorkflowError_When_caseHandoverRequestDeletionFails() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    when(this.sessionRepository.findByUser(any())).thenReturn(singletonList(session));
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    AskerDeletionWorkflowDTO workflowDTO =
+        new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
+
+    this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
+    List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
+
+    assertThat(workflowErrors, hasSize(1));
+    assertThat(logCaptor.contains(Level.ERROR, "UserService delete workflow error")).isTrue();
+    assertThat(workflowErrors.get(0).getDeletionSourceType(), is(ASKER));
+    assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+    assertThat(workflowErrors.get(0).getIdentifier(), is(session.getId().toString()));
+    assertThat(
+        workflowErrors.get(0).getReason(),
+        is("Unable to delete case handover requests for session"));
     assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
@@ -18,6 +18,7 @@ import ch.qos.logback.classic.Level;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatDeleteGroupException;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
@@ -45,6 +46,8 @@ class DeleteSingleRoomAndSessionActionTest {
 
   @Mock private RocketChatService rocketChatService;
 
+  @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
+
   private LogbackCaptor logCaptor;
 
   @BeforeEach
@@ -71,6 +74,8 @@ class DeleteSingleRoomAndSessionActionTest {
     verify(this.rocketChatService, times(1)).deleteGroupAsTechnicalUser(any());
     verify(this.sessionDataRepository, times(1)).findBySessionId(session.getId());
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
+    verify(this.caseHandoverRequestRepository, times(1)).findBySessionId(session.getId());
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(any());
     verify(this.sessionRepository, times(1)).delete(session);
   }
 
@@ -82,6 +87,7 @@ class DeleteSingleRoomAndSessionActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     SessionDeletionWorkflowDTO workflowDTO =
         new SessionDeletionWorkflowDTO(session, new ArrayList<>());
@@ -89,8 +95,8 @@ class DeleteSingleRoomAndSessionActionTest {
     this.deleteSingleRoomAndSessionAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(3));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(3);
+    assertThat(workflowErrors, hasSize(4));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(4);
   }
 
   @Test
@@ -131,6 +137,27 @@ class DeleteSingleRoomAndSessionActionTest {
     assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
     assertThat(workflowErrors.get(0).getIdentifier(), is(session.getId().toString()));
     assertThat(workflowErrors.get(0).getReason(), is("Unable to delete session data from session"));
+    assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
+  }
+
+  @Test
+  void execute_Should_returnExpectedWorkflowError_When_caseHandoverRequestDeletionFails() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    SessionDeletionWorkflowDTO workflowDTO =
+        new SessionDeletionWorkflowDTO(session, new ArrayList<>());
+
+    this.deleteSingleRoomAndSessionAction.execute(workflowDTO);
+    List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
+
+    assertThat(workflowErrors, hasSize(1));
+    assertThat(logCaptor.contains(Level.ERROR, "UserService delete workflow error")).isTrue();
+    assertThat(workflowErrors.get(0).getDeletionSourceType(), is(ASKER));
+    assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+    assertThat(workflowErrors.get(0).getIdentifier(), is(session.getId().toString()));
+    assertThat(
+        workflowErrors.get(0).getReason(),
+        is("Unable to delete case handover requests for session"));
     assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteCaseHandoverRequestsForConsultantActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteCaseHandoverRequestsForConsultantActionTest.java
@@ -1,0 +1,141 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import de.caritas.cob.userservice.testutils.LogbackCaptor;
+import java.util.ArrayList;
+import java.util.List;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteCaseHandoverRequestsForConsultantActionTest {
+
+  @InjectMocks
+  private DeleteCaseHandoverRequestsForConsultantAction
+      deleteCaseHandoverRequestsForConsultantAction;
+
+  @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  private LogbackCaptor logCaptor;
+
+  @BeforeEach
+  void setup() {
+    logCaptor = LogbackCaptor.forClass(DeleteCaseHandoverRequestsForConsultantAction.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logCaptor.detach();
+  }
+
+  @Test
+  void
+      execute_Should_returnEmptyListAndPerformNoDeletion_When_consultantHasNoCaseHandoverRequests() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultantId");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, emptyList());
+
+    this.deleteCaseHandoverRequestsForConsultantAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+    assertThat(logCaptor.events()).isEmpty();
+    verify(this.caseHandoverRequestRepository, times(1))
+        .findByRequesterConsultantId("consultantId");
+    verify(this.caseHandoverRequestRepository, times(1)).findByPreviousConsultantId("consultantId");
+  }
+
+  @Test
+  void execute_Should_deleteCaseHandoverRequests_When_consultantIsRequesterOrPreviousConsultant() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultantId");
+    CaseHandoverRequest requesterRequest = new EasyRandom().nextObject(CaseHandoverRequest.class);
+    requesterRequest.setId(1L);
+    CaseHandoverRequest previousRequest = new EasyRandom().nextObject(CaseHandoverRequest.class);
+    previousRequest.setId(2L);
+    when(this.caseHandoverRequestRepository.findByRequesterConsultantId("consultantId"))
+        .thenReturn(singletonList(requesterRequest));
+    when(this.caseHandoverRequestRepository.findByPreviousConsultantId("consultantId"))
+        .thenReturn(singletonList(previousRequest));
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, emptyList());
+
+    this.deleteCaseHandoverRequestsForConsultantAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+    ArgumentCaptor<List<CaseHandoverRequest>> captor = ArgumentCaptor.forClass(List.class);
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(captor.capture());
+    assertThat(captor.getValue(), hasSize(2));
+  }
+
+  @Test
+  void
+      execute_Should_deduplicateCaseHandoverRequest_When_consultantIsBothRequesterAndPreviousConsultantOfSameRequest() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultantId");
+    CaseHandoverRequest sharedRequest = new EasyRandom().nextObject(CaseHandoverRequest.class);
+    sharedRequest.setId(1L);
+    when(this.caseHandoverRequestRepository.findByRequesterConsultantId("consultantId"))
+        .thenReturn(singletonList(sharedRequest));
+    when(this.caseHandoverRequestRepository.findByPreviousConsultantId("consultantId"))
+        .thenReturn(singletonList(sharedRequest));
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, emptyList());
+
+    this.deleteCaseHandoverRequestsForConsultantAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+    ArgumentCaptor<List<CaseHandoverRequest>> captor = ArgumentCaptor.forClass(List.class);
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(captor.capture());
+    assertThat(captor.getValue(), hasSize(1));
+  }
+
+  @Test
+  void execute_Should_returnExpectedWorkflowErrorAndLogError_When_deletionFails() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultantId");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, new ArrayList<>());
+    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+
+    this.deleteCaseHandoverRequestsForConsultantAction.execute(workflowDTO);
+    List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
+
+    assertThat(workflowErrors, hasSize(1));
+    assertThat(workflowErrors.get(0).getDeletionSourceType(), is(CONSULTANT));
+    assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+    assertThat(workflowErrors.get(0).getIdentifier(), is("consultantId"));
+    assertThat(
+        workflowErrors.get(0).getReason(),
+        is("Could not delete case handover requests for consultant"));
+    assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
+    assertThat(logCaptor.contains(Level.ERROR, "UserService delete workflow error")).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

- The anonymous-user deletion scheduler (`DeleteUserAnonymousService.deleteInactiveAnonymousUsers`) was throwing `SQLIntegrityConstraintViolationException` on `case_handover_request_session_fk` roughly once per hourly run on Pre-Dev (confirmed via `kubectl logs` on the `oriso-platform-userservice` pod, 8 occurrences in ~8h uptime, 27 in the fuller log window).
- Root cause: `case_handover_request` (added by the Case Handover feature) has a hard FK to `session.id` with no cascade, but `DeleteRoomsAndSessionAction.performSessionDeletion` never deleted those rows before deleting the session.
- Fix: added a `deleteCaseHandoverRequests` step (via new `CaseHandoverRequestRepository.findBySessionId`) run before session deletion, used by both the scheduled asker-deletion path and the single-session admin-delete path.
- Also closed the equivalent latent gap on the consultant-deletion path: `case_handover_request` also FKs to `consultant.consultant_id` via `requester_consultant_id`/`previous_consultant_id`. Added `DeleteCaseHandoverRequestsForConsultantAction`, wired into `DeleteUserAccountService.performConsultantDeletion` before the consultant row is deleted. This hasn't fired in Pre-Dev logs yet but shares the same root cause and would eventually hit the same class of FK violation.
- Unrelated to the previously-fixed Keycloak 401 issue on the same scheduler thread.

## Test plan

- [x] `mvn -o -Dspotless.check.skip=true test-compile` — clean compile
- [x] Ran the affected unit test suites directly via JUnit console launcher (JDK21 — this repo's Mockito inline-mock agent is incompatible with JDK25): `DeleteAskerRoomsAndSessionsActionTest`, `DeleteSingleRoomAndSessionActionTest`, `DeleteCaseHandoverRequestsForConsultantActionTest`, `DeleteUserAccountServiceTest` — 22/22 pass
- [x] Verified against a clean `pre-dev` base in an isolated worktree (not the stale WIP branch this was drafted on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)