### PR TITLE
chore: add fork NOTICE (Caritas upstream attribution)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+ORISO User Service
+Copyright 2025-2026 Open Resilience Initiative
+
+This repository is a modified version of Onlineberatung/onlineBeratung-userservice
+(original work Copyright virtualidentity AG and contributors /
+Caritas Deutschland, licensed under AGPL-3.0).
+
+This version has been modified by the Open Resilience Initiative,
+2025-2026. The git history is the record of modifications
+(AGPL-3.0 section 5(a)).


### PR DESCRIPTION
## Why
Part of the License & Attribution Compliance epic (ORISO-Docs#50). This repository is a **fork of a Caritas Onlineberatung service** (AGPL-3.0) and already ships the AGPL `LICENSE`, but had **no `NOTICE`** — so the required fork attribution and the AGPL §5(a) modified-version marking were missing.

## What
Adds `NOTICE` following the pattern already used in ORISO-Frontend:
- upstream attribution (virtualidentity AG / Caritas Deutschland, AGPL-3.0),
- ORI modifications (Copyright 2025–2026 Open Resilience Initiative),
- AGPL §5(a) statement pointing at the git history as the record of modifications.

No code or LICENSE change — attribution only.

Refs OpenResilienceInitiative/ORISO-Docs#50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
