### PR TITLE
fix: default session supervisionOptedOut to false (#462)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/model/Session.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Session.java
@@ -205,10 +205,15 @@ public class Session implements TenantAware {
    * The ratsuchende's supervision opt-out (grill 2026-07-13, supersedes the ADR-008 item-4 binary
    * per-reason consent flag). Supervision is allowed by default (false); when the client switches
    * this on, no supervisor may be attached to the case and any active supervisors are removed.
-   * Nullable + default false so a row predating the column reads as "not opted out".
+   *
+   * <p>The column is NOT NULL, so a new session must never leave this null:
+   * {@code @Builder.Default} (and the field initializer for the no-args constructor) keep it {@code
+   * false} at creation, since Hibernate includes the column in every INSERT and the DB default only
+   * applies to omitted columns.
    */
+  @Builder.Default
   @Column(name = "is_supervision_opted_out", columnDefinition = "bit default false")
-  private Boolean supervisionOptedOut;
+  private Boolean supervisionOptedOut = false;
 
   @OneToMany(
       targetEntity = SessionTopic.class,

--- a/src/test/java/de/caritas/cob/userservice/api/model/SessionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/model/SessionTest.java
@@ -47,4 +47,27 @@ public class SessionTest {
 
     assertThat(equals, is(true));
   }
+
+  @Test
+  public void builder_Should_defaultSupervisionOptedOutToFalse() {
+    // The is_supervision_opted_out column is NOT NULL. A newly built session must therefore carry
+    // a non-null value, otherwise Hibernate inserts NULL and every session creation fails with a
+    // constraint violation. @Builder ignores plain field initializers, so this pins
+    // @Builder.Default.
+    Session session =
+        Session.builder()
+            .registrationType(Session.RegistrationType.REGISTERED)
+            .postcode("12345")
+            .status(Session.SessionStatus.NEW)
+            .build();
+
+    assertThat(session.getSupervisionOptedOut(), is(false));
+  }
+
+  @Test
+  public void noArgsConstructor_Should_defaultSupervisionOptedOutToFalse() {
+    Session session = new Session();
+
+    assertThat(session.getSupervisionOptedOut(), is(false));
+  }
 }


### PR DESCRIPTION
Fixes #462.

## Why (High — all session creation was broken on Pre-Dev)

Migration `0067_session_supervision_opt_out` added `session.is_supervision_opted_out` as **NOT NULL**. But the JPA field is a nullable `Boolean` set only by the supervisor opt-out endpoint — never at session creation. Hibernate includes the column in every INSERT, so a new session sent `is_supervision_opted_out = NULL` (the DB `DEFAULT 0` only applies to *omitted* columns) and failed:

```
Error: 1048-23000: Column 'is_supervision_opted_out' cannot be null
```

Every session insert failed — no `session` row of any type was created on Pre-Dev after 2026-07-16. Anonymous Live Chat redeem surfaced it as an empty-body **HTTP 409**; it also blocked regular enquiries, group chats, everything.

## What changed

- `Session.supervisionOptedOut` now defaults to `false` at creation via **`@Builder.Default`** plus the field initializer.
  - `@Builder` (used by `SessionService`) ignores plain field initializers — hence `@Builder.Default`.
  - The initializer also covers the no-args-constructor + setters path.
- No behaviour change for reads: the only consumer, `SessionSupervisorFacade`, uses `Boolean.TRUE.equals(getSupervisionOptedOut())`, which already treats `null` and `false` identically.

## Tests (TDD, RED→GREEN)

- `builder_Should_defaultSupervisionOptedOutToFalse` — `Session.builder()...build()` yields `false` (was `null`; RED).
- `noArgsConstructor_Should_defaultSupervisionOptedOutToFalse` — `new Session()` yields `false`.
- Full UserService unit suite on Java 21: **3,618 tests, 0 failures, 0 errors**. `spotless:apply` clean.

## Acceptance after deploy (Pre-Dev only)

- [ ] A new session (any type) inserts without the constraint violation.
- [ ] Anonymous Live Chat redeem creates a session (not 409), then the full flow: cross-tenant queue, accept, encrypted two-way.

> Sibling note (not in this PR): `Session.isConsultantDirectlySet` is also a nullable `Boolean` on a `nullable=false` column without `@Builder.Default`; it is not currently failing (all paths set it), but it is the same latent shape and worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)