### PR TITLE
fix: PATCH /users returns 404 instead of 500 for orphaned Keycloak accounts

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -188,7 +188,8 @@ class UserAccountControllerDelegate {
 
     Optional<Map<String, Object>> patchResponse = accountManager.patchUser(patchMap);
     if (patchResponse.isEmpty()) {
-      throw new IllegalStateException("patch response not valid");
+      throw new NotFoundException(
+          "User with id %s not found in user or consultant repository", userId);
     }
 
     userDtoMapper

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -501,15 +501,17 @@ class UserAccountControllerDelegateTest {
   }
 
   @Test
-  void patchUser_emptyPatchResponse_throwsIllegalStateException() {
-    // A successful identity patch must return updated attributes.
+  void patchUser_emptyPatchResponse_throwsNotFoundException() {
+    // Orphaned Keycloak accounts (no user or consultant DB record) must yield 404, not 500.
     var patchUserDTO = new PatchUserDTO();
     var patchMap = Map.<String, Object>of("firstName", "Ada");
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
     when(userDtoMapper.mapOf(patchUserDTO, authenticatedUser)).thenReturn(Optional.of(patchMap));
     when(accountManager.patchUser(patchMap)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> delegate.patchUser(patchUserDTO))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining(USER_ID);
   }
 
   @Test


### PR DESCRIPTION
## Problem
An advice seeker whose Keycloak account has no matching active DB record gets an HTTP 500 on login: the SPA's post-login `PATCH /users` reaches `UserAccountControllerDelegate.patchUser`, which threw a bare `IllegalStateException("patch response not valid")` when `AccountManager.patchUser` finds neither a user nor a consultant. The client is locked out on error.500.html (observed on Pre-Dev with the seeded `test-user-001`).

## What changed
- `UserAccountControllerDelegate.patchUser` throws `NotFoundException` (→ 404 via `ApiResponseEntityExceptionHandler`) when the account has no DB record
- Test rewritten red-first: unknown id → NotFoundException with the user id in the message; found advice-seeker/consultant behavior unchanged
- `AccountManager` contract untouched; the only other caller (`UserTwoFactorAuthControllerDelegate`) ignores the Optional and is unaffected

## Verification
- `./mvnw -Dtest='UserAccountControllerDelegateTest,AccountManagerTest' test` — 58/58 pass (Temurin 21)
- `./mvnw spotless:apply` clean

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)