### PR TITLE
fix(coderabbit): truly automatic review on dev (A)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,11 +14,9 @@ reviews:
 
   auto_review:
     enabled: true
-    description_keyword: "coderabbit: review"
-    auto_incremental_review: false
+    auto_incremental_review: true
     drafts: false
-    labels:
-      - "coderabbit"
+    labels: []
     base_branches:
       - "dev"
 
@@ -28,7 +26,7 @@ reviews:
     - "src/**"
     - "pom.xml"
     - ".github/**"
-    - "*.md"
+    - "**/*.md"
 
   path_instructions:
     - path: "src/main/**/*.java"


### PR DESCRIPTION
Makes CodeRabbit auto-review actually run on `dev` instead of being silently gated (Frank: option A). Empties the `auto_review.labels` filter and drops `description_keyword` (both made review opt-in), sets `auto_incremental_review: true` so late pushes are re-reviewed in the merge-blocking workflow, and widens the `*.md` path filter to `**/*.md` so nested docs are covered. `base_branches` stays `[dev]` per the earlier 'nur auf dev' decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)