### PR TITLE
test: de-flake ArchiveOrDeleteSessionStatisticsEventTest (fixed timestamp)

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/service/statistics/event/ArchiveOrDeleteSessionStatisticsEventTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/statistics/event/ArchiveOrDeleteSessionStatisticsEventTest.java
@@ -22,7 +22,7 @@ class ArchiveOrDeleteSessionStatisticsEventTest {
   private ArchiveOrDeleteSessionStatisticsEvent archiveOrDeleteSessionStatisticsEvent;
   private static final Long TENANT_ID = 2L;
   private static final String USER_ID = "userId";
-  private static final LocalDateTime END_DATE = LocalDateTime.now();
+  private static final LocalDateTime END_DATE = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
 
   @BeforeEach
   public void setup() throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
**Handover to @Shirloin — please analyse carefully before merging.**

**What:** Replaces the flaky `END_DATE = LocalDateTime.now()` constant in `ArchiveOrDeleteSessionStatisticsEventTest` with a fixed `LocalDateTime.of(2024,1,15,10,30,45)`.

**Why it's still needed:** on current `pre-dev` the test still uses `LocalDateTime.now()` (`ArchiveOrDeleteSessionStatisticsEventTest.java:25`) — the fix has NOT landed.

**Concerns / things to check:**
- Branch is ~384 commits behind `pre-dev`. No textual conflict on the target line, but **rebase / "Update branch" first** so CI runs against the live suite.
- Recovered-WIP origin; **git author is literally "Your Name"** (misconfigured) — fix authorship before merge.
- Test-only, one-line change; low risk.
- Do not self-merge — required gates apply.

_Opened by Claude during 2026-07-17 branch reconciliation; content-verified against pre-dev._