### PR TITLE
feat: guard against duplicate active tenant invites per role

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import jakarta.persistence.LockModeType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,9 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   Optional<AccountInvite> findByTokenHash(String tokenHash);
+
+  boolean existsByTenantIdAndTargetRoleAndStatusIn(
+      Long tenantId, AccountInviteTargetRole targetRole, Collection<AccountInviteStatus> statuses);
 
   @Query(
       "SELECT i FROM AccountInvite i"

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.service.accountinvite;
 
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -16,13 +17,16 @@ import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
@@ -31,11 +35,14 @@ public class AccountInviteService {
   private static final int TOKEN_BYTES = 32;
   private static final long DEFAULT_EXPIRY_DAYS = 30L;
   private static final SecureRandom RANDOM = new SecureRandom();
+  private static final List<AccountInviteStatus> ACTIVE_TENANT_INVITE_STATUSES =
+      List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT);
 
   private final @NonNull AccountInviteRepository accountInviteRepository;
   private final @NonNull InviteEmailTemplateRepository templateRepository;
   private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull TenantService tenantService;
 
   @Transactional
   public AccountInvite createInvite(CreateAccountInviteCommand command) {
@@ -47,6 +54,11 @@ public class AccountInviteService {
     }
     if (isBlank(command.recipientEmail())) {
       throw new BadRequestException("recipientEmail is required");
+    }
+    if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN
+        && command.tenantId() != null
+        && isTenantIdTaken(command.tenantId())) {
+      throw new BadRequestException("tenantId " + command.tenantId() + " is already taken");
     }
 
     LocalDateTime now = LocalDateTime.now();
@@ -277,6 +289,25 @@ public class AccountInviteService {
             .build();
     delivery = deliveryRepository.save(delivery);
     return new InviteSendResult(invite, delivery, rawToken, acceptUrl);
+  }
+
+  private boolean isTenantIdTaken(Long tenantId) {
+    if (tenantExists(tenantId)) {
+      return true;
+    }
+    return accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
+        tenantId, AccountInviteTargetRole.TENANT_ADMIN, ACTIVE_TENANT_INVITE_STATUSES);
+  }
+
+  private boolean tenantExists(Long tenantId) {
+    try {
+      return tenantService.getRestrictedTenantData(tenantId) != null;
+    } catch (HttpClientErrorException exception) {
+      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
+        return false;
+      }
+      throw exception;
+    }
   }
 
   private AccountInvite findInvite(Long inviteId) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -21,6 +22,7 @@ import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
 class AccountInviteServiceTest {
@@ -40,6 +44,7 @@ class AccountInviteServiceTest {
   @Mock private InviteEmailTemplateRepository templateRepository;
   @Mock private InviteEmailDeliveryRepository deliveryRepository;
   @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private TenantService tenantService;
 
   @InjectMocks private AccountInviteService service;
 
@@ -747,5 +752,135 @@ class AccountInviteServiceTest {
   void hash_Should_differ_forDifferentInput() {
     assertThat(AccountInviteService.hash("token-a"))
         .isNotEqualTo(AccountInviteService.hash("token-b"));
+  }
+
+  @Test
+  void createInvite_Should_ThrowBadRequest_When_TenantAdminTenantIdMatchesExistingTenant() {
+    when(tenantService.getRestrictedTenantData(7L))
+        .thenReturn(new RestrictedTenantDTO().name("Existing Tenant"));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            7L,
+            "owner@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void createInvite_Should_ThrowBadRequest_When_TenantAdminTenantIdUsedByActiveInvite() {
+    when(tenantService.getRestrictedTenantData(7L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
+            7L,
+            AccountInviteTargetRole.TENANT_ADMIN,
+            List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
+        .thenReturn(true);
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            7L,
+            "owner@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_TenantIdOnlyUsedByTerminalInvite() {
+    when(tenantService.getRestrictedTenantData(7L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
+            7L,
+            AccountInviteTargetRole.TENANT_ADMIN,
+            List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
+        .thenReturn(false);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            7L,
+            "owner@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L);
+
+    AccountInvite invite = service.createInvite(command);
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getTenantId()).isEqualTo(7L);
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_NonTenantAdminRoleReusesCollidingTenantId() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "counsellor@example.org",
+            "New",
+            "Counsellor",
+            null,
+            null,
+            30L);
+
+    AccountInvite invite = service.createInvite(command);
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    verify(tenantService, never()).getRestrictedTenantData(any(Long.class));
+    verify(accountInviteRepository, never())
+        .existsByTenantIdAndTargetRoleAndStatusIn(any(), any(), any());
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_TenantAdminTenantIdIsFree() {
+    when(tenantService.getRestrictedTenantData(9L))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
+            9L,
+            AccountInviteTargetRole.TENANT_ADMIN,
+            List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
+        .thenReturn(false);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            9L,
+            "owner2@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L);
+
+    AccountInvite invite = service.createInvite(command);
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getTenantId()).isEqualTo(9L);
   }
 }


### PR DESCRIPTION
## What

Guards tenant invites so that only one active invite can exist per tenant + target role. An invite is considered active while its status is `DRAFT` or `EMAIL_SENT`. When a `TENANT_ADMIN` invite is created with a `tenantId` that is already taken — either by an existing tenant or by another active invite for the same tenant + `TENANT_ADMIN` role — the request is rejected with a `BadRequestException` and no invite is persisted.

## Why

Without this guard, multiple concurrent `DRAFT`/`EMAIL_SENT` tenant-admin invites could be created for the same `tenantId`, which would lead to id-collision problems when the invites are accepted. Terminal (non-active) invites do not block reuse, and non-`TENANT_ADMIN` roles are unaffected.

## How

- `AccountInviteRepository`: new derived query `existsByTenantIdAndTargetRoleAndStatusIn(tenantId, targetRole, statuses)`.
- `AccountInviteService`: `createInvite` checks `isTenantIdTaken(...)` for `TENANT_ADMIN` invites with a non-null `tenantId`; the check combines `TenantService.getRestrictedTenantData` (existing tenant) with the new repository guard over the active statuses `{DRAFT, EMAIL_SENT}`.
- `AccountInviteServiceTest`: 5 new unit tests covering collision with an existing tenant, collision with an active invite, success for terminal-only invites, success for non-`TENANT_ADMIN` roles reusing a colliding id, and success for a free tenant id.

## Notes

This work was rescued from an uncommitted worktree (branch `feat/tenant-invite-id-collision-guard`, stale base ~112 commits behind). The three-file change was committed, then cherry-picked onto a fresh branch off `origin/pre-dev`; trivial import conflicts and an additive test-file conflict were resolved as a union. The touched test class passes (55/55, JDK 25 with `-Dnet.bytebuddy.experimental=true`), and `spotless:apply` reported no formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
