### PR TITLE
feat(case-handover): per-language client notification templates + in-chat system message on grant

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/model/CaseHandoverReasonPolicy.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/CaseHandoverReasonPolicy.java
@@ -5,11 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "case_handover_reason_policy")
@@ -41,6 +44,13 @@ public class CaseHandoverReasonPolicy {
 
   @Column(name = "policy_authority", nullable = false, length = 255)
   private String policyAuthority;
+
+  /**
+   * Client-facing notification templates per language (de/en/tr/uk), {{newAdvisor}} placeholder.
+   */
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "client_notification_templates", columnDefinition = "json")
+  private Map<String, String> clientNotificationTemplates;
 
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -24,11 +24,13 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverReasonPolicyRepositor
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -58,10 +60,70 @@ public class CaseHandoverService {
   private static final String OUTCOME_ALREADY_ANSWERED = "ALREADY_ANSWERED";
   private static final String OUTCOME_NOT_REQUESTED = "NOT_REQUESTED";
 
+  /**
+   * Default client-facing notification templates per reason and language (de/en/tr/uk). Source:
+   * vault doc "Case Handover — System-Benachrichtigungen & Rechtstexte (Entwurf)"; tr/uk are
+   * machine-drafted pending native review. {@code {{newAdvisor}}} is substituted at send time.
+   */
+  private static final Map<String, Map<String, String>> DEFAULT_CLIENT_NOTIFICATION_TEMPLATES =
+      Map.of(
+          "COUNSELLOR_ASKED_FOR_ADVICE",
+          Map.of(
+              "de",
+              "Du hast zugestimmt: {{newAdvisor}} kann dieses Gespräch zeitweise mitlesen, um deine Berater:in fachlich zu unterstützen. Deine Berater:in bleibt für dich zuständig.",
+              "en",
+              "You have given your consent: {{newAdvisor}} can temporarily read this conversation to support your counsellor professionally. Your counsellor remains responsible for you.",
+              "tr",
+              "Onay verdiniz: {{newAdvisor}}, danışmanınıza mesleki destek sağlamak için bu görüşmeyi geçici olarak okuyabilir. Danışmanınız sizin için sorumlu olmaya devam eder.",
+              "uk",
+              "Ви надали згоду: {{newAdvisor}} може тимчасово читати цю розмову, щоб професійно підтримати вашого консультанта. Ваш консультант і надалі відповідає за вас."),
+          "COUNSELLOR_ON_HOLIDAY",
+          Map.of(
+              "de",
+              "Deine bisherige Berater:in ist zurzeit abwesend. Während dieser Zeit betreut {{newAdvisor}} deinen Fall.",
+              "en",
+              "Your previous counsellor is currently away. During this time, {{newAdvisor}} is looking after your case.",
+              "tr",
+              "Önceki danışmanınız şu anda izinde. Bu süre boyunca vakanızla {{newAdvisor}} ilgilenecek.",
+              "uk",
+              "Ваш попередній консультант наразі відсутній. У цей час вашою справою опікується {{newAdvisor}}."),
+          "OTHER_EMERGENCY",
+          Map.of(
+              "de",
+              "Aus einem dringenden Grund hat {{newAdvisor}} deinen Fall übernommen. Du musst nichts weiter tun.",
+              "en",
+              "For an urgent reason, {{newAdvisor}} has taken over your case. You don't need to do anything.",
+              "tr",
+              "Acil bir nedenden dolayı vakanızı {{newAdvisor}} devraldı. Herhangi bir şey yapmanız gerekmiyor.",
+              "uk",
+              "З невідкладної причини вашу справу перейняв(-ла) {{newAdvisor}}. Вам нічого не потрібно робити."),
+          "COUNSELLOR_IS_ILL",
+          Map.of(
+              "de",
+              "Deine bisherige Berater:in ist leider erkrankt. Damit du nicht warten musst, hat {{newAdvisor}} deinen Fall übernommen.",
+              "en",
+              "Your previous counsellor is unfortunately ill. So you don't have to wait, {{newAdvisor}} has taken over your case.",
+              "tr",
+              "Önceki danışmanınız maalesef hastalandı. Beklemek zorunda kalmamanız için vakanızı {{newAdvisor}} devraldı.",
+              "uk",
+              "На жаль, ваш попередній консультант захворів. Щоб вам не довелося чекати, вашу справу перейняв(-ла) {{newAdvisor}}."),
+          "COUNSELLOR_LEFT",
+          Map.of(
+              "de",
+              "Deine bisherige Berater:in ist nicht mehr in dieser Beratungsstelle tätig. Deine Beratung führt ab jetzt {{newAdvisor}} weiter.",
+              "en",
+              "Your previous counsellor no longer works at this counselling centre. From now on, {{newAdvisor}} will continue your counselling.",
+              "tr",
+              "Önceki danışmanınız artık bu danışma merkezinde çalışmıyor. Danışmanlığınıza bundan sonra {{newAdvisor}} devam edecek.",
+              "uk",
+              "Ваш попередній консультант більше не працює в цьому консультаційному центрі. Відтепер ваше консультування продовжить {{newAdvisor}}."));
+
   private static final List<CaseHandoverReason> DEFAULT_REASONS =
       List.of(
           CaseHandoverReason.builder()
               .code("COUNSELLOR_ASKED_FOR_ADVICE")
+              .clientNotificationTemplates(
+                  DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get("COUNSELLOR_ASKED_FOR_ADVICE"))
               .label("Counsellor asked for advice")
               .clientConsentRequired(true)
               .accessAllowed(true)
@@ -71,6 +133,8 @@ public class CaseHandoverService {
               .build(),
           CaseHandoverReason.builder()
               .code("COUNSELLOR_ON_HOLIDAY")
+              .clientNotificationTemplates(
+                  DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get("COUNSELLOR_ON_HOLIDAY"))
               .label("Counsellor is on holiday")
               .clientConsentRequired(false)
               .accessAllowed(true)
@@ -80,6 +144,8 @@ public class CaseHandoverService {
               .build(),
           CaseHandoverReason.builder()
               .code("OTHER_EMERGENCY")
+              .clientNotificationTemplates(
+                  DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get("OTHER_EMERGENCY"))
               .label("Other emergency")
               .clientConsentRequired(false)
               .accessAllowed(true)
@@ -89,6 +155,8 @@ public class CaseHandoverService {
               .build(),
           CaseHandoverReason.builder()
               .code("COUNSELLOR_IS_ILL")
+              .clientNotificationTemplates(
+                  DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get("COUNSELLOR_IS_ILL"))
               .label("Counsellor is ill")
               .clientConsentRequired(false)
               .accessAllowed(true)
@@ -98,6 +166,8 @@ public class CaseHandoverService {
               .build(),
           CaseHandoverReason.builder()
               .code("COUNSELLOR_LEFT")
+              .clientNotificationTemplates(
+                  DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get("COUNSELLOR_LEFT"))
               .label("Counsellor does not work here anymore")
               .clientConsentRequired(false)
               .accessAllowed(true)
@@ -113,6 +183,7 @@ public class CaseHandoverService {
   private final @NonNull UserAccountService userAccountService;
   private final @NonNull EventNotificationService eventNotificationService;
   private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull MatrixSessionSystemMessageService matrixSessionSystemMessageService;
 
   public List<CaseHandoverReason> listReasons() {
     List<CaseHandoverReasonPolicy> policies =
@@ -533,6 +604,7 @@ public class CaseHandoverService {
         .enabled(Boolean.TRUE.equals(policy.getEnabled()))
         .displayOrder(policy.getDisplayOrder())
         .policyAuthority(policy.getPolicyAuthority())
+        .clientNotificationTemplates(policy.getClientNotificationTemplates())
         .build();
   }
 
@@ -555,8 +627,29 @@ public class CaseHandoverService {
         reason.getPolicyAuthority() == null || reason.getPolicyAuthority().isBlank()
             ? POLICY_AUTHORITY
             : reason.getPolicyAuthority().trim());
+    policy.setClientNotificationTemplates(
+        sanitizeNotificationTemplates(reason.getClientNotificationTemplates()));
     policy.setUpdatedAt(now);
     return policy;
+  }
+
+  private Map<String, String> sanitizeNotificationTemplates(Map<String, String> templates) {
+    if (templates == null || templates.isEmpty()) {
+      return null;
+    }
+    Map<String, String> sanitized = new LinkedHashMap<>();
+    templates.forEach(
+        (language, template) -> {
+          if (language == null || template == null) {
+            return;
+          }
+          var languageKey = language.trim().toLowerCase();
+          var text = template.trim();
+          if (languageKey.matches("[a-z]{2}") && !text.isBlank()) {
+            sanitized.put(languageKey, text);
+          }
+        });
+    return sanitized.isEmpty() ? null : sanitized;
   }
 
   private String normalizeReasonCode(String reasonCode) {
@@ -622,6 +715,7 @@ public class CaseHandoverService {
     Session session = request.getSession();
     Consultant requester = request.getRequesterConsultant();
     String requesterName = resolveConsultantName(requester);
+    postGrantedChatSystemMessage(request, session, requesterName);
     String text =
         String.format(
             "%s took over your case. Reason: %s. Explanation: %s",
@@ -653,6 +747,52 @@ public class CaseHandoverService {
           session.getId(),
           session.getTenantId());
     }
+  }
+
+  /**
+   * Posts the designed in-chat system notification ("new counsellor took over your case") into the
+   * session's Matrix room. Emission failures must never fail the handover itself.
+   */
+  private void postGrantedChatSystemMessage(
+      CaseHandoverRequest request, Session session, String requesterName) {
+    try {
+      var description = resolveClientNotificationDescription(request, requesterName);
+      matrixSessionSystemMessageService.postCaseHandoverGrantedMessage(
+          session, requesterName, request.getReasonLabel(), request.getExplanation(), description);
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Case-handover system message for session {} could not be posted: {}",
+          session.getId(),
+          exception.getMessage());
+    }
+  }
+
+  private String resolveClientNotificationDescription(
+      CaseHandoverRequest request, String requesterName) {
+    var reasonCode = normalizeReasonCode(request.getReasonCode());
+    Map<String, String> templates =
+        caseHandoverReasonPolicyRepository
+            .findById(reasonCode)
+            .map(CaseHandoverReasonPolicy::getClientNotificationTemplates)
+            .filter(map -> map != null && !map.isEmpty())
+            .orElseGet(() -> DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get(reasonCode));
+    if (templates == null || templates.isEmpty()) {
+      return null;
+    }
+    var language = resolveSessionLanguage(request.getSession());
+    var template =
+        templates.getOrDefault(
+            language,
+            templates.getOrDefault(
+                "de", templates.getOrDefault("en", templates.values().iterator().next())));
+    return template.replace("{{newAdvisor}}", requesterName);
+  }
+
+  private String resolveSessionLanguage(Session session) {
+    if (session == null || session.getLanguageCode() == null) {
+      return "de";
+    }
+    return session.getLanguageCode().name().toLowerCase(Locale.ROOT);
   }
 
   private void notifyPendingConsent(CaseHandoverRequest request) {
@@ -783,6 +923,7 @@ public class CaseHandoverService {
     private boolean enabled;
     private Integer displayOrder;
     private String policyAuthority;
+    private Map<String, String> clientNotificationTemplates;
   }
 
   @Data

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
@@ -26,6 +26,10 @@ public class MatrixSessionSystemMessageService {
 
   public static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
   public static final String USER_LEFT_CHAT_TYPE = "USER_LEFT_CHAT";
+  public static final String CASE_HANDOVER_GRANTED_TYPE = "CASE_HANDOVER_GRANTED";
+
+  private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
+      new com.fasterxml.jackson.databind.ObjectMapper();
 
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull AgencyMatrixCredentialClient agencyMatrixCredentialClient;
@@ -57,6 +61,95 @@ public class MatrixSessionSystemMessageService {
         .ifPresent(
             credentials ->
                 sendUserLeftMessage(session.getId(), roomId, displayUsername, credentials));
+  }
+
+  /**
+   * Notifies the room that a new counsellor took over the case (case handover GRANTED). The message
+   * is a normal m.text event with the [SYSTEM_NOTIFICATION] JSON envelope the web client renders as
+   * a system card. Posted as the new (requester) consultant when possible.
+   *
+   * @param session the handed-over session (room + participants)
+   * @param newAdvisorName display name of the consultant who took over
+   * @param reasonLabel the selected handover reason label
+   * @param explanation the free-text explanation given by the requester
+   * @param description localized client-facing template text (nullable)
+   */
+  public void postCaseHandoverGrantedMessage(
+      Session session,
+      String newAdvisorName,
+      String reasonLabel,
+      String explanation,
+      String description) {
+    if (session == null || session.getId() == null) {
+      return;
+    }
+    var matrixRoomId = session.getMatrixRoomId();
+    if (isBlank(matrixRoomId)) {
+      matrixRoomId =
+          sessionService.getSession(session.getId()).map(Session::getMatrixRoomId).orElse(null);
+    }
+    if (isBlank(matrixRoomId)) {
+      return;
+    }
+
+    var body = buildCaseHandoverGrantedBody(newAdvisorName, reasonLabel, explanation, description);
+    if (body == null) {
+      return;
+    }
+    var roomId = matrixRoomId;
+    resolveMatrixCredentialsPreferConsultant(session)
+        .ifPresent(credentials -> sendSystemMessage(session.getId(), roomId, body, credentials));
+  }
+
+  private void sendSystemMessage(
+      Long sessionId, String matrixRoomId, String body, MatrixCredentials credentials) {
+    var accessToken = credentials.accessToken(matrixSynapseService);
+    if (accessToken == null) {
+      log.warn(
+          "Skipping Matrix system message for session {} — token unavailable for {}",
+          sessionId,
+          credentials.principal());
+      return;
+    }
+    var response = matrixSynapseService.sendMessage(matrixRoomId, body, accessToken);
+    if (response != null && response.containsKey("error")) {
+      log.warn("Matrix system message for session {} failed: {}", sessionId, response.get("error"));
+    }
+  }
+
+  private Optional<MatrixCredentials> resolveMatrixCredentialsPreferConsultant(Session session) {
+    Consultant consultant = session.getConsultant();
+    if (consultant != null && isNotBlank(consultant.getId())) {
+      consultant = consultantService.getConsultant(consultant.getId()).orElse(consultant);
+      if (isNotBlank(consultant.getMatrixUserId())) {
+        return Optional.of(MatrixCredentials.forMatrixUser(consultant.getMatrixUserId()));
+      }
+    }
+    return resolveMatrixCredentials(session);
+  }
+
+  private String buildCaseHandoverGrantedBody(
+      String newAdvisorName, String reasonLabel, String explanation, String description) {
+    var payload = new java.util.LinkedHashMap<String, String>();
+    payload.put("type", CASE_HANDOVER_GRANTED_TYPE);
+    if (isNotBlank(newAdvisorName)) {
+      payload.put("username", newAdvisorName);
+    }
+    if (isNotBlank(description)) {
+      payload.put("description", description);
+    }
+    if (isNotBlank(reasonLabel)) {
+      payload.put("reasonLabel", reasonLabel);
+    }
+    if (isNotBlank(explanation)) {
+      payload.put("explanation", explanation);
+    }
+    try {
+      return SYSTEM_NOTIFICATION_PREFIX + OBJECT_MAPPER.writeValueAsString(payload);
+    } catch (com.fasterxml.jackson.core.JsonProcessingException exception) {
+      log.warn("Could not serialize case-handover system message payload", exception);
+      return null;
+    }
   }
 
   private void sendUserLeftMessage(

--- a/src/main/resources/db/changelog/changeset/0069_case_handover_notification_templates/0069_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0069_case_handover_notification_templates/0069_changeSet.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+  <changeSet id="0069_case_handover_notification_templates" author="caritas">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists
+            tableName="case_handover_reason_policy"
+            columnName="client_notification_templates"/>
+      </not>
+    </preConditions>
+    <sqlFile
+        path="db/changelog/changeset/0069_case_handover_notification_templates/addClientNotificationTemplates.sql"
+        splitStatements="true"
+        endDelimiter=";"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0069_case_handover_notification_templates/addClientNotificationTemplates.sql
+++ b/src/main/resources/db/changelog/changeset/0069_case_handover_notification_templates/addClientNotificationTemplates.sql
@@ -1,0 +1,2 @@
+ALTER TABLE case_handover_reason_policy
+    ADD COLUMN client_notification_templates JSON NULL;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -110,6 +110,8 @@
     file="db/changelog/changeset/0067_session_supervision_opt_out/0067_changeSet.xml" />
   <include
     file="db/changelog/changeset/0068_consultant_assigned_supervisor/0068_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0069_case_handover_notification_templates/0069_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.CaseHandoverService.CaseHandoverReason;
 import de.caritas.cob.userservice.api.service.CaseHandoverService.CaseHandoverStatus;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import java.time.LocalDateTime;
@@ -55,6 +56,7 @@ class CaseHandoverServiceTest {
   @Mock private UserAccountService userAccountService;
   @Mock private EventNotificationService eventNotificationService;
   @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
 
   private Consultant requester;
   private Consultant previous;
@@ -136,6 +138,26 @@ class CaseHandoverServiceTest {
     verify(matrixSynapseService)
         .inviteUserToRoom("!room:matrix", "@requester:matrix", "previous-token");
     verify(matrixSynapseService).joinRoom("!room:matrix", "requester-token");
+  }
+
+  @Test
+  void requestAccess_postsCaseHandoverSystemMessage_WhenGranted() throws Exception {
+    session.setMatrixRoomId("!room:matrix");
+    requester.setMatrixUserId("@requester:matrix");
+    previous.setMatrixUserId("@previous:matrix");
+    when(matrixSynapseService.loginAsUserAccessToken(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn("token");
+    when(matrixSynapseService.joinRoom("!room:matrix", "token")).thenReturn(true);
+
+    caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
+
+    verify(matrixSessionSystemMessageService)
+        .postCaseHandoverGrantedMessage(
+            org.mockito.ArgumentMatchers.eq(session),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq("Other emergency"),
+            org.mockito.ArgumentMatchers.eq("Colleague is unavailable."),
+            org.mockito.ArgumentMatchers.contains("deinen Fall übernommen"));
   }
 
   @Test


### PR DESCRIPTION
## What

Implements both backend gaps for the case-handover experience (Figma Sections 03/04/06):

**Per-language client notification templates**
- New JSON column `client_notification_templates` on `case_handover_reason_policy` (liquibase `0069`, precondition-guarded `MARK_RAN`), mapped with `@JdbcTypeCode(SqlTypes.JSON)` (same pattern as `Chat.hint_message_translations`).
- `clientNotificationTemplates` round-trips through admin GET/PUT `/users/case-handover/reason-policies`; input sanitized (two-letter lowercase language keys, blanks dropped).
- Default reasons now ship reviewed de/en templates plus tr/uk machine drafts (`{{newAdvisor}}` placeholder) — source: vault doc "Case Handover — System-Benachrichtigungen & Rechtstexte (Entwurf)".

**In-chat system message on GRANTED**
- `MatrixSessionSystemMessageService.postCaseHandoverGrantedMessage(...)`: posts a normal `m.text` with the `[SYSTEM_NOTIFICATION]` JSON envelope (`type: CASE_HANDOVER_GRANTED`, `username`, `description`, `reasonLabel`, `explanation`) — exactly the `USER_LEFT_CHAT` pattern the web client already parses. Posted as the new (requester) consultant, falling back to the generic credential resolution.
- Hooked into `CaseHandoverService.notifyGranted(...)` — the single choke point for both GRANTED paths (immediate grant + client-consent approve). Template resolved by session language with de→en fallback; emission failures log and never fail the handover.

## Verification

- `CaseHandoverServiceTest` extended: granted path verifies the posted system message incl. localized description; `CaseHandoverControllerTest` green. 32/32 tests green, `spotless:apply` run, build green (JDK 21 via Docker).
- Frontend rendering counterpart: OpenResilienceInitiative/ORISO-Frontend#502. Admin editor counterpart: OpenResilienceInitiative/ORISO-Admin#360.

Closes #464.
Refs OpenResilienceInitiative/ORISO-Frontend#491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
