### PR TITLE
fix: treat anonymous usernames as a global namespace across tenants (#440)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
@@ -8,6 +8,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.LinkedList;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -69,9 +70,37 @@ public class AnonymousUsernameRegistry {
     // out low ids again. Besides the local DB we must therefore also consult Keycloak: a username
     // that still exists there (e.g. a previous anonymous user) would otherwise trigger a 409
     // "username already exists" when creating the Keycloak account during invite-link redeem.
-    return userService.findUserByUsername(username).isPresent()
-        || consultantService.getConsultantByUsername(username).isPresent()
+    //
+    // The anonymous username namespace is GLOBAL, not per-tenant: Matrix user IDs are global
+    // (@anon_18:<server>) and the anonymous live-chat queue is deliberately cross-tenant. The DB
+    // lookups below are tenant-filtered, so without the technical-context bypass a caller in
+    // tenant 83 cannot see an anon user of tenant 1, hands the name out again, and Matrix rejects
+    // it with M_USER_IN_USE -> 500 on every redeem (self-perpetuating: the same id is picked
+    // again on each retry). Keycloak is already global and needs no bypass.
+    return runCrossTenant(
+            () ->
+                userService.findUserByUsername(username).isPresent()
+                    || consultantService.getConsultantByUsername(username).isPresent())
         || !identityClient.isUsernameAvailable(username);
+  }
+
+  /**
+   * Runs a lookup in technical tenant context so {@code TenantAspect} disables the Hibernate {@code
+   * tenantFilter}; the caller's tenant is restored afterwards so no other query in the same request
+   * leaks across tenants.
+   */
+  private boolean runCrossTenant(java.util.function.BooleanSupplier lookup) {
+    var callerTenant = TenantContext.getCurrentTenant();
+    try {
+      TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+      return lookup.getAsBoolean();
+    } finally {
+      if (callerTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenant(callerTenant);
+      }
+    }
   }
 
   private int obtainUsernameId(String username) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
@@ -17,9 +17,11 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,6 +44,11 @@ class AnonymousUsernameRegistryTest {
     setField(anonymousUsernameRegistry, "usernamePrefix", "Ratsuchende_r ");
     // By default every candidate username is free in Keycloak; individual tests override this.
     when(identityClient.isUsernameAvailable(anyString())).thenReturn(true);
+  }
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
   }
 
   @Test
@@ -245,5 +252,40 @@ class AnonymousUsernameRegistryTest {
     anonymousUsernameRegistry.removeRegistryIdByUsername(null);
     List<Integer> resultingRegistry = getIdRegistryField();
     assertThat(resultingRegistry, is(idRegistryListWithoutThree));
+  }
+
+  @Test
+  void generateUniqueUsername_Should_TreatUsernameOfAnotherTenantAsOccupied() {
+    // The anonymous username namespace is global: Matrix user IDs are global and the anonymous
+    // live-chat queue is deliberately cross-tenant. The DB lookups are tenant-filtered, so a
+    // caller in tenant 83 must still see an anon user that belongs to tenant 1 - otherwise the
+    // name is handed out again and Matrix rejects it with M_USER_IN_USE (500 on invite redeem).
+    TenantContext.setCurrentTenant(83L);
+    setIdRegistryField(new LinkedList<>());
+    // Simulate the Hibernate tenantFilter: "Ratsuchende_r 1" is only visible cross-tenant.
+    when(userService.findUserByUsername(any()))
+        .thenAnswer(
+            invocation ->
+                TenantContext.isTechnicalOrSuperAdminContext()
+                        && "Ratsuchende_r 1".equals(invocation.getArgument(0))
+                    ? Optional.of(USER)
+                    : Optional.empty());
+
+    anonymousUsernameRegistry.generateUniqueUsername();
+
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(usernameTranscoder, times(1)).encodeUsername(argumentCaptor.capture());
+    assertThat(argumentCaptor.getValue(), is("Ratsuchende_r 2"));
+  }
+
+  @Test
+  void generateUniqueUsername_Should_RestoreCallerTenantAfterTheCrossTenantLookup() {
+    TenantContext.setCurrentTenant(83L);
+    setIdRegistryField(new LinkedList<>());
+    when(userService.findUserByUsername(any())).thenReturn(Optional.empty());
+
+    anonymousUsernameRegistry.generateUniqueUsername();
+
+    assertThat(TenantContext.getCurrentTenant(), is(83L));
   }
 }


### PR DESCRIPTION
Fixes #440.

## Why

Anonymous Live Chat is **broken on Pre-Dev right now**: every invite-link redeem returns `500`, and it is self-perpetuating — the generator deterministically picks the same colliding username on every retry, so a restart does not help.

Found live while proving the cross-tenant Live Chat queue (E2E run `e2e-20260711-1357`, follow-up F4).

## Root cause

`AnonymousUsernameRegistry.isUsernameOccupied` checked the local DB (tenant-filtered) and Keycloak (global). But the anonymous username namespace is **global**:

- Matrix user IDs are global (`@anon_18:<server>`) and Matrix is the chat backend since the Matrix-only migration.
- The anonymous live-chat queue is deliberately **cross-agency and cross-tenant** (topic-only queue) — so anonymous users of *any* tenant share one `anon_<n>` namespace.

A tenant-83 redeem could not see `anon_18` (tenant 1) through the Hibernate `tenantFilter`, concluded the name was free, created the Keycloak user, and then failed at Matrix:

```
MatrixSynapseService: Could not create user (enc.MFXG63S7GE4A....) in Matrix.
Status: 400 BAD_REQUEST, {"errcode":"M_USER_IN_USE","error":"User ID already taken."}
-> InternalServerErrorException: Could not provision Matrix user
   at AnonymousUserCreatorService.createAnonymousUser
   at CreateAnonymousEnquiryFacade.createAnonymousEnquiry
   at AgencyInviteLinkService.redeem
```

Live evidence (Pre-Dev `user` table): `anon_18` → `tenant_id = 1`, `delete_date NULL`; `anon_17` → `tenant_id = 83`.

The same class of bug was already patched once for Keycloak (see the existing comment about the in-memory `ID_REGISTRY` resetting on restart). The Matrix migration reintroduced it at the tenant seam.

## What changed

- `isUsernameOccupied` now runs its two DB lookups in **technical tenant context**, mirroring the existing `runCrossTenant` pattern in `AnonymousEnquiryConversationListProvider` (#424). `TenantAspect` disables the Hibernate `tenantFilter`; the caller's tenant is restored in a `finally` so no other query in the request leaks across tenants.
- Keycloak is already global and is queried unchanged, outside the bypass.
- Registered (non-anonymous) paths are untouched and stay strictly tenant-isolated.

## Tests

TDD: the new test was RED against `pre-dev` and is GREEN with the fix.

- `generateUniqueUsername_Should_TreatUsernameOfAnotherTenantAsOccupied` — simulates the tenant filter (a name visible only cross-tenant) and asserts the name is skipped. **Was RED** (`expected "Ratsuchende_r 2" but was "Ratsuchende_r 1"`).
- `generateUniqueUsername_Should_RestoreCallerTenantAfterTheCrossTenantLookup` — asserts the caller's tenant is restored.

Full local unit gate on Java 21: **3,567 tests, 0 failures, 0 errors**. `spotless:apply` clean.

## Acceptance after deploy (Pre-Dev only)

- [ ] `POST /service/agencies/invitelinks/{token}/redeem` returns a created anonymous session (not 500).
- [ ] A consultant of a **different tenant** who is live for the topic sees the anonymous session in the queue (cross-tenant proof F4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)