### PR TITLE
feat(timeline): real-time notification push + waiting-room writer

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/AnonymousConversationCreatorService.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.List;
@@ -41,6 +42,7 @@ public class AnonymousConversationCreatorService {
   private final @NonNull AgencyService agencyService;
   private final @NonNull ConsultantAgencyService consultantAgencyService;
   private final @NonNull LiveEventNotificationService liveEventNotificationService;
+  private final @NonNull EventNotificationService eventNotificationService;
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
 
   /**
@@ -144,5 +146,10 @@ public class AnonymousConversationCreatorService {
 
     liveEventNotificationService.sendLiveNewAnonymousEnquiryEventToUsers(
         consultantIds, session.getId());
+
+    // WP-06 Slice 3: persist a `waiting_room.client.joined` timeline card for the same consultants
+    // the live event reaches, so a client entering the live-chat waiting room shows up in the
+    // Activity Timeline. Best-effort — must never break anonymous-conversation creation.
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(session, consultantIds);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationService.java
@@ -52,6 +52,26 @@ public class LiveEventNotificationService {
     }
   }
 
+  /**
+   * WP-06 Activity Timeline: nudge a single recipient's client to refresh its notification feed the
+   * moment a timeline {@code event_notification} is persisted, so the Activity Timeline updates in
+   * real time instead of waiting for the slow fallback poll.
+   *
+   * <p>Reuses the {@code DIRECT_MESSAGE} event type the client already listens for — this avoids
+   * coupling a new live-service enum value across the separate live-service deployment — and
+   * carries only the recipient user id, never any notification content, keeping the privacy
+   * boundary intact (ADR-AT-01 / FE-H01). Best-effort like every live event.
+   *
+   * @param userId the recipient whose client should refresh its Activity Timeline
+   */
+  public void sendEventNotificationCreatedEventToUser(String userId) {
+    if (isNotBlank(userId)) {
+      var liveEventMessage =
+          new LiveEventMessage().eventType(DIRECT_MESSAGE).userIds(singletonList(userId));
+      sendLiveEventMessage(liveEventMessage);
+    }
+  }
+
   private void sendLiveEventMessage(LiveEventMessage liveEventMessage) {
     sendLiveEventMessage(
         liveEventMessage,

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -211,6 +211,49 @@ public class EventNotificationService {
             });
   }
 
+  /**
+   * WP-06 Slice 3 (Tier 3): persist a {@code waiting_room.client.joined} timeline event for each
+   * eligible consultant when a client enters the anonymous live-chat waiting room (a new anonymous
+   * enquiry). Mirrors the recipients already reached by the {@code NEW_ANONYMOUS_ENQUIRY} live
+   * event — the Activity Timeline is the consultant's inbox — and carries the same structured
+   * params (ADR-AT-01) plus a title/text fallback. Best-effort: a failed notification must never
+   * break anonymous-conversation creation, so per-recipient failures are swallowed and logged.
+   */
+  @Transactional
+  public void createWaitingRoomClientJoinedNotifications(
+      Session session, Collection<String> recipientConsultantIds) {
+    if (session == null || recipientConsultantIds == null) {
+      return;
+    }
+    String actionPath = buildSessionActionPath(session, null, true);
+    String params = buildNewClientRequestParams(session);
+    recipientConsultantIds.stream()
+        .filter(id -> id != null && !id.isBlank())
+        .distinct()
+        .forEach(
+            consultantId -> {
+              try {
+                createEvent(
+                    consultantId,
+                    "waiting_room.client.joined",
+                    CATEGORY_SYSTEM,
+                    "Client joined the waiting room",
+                    "A client is waiting in the live chat.",
+                    params,
+                    actionPath,
+                    session.getId(),
+                    session.getTenantId());
+              } catch (RuntimeException ex) {
+                log.warn(
+                    "Could not persist waiting_room.client.joined notification for consultant {} "
+                        + "(session {})",
+                    consultantId,
+                    session.getId(),
+                    ex);
+              }
+            });
+  }
+
   private String buildNewClientRequestParams(Session session) {
     Map<String, Object> params = baseParams(session);
     if (session.getAgencyId() != null) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -49,6 +50,7 @@ public class EventNotificationService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull IdentityTombstoneService identityTombstoneService;
   private final @NonNull EventNotificationDeduplicationWriter deduplicationWriter;
+  private final @NonNull LiveEventNotificationService liveEventNotificationService;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
   private final ObjectMapper paramsObjectMapper = new ObjectMapper();
 
@@ -602,6 +604,9 @@ public class EventNotificationService {
             sourceSessionId,
             tenantId,
             null));
+    // Real-time backbone: nudge the recipient's client to refresh the Activity Timeline now
+    // instead of on the next 15s poll. Best-effort; carries only the recipient id (no content).
+    liveEventNotificationService.sendEventNotificationCreatedEventToUser(recipientUserId);
   }
 
   /** Persists an event at most once for a producer-owned key and recipient. */
@@ -639,6 +644,8 @@ public class EventNotificationService {
               sourceSessionId,
               tenantId,
               deduplicationKey));
+      // Only nudge on a genuine first persist — a duplicate-key race (below) already delivered.
+      liveEventNotificationService.sendEventNotificationCreatedEventToUser(recipientUserId);
     } catch (DataIntegrityViolationException duplicate) {
       // Another scheduler replica won the unique-key race. The desired event already exists.
       log.debug(

--- a/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/conversation/anonymous/AnonymousConversationCreatorServiceTest.java
@@ -32,6 +32,7 @@ import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import java.util.List;
@@ -56,6 +57,7 @@ class AnonymousConversationCreatorServiceTest {
   @Mock AgencyService agencyService;
   @Mock ConsultantAgencyService consultantAgencyService;
   @Mock LiveEventNotificationService liveEventNotificationService;
+  @Mock EventNotificationService eventNotificationService;
   @Mock TopicConsultantRoutingService topicConsultantRoutingService;
 
   EasyRandom easyRandom = new EasyRandom();
@@ -98,6 +100,9 @@ class AnonymousConversationCreatorServiceTest {
     verifyNoInteractions(createEnquiryMessageFacade);
     verify(liveEventNotificationService)
         .sendLiveNewAnonymousEnquiryEventToUsers(List.of("consultant-id"), session.getId());
+    // WP-06 Slice 3: the same recipients also get a waiting_room.client.joined timeline card.
+    verify(eventNotificationService)
+        .createWaitingRoomClientJoinedNotifications(session, List.of("consultant-id"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/liveevents/LiveEventNotificationServiceTest.java
@@ -175,6 +175,33 @@ public class LiveEventNotificationServiceTest {
     assertEquals(EventType.NEW_ANONYMOUS_ENQUIRY, captor.getValue().getEventType());
   }
 
+  // WP-06 Activity Timeline: single-recipient live refresh nudge fired when an event_notification
+  // is persisted, so the Activity Timeline updates in real time instead of on the slow fallback
+  // poll. Reuses DIRECT_MESSAGE (no new live-service enum), carries only the recipient user id.
+  @Test
+  public void sendEventNotificationCreatedEventToUser_Should_sendDirectMessageEventForRecipient()
+      throws ApiException {
+    this.liveEventNotificationService.sendEventNotificationCreatedEventToUser("recipient-1");
+
+    verify(this.liveControllerApi, times(1))
+        .sendLiveEvent(
+            new LiveEventMessage().eventType(DIRECT_MESSAGE).userIds(singletonList("recipient-1")));
+  }
+
+  @Test
+  public void sendEventNotificationCreatedEventToUser_Should_doNothing_When_userIdIsBlank() {
+    this.liveEventNotificationService.sendEventNotificationCreatedEventToUser("  ");
+
+    verifyNoInteractions(this.liveControllerApi);
+  }
+
+  @Test
+  public void sendEventNotificationCreatedEventToUser_Should_doNothing_When_userIdIsNull() {
+    this.liveEventNotificationService.sendEventNotificationCreatedEventToUser(null);
+
+    verifyNoInteractions(this.liveControllerApi);
+  }
+
   @Test
   public void sendAcceptAnonymousEnquiryEventToUser_Should_doNothing_When_userIdIsNull() {
     this.liveEventNotificationService.sendAcceptAnonymousEnquiryEventToUser(null);

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -140,6 +140,61 @@ class EventNotificationServiceTest {
   }
 
   // ---------------------------------------------------------------------------
+  // createWaitingRoomClientJoinedNotifications (anonymous live-chat waiting room)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createWaitingRoomClientJoinedNotifications_persistsEventPerRecipient() throws Exception {
+    Session session = sessionMock();
+
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(
+        session, List.of("consultant-a", "consultant-b"));
+
+    verify(eventNotificationRepository, times(2)).save(eventCaptor.capture());
+    EventNotification first = eventCaptor.getAllValues().get(0);
+    assertEquals("waiting_room.client.joined", first.getEventType());
+    assertEquals(EventNotificationService.CATEGORY_SYSTEM, first.getCategory());
+    assertEquals("consultant-a", first.getRecipientUserId());
+    assertEquals(Long.valueOf(100L), first.getSourceSessionId());
+    assertEquals("/sessions/consultant/sessionView/rc-group-1/100", first.getActionPath());
+    assertEquals("consultant-b", eventCaptor.getAllValues().get(1).getRecipientUserId());
+
+    JsonNode params = objectMapper.readTree(first.getParams());
+    assertEquals(100L, params.get("sessionId").asLong());
+    assertEquals(42L, params.get("agencyId").asLong());
+    assertEquals(1, params.get("consultingTypeId").asInt());
+  }
+
+  @Test
+  void createWaitingRoomClientJoinedNotifications_skipsBlankAndDeduplicatesRecipients() {
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(
+        sessionMock(), Arrays.asList("consultant-a", null, "  ", "consultant-a", "consultant-b"));
+
+    verify(eventNotificationRepository, times(2)).save(any());
+  }
+
+  @Test
+  void createWaitingRoomClientJoinedNotifications_doesNothingForNullInputs() {
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(
+        null, List.of("consultant-a"));
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(sessionMock(), null);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createWaitingRoomClientJoinedNotifications_swallowsExceptionForOneRecipientAndContinues() {
+    when(eventNotificationRepository.save(any()))
+        .thenThrow(new RuntimeException("DB error"))
+        .thenReturn(mock(EventNotification.class));
+
+    eventNotificationService.createWaitingRoomClientJoinedNotifications(
+        sessionMock(), List.of("consultant-a", "consultant-b"));
+
+    verify(eventNotificationRepository, times(2)).save(any());
+  }
+
+  // ---------------------------------------------------------------------------
   // createInquiryAcceptedNotification
   // ---------------------------------------------------------------------------
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -53,6 +53,11 @@ class EventNotificationServiceTest {
   @Mock private ConsultantRepository consultantRepository;
   @Mock private IdentityTombstoneService identityTombstoneService;
   @Mock private EventNotificationDeduplicationWriter deduplicationWriter;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService
+      liveEventNotificationService;
+
   @Captor private ArgumentCaptor<EventNotification> eventCaptor;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -665,6 +670,75 @@ class EventNotificationServiceTest {
         "user-1", "message.new", null, "Title", "Text", null, 1L, 1L);
     verify(eventNotificationRepository).save(eventCaptor.capture());
     assertEquals(EventNotificationService.CATEGORY_SYSTEM, eventCaptor.getValue().getCategory());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Real-time backbone: every persisted notification nudges its recipient's client
+  // to refresh the Activity Timeline feed (no 15s poll wait). Carries no content.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void createEvent_firesLiveRefreshToRecipientAfterPersist() {
+    eventNotificationService.createEvent(
+        "user-1", "message.new", EventNotificationService.CATEGORY_MESSAGE, "T", "B", null, 1L, 1L);
+
+    verify(eventNotificationRepository).save(any());
+    verify(liveEventNotificationService).sendEventNotificationCreatedEventToUser("user-1");
+  }
+
+  @Test
+  void createEvent_doesNotFireLiveRefreshForBlankRecipient() {
+    eventNotificationService.createEvent(
+        "  ", "message.new", EventNotificationService.CATEGORY_MESSAGE, "T", "B", null, 1L, 1L);
+
+    verify(liveEventNotificationService, never()).sendEventNotificationCreatedEventToUser(any());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_firesLiveRefreshToRecipient() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByGroupId("rc-group-1")).thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "rc-group-1", "someone-else", "hi", false);
+
+    verify(liveEventNotificationService).sendEventNotificationCreatedEventToUser("asker-1");
+  }
+
+  @Test
+  void createEventOnce_firesLiveRefreshOnFirstPersistOnly() {
+    when(eventNotificationRepository.existsByRecipientUserIdAndDeduplicationKey(
+            "consultant-1", "group-chat:reminder:42:0"))
+        .thenReturn(false, true);
+
+    eventNotificationService.createEventOnce(
+        "group-chat:reminder:42:0",
+        "consultant-1",
+        "group_chat.reminder",
+        EventNotificationService.CATEGORY_SYSTEM,
+        "Reminder",
+        "Soon",
+        "{\"seriesId\":42}",
+        null,
+        42L,
+        null);
+    eventNotificationService.createEventOnce(
+        "group-chat:reminder:42:0",
+        "consultant-1",
+        "group_chat.reminder",
+        EventNotificationService.CATEGORY_SYSTEM,
+        "Reminder",
+        "Soon",
+        "{\"seriesId\":42}",
+        null,
+        42L,
+        null);
+
+    verify(liveEventNotificationService, times(1))
+        .sendEventNotificationCreatedEventToUser("consultant-1");
   }
 
   @Test


### PR DESCRIPTION
Two cohesive backend improvements to the Activity Timeline, same service (`EventNotificationService`), same reviewer.

## 1. Real-time push (replaces the 15s poll lag)
The feed only refreshed on the frontend's 15s poll, so even event types that already have writers surfaced up to 15s late. `EventNotificationService` now fires a best-effort live event to the recipient whenever an `event_notification` is persisted (`createEvent`; first genuine persist in `createEventOnce`). New `LiveEventNotificationService.sendEventNotificationCreatedEventToUser(userId)` reuses the existing **`DIRECT_MESSAGE`** event type (no new cross-service enum) and carries **only the recipient id — never content** (ADR-AT-01 / FE-H01). FE counterpart: ORISO-Frontend #474.

## 2. `waiting_room.client.joined` writer
This designed event type was seeded in the FE registry ahead of a writer. A client entering the anonymous live-chat waiting room already fans a `NEW_ANONYMOUS_ENQUIRY` live event out to eligible consultants; we now persist a matching timeline card for the same recipients. Structured params, best-effort — never breaks anonymous-conversation creation.

## Tests (TDD)
- `EventNotificationServiceTest` (75): live refresh fires after persist / not for blank / message-recipient / dedup-once; `waiting_room.client.joined` per-recipient, dedup, null-guard, best-effort.
- `LiveEventNotificationServiceTest` (18): new push sends `DIRECT_MESSAGE`, no-op on blank/null.
- `AnonymousConversationCreatorServiceTest` (6): the enquiry flow also creates the waiting-room notifications.

Refs OpenResilienceInitiative/ORISO-Frontend#473 (real-time backbone), OpenResilienceInitiative/ORISO-Frontend#420 (waiting-room writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)