### PR TITLE
fix: tolerate duplicate anonymous usernames and enrichment failures i…

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** {@link ConversationListProvider} to provide anonymous enquiry conversations. */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AnonymousEnquiryConversationListProvider implements ConversationListProvider {
@@ -57,8 +59,20 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
             .map(session -> new SessionMapper().toConsultantSessionDto(session))
             .collect(Collectors.toList());
 
-    this.consultantSessionEnricher.updateRequiredConsultantSessionValues(
-        sessions, pageableListRequest.getRcToken(), consultant);
+    // The queue must stay visible even when enrichment (chat room info, last message,
+    // topic details) fails — an un-enriched card can still be accepted, an empty queue
+    // cannot. Without this guard a single enrichment error 500s the endpoint and the
+    // frontend treats the anonymous feed as empty.
+    try {
+      this.consultantSessionEnricher.updateRequiredConsultantSessionValues(
+          sessions, pageableListRequest.getRcToken(), consultant);
+    } catch (Exception e) {
+      log.error(
+          "Anonymous enquiry enrichment failed for consultant {} — returning {} un-enriched queue entries",
+          consultant.getId(),
+          sessions.size(),
+          e);
+    }
 
     return new ConsultantSessionListResponseDTO()
         .sessions(sessions)

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/UserRepository.java
@@ -24,7 +24,15 @@ public interface UserRepository extends CrudRepository<User, String> {
 
   List<User> findAllByDeleteDateIsNull();
 
-  Optional<User> findByUsernameInAndDeleteDateIsNull(Collection<String> usernames);
+  /**
+   * Username lookups must tolerate duplicates: user.username carries no unique constraint and
+   * generated anonymous usernames repeat across service restarts (the in-memory id registry
+   * resets), so a single-result finder would throw {@code IncorrectResultSizeDataAccessException}
+   * as soon as two rows share a name — which 500s the anonymous invite-link redeem. Callers pick
+   * the oldest matching row deterministically.
+   */
+  List<User> findAllByUsernameInAndDeleteDateIsNullOrderByCreateDateAsc(
+      Collection<String> usernames);
 
   /**
    * Find all users whose create date is older than given date and having no new registered session

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionEnricher.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionEnricher.java
@@ -10,11 +10,13 @@ import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentServ
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Service class to enrich a session of an consultant with required Rocket.Chat data. */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConsultantSessionEnricher {
@@ -40,10 +42,26 @@ public class ConsultantSessionEnricher {
                 .rocketChatUserId(consultant.getRocketChatId())
                 .build());
 
+    // Enrichment is additive (read state, last message, topic details). One session that
+    // fails to enrich must not take the whole list down — a consultant seeing a session
+    // card without a last-message preview beats not seeing the session at all.
     consultantSessionResponseDTOs.forEach(
-        consultantSessionResponseDTO ->
+        consultantSessionResponseDTO -> {
+          try {
             this.enrichConsultantSession(
-                consultantSessionResponseDTO, rocketChatRoomInformation, consultant));
+                consultantSessionResponseDTO, rocketChatRoomInformation, consultant);
+          } catch (Exception e) {
+            var sessionId =
+                consultantSessionResponseDTO.getSession() != null
+                    ? consultantSessionResponseDTO.getSession().getId()
+                    : null;
+            log.error(
+                "Failed to enrich session {} for consultant {} — returning it un-enriched",
+                sessionId,
+                consultant.getId(),
+                e);
+          }
+        });
     return consultantSessionResponseDTOs;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserService.java
@@ -129,14 +129,20 @@ public class UserService {
   /**
    * Finds an user by the given username (searches for encoded and decoded version of it).
    *
+   * <p>user.username is not unique (generated anonymous usernames repeat across restarts), so the
+   * lookup returns the oldest matching row instead of failing on duplicates.
+   *
    * @param username the username to search for
    * @return {@link Optional} of {@link User}
    */
   public Optional<User> findUserByUsername(String username) {
-    return userRepository.findByUsernameInAndDeleteDateIsNull(
-        List.of(
-            usernameTranscoder.encodeUsername(username),
-            usernameTranscoder.decodeUsername(username)));
+    return userRepository
+        .findAllByUsernameInAndDeleteDateIsNullOrderByCreateDateAsc(
+            List.of(
+                usernameTranscoder.encodeUsername(username),
+                usernameTranscoder.decodeUsername(username)))
+        .stream()
+        .findFirst();
   }
 
   public Optional<User> findUserByEmail(String email) {


### PR DESCRIPTION
…n live chat queue

Anonymous usernames are generated from an in-memory id registry that resets on every restart, and user.username carries no unique constraint, so the same generated name accumulates duplicate rows over time. The username-occupied probe during invite-link redeem used a single-result finder over IN(encoded, decoded) and threw IncorrectResultSizeDataAccessException ('2 results were returned') as soon as a candidate name had two rows. The exception propagated uncaught, redeem returned 500, no session was created, and the consultant Live Chat queue stayed empty. Magic-link login shared the same throwing lookup.

The lookup now returns all matches ordered by create date and callers take the oldest row: duplicates read as 'occupied' and the generator advances to the next free name instead of failing the request.

Additionally the anonymous enquiry list no longer 500s when session enrichment (room info, last message, topic details) fails: enrichment errors are logged and the queue entries are returned un-enriched, per session, so one bad session or a failing downstream service cannot blank the whole queue.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

