### PR TITLE
fix: harden anonymous live-chat redemption and acceptance

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -815,7 +815,15 @@ public class KeycloakService implements IdentityClient {
    * @return {@link List} of found users
    */
   public List<UserRepresentation> findByUsername(String username) {
-    return keycloakClient.getUsersResource().search(username);
+    try {
+      return keycloakClient.getUsersResource().search(username);
+    } catch (NotAuthorizedException e) {
+      log.warn(
+          "Keycloak admin session was unauthorized while searching for username, forcing token"
+              + " refresh and retrying once");
+      keycloakClient.refreshAdminSession();
+      return keycloakClient.getUsersResource().search(username);
+    }
   }
 
   public UserRepresentation getById(String userId) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import jakarta.transaction.Transactional;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import lombok.NonNull;
@@ -157,8 +158,9 @@ class UserRegistrationControllerDelegate {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @Transactional
   ResponseEntity<Void> acceptEnquiry(Long sessionId) {
-    var session = sessionService.getSession(sessionId);
+    var session = sessionService.getSessionForUpdate(sessionId);
 
     // MATRIX MIGRATION: Removed groupId check - Matrix sessions don't have RocketChat groupId
     if (session.isEmpty()) {

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacade.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import jakarta.transaction.Transactional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,10 +26,11 @@ public class AcceptAnonymousEnquiryFacade {
    *
    * @param sessionId the id of the anonymous session
    */
+  @Transactional
   public void acceptAnonymousEnquiry(Long sessionId) {
     var session =
         sessionService
-            .getSession(sessionId)
+            .getSessionForUpdate(sessionId)
             .orElseThrow(
                 () -> new NotFoundException("Session with id %s does not exist", sessionId));
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -5,17 +5,23 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.RegistrationType;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface SessionRepository extends CrudRepository<Session, Long> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT session FROM Session session WHERE session.id = :sessionId")
+  Optional<Session> findByIdForUpdate(@Param("sessionId") Long sessionId);
 
   /**
    * Find a {@link Session} by a consultant id and a session status.

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -102,6 +102,11 @@ public class SessionService {
     return sessionRepository.findById(sessionId);
   }
 
+  /** Returns the session while holding a write lock for the surrounding transaction. */
+  public Optional<Session> getSessionForUpdate(Long sessionId) {
+    return sessionRepository.findByIdForUpdate(sessionId);
+  }
+
   /**
    * Returns the session only if the authenticated user is allowed to access it.
    *

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1378,6 +1378,22 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void findByUsername_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(USERNAME))
+        .thenThrow(new jakarta.ws.rs.NotAuthorizedException("Bearer"))
+        .thenReturn(singletonList(userRepresentation));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    List<UserRepresentation> result = keycloakService.findByUsername(USERNAME);
+
+    assertThat(result, is(singletonList(userRepresentation)));
+    verify(keycloakClient).refreshAdminSession();
+    verify(usersResource, times(2)).search(USERNAME);
+  }
+
+  @Test
   public void deleteUser_Should_RemoveUser_When_UserExists() {
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -204,7 +204,7 @@ class UserRegistrationControllerDelegateTest {
 
   @Test
   void acceptEnquiryShouldReturnInternalServerErrorWhenSessionIsMissing() {
-    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.empty());
+    when(sessionService.getSessionForUpdate(SESSION_ID)).thenReturn(Optional.empty());
 
     var response = delegate.acceptEnquiry(SESSION_ID);
 
@@ -216,7 +216,7 @@ class UserRegistrationControllerDelegateTest {
   void acceptEnquiryShouldAssignRegisteredEnquiry() {
     var session = new Session();
     var consultant = new Consultant();
-    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(sessionService.getSessionForUpdate(SESSION_ID)).thenReturn(Optional.of(session));
     when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
 
     var response = delegate.acceptEnquiry(SESSION_ID);

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacadeTest.java
@@ -37,7 +37,7 @@ class AcceptAnonymousEnquiryFacadeTest {
   @Test
   void acceptAnonymousEnquiry_Should_useServicesCorrectly_When_sessionExists() {
     Session session = new EasyRandom().nextObject(Session.class);
-    when(this.sessionService.getSession(session.getId())).thenReturn(Optional.of(session));
+    when(this.sessionService.getSessionForUpdate(session.getId())).thenReturn(Optional.of(session));
 
     this.acceptAnonymousEnquiryFacade.acceptAnonymousEnquiry(session.getId());
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -252,6 +252,17 @@ class SessionServiceTest {
   }
 
   @Test
+  void getSessionForUpdate_Should_ReturnLockedSession() {
+    when(sessionRepository.findByIdForUpdate(ENQUIRY_ID)).thenReturn(Optional.of(SESSION));
+
+    Optional<Session> result = sessionService.getSessionForUpdate(ENQUIRY_ID);
+
+    assertTrue(result.isPresent());
+    assertEquals(SESSION, result.get());
+    verify(sessionRepository).findByIdForUpdate(ENQUIRY_ID);
+  }
+
+  @Test
   void updateConsultantAndStatusForSession_Should_SaveSession() {
 
     sessionService.updateConsultantAndStatusForSession(SESSION, CONSULTANT, SessionStatus.NEW);


### PR DESCRIPTION
## Summary

- refresh the cached Keycloak admin session and retry once when anonymous username lookup receives HTTP 401
- serialize anonymous live-chat acceptance with a pessimistic session-row lock
- apply the locked lookup to both the current conversation route and the legacy route used by the consultant UI
- add regression coverage for the expired-admin-session and locked-session paths

## Root causes

1. The Keycloak access token cached by UserService can outlive Keycloak's server-side admin session. Anonymous External Inbound redemption checks candidate usernames through `findByUsername`; an HTTP 401 aborted redemption before the session was created.
2. Both acceptance routes read the anonymous session without a lock. Two consultants accepting concurrently could both observe `NEW`, both receive HTTP 200, and create separate Matrix conversations for the same enquiry.

## Validation

- RED/GREEN: expired-admin-session regression failed before the retry and passed after it
- RED/GREEN: legacy UI acceptance test failed before the locked lookup and passed after it
- focused and related unit suites: green
- full UserService unit suite: 3,454 tests, 0 failures, 0 errors, 7 skipped
- Maven package: successful
- real PreDev External Inbound E2E:
  - invite redemption creates the anonymous live-chat session
  - two consultants see the same queue
  - concurrent acceptance yields exactly one HTTP 200 and one HTTP 409
  - the accepted enquiry disappears from both queues
  - two-way encrypted messages survive reload
  - audio and video calls connect both participants to the same call room
  - closed/no-consultant state offers the anonymous mail fallback
  - all test sessions, synthetic users, invite link, credentials, runtime patch, and temporary image were removed
- PreDev was restored to its original UserService image digest after runtime proof

Closes OpenResilienceInitiative/ORISO-UserService#447
Closes OpenResilienceInitiative/ORISO-UserService#451
Refs OpenResilienceInitiative/ORISO-UserService#431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
