### PR TITLE
fix: check Matrix when choosing anonymous usernames (#460)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -314,6 +314,52 @@ public class MatrixSynapseService {
   }
 
   /**
+   * Checks whether a Matrix user with the given localpart already exists on this homeserver.
+   *
+   * <p>Matrix user IDs are global (not per-tenant), so this is the authoritative occupancy check
+   * for anonymous usernames: a localpart can be orphaned in Matrix (present here but absent from
+   * MariaDB and Keycloak, e.g. left behind by a rolled-back or externally cleaned-up account), and
+   * such an orphan still makes {@code createUser} fail with {@code M_USER_IN_USE}.
+   *
+   * @param localpart the Matrix localpart (the part before {@code :server}); it is lowercased,
+   *     because Synapse stores localparts in lower case
+   * @return {@code true} if the user exists, {@code false} if it does not (HTTP 404) or if
+   *     existence could not be determined (so callers still make forward progress rather than
+   *     looping forever when the admin API is unavailable)
+   */
+  public boolean userExists(String localpart) {
+    if (localpart == null || localpart.isBlank()) {
+      return false;
+    }
+    String matrixUserId =
+        "@" + localpart.toLowerCase(java.util.Locale.ROOT) + ":" + matrixConfig.getServerName();
+    try {
+      String adminToken = getAdminToken();
+      if (adminToken == null) {
+        log.warn("Could not get admin token for Matrix user existence check of {}", matrixUserId);
+        return false;
+      }
+      URI url =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
+      var headers = new HttpHeaders();
+      headers.setBearerAuth(adminToken);
+      var response =
+          restTemplate.exchange(
+              url,
+              org.springframework.http.HttpMethod.GET,
+              new HttpEntity<>(headers),
+              String.class);
+      return response.getStatusCode().is2xxSuccessful();
+    } catch (org.springframework.web.client.HttpClientErrorException.NotFound ex) {
+      return false;
+    } catch (Exception ex) {
+      log.warn("Could not check Matrix user existence for {}: {}", matrixUserId, ex.getMessage());
+      return false;
+    }
+  }
+
+  /**
    * Creates a short-lived Matrix access token for a user via the Synapse admin API.
    *
    * @param matrixUserId full Matrix user ID, e.g. {@code @user:server}

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
@@ -4,6 +4,7 @@ import static java.lang.Integer.parseInt;
 import static java.util.Collections.sort;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -23,7 +24,13 @@ public class AnonymousUsernameRegistry {
   private final @NonNull UserService userService;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
   private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
+
+  // Dedicated transcoder for building the Matrix localpart during the occupancy check. It is kept
+  // separate from usernameTranscoder (which encodes the single returned username) so the Matrix
+  // check never perturbs callers that verify how often the returned value is encoded.
+  private final UsernameTranscoder matrixLocalpartTranscoder = new UsernameTranscoder();
 
   @Value("${anonymous.username.prefix}")
   private String usernamePrefix;
@@ -81,7 +88,23 @@ public class AnonymousUsernameRegistry {
             () ->
                 userService.findUserByUsername(username).isPresent()
                     || consultantService.getConsultantByUsername(username).isPresent())
-        || !identityClient.isUsernameAvailable(username);
+        || !identityClient.isUsernameAvailable(username)
+        || existsInMatrix(username);
+  }
+
+  /**
+   * Matrix user IDs are global, so a localpart occupied in Matrix must not be handed out again even
+   * when it is absent from MariaDB and Keycloak (an orphan left behind by a rolled-back or
+   * externally cleaned-up account). Without this check such an orphan is deemed free, {@code
+   * createUser} fails with {@code M_USER_IN_USE}, and — because the generator is deterministic —
+   * every retry collides on the same id, so invite-link redeem returns 500 indefinitely.
+   *
+   * <p>The Matrix localpart has been written in two forms over time (the encoded username and, for
+   * older accounts, the plain one), so both are checked.
+   */
+  private boolean existsInMatrix(String username) {
+    return matrixSynapseService.userExists(matrixLocalpartTranscoder.encodeUsername(username))
+        || matrixSynapseService.userExists(username);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.conversation.service.user.anonymous.AnonymousUsernameRegistry;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
@@ -36,6 +37,7 @@ class AnonymousUsernameRegistryTest {
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
   @Mock private IdentityClient identityClient;
+  @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private UsernameTranscoder usernameTranscoder;
 
   @BeforeEach
@@ -270,6 +272,24 @@ class AnonymousUsernameRegistryTest {
                         && "Ratsuchende_r 1".equals(invocation.getArgument(0))
                     ? Optional.of(USER)
                     : Optional.empty());
+
+    anonymousUsernameRegistry.generateUniqueUsername();
+
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(usernameTranscoder, times(1)).encodeUsername(argumentCaptor.capture());
+    assertThat(argumentCaptor.getValue(), is("Ratsuchende_r 2"));
+  }
+
+  @Test
+  void generateUniqueUsername_Should_TreatUsernameOrphanedInMatrixAsOccupied() {
+    // A localpart can survive in Matrix while absent from MariaDB and Keycloak (a rolled-back or
+    // externally cleaned-up anonymous account). Matrix user IDs are global, so such an orphan must
+    // be skipped - otherwise createUser fails with M_USER_IN_USE and, because the generator is
+    // deterministic, every redeem retry collides on the same id (invite redeem 500 forever).
+    setIdRegistryField(new LinkedList<>());
+    when(userService.findUserByUsername(any())).thenReturn(Optional.empty());
+    when(consultantService.getConsultantByUsername(any())).thenReturn(Optional.empty());
+    when(matrixSynapseService.userExists("Ratsuchende_r 1")).thenReturn(true);
 
     anonymousUsernameRegistry.generateUniqueUsername();
 


### PR DESCRIPTION
Fixes #460.

## Why

After #441 (tenant-global DB check) and #448 (Keycloak-401 retry + acceptance lock), anonymous Live Chat invite redeem **still returned 500** on Pre-Dev. Found live on `e2e-20260717` while proving the cross-tenant queue (F4).

`AnonymousUsernameRegistry.isUsernameOccupied` checks MariaDB (now tenant-global) and Keycloak, but **never Matrix**. Matrix user IDs are global, and a localpart can survive in Matrix while absent from both MariaDB and Keycloak — an orphan from a rolled-back anonymous creation, or from an E2E cleanup that removed the DB + Keycloak users but not the Matrix account. That orphan is deemed free, `createUser` fails with `M_USER_IN_USE`, and because the generator is deterministic every retry collides on the same id → redeem 500 forever.

## Live evidence (Pre-Dev, with #441 + #448 already deployed)

```
Could not create user (enc.MFXG63S7GMYA....) in Matrix — M_USER_IN_USE
```

`enc.MFXG63S7GMYA....` = `anon_30`. DB (root, all tenants): **0 rows**. Keycloak: reported available. Matrix: taken → orphan. The stored Matrix localpart is inconsistent across eras (`@enc.mfxg63s7...:server` vs `@anon_8:server`), so both forms are checked.

## What changed

- `MatrixSynapseService.userExists(localpart)` — Synapse admin `GET /_synapse/admin/v2/users/{userId}` (200 → exists, 404 → free, unknown → false so the generator always makes forward progress; can't loop forever if the admin API is down).
- `AnonymousUsernameRegistry.isUsernameOccupied` now also consults Matrix — after the DB and Keycloak checks (short-circuit keeps Matrix as the last, most expensive gate) — for both the encoded and the plain localpart, via a dedicated transcoder so callers verifying the returned-value encoding are unaffected.

## Tests

TDD, RED→GREEN:
- `generateUniqueUsername_Should_TreatUsernameOrphanedInMatrixAsOccupied` — a name present only in Matrix is skipped.
- Full UserService unit suite on Java 21: **3,599 tests, 0 failures, 0 errors, 7 skipped**. `spotless:apply` clean. `MatrixSynapseServiceTest` 52/52.

## Acceptance after deploy (Pre-Dev only)

- [ ] Invite redeem creates an anonymous session (not 500).
- [ ] Cross-tenant proof (F4): a different-tenant live consultant sees the anonymous topic session.

> Note: this fixes the registry so it stops *handing out* colliding names. The pre-existing Matrix orphans (`anon_18`, `anon_30`, …) are cleaned up separately as ops (they will simply be skipped now, but cleaning them keeps the id space tidy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)