### PR TITLE
feat(auth): self-service password reset (mirrors Magic Link)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -29,6 +29,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDt
 import de.caritas.cob.userservice.api.adapters.web.dto.OccurrenceOverrideRequest;
 import de.caritas.cob.userservice.api.adapters.web.dto.OneTimePasswordDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetConfirmDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PatchUserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ReassignmentNotificationDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.RocketChatGroupIdDTO;
@@ -107,6 +109,18 @@ public class UserController implements UsersApi {
   public ResponseEntity<KeycloakLoginResponseDTO> consumeMagicLink(
       @Valid @RequestBody MagicLinkConsumeDTO consumeDTO) {
     return userRegistrationControllerDelegate.consumeMagicLink(consumeDTO);
+  }
+
+  @org.springframework.web.bind.annotation.PostMapping("/users/password-reset/request")
+  public ResponseEntity<Void> requestPasswordReset(
+      @Valid @RequestBody PasswordResetRequestDTO requestDTO) {
+    return userRegistrationControllerDelegate.requestPasswordReset(requestDTO);
+  }
+
+  @org.springframework.web.bind.annotation.PostMapping("/users/password-reset/confirm")
+  public ResponseEntity<Void> confirmPasswordReset(
+      @Valid @RequestBody PasswordResetConfirmDTO confirmDTO) {
+    return userRegistrationControllerDelegate.confirmPasswordReset(confirmDTO);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -11,6 +11,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetConfirmDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
@@ -24,6 +26,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import java.net.URLDecoder;
@@ -53,6 +56,7 @@ class UserRegistrationControllerDelegate {
   private final @NonNull UserHelper userHelper;
   private final @NonNull IdentityClient identityClient;
   private final @NonNull MagicLinkLoginService magicLinkLoginService;
+  private final @NonNull PasswordResetService passwordResetService;
   private final @NonNull SessionDeleteService sessionDeleteService;
 
   @Value("${feature.topics.enabled}")
@@ -87,6 +91,18 @@ class UserRegistrationControllerDelegate {
         .consumeMagicLink(consumeDTO.getToken())
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.badRequest().build());
+  }
+
+  ResponseEntity<Void> requestPasswordReset(PasswordResetRequestDTO requestDTO) {
+    passwordResetService.requestPasswordReset(requestDTO.getUsername(), requestDTO.getLocale());
+    return ResponseEntity.noContent().build();
+  }
+
+  ResponseEntity<Void> confirmPasswordReset(PasswordResetConfirmDTO confirmDTO) {
+    boolean succeeded =
+        passwordResetService.confirmPasswordReset(
+            confirmDTO.getToken(), confirmDTO.getNewPassword());
+    return succeeded ? ResponseEntity.noContent().build() : ResponseEntity.badRequest().build();
   }
 
   ResponseEntity<Void> registerUser(UserDTO user) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -101,10 +101,14 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
         return true;
       }
       // Password reset endpoints are public login bootstrap endpoints too (ORISO-Helm#72) and
-      // must work without a CSRF token — the requester has no session yet.
-      if (request.getRequestURI() != null
-          && request.getRequestURI().toLowerCase().contains("/users/password-reset/")) {
-        return true;
+      // must work without a CSRF token — the requester has no session yet. Scope the exemption to
+      // the two exact routes (optionally under a /service prefix), never an arbitrary substring.
+      if (request.getRequestURI() != null) {
+        String lowerUri = request.getRequestURI().toLowerCase();
+        if (lowerUri.endsWith("/users/password-reset/request")
+            || lowerUri.endsWith("/users/password-reset/confirm")) {
+          return true;
+        }
       }
       // Invite-link redeem is a public bootstrap endpoint too — anyone opening the shared link
       // hits it before any session / CSRF cookie exists.

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -100,6 +100,12 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
           && request.getRequestURI().toLowerCase().contains("/users/magic-link/")) {
         return true;
       }
+      // Password reset endpoints are public login bootstrap endpoints too (ORISO-Helm#72) and
+      // must work without a CSRF token — the requester has no session yet.
+      if (request.getRequestURI() != null
+          && request.getRequestURI().toLowerCase().contains("/users/password-reset/")) {
+        return true;
+      }
       // Invite-link redeem is a public bootstrap endpoint too — anyone opening the shared link
       // hits it before any session / CSRF cookie exists.
       if (request.getRequestURI() != null

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetConfirmDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetConfirmDTO.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class PasswordResetConfirmDTO {
+
+  @NotBlank private String token;
+  @NotBlank private String newPassword;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetRequestDTO.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class PasswordResetRequestDTO {
+
+  @NotBlank private String username;
+  private String locale;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -109,6 +109,8 @@ public class SecurityConfig {
                     "/service/error-reports",
                     "/users/magic-link/request",
                     "/users/magic-link/consume",
+                    "/users/password-reset/request",
+                    "/users/password-reset/confirm",
                     "/users/invitelinks/*/redeem")
                 .permitAll()
                 .requestMatchers(
@@ -116,13 +118,21 @@ public class SecurityConfig {
                     "/users/magic-link/request",
                     "/service/users/magic-link/request",
                     "/users/magic-link/consume",
-                    "/service/users/magic-link/consume")
+                    "/service/users/magic-link/consume",
+                    "/users/password-reset/request",
+                    "/service/users/password-reset/request",
+                    "/users/password-reset/confirm",
+                    "/service/users/password-reset/confirm")
                 .permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**")
                 .permitAll()
                 .requestMatchers(
                     RegexRequestMatcher.regexMatcher(
                         HttpMethod.POST, ".*/users/magic-link/(request|consume)$"))
+                .permitAll()
+                .requestMatchers(
+                    RegexRequestMatcher.regexMatcher(
+                        HttpMethod.POST, ".*/users/password-reset/(request|confirm)$"))
                 .permitAll()
                 .requestMatchers(HttpMethod.GET, "/conversations/anonymous/{sessionId:[0-9]+}")
                 .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT)

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -130,10 +130,8 @@ public class SecurityConfig {
                     RegexRequestMatcher.regexMatcher(
                         HttpMethod.POST, ".*/users/magic-link/(request|consume)$"))
                 .permitAll()
-                .requestMatchers(
-                    RegexRequestMatcher.regexMatcher(
-                        HttpMethod.POST, ".*/users/password-reset/(request|confirm)$"))
-                .permitAll()
+                // Password-reset request/confirm are already permitted by the exact requestMatchers
+                // above (with and without the /service prefix); no broad regex needed.
                 .requestMatchers(HttpMethod.GET, "/conversations/anonymous/{sessionId:[0-9]+}")
                 .hasAnyAuthority(ANONYMOUS_DEFAULT, USER_DEFAULT)
                 .requestMatchers(

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -86,6 +86,11 @@ public class PasswordResetService {
   /**
    * Validates the one-time token and, if valid, sets the new password in Keycloak.
    *
+   * <p>The token is only consumed once {@link KeycloakService#updatePassword} succeeds — if
+   * Keycloak rejects the password (e.g. policy violation), the token stays valid so the user can
+   * retry with a different password using the same emailed link, mirroring how {@link
+   * MagicLinkLoginService} restores its token on a failed exchange.
+   *
    * @return true if the password was updated, false if the token is missing/invalid/expired
    */
   public boolean confirmPasswordReset(String token, String newPassword) {
@@ -94,12 +99,13 @@ public class PasswordResetService {
     }
 
     cleanupExpiredTokens();
-    ResetTokenEntry entry = resetTokens.remove(token);
+    ResetTokenEntry entry = resetTokens.get(token);
     if (entry == null || entry.getExpiresAt().isBefore(Instant.now())) {
       return false;
     }
 
     keycloakService.updatePassword(entry.getKeycloakUserId(), newPassword);
+    resetTokens.remove(token);
     return true;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -5,12 +5,14 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
 import jakarta.mail.PasswordAuthentication;
@@ -25,9 +27,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,14 +70,29 @@ public class PasswordResetService {
    * response returns in near-constant time regardless of whether the account exists — mitigates
    * timing-based account enumeration. Overridable in tests with a synchronous executor.
    */
-  private Executor passwordResetExecutor =
-      Executors.newFixedThreadPool(
+  private final ThreadPoolExecutor defaultPasswordResetExecutor =
+      new ThreadPoolExecutor(
+          2,
           4,
+          30L,
+          TimeUnit.SECONDS,
+          // Bounded queue: this is a public, unauthenticated endpoint — an unbounded queue
+          // would let request floods accumulate work in memory. Overflow is rejected (and
+          // swallowed by the caller) so the HTTP response stays identical either way.
+          new ArrayBlockingQueue<>(200),
           runnable -> {
             Thread thread = new Thread(runnable, "password-reset-dispatch");
             thread.setDaemon(true);
             return thread;
-          });
+          },
+          new ThreadPoolExecutor.AbortPolicy());
+
+  private Executor passwordResetExecutor = defaultPasswordResetExecutor;
+
+  @PreDestroy
+  void shutdownPasswordResetExecutor() {
+    defaultPasswordResetExecutor.shutdown();
+  }
 
   /** Seam for sending the reset mail; the default delivers via SMTP. Overridable in tests. */
   private PasswordResetMailSender mailSender = this::sendViaSmtp;
@@ -107,8 +127,14 @@ public class PasswordResetService {
 
     String username = usernameInput.trim();
     String resolvedLocale = resolveLocale(locale);
-    // Dispatch asynchronously so the response time does not reveal whether the account exists.
-    passwordResetExecutor.execute(() -> processPasswordResetRequest(username, resolvedLocale));
+    try {
+      // Dispatch asynchronously so the response time does not reveal whether the account exists.
+      passwordResetExecutor.execute(() -> processPasswordResetRequest(username, resolvedLocale));
+    } catch (RejectedExecutionException ex) {
+      // Queue saturated (flood/overload): drop the dispatch, keep the response identical so
+      // neither existence nor the drop is observable. No PII in the log.
+      log.warn("Password reset dispatch rejected — executor queue saturated");
+    }
   }
 
   private void processPasswordResetRequest(String username, String locale) {
@@ -157,15 +183,18 @@ public class PasswordResetService {
 
     try {
       keycloakService.updatePassword(entry.getKeycloakUserId(), newPassword);
-    } catch (RuntimeException ex) {
-      // Keycloak rejected the update (e.g. password policy violation). Re-insert the token so the
-      // user can retry with a different password using the same emailed link, mirroring how
-      // MagicLinkLoginService restores its token on a failed exchange. Note: there is a small
-      // window between the remove above and this re-insert during which a concurrent confirm would
-      // observe the token as absent — an acceptable trade for guaranteed single-use on success.
+    } catch (CustomValidationHttpStatusException ex) {
+      // Definitive password-policy rejection: Keycloak did NOT apply the password, so the token
+      // can safely be restored for a retry with a different password via the same emailed link
+      // (mirrors MagicLinkLoginService). Note: there is a small window between the remove above
+      // and this re-insert during which a concurrent confirm would observe the token as absent —
+      // an acceptable trade for guaranteed single-use on success.
       resetTokens.put(token, entry);
       throw ex;
     }
+    // Any other failure: the update outcome is unknown (Keycloak may have applied the password
+    // before the error surfaced), so the token stays consumed — re-inserting could allow a second
+    // password change with an already-used link.
     return true;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -1,0 +1,392 @@
+package de.caritas.cob.userservice.api.service.auth;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.user.UserService;
+import jakarta.mail.Authenticator;
+import jakarta.mail.Message;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Self-service password reset, mirroring {@link MagicLinkLoginService}: generates our own one-time
+ * token and sends our own branded, localized email directly via SMTP, instead of handing off to
+ * Keycloak's hosted reset-credentials pages/theme (ORISO-Helm#72).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+  private static final Duration RESET_TOKEN_TTL = Duration.ofMinutes(120);
+
+  private final @NonNull UserService userService;
+  private final @NonNull ConsultantService consultantService;
+  private final @NonNull KeycloakService keycloakService;
+  private final @NonNull RestTemplate restTemplate;
+
+  private final Map<String, ResetTokenEntry> resetTokens = new ConcurrentHashMap<>();
+
+  @Value("${identity.email-dummy-suffix:@beratungcaritas.de}")
+  private String emailDummySuffix;
+
+  @Value("${password.reset.frontend.base-url:https://app.oriso.org}")
+  private String passwordResetFrontendBaseUrl;
+
+  @Value("${consulting.type.service.api.url:}")
+  private String consultingTypeServiceApiUrl;
+
+  /**
+   * Always completes without signalling whether the account exists, to avoid account enumeration.
+   * If an eligible account is found, a reset email is sent best-effort.
+   */
+  public void requestPasswordReset(String usernameInput, String locale) {
+    if (isBlank(usernameInput)) {
+      return;
+    }
+
+    Optional<AccountResetTarget> accountOptional = resolveAccount(usernameInput.trim());
+    if (accountOptional.isEmpty()) {
+      return;
+    }
+
+    AccountResetTarget account = accountOptional.get();
+    if (isBlank(account.getEmail())
+        || (emailDummySuffix != null && account.getEmail().endsWith(emailDummySuffix))) {
+      return;
+    }
+
+    sendPasswordResetEmailSafely(account, resolveLocale(locale));
+  }
+
+  /**
+   * Validates the one-time token and, if valid, sets the new password in Keycloak.
+   *
+   * @return true if the password was updated, false if the token is missing/invalid/expired
+   */
+  public boolean confirmPasswordReset(String token, String newPassword) {
+    if (isBlank(token) || isBlank(newPassword)) {
+      return false;
+    }
+
+    cleanupExpiredTokens();
+    ResetTokenEntry entry = resetTokens.remove(token);
+    if (entry == null || entry.getExpiresAt().isBefore(Instant.now())) {
+      return false;
+    }
+
+    keycloakService.updatePassword(entry.getKeycloakUserId(), newPassword);
+    return true;
+  }
+
+  private Optional<AccountResetTarget> resolveAccount(String username) {
+    var transcoder = new UsernameTranscoder();
+    String decoded = transcoder.decodeUsername(username);
+    String encoded = transcoder.encodeUsername(username);
+
+    Optional<User> userOptional = userService.findUserByUsername(username);
+    if (userOptional.isEmpty() && !decoded.equals(username)) {
+      userOptional = userService.findUserByUsername(decoded);
+    }
+    if (userOptional.isEmpty() && !encoded.equals(username)) {
+      userOptional = userService.findUserByUsername(encoded);
+    }
+    if (userOptional.isPresent()) {
+      User user = userOptional.get();
+      return Optional.of(new AccountResetTarget(user.getUserId(), user.getEmail()));
+    }
+
+    Optional<Consultant> consultantOptional =
+        consultantService.findConsultantByUsernameOrEmail(username, username);
+    return consultantOptional.map(
+        consultant -> new AccountResetTarget(consultant.getId(), consultant.getEmail()));
+  }
+
+  private String resolveLocale(String locale) {
+    return isNotBlank(locale) && EMAIL_CONTENT.containsKey(locale) ? locale : "de";
+  }
+
+  private void sendPasswordResetEmailSafely(AccountResetTarget target, String locale) {
+    try {
+      var smtpSettingsOptional = resolveGlobalSmtpSettings();
+      if (smtpSettingsOptional.isEmpty()) {
+        return;
+      }
+      var smtpSettings = smtpSettingsOptional.get();
+      String oneTimeToken = generateAndStoreToken(target.getKeycloakUserId());
+      String resetUrl = buildResetFrontendUrl(oneTimeToken);
+      EmailContent content = EMAIL_CONTENT.get(locale);
+
+      Properties props = new Properties();
+      props.put("mail.smtp.auth", "true");
+      props.put("mail.smtp.host", smtpSettings.getHost());
+      props.put("mail.smtp.port", String.valueOf(smtpSettings.getPort()));
+      if (smtpSettings.isSecure()) {
+        props.put("mail.smtp.ssl.enable", "true");
+      } else {
+        props.put("mail.smtp.starttls.enable", "true");
+      }
+
+      jakarta.mail.Session session =
+          jakarta.mail.Session.getInstance(
+              props,
+              new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                  return new PasswordAuthentication(
+                      smtpSettings.getUsername(), smtpSettings.getPassword());
+                }
+              });
+
+      Message message = new MimeMessage(session);
+      message.setFrom(new InternetAddress(smtpSettings.getFrom()));
+      message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(target.getEmail()));
+      message.setSubject(content.getSubject());
+      message.setContent(
+          buildHtml(content, resetUrl, smtpSettings.getEmailThemeColor()),
+          "text/html; charset=UTF-8");
+      Transport.send(message);
+    } catch (Exception ex) {
+      log.warn(
+          "Password reset email dispatch failed for account {}, reason: {}",
+          target.getKeycloakUserId(),
+          ex.getMessage());
+    }
+  }
+
+  private String buildHtml(EmailContent content, String resetUrl, String emailThemeColor) {
+    String color =
+        isNotBlank(emailThemeColor) && emailThemeColor.matches("^#([A-Fa-f0-9]{6})$")
+            ? emailThemeColor
+            : "#d80003";
+
+    return "<!doctype html><html><body style=\"margin:0;padding:0;background:#f6f7fb;font-family:Arial,sans-serif;\">"
+        + "<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding:24px 0;\">"
+        + "<tr><td align=\"center\">"
+        + "<table role=\"presentation\" width=\"620\" cellpadding=\"0\" cellspacing=\"0\" style=\"max-width:620px;background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;\">"
+        + "<tr><td style=\"background:"
+        + color
+        + ";padding:18px 24px;color:#ffffff;font-size:20px;font-weight:700;\">Caritas Online-Beratung</td></tr>"
+        + "<tr><td style=\"padding:28px 24px 8px 24px;color:#111827;font-size:22px;line-height:30px;font-weight:700;\">"
+        + content.getSubject()
+        + "</td></tr>"
+        + "<tr><td style=\"padding:0 24px 14px 24px;color:#374151;font-size:16px;line-height:24px;\">"
+        + content.getIntro()
+        + "</td></tr>"
+        + "<tr><td style=\"padding:0 24px 18px 24px;\"><a href=\""
+        + resetUrl
+        + "\" style=\"display:inline-block;background:"
+        + color
+        + ";color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;\">"
+        + content.getLinkLabel()
+        + "</a></td></tr>"
+        + "<tr><td style=\"padding:0 24px 24px 24px;color:#6b7280;font-size:14px;line-height:22px;\">"
+        + content.getExpiry()
+        + "</td></tr>"
+        + "</table></td></tr></table></body></html>";
+  }
+
+  private String generateAndStoreToken(String keycloakUserId) {
+    String token =
+        UUID.randomUUID().toString().replace("-", "")
+            + UUID.randomUUID().toString().replace("-", "");
+    resetTokens.put(
+        token, new ResetTokenEntry(keycloakUserId, Instant.now().plus(RESET_TOKEN_TTL)));
+    return token;
+  }
+
+  private void cleanupExpiredTokens() {
+    Instant now = Instant.now();
+    resetTokens.entrySet().removeIf(entry -> entry.getValue().getExpiresAt().isBefore(now));
+  }
+
+  private String buildResetFrontendUrl(String oneTimeToken) {
+    return normalizeBaseUrl(passwordResetFrontendBaseUrl)
+        + "/password-reset/confirm?token="
+        + URLEncoder.encode(oneTimeToken, StandardCharsets.UTF_8);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Optional<GlobalSmtpSettings> resolveGlobalSmtpSettings() {
+    if (isBlank(consultingTypeServiceApiUrl)) {
+      return Optional.empty();
+    }
+    try {
+      String settingsUrl = normalizeBaseUrl(consultingTypeServiceApiUrl) + "/settings";
+      Map<String, Object> settingsResponse = restTemplate.getForObject(settingsUrl, Map.class);
+      if (settingsResponse == null || settingsResponse.isEmpty()) {
+        return Optional.empty();
+      }
+
+      boolean systemEmailsEnabled =
+          asBooleanSettingValue(
+              settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
+      boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
+      String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
+      Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
+      boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
+      String username = asStringSettingValue(settingsResponse.get("globalSmtpUsername"));
+      String password = asStringSettingValue(settingsResponse.get("globalSmtpPassword"));
+      String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
+      String emailThemeColor =
+          asStringSettingValue(settingsResponse.get("globalSmtpEmailThemeColor"));
+
+      if (!systemEmailsEnabled
+          || !smtpEnabled
+          || isBlank(host)
+          || port == null
+          || isBlank(username)
+          || isBlank(password)
+          || isBlank(from)) {
+        return Optional.empty();
+      }
+
+      return Optional.of(
+          new GlobalSmtpSettings(host, port, secure, username, password, from, emailThemeColor));
+    } catch (Exception ex) {
+      log.debug(
+          "Could not resolve global SMTP settings for password reset mail: {}", ex.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  private boolean asBooleanSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    if (value instanceof Boolean) {
+      return (Boolean) value;
+    }
+    if (value instanceof String) {
+      return "true".equalsIgnoreCase((String) value);
+    }
+    return false;
+  }
+
+  private String asStringSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    return nonNull(value) ? String.valueOf(value).trim() : null;
+  }
+
+  private Integer asIntSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    }
+    if (value instanceof String && isNotBlank((String) value)) {
+      try {
+        return Integer.parseInt(((String) value).trim());
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object unwrapSettingValue(Object raw) {
+    if (raw instanceof Map<?, ?>) {
+      return ((Map<String, Object>) raw).get("value");
+    }
+    return raw;
+  }
+
+  private String normalizeBaseUrl(String value) {
+    if (isBlank(value)) {
+      return "";
+    }
+    return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+  }
+
+  @lombok.Value
+  private static class AccountResetTarget {
+    String keycloakUserId;
+    String email;
+  }
+
+  @lombok.Value
+  private static class ResetTokenEntry {
+    String keycloakUserId;
+    Instant expiresAt;
+  }
+
+  @lombok.Value
+  private static class GlobalSmtpSettings {
+    String host;
+    Integer port;
+    boolean secure;
+    String username;
+    String password;
+    String from;
+    String emailThemeColor;
+  }
+
+  @lombok.Value
+  private static class EmailContent {
+    String subject;
+    String intro;
+    String linkLabel;
+    String expiry;
+  }
+
+  private static final Map<String, EmailContent> EMAIL_CONTENT =
+      Map.of(
+          "de",
+          new EmailContent(
+              "Passwort zurücksetzen",
+              "Es wurde eine Änderung der Anmeldeinformationen für Ihren Account Caritas Onlineberatung angefordert. Wenn Sie diese Änderung beantragt haben, klicken Sie auf den unten stehenden Link.",
+              "Link zum Zurücksetzen von Anmeldeinformationen",
+              "Die Gültigkeit des Links wird in 120 Minuten verfallen. Sollten Sie keine Änderung vollziehen wollen, können Sie diese Nachricht ignorieren."),
+          "en",
+          new EmailContent(
+              "Reset password",
+              "A change of login credentials for your Caritas Online Counselling account has been requested. If you requested this change, click the link below.",
+              "Link to reset login credentials",
+              "This link will expire in 120 minutes. If you do not want to make this change, you can ignore this message."),
+          "fr",
+          new EmailContent(
+              "Réinitialiser le mot de passe",
+              "Une modification des informations de connexion de votre compte Caritas Online-Beratung a été demandée. Si vous êtes à l'origine de cette demande, cliquez sur le lien ci-dessous.",
+              "Lien pour réinitialiser les informations de connexion",
+              "Ce lien expirera dans 120 minutes. Si vous ne souhaitez pas effectuer cette modification, vous pouvez ignorer ce message."),
+          "ru",
+          new EmailContent(
+              "Сброс пароля",
+              "Был запрошен сброс учётных данных для входа в ваш аккаунт Caritas Online-Beratung. Если вы запросили это изменение, перейдите по ссылке ниже.",
+              "Ссылка для сброса учётных данных",
+              "Срок действия ссылки истекает через 120 минут. Если вы не хотите вносить это изменение, просто проигнорируйте это письмо."),
+          "ti",
+          new EmailContent(
+              "ፓስዎርድ ዳግማይ ምቕማጥ",
+              "ንኣካውንትካ Caritas Online-Beratung ናይ መእተዊ ሓበሬታ ንምቕያር ተሓቲቱ ኣሎ። እዚ ለውጢ እዚ ንስኻ እንተኾንካ ሓቲትካዮ፣ ነቲ ኣብ ታሕቲ ዘሎ ሊንክ ጠውቕ።",
+              "ናይ መእተዊ ሓበሬታ ዳግማይ ንምቕማጥ ዝኸውን ሊንክ",
+              "ጽንዓት እዚ ሊንክ እዚ ኣብ 120 ደቓይቕ ክውዳእ እዩ። እዚ ለውጢ እዚ ክትገብር ዘይትደሊ እንተኾንካ፣ ነዚ መልእኽቲ እዚ ክትንዕቆ ትኽእል ኢኻ።"),
+          "tr",
+          new EmailContent(
+              "Şifreyi sıfırla",
+              "Caritas Online-Beratung hesabınız için oturum açma bilgilerinizde bir değişiklik talep edildi. Bu değişikliği siz talep ettiyseniz aşağıdaki bağlantıya tıklayın.",
+              "Oturum açma bilgilerini sıfırlama bağlantısı",
+              "Bu bağlantının geçerlilik süresi 120 dakika içinde dolacaktır. Bu değişikliği yapmak istemiyorsanız bu mesajı yok sayabilirsiniz."));
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import jakarta.annotation.PostConstruct;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
 import jakarta.mail.PasswordAuthentication;
@@ -25,6 +26,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +39,12 @@ import org.springframework.web.client.RestTemplate;
  * Self-service password reset, mirroring {@link MagicLinkLoginService}: generates our own one-time
  * token and sends our own branded, localized email directly via SMTP, instead of handing off to
  * Keycloak's hosted reset-credentials pages/theme (ORISO-Helm#72).
+ *
+ * <p><b>Known single-replica limitation:</b> reset tokens live only in this process's heap ({@link
+ * #resetTokens}). A restart or a crash invalidates every outstanding reset link, and the feature is
+ * <b>not safe to run with more than one replica</b> — a request handled by replica A stores the
+ * token in A's memory, so a confirm routed to replica B will not find it. This is a deliberate,
+ * documented deferral: a Redis/DB-backed store is intentionally out of scope for this change.
  */
 @Slf4j
 @Service
@@ -51,14 +60,41 @@ public class PasswordResetService {
 
   private final Map<String, ResetTokenEntry> resetTokens = new ConcurrentHashMap<>();
 
+  /**
+   * Runs the (potentially slow) account lookup + mail dispatch off the request thread so the HTTP
+   * response returns in near-constant time regardless of whether the account exists — mitigates
+   * timing-based account enumeration. Overridable in tests with a synchronous executor.
+   */
+  private Executor passwordResetExecutor =
+      Executors.newFixedThreadPool(
+          4,
+          runnable -> {
+            Thread thread = new Thread(runnable, "password-reset-dispatch");
+            thread.setDaemon(true);
+            return thread;
+          });
+
+  /** Seam for sending the reset mail; the default delivers via SMTP. Overridable in tests. */
+  private PasswordResetMailSender mailSender = this::sendViaSmtp;
+
   @Value("${identity.email-dummy-suffix:@beratungcaritas.de}")
   private String emailDummySuffix;
 
-  @Value("${password.reset.frontend.base-url:https://app.oriso.org}")
+  @Value("${password.reset.frontend.base-url:}")
   private String passwordResetFrontendBaseUrl;
 
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
+
+  @PostConstruct
+  void logFeatureAvailability() {
+    if (isBlank(passwordResetFrontendBaseUrl)) {
+      log.warn(
+          "Self-service password reset is DISABLED: required property "
+              + "'password.reset.frontend.base-url' (env PASSWORD_RESET_FRONTEND_BASE_URL) is unset. "
+              + "Reset emails will not be sent until it is configured.");
+    }
+  }
 
   /**
    * Always completes without signalling whether the account exists, to avoid account enumeration.
@@ -69,18 +105,31 @@ public class PasswordResetService {
       return;
     }
 
-    Optional<AccountResetTarget> accountOptional = resolveAccount(usernameInput.trim());
-    if (accountOptional.isEmpty()) {
-      return;
-    }
+    String username = usernameInput.trim();
+    String resolvedLocale = resolveLocale(locale);
+    // Dispatch asynchronously so the response time does not reveal whether the account exists.
+    passwordResetExecutor.execute(() -> processPasswordResetRequest(username, resolvedLocale));
+  }
 
-    AccountResetTarget account = accountOptional.get();
-    if (isBlank(account.getEmail())
-        || (emailDummySuffix != null && account.getEmail().endsWith(emailDummySuffix))) {
-      return;
-    }
+  private void processPasswordResetRequest(String username, String locale) {
+    try {
+      Optional<AccountResetTarget> accountOptional = resolveAccount(username);
+      if (accountOptional.isEmpty()) {
+        return;
+      }
 
-    sendPasswordResetEmailSafely(account, resolveLocale(locale));
+      AccountResetTarget account = accountOptional.get();
+      if (isBlank(account.getEmail())
+          || (emailDummySuffix != null && account.getEmail().endsWith(emailDummySuffix))) {
+        return;
+      }
+
+      sendPasswordResetEmailSafely(account, locale);
+    } catch (RuntimeException ex) {
+      // Never leak PII (account id, email, raw message) — log the exception class only.
+      log.warn("Password reset request processing failed ({})", ex.getClass().getSimpleName());
+      log.debug("Password reset request processing failure detail", ex);
+    }
   }
 
   /**
@@ -99,13 +148,24 @@ public class PasswordResetService {
     }
 
     cleanupExpiredTokens();
-    ResetTokenEntry entry = resetTokens.get(token);
+    // Claim the token atomically (remove-first) so two concurrent confirmations cannot both
+    // succeed against the same token — this closes the double-confirm race.
+    ResetTokenEntry entry = resetTokens.remove(token);
     if (entry == null || entry.getExpiresAt().isBefore(Instant.now())) {
       return false;
     }
 
-    keycloakService.updatePassword(entry.getKeycloakUserId(), newPassword);
-    resetTokens.remove(token);
+    try {
+      keycloakService.updatePassword(entry.getKeycloakUserId(), newPassword);
+    } catch (RuntimeException ex) {
+      // Keycloak rejected the update (e.g. password policy violation). Re-insert the token so the
+      // user can retry with a different password using the same emailed link, mirroring how
+      // MagicLinkLoginService restores its token on a failed exchange. Note: there is a small
+      // window between the remove above and this re-insert during which a concurrent confirm would
+      // observe the token as absent — an acceptable trade for guaranteed single-use on success.
+      resetTokens.put(token, entry);
+      throw ex;
+    }
     return true;
   }
 
@@ -137,51 +197,87 @@ public class PasswordResetService {
   }
 
   private void sendPasswordResetEmailSafely(AccountResetTarget target, String locale) {
-    try {
-      var smtpSettingsOptional = resolveGlobalSmtpSettings();
-      if (smtpSettingsOptional.isEmpty()) {
-        return;
-      }
-      var smtpSettings = smtpSettingsOptional.get();
-      String oneTimeToken = generateAndStoreToken(target.getKeycloakUserId());
-      String resetUrl = buildResetFrontendUrl(oneTimeToken);
-      EmailContent content = EMAIL_CONTENT.get(locale);
-
-      Properties props = new Properties();
-      props.put("mail.smtp.auth", "true");
-      props.put("mail.smtp.host", smtpSettings.getHost());
-      props.put("mail.smtp.port", String.valueOf(smtpSettings.getPort()));
-      if (smtpSettings.isSecure()) {
-        props.put("mail.smtp.ssl.enable", "true");
-      } else {
-        props.put("mail.smtp.starttls.enable", "true");
-      }
-
-      jakarta.mail.Session session =
-          jakarta.mail.Session.getInstance(
-              props,
-              new Authenticator() {
-                @Override
-                protected PasswordAuthentication getPasswordAuthentication() {
-                  return new PasswordAuthentication(
-                      smtpSettings.getUsername(), smtpSettings.getPassword());
-                }
-              });
-
-      Message message = new MimeMessage(session);
-      message.setFrom(new InternetAddress(smtpSettings.getFrom()));
-      message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(target.getEmail()));
-      message.setSubject(content.getSubject());
-      message.setContent(
-          buildHtml(content, resetUrl, smtpSettings.getEmailThemeColor()),
-          "text/html; charset=UTF-8");
-      Transport.send(message);
-    } catch (Exception ex) {
+    // Fail closed: without an explicitly configured frontend base URL we cannot build a usable
+    // reset link, so the feature stays disabled instead of emailing a wrong/production URL.
+    if (isBlank(passwordResetFrontendBaseUrl)) {
       log.warn(
-          "Password reset email dispatch failed for account {}, reason: {}",
-          target.getKeycloakUserId(),
-          ex.getMessage());
+          "Password reset email not sent: 'password.reset.frontend.base-url' is not configured.");
+      return;
     }
+
+    var smtpSettingsOptional = resolveGlobalSmtpSettings();
+    if (smtpSettingsOptional.isEmpty()) {
+      return;
+    }
+    var smtpSettings = smtpSettingsOptional.get();
+
+    // Bound the in-memory token map: purge expired entries before inserting a new one.
+    cleanupExpiredTokens();
+    String oneTimeToken = generateAndStoreToken(target.getKeycloakUserId());
+    String resetUrl = buildResetFrontendUrl(oneTimeToken);
+    EmailContent content = EMAIL_CONTENT.get(locale);
+
+    try {
+      mailSender.send(target.getEmail(), locale, resetUrl, smtpSettings, content);
+    } catch (Exception ex) {
+      // Do not leave a token behind for a mail that never went out, and never log PII (account id,
+      // recipient, or the raw exception message) — record the exception class only.
+      resetTokens.remove(oneTimeToken);
+      log.warn("Password reset email dispatch failed ({})", ex.getClass().getSimpleName());
+      log.debug("Password reset email dispatch failure detail", ex);
+    }
+  }
+
+  private void sendViaSmtp(
+      String recipient,
+      String locale,
+      String resetUrl,
+      GlobalSmtpSettings smtpSettings,
+      EmailContent content)
+      throws Exception {
+    Properties props = new Properties();
+    props.put("mail.smtp.auth", "true");
+    props.put("mail.smtp.host", smtpSettings.getHost());
+    props.put("mail.smtp.port", String.valueOf(smtpSettings.getPort()));
+    if (smtpSettings.isSecure()) {
+      props.put("mail.smtp.ssl.enable", "true");
+    } else {
+      props.put("mail.smtp.starttls.enable", "true");
+    }
+
+    jakarta.mail.Session session =
+        jakarta.mail.Session.getInstance(
+            props,
+            new Authenticator() {
+              @Override
+              protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(
+                    smtpSettings.getUsername(), smtpSettings.getPassword());
+              }
+            });
+
+    Message message = new MimeMessage(session);
+    message.setFrom(new InternetAddress(smtpSettings.getFrom()));
+    message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(recipient));
+    message.setSubject(content.getSubject());
+    message.setContent(
+        buildHtml(content, resetUrl, smtpSettings.getEmailThemeColor()),
+        "text/html; charset=UTF-8");
+    Transport.send(message);
+  }
+
+  /**
+   * Seam so tests can capture the recipient, locale and reset URL without opening an SMTP socket.
+   */
+  @FunctionalInterface
+  interface PasswordResetMailSender {
+    void send(
+        String recipient,
+        String locale,
+        String resetUrl,
+        GlobalSmtpSettings smtpSettings,
+        EmailContent content)
+        throws Exception;
   }
 
   private String buildHtml(EmailContent content, String resetUrl, String emailThemeColor) {
@@ -217,6 +313,8 @@ public class PasswordResetService {
   }
 
   private String generateAndStoreToken(String keycloakUserId) {
+    // Cap at one outstanding token per account: a fresh request supersedes any previous link.
+    resetTokens.values().removeIf(entry -> entry.getKeycloakUserId().equals(keycloakUserId));
     String token =
         UUID.randomUUID().toString().replace("-", "")
             + UUID.randomUUID().toString().replace("-", "");
@@ -339,7 +437,7 @@ public class PasswordResetService {
   }
 
   @lombok.Value
-  private static class GlobalSmtpSettings {
+  static class GlobalSmtpSettings {
     String host;
     Integer port;
     boolean secure;
@@ -350,7 +448,7 @@ public class PasswordResetService {
   }
 
   @lombok.Value
-  private static class EmailContent {
+  static class EmailContent {
     String subject;
     String intro;
     String linkLabel;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,6 +37,9 @@ server.port=8082
 server.host=http://localhost
 app.base.url=http://localhost:8082
 system.notification.frontend.base-url=${SYSTEM_NOTIFICATION_FRONTEND_BASE_URL:https://app.oriso.org}
+# Self-service password reset link base URL. No default on purpose: when unset the feature is
+# disabled (fail closed) rather than emailing a hardcoded production URL. Set per environment.
+password.reset.frontend.base-url=${PASSWORD_RESET_FRONTEND_BASE_URL:}
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -376,6 +376,7 @@ class UserRegistrationControllerDelegateTest {
     var response = delegate.confirmPasswordReset(confirm);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(passwordResetService).confirmPasswordReset("valid-token", "NewPassw0rd!");
   }
 
   @Test
@@ -388,6 +389,7 @@ class UserRegistrationControllerDelegateTest {
     var response = delegate.confirmPasswordReset(confirm);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    verify(passwordResetService).confirmPasswordReset("bad-token", "NewPassw0rd!");
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -20,6 +20,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetConfirmDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
@@ -37,6 +39,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import java.util.List;
@@ -70,6 +73,7 @@ class UserRegistrationControllerDelegateTest {
   @Mock private UserHelper userHelper;
   @Mock private IdentityClient identityClient;
   @Mock private MagicLinkLoginService magicLinkLoginService;
+  @Mock private PasswordResetService passwordResetService;
   @Mock private SessionDeleteService sessionDeleteService;
 
   @InjectMocks private UserRegistrationControllerDelegate delegate;
@@ -348,6 +352,42 @@ class UserRegistrationControllerDelegateTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     verify(createUserFacade).createUserAccountWithInitializedConsultingType(user);
+  }
+
+  @Test
+  void requestPasswordReset_returnsNoContent_and_delegatesToService() {
+    var request = new PasswordResetRequestDTO();
+    request.setUsername(USERNAME);
+    request.setLocale("de");
+
+    var response = delegate.requestPasswordReset(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(passwordResetService).requestPasswordReset(USERNAME, "de");
+  }
+
+  @Test
+  void confirmPasswordReset_returnsNoContent_When_TokenValid() {
+    var confirm = new PasswordResetConfirmDTO();
+    confirm.setToken("valid-token");
+    confirm.setNewPassword("NewPassw0rd!");
+    when(passwordResetService.confirmPasswordReset("valid-token", "NewPassw0rd!")).thenReturn(true);
+
+    var response = delegate.confirmPasswordReset(confirm);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  void confirmPasswordReset_returnsBadRequest_When_TokenInvalid() {
+    var confirm = new PasswordResetConfirmDTO();
+    confirm.setToken("bad-token");
+    confirm.setNewPassword("NewPassw0rd!");
+    when(passwordResetService.confirmPasswordReset("bad-token", "NewPassw0rd!")).thenReturn(false);
+
+    var response = delegate.confirmPasswordReset(confirm);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -1,0 +1,249 @@
+package de.caritas.cob.userservice.api.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.user.UserService;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PasswordResetServiceTest {
+
+  @Mock private UserService userService;
+  @Mock private ConsultantService consultantService;
+  @Mock private KeycloakService keycloakService;
+  @Mock private RestTemplate restTemplate;
+
+  @InjectMocks private PasswordResetService passwordResetService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(passwordResetService, "emailDummySuffix", "@beratungcaritas.de");
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "");
+    ReflectionTestUtils.setField(
+        passwordResetService, "passwordResetFrontendBaseUrl", "https://app.oriso.org");
+  }
+
+  // --- requestPasswordReset ---
+
+  @Test
+  void requestPasswordReset_Should_DoNothing_When_UsernameIsBlank() {
+    assertThatCode(() -> passwordResetService.requestPasswordReset("  ", "de"))
+        .doesNotThrowAnyException();
+    verify(userService, never()).findUserByUsername(anyString());
+  }
+
+  @Test
+  void requestPasswordReset_Should_DoNothing_When_UsernameIsNull() {
+    assertThatCode(() -> passwordResetService.requestPasswordReset(null, "de"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestPasswordReset_Should_CompleteSilently_When_AccountNotFound() {
+    when(userService.findUserByUsername(anyString())).thenReturn(Optional.empty());
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+
+    assertThatCode(() -> passwordResetService.requestPasswordReset("unknown-user", "de"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestPasswordReset_Should_CompleteSilently_When_EmailIsBlank() {
+    User user = new User();
+    user.setUserId("u-1");
+    user.setUsername("testuser");
+    user.setEmail("  ");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+
+    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "de"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestPasswordReset_Should_CompleteSilently_When_EmailEndsWithDummySuffix() {
+    User user = new User();
+    user.setUserId("u-1");
+    user.setUsername("testuser");
+    user.setEmail("testuser@beratungcaritas.de");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+
+    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "de"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestPasswordReset_Should_CompleteSilently_When_SmtpNotConfigured() {
+    User user = validUser();
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+
+    // consultingTypeServiceApiUrl is blank (set in @BeforeEach) → SMTP not available
+    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "de"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void requestPasswordReset_Should_AttemptSmtpSend_When_ValidSmtpSettingsReturned() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    User user = validUser();
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(
+            Map.of(
+                "globalFeatureSystemNotificationEmailsEnabled", true,
+                "globalSmtpEnabled", true,
+                "globalSmtpHost", "smtp.invalid",
+                "globalSmtpPort", 587,
+                "globalSmtpUsername", "user",
+                "globalSmtpPassword", "pass",
+                "globalSmtpFrom", "noreply@example.com"));
+
+    // Transport.send fails against smtp.invalid but the exception is caught, never rethrown.
+    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "en"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void requestPasswordReset_Should_FallBackToGerman_When_LocaleIsUnknown() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    User user = validUser();
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(
+            Map.of(
+                "globalFeatureSystemNotificationEmailsEnabled", true,
+                "globalSmtpEnabled", true,
+                "globalSmtpHost", "smtp.invalid",
+                "globalSmtpPort", 587,
+                "globalSmtpUsername", "user",
+                "globalSmtpPassword", "pass",
+                "globalSmtpFrom", "noreply@example.com"));
+
+    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "xx-unknown"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void requestPasswordReset_Should_ResolveViaConsultant_When_UserNotFound() {
+    when(userService.findUserByUsername(anyString())).thenReturn(Optional.empty());
+    Consultant consultant = new Consultant();
+    consultant.setId("c-1");
+    consultant.setUsername("consultant1");
+    consultant.setEmail("consultant@example.com");
+    when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
+        .thenReturn(Optional.of(consultant));
+
+    // SMTP not configured → completes silently, but proves consultant path was taken (no NPE)
+    assertThatCode(() -> passwordResetService.requestPasswordReset("consultant1", "de"))
+        .doesNotThrowAnyException();
+  }
+
+  // --- confirmPasswordReset ---
+
+  @Test
+  void confirmPasswordReset_Should_ReturnFalse_When_TokenIsBlank() {
+    assertThat(passwordResetService.confirmPasswordReset("  ", "NewPassw0rd!")).isFalse();
+    verify(keycloakService, never()).updatePassword(anyString(), anyString());
+  }
+
+  @Test
+  void confirmPasswordReset_Should_ReturnFalse_When_NewPasswordIsBlank() {
+    assertThat(passwordResetService.confirmPasswordReset("some-token", "  ")).isFalse();
+  }
+
+  @Test
+  void confirmPasswordReset_Should_ReturnFalse_When_TokenNotFound() {
+    assertThat(passwordResetService.confirmPasswordReset("non-existent-token", "NewPassw0rd!"))
+        .isFalse();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void confirmPasswordReset_Should_ReturnTrue_And_UpdatePassword_When_TokenValid() {
+    ConcurrentHashMap<String, Object> tokens = injectToken("valid-token", 900);
+
+    boolean result = passwordResetService.confirmPasswordReset("valid-token", "NewPassw0rd!");
+
+    assertThat(result).isTrue();
+    verify(keycloakService).updatePassword("user-keycloak-id", "NewPassw0rd!");
+    // Token must be single-use.
+    assertThat(tokens).doesNotContainKey("valid-token");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void confirmPasswordReset_Should_ReturnFalse_When_TokenExpired() {
+    injectToken("expired-token", -60);
+
+    boolean result = passwordResetService.confirmPasswordReset("expired-token", "NewPassw0rd!");
+
+    assertThat(result).isFalse();
+    verify(keycloakService, never()).updatePassword(anyString(), anyString());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void confirmPasswordReset_Should_CleanupExpiredTokens_Before_Lookup() {
+    ConcurrentHashMap<String, Object> tokens = injectToken("stale-token", -60);
+    assertThat(tokens).containsKey("stale-token");
+
+    passwordResetService.confirmPasswordReset("any-other-token", "NewPassw0rd!");
+
+    assertThat(tokens).doesNotContainKey("stale-token");
+  }
+
+  private User validUser() {
+    User user = new User();
+    user.setUserId("u-1");
+    user.setUsername("testuser");
+    user.setEmail("real@example.com");
+    return user;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ConcurrentHashMap<String, Object> injectToken(String token, long offsetSeconds) {
+    ConcurrentHashMap<String, Object> tokens =
+        (ConcurrentHashMap<String, Object>)
+            ReflectionTestUtils.getField(passwordResetService, "resetTokens");
+    for (Class<?> cls : PasswordResetService.class.getDeclaredClasses()) {
+      if (cls.getSimpleName().equals("ResetTokenEntry")) {
+        try {
+          cls.getDeclaredConstructors()[0].setAccessible(true);
+          Object entry =
+              cls.getDeclaredConstructors()[0].newInstance(
+                  "user-keycloak-id", Instant.now().plusSeconds(offsetSeconds));
+          tokens.put(token, entry);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return tokens;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -14,24 +14,25 @@ import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.auth.PasswordResetService.PasswordResetMailSender;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class PasswordResetServiceTest {
 
   @Mock private UserService userService;
@@ -41,13 +42,26 @@ class PasswordResetServiceTest {
 
   @InjectMocks private PasswordResetService passwordResetService;
 
+  /** Captures every mail the service tries to send, without opening an SMTP socket. */
+  private final List<SentMail> sentMails = new ArrayList<>();
+
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(passwordResetService, "emailDummySuffix", "@beratungcaritas.de");
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "");
     ReflectionTestUtils.setField(
         passwordResetService, "passwordResetFrontendBaseUrl", "https://app.oriso.org");
+    // Run dispatch synchronously so request-flow assertions are deterministic.
+    ReflectionTestUtils.setField(
+        passwordResetService, "passwordResetExecutor", (Executor) Runnable::run);
+    // Replace the real SMTP sender with a capturing seam — no network in tests.
+    PasswordResetMailSender capturingSender =
+        (recipient, locale, resetUrl, smtpSettings, content) ->
+            sentMails.add(new SentMail(recipient, locale, resetUrl));
+    ReflectionTestUtils.setField(passwordResetService, "mailSender", capturingSender);
   }
+
+  private record SentMail(String recipient, String locale, String resetUrl) {}
 
   // --- requestPasswordReset ---
 
@@ -109,46 +123,47 @@ class PasswordResetServiceTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  void requestPasswordReset_Should_AttemptSmtpSend_When_ValidSmtpSettingsReturned() {
+  void
+      requestPasswordReset_Should_SendMailWithProperRecipientLocaleAndResetUrl_When_SmtpConfigured() {
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
-    User user = validUser();
-    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
-    when(restTemplate.getForObject(anyString(), any()))
-        .thenReturn(
-            Map.of(
-                "globalFeatureSystemNotificationEmailsEnabled", true,
-                "globalSmtpEnabled", true,
-                "globalSmtpHost", "smtp.invalid",
-                "globalSmtpPort", 587,
-                "globalSmtpUsername", "user",
-                "globalSmtpPassword", "pass",
-                "globalSmtpFrom", "noreply@example.com"));
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
 
-    // Transport.send fails against smtp.invalid but the exception is caught, never rethrown.
-    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "en"))
-        .doesNotThrowAnyException();
+    passwordResetService.requestPasswordReset("testuser", "en");
+
+    assertThat(sentMails).hasSize(1);
+    SentMail mail = sentMails.get(0);
+    assertThat(mail.recipient()).isEqualTo("real@example.com");
+    assertThat(mail.locale()).isEqualTo("en");
+    // Reset URL must be built from the configured base URL and carry a 64-hex-char one-time token.
+    assertThat(mail.resetUrl())
+        .startsWith("https://app.oriso.org/password-reset/confirm?token=")
+        .matches("https://app\\.oriso\\.org/password-reset/confirm\\?token=[0-9a-f]{64}");
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void requestPasswordReset_Should_FallBackToGerman_When_LocaleIsUnknown() {
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
-    User user = validUser();
-    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
-    when(restTemplate.getForObject(anyString(), any()))
-        .thenReturn(
-            Map.of(
-                "globalFeatureSystemNotificationEmailsEnabled", true,
-                "globalSmtpEnabled", true,
-                "globalSmtpHost", "smtp.invalid",
-                "globalSmtpPort", 587,
-                "globalSmtpUsername", "user",
-                "globalSmtpPassword", "pass",
-                "globalSmtpFrom", "noreply@example.com"));
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
 
-    assertThatCode(() -> passwordResetService.requestPasswordReset("testuser", "xx-unknown"))
-        .doesNotThrowAnyException();
+    passwordResetService.requestPasswordReset("testuser", "xx-unknown");
+
+    assertThat(sentMails).hasSize(1);
+    assertThat(sentMails.get(0).locale()).isEqualTo("de");
+  }
+
+  @Test
+  void requestPasswordReset_Should_NotSendMail_When_FrontendBaseUrlUnset() {
+    ReflectionTestUtils.setField(passwordResetService, "passwordResetFrontendBaseUrl", "");
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+
+    passwordResetService.requestPasswordReset("testuser", "en");
+
+    // Fail closed: no base URL -> no mail, and restTemplate is never even consulted.
+    assertThat(sentMails).isEmpty();
+    verify(restTemplate, never()).getForObject(anyString(), any());
   }
 
   @Test
@@ -243,6 +258,17 @@ class PasswordResetServiceTest {
     user.setUsername("testuser");
     user.setEmail("real@example.com");
     return user;
+  }
+
+  private Map<String, Object> validSmtpSettings() {
+    return Map.of(
+        "globalFeatureSystemNotificationEmailsEnabled", true,
+        "globalSmtpEnabled", true,
+        "globalSmtpHost", "smtp.invalid",
+        "globalSmtpPort", 587,
+        "globalSmtpUsername", "user",
+        "globalSmtpPassword", "pass",
+        "globalSmtpFrom", "noreply@example.com");
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -2,8 +2,10 @@ package de.caritas.cob.userservice.api.service.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -194,6 +196,23 @@ class PasswordResetServiceTest {
     verify(keycloakService).updatePassword("user-keycloak-id", "NewPassw0rd!");
     // Token must be single-use.
     assertThat(tokens).doesNotContainKey("valid-token");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void confirmPasswordReset_Should_KeepToken_When_KeycloakRejectsPassword() {
+    // If Keycloak rejects the new password (e.g. policy violation), the token must survive so
+    // the user can retry with a different password using the same emailed link — it must not be
+    // burned on a failed attempt.
+    ConcurrentHashMap<String, Object> tokens = injectToken("retry-token", 900);
+    doThrow(new RuntimeException("password policy violation"))
+        .when(keycloakService)
+        .updatePassword("user-keycloak-id", "weak");
+
+    assertThatThrownBy(() -> passwordResetService.confirmPasswordReset("retry-token", "weak"))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(tokens).containsKey("retry-token");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -215,19 +218,38 @@ class PasswordResetServiceTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void confirmPasswordReset_Should_KeepToken_When_KeycloakRejectsPassword() {
-    // If Keycloak rejects the new password (e.g. policy violation), the token must survive so
-    // the user can retry with a different password using the same emailed link — it must not be
-    // burned on a failed attempt.
+  void confirmPasswordReset_Should_KeepToken_When_KeycloakRejectsPasswordPolicy() {
+    // Definitive policy rejection: Keycloak did NOT apply the password, so the token must
+    // survive for a retry with a different password using the same emailed link.
     ConcurrentHashMap<String, Object> tokens = injectToken("retry-token", 900);
-    doThrow(new RuntimeException("password policy violation"))
+    doThrow(
+            new CustomValidationHttpStatusException(
+                HttpStatusExceptionReason.PASSWORD_NOT_VALID, HttpStatus.BAD_REQUEST))
         .when(keycloakService)
         .updatePassword("user-keycloak-id", "weak");
 
     assertThatThrownBy(() -> passwordResetService.confirmPasswordReset("retry-token", "weak"))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(CustomValidationHttpStatusException.class);
 
     assertThat(tokens).containsKey("retry-token");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void confirmPasswordReset_Should_ConsumeToken_When_UpdateFailsIndeterminately() {
+    // A generic failure can occur AFTER Keycloak applied the password — the outcome is unknown,
+    // so the token must stay consumed; restoring it could allow a second password change with an
+    // already-used link.
+    ConcurrentHashMap<String, Object> tokens = injectToken("indeterminate-token", 900);
+    doThrow(new RuntimeException("connection reset"))
+        .when(keycloakService)
+        .updatePassword("user-keycloak-id", "NewPassw0rd!");
+
+    assertThatThrownBy(
+            () -> passwordResetService.confirmPasswordReset("indeterminate-token", "NewPassw0rd!"))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(tokens).doesNotContainKey("indeterminate-token");
   }
 
   @Test


### PR DESCRIPTION
**Affected repos:** ORISO-UserService, ORISO-Frontend (https://github.com/OpenResilienceInitiative/ORISO-Frontend/pull/470 for the frontend half)

## Why
Closes the need for ORISO-Helm#72 (localizing Keycloak's hosted password-reset email) by moving password reset fully in-app, mirroring the existing self-service Magic Link login pattern instead of depending on Keycloak's theme.

## What changed
- New `PasswordResetService` (`service/auth/`), architecturally identical to `MagicLinkLoginService`:
  - `requestPasswordReset(username, locale)` — resolves the account (asker or consultant, same username-transcoder fallback logic as Magic Link), generates a one-time token (120 min TTL, in-memory store), and sends a branded HTML email directly via the existing global SMTP settings (from ConsultingTypeService), localized into all 6 platform languages. Always completes silently regardless of whether the account exists or has a real (non-dummy) email, to avoid account enumeration — this is stricter than Magic Link, which does leak an enabled/not-enabled distinction.
  - `confirmPasswordReset(token, newPassword)` — validates the one-time token, then calls the existing `KeycloakService.updatePassword` to actually set the new password. Token is single-use.
- New endpoints: `POST /users/password-reset/request`, `POST /users/password-reset/confirm`, wired through `UserController` → `UserRegistrationControllerDelegate`, same pattern as the magic-link endpoints.
- `SecurityConfig` + `StatelessCsrfFilter`: whitelisted the new endpoints as public/CSRF-exempt bootstrap endpoints (the requester has no session yet), same treatment as magic-link.
- New config: `password.reset.frontend.base-url` (defaults to `https://app.oriso.org`), used to build the link sent in the email.

## Tests
- 15 new unit tests for `PasswordResetService` (blank/unknown/dummy-email inputs, SMTP not-configured, SMTP happy-path, locale fallback, consultant-vs-asker resolution, token expiry/single-use/cleanup, confirm success/failure).
- Updated `UserRegistrationControllerDelegateTest` with the new mock + 3 delegate-level tests.
- Full suite: 3558 tests pass, no regressions.

## Verified on Pre-Dev
- Hot-deployed (`docker build` → `k3s ctr images import` → `kubectl set image`, image tag `oriso-userservice:password-reset-e2e`) — not a persistent deploy, will be overwritten by the next real `:dev` rollout, so this PR still needs to merge to persist.
- `POST /service/users/password-reset/request` responds `204` for both known and unknown accounts (no enumeration).
- Confirmed Pre-Dev's global SMTP is enabled and configured (`globalSmtpEnabled=true`, real host), so the email-send path is live and will fire for any account with a real email.

## Not yet done
- Full click-through of a received reset email end-to-end — need a Pre-Dev consultant account with a real inbox to finish this (askers don't have real emails by design). Will follow up with a screenshot once available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-service password reset request and confirmation endpoints (no-auth + CSRF exempt), backed by validated request payloads.
  * Implemented one-time, time-limited reset tokens and localized HTML reset emails with environment-driven link generation via `password.reset.frontend.base-url`.
* **Security**
  * Exempted password-reset routes from authentication and CSRF checks (exact request/confirm paths, including optional `/service` prefix).
* **Bug Fixes**
  * Reset confirmation fails safely on invalid/expired inputs; tokens are consumed only after a successful password update.
* **Tests**
  * Added unit tests for controller delegation and password reset service success/failure and token lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->