### PR TITLE
feat(team-discussion): side room per open enquiry, hard close at accept, hybrid notification fan-out

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -396,6 +396,48 @@ public class MatrixRoomClient {
     }
   }
 
+  /**
+   * Sets the room-wide {@code events_default} power level. With member power level 0 and {@code
+   * events_default} raised above it, no ordinary member can post any more — the protocol-level
+   * read-only switch used when a Team-Besprechung is archived (US#473 / ADR-016).
+   */
+  public boolean setRoomEventsDefaultPowerLevel(String roomId, int powerLevel, String accessToken) {
+    try {
+      var url = buildUrl(ENDPOINT_POWER_LEVELS, Map.of("roomId", roomId));
+
+      HttpHeaders headers = getClientHttpHeaders(accessToken);
+      HttpEntity<Void> getRequest = new HttpEntity<>(headers);
+
+      ResponseEntity<Map> currentResponse =
+          restTemplate.exchange(url, HttpMethod.GET, getRequest, Map.class);
+
+      if (currentResponse.getBody() == null) {
+        log.error("Failed to get current power levels for room {}", roomId);
+        return false;
+      }
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> powerLevels = new HashMap<>(currentResponse.getBody());
+      powerLevels.put("events_default", powerLevel);
+
+      HttpEntity<Map<String, Object>> updateRequest = new HttpEntity<>(powerLevels, headers);
+      restTemplate.put(url, updateRequest);
+
+      log.info("Set events_default power level {} in room {}", powerLevel, roomId);
+      return true;
+    } catch (HttpClientErrorException ex) {
+      log.error(
+          "Matrix Error: Could not set events_default in room ({}). Status: {}, Response: {}",
+          roomId,
+          ex.getStatusCode(),
+          ex.getResponseBodyAsString());
+      return false;
+    } catch (Exception e) {
+      log.error("Failed to set events_default in room {}: {}", roomId, e.getMessage());
+      return false;
+    }
+  }
+
   public boolean removeUserFromRoom(String roomId, String userId, String accessToken) {
     try {
       var url = buildUrl(ENDPOINT_MEMBERSHIP, Map.of("roomId", roomId, "userId", userId));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -1414,6 +1414,14 @@ public class MatrixSynapseService {
   }
 
   /**
+   * Raises the room-wide {@code events_default} power level so ordinary members can no longer post
+   * (protocol-level read-only, US#473 team-discussion archive).
+   */
+  public boolean setRoomEventsDefaultPowerLevel(String roomId, int powerLevel, String accessToken) {
+    return matrixRoomClient.setRoomEventsDefaultPowerLevel(roomId, powerLevel, accessToken);
+  }
+
+  /**
    * Removes a user from a Matrix room (kick/leave).
    *
    * @param roomId The Matrix room ID

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
@@ -1,8 +1,10 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.NotificationRoomLevel;
 import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.TeamDiscussionNotificationService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventNotificationController {
 
   private final @NonNull EventNotificationService eventNotificationService;
+  private final @NonNull TeamDiscussionNotificationService teamDiscussionNotificationService;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final Optional<RedisMessageMirrorService> redisMessageMirrorService;
 
@@ -72,6 +75,16 @@ public class EventNotificationController {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
+    if (request.getTeamDiscussion() != null && request.getTeamDiscussion()) {
+      // US#473: team-discussion rooms have no session recipient pair — dedicated hybrid fan-out.
+      teamDiscussionNotificationService.createTeamDiscussionNotification(
+          request.getRoomId(),
+          authenticatedUser.getUserId(),
+          request.getSenderDisplayName(),
+          request.getMentionedUserIds());
+      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     if (request.getThreadRootId() != null && !request.getThreadRootId().isBlank()) {
       eventNotificationService.createThreadReplyNotificationFromRoom(
           request.getRoomId(),
@@ -107,6 +120,60 @@ public class EventNotificationController {
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 
+  /**
+   * US#473: mirrors the user's per-conversation notification level (All / Mentions / Muted /
+   * Snoozed) so the server-side fan-out can honour it.
+   */
+  @PatchMapping("/conversation-level")
+  public ResponseEntity<Void> updateConversationLevel(
+      @RequestBody ConversationLevelRequestDTO request) {
+    if (request == null || request.getRoomId() == null || request.getRoomId().isBlank()) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+    NotificationRoomLevel.Level level;
+    try {
+      level =
+          request.getLevel() != null
+              ? NotificationRoomLevel.Level.valueOf(request.getLevel().toUpperCase())
+              : NotificationRoomLevel.Level.ALL;
+    } catch (IllegalArgumentException ex) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+    teamDiscussionNotificationService.updateConversationLevel(
+        authenticatedUser.getUserId(), request.getRoomId(), level, request.getSnoozedUntil());
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  public static class ConversationLevelRequestDTO {
+    @NotBlank private String roomId;
+    private String level;
+    private java.time.LocalDateTime snoozedUntil;
+
+    public String getRoomId() {
+      return roomId;
+    }
+
+    public void setRoomId(String roomId) {
+      this.roomId = roomId;
+    }
+
+    public String getLevel() {
+      return level;
+    }
+
+    public void setLevel(String level) {
+      this.level = level;
+    }
+
+    public java.time.LocalDateTime getSnoozedUntil() {
+      return snoozedUntil;
+    }
+
+    public void setSnoozedUntil(java.time.LocalDateTime snoozedUntil) {
+      this.snoozedUntil = snoozedUntil;
+    }
+  }
+
   public static class MessageEventRequestDTO {
     @NotBlank private String roomId;
     private String messagePreview;
@@ -115,6 +182,24 @@ public class EventNotificationController {
     private Boolean supervisorMessage;
     private String senderDisplayName;
     private String threadParentPreview;
+    private Boolean teamDiscussion;
+    private java.util.List<String> mentionedUserIds;
+
+    public Boolean getTeamDiscussion() {
+      return teamDiscussion;
+    }
+
+    public void setTeamDiscussion(Boolean teamDiscussion) {
+      this.teamDiscussion = teamDiscussion;
+    }
+
+    public java.util.List<String> getMentionedUserIds() {
+      return mentionedUserIds;
+    }
+
+    public void setMentionedUserIds(java.util.List<String> mentionedUserIds) {
+      this.mentionedUserIds = mentionedUserIds;
+    }
 
     public String getRoomId() {
       return roomId;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TeamDiscussionController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TeamDiscussionController.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.facade.TeamDiscussionFacade;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * US#473 / ADR-016: Team-Besprechung endpoints. Consultant-only (SecurityConfig); participation
+ * right = enquiry visibility right, enforced in the facade.
+ */
+@RestController
+@RequestMapping("/users/sessions")
+@RequiredArgsConstructor
+public class TeamDiscussionController {
+
+  private final @NonNull TeamDiscussionFacade teamDiscussionFacade;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  /** Opens (and lazily creates) the enquiry's team discussion; joins the caller into the room. */
+  @PostMapping("/{sessionId}/team-discussion")
+  public ResponseEntity<TeamDiscussionResponseDTO> getOrCreate(@PathVariable Long sessionId) {
+    var view = teamDiscussionFacade.getOrCreateDiscussion(sessionId, authenticatedUser.getUserId());
+    return ResponseEntity.ok(TeamDiscussionResponseDTO.from(view));
+  }
+
+  /** Returns the discussion if one exists — including ARCHIVED (read-only archive access). */
+  @GetMapping("/{sessionId}/team-discussion")
+  public ResponseEntity<TeamDiscussionResponseDTO> get(@PathVariable Long sessionId) {
+    return teamDiscussionFacade
+        .getDiscussion(sessionId, authenticatedUser.getUserId())
+        .map(view -> ResponseEntity.ok(TeamDiscussionResponseDTO.from(view)))
+        .orElseGet(() -> new ResponseEntity<>(HttpStatus.NO_CONTENT));
+  }
+
+  public record TeamDiscussionResponseDTO(
+      String matrixRoomId, String status, LocalDateTime archiveDate) {
+
+    static TeamDiscussionResponseDTO from(TeamDiscussionFacade.TeamDiscussionView view) {
+      return new TeamDiscussionResponseDTO(
+          view.matrixRoomId(), view.status().name(), view.archiveDate());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -246,7 +246,9 @@ public class SecurityConfig {
                     "/users/sessions/{sessionId:[0-9]+}/supervisors",
                     "/users/sessions/{sessionId:[0-9]+}/supervisors/{supervisorId:[0-9]+}",
                     "/service/users/sessions/{sessionId:[0-9]+}/supervisors",
-                    "/service/users/sessions/{sessionId:[0-9]+}/supervisors/{supervisorId:[0-9]+}")
+                    "/service/users/sessions/{sessionId:[0-9]+}/supervisors/{supervisorId:[0-9]+}",
+                    "/users/sessions/{sessionId:[0-9]+}/team-discussion",
+                    "/service/users/sessions/{sessionId:[0-9]+}/team-discussion")
                 .hasAuthority(CONSULTANT_DEFAULT)
                 .requestMatchers(
                     "/conversations/anonymous/{sessionId:[0-9]+}/finish",

--- a/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
@@ -68,7 +68,7 @@ public class TeamDiscussionFacade {
 
     Optional<TeamDiscussion> existing = teamDiscussionRepository.findBySessionId(sessionId);
     if (existing.isPresent()) {
-      TeamDiscussion discussion = existing.get();
+      TeamDiscussion discussion = reconcileOnAccess(existing.get(), session);
       joinConsultantBestEffort(discussion, session, consultant);
       return toView(discussion);
     }
@@ -86,6 +86,11 @@ public class TeamDiscussionFacade {
                 .createdByConsultantId(consultant.getId())
                 .tenantId(session.getTenantId())
                 .build());
+    // Create/accept race: re-read the assignment state after committing the row — if the case
+    // was accepted while we were creating the room, archive immediately instead of leaving an
+    // OPEN discussion on an assigned case.
+    Session freshSession = sessionRepository.findById(sessionId).orElse(session);
+    discussion = reconcileOnAccess(discussion, freshSession);
     joinConsultantBestEffort(discussion, session, consultant);
     return toView(discussion);
   }
@@ -95,7 +100,32 @@ public class TeamDiscussionFacade {
     featureGate.requireEnabled();
     Session session = loadSession(sessionId);
     requireEligibleConsultant(session, consultantId);
-    return teamDiscussionRepository.findBySessionId(sessionId).map(this::toView);
+    return teamDiscussionRepository
+        .findBySessionId(sessionId)
+        .map(discussion -> reconcileOnAccess(discussion, session))
+        .map(this::toView);
+  }
+
+  /**
+   * Lazy reconciliation on every access (review findings F2/F3): an OPEN discussion on an
+   * already-accepted case is archived now (the accept-time hook may have raced the creation), and
+   * an ARCHIVED discussion whose read-only switch failed gets the power-level call retried.
+   */
+  private TeamDiscussion reconcileOnAccess(TeamDiscussion discussion, Session session) {
+    boolean sessionAccepted =
+        session.getConsultant() != null || session.getStatus() != SessionStatus.NEW;
+    if (discussion.getStatus() == TeamDiscussion.Status.OPEN && sessionAccepted) {
+      archiveDiscussion(session, discussion);
+      return discussion;
+    }
+    if (discussion.getStatus() == TeamDiscussion.Status.ARCHIVED
+        && !discussion.isReadOnlyApplied()) {
+      if (makeRoomReadOnlyBestEffort(session, discussion)) {
+        discussion.setReadOnlyApplied(true);
+        teamDiscussionRepository.save(discussion);
+      }
+    }
+    return discussion;
   }
 
   /**
@@ -115,16 +145,7 @@ public class TeamDiscussionFacade {
           || discussionOpt.get().getStatus() == TeamDiscussion.Status.ARCHIVED) {
         return;
       }
-      TeamDiscussion discussion = discussionOpt.get();
-      discussion.setStatus(TeamDiscussion.Status.ARCHIVED);
-      discussion.setArchiveDate(LocalDateTime.now());
-      teamDiscussionRepository.save(discussion);
-
-      makeRoomReadOnlyBestEffort(session, discussion);
-      log.info(
-          "Archived team discussion for session {} (room {})",
-          session.getId(),
-          discussion.getMatrixRoomId());
+      archiveDiscussion(session, discussionOpt.get());
     } catch (Exception ex) {
       log.error(
           "Failed to archive team discussion for session {}: {}",
@@ -244,16 +265,39 @@ public class TeamDiscussionFacade {
             .build());
   }
 
-  private void makeRoomReadOnlyBestEffort(Session session, TeamDiscussion discussion) {
+  /**
+   * ARCHIVED is persisted first (notifications must stop at acceptance regardless), then the
+   * read-only switch is attempted; a failure is tracked via {@code readOnlyApplied=false} and
+   * retried on next access ({@link #reconcileOnAccess}) instead of being forgotten.
+   */
+  private void archiveDiscussion(Session session, TeamDiscussion discussion) {
+    discussion.setStatus(TeamDiscussion.Status.ARCHIVED);
+    discussion.setArchiveDate(LocalDateTime.now());
+    discussion.setReadOnlyApplied(false);
+    teamDiscussionRepository.save(discussion);
+
+    if (makeRoomReadOnlyBestEffort(session, discussion)) {
+      discussion.setReadOnlyApplied(true);
+      teamDiscussionRepository.save(discussion);
+    }
+    log.info(
+        "Archived team discussion for session {} (room {}, readOnlyApplied={})",
+        session.getId(),
+        discussion.getMatrixRoomId(),
+        discussion.isReadOnlyApplied());
+  }
+
+  private boolean makeRoomReadOnlyBestEffort(Session session, TeamDiscussion discussion) {
     try {
       String agencyToken = loginAgencyOperator(session);
-      matrixSynapseService.setRoomEventsDefaultPowerLevel(
+      return matrixSynapseService.setRoomEventsDefaultPowerLevel(
           discussion.getMatrixRoomId(), ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL, agencyToken);
     } catch (Exception ex) {
       log.error(
           "Could not set team discussion room {} read-only: {}",
           discussion.getMatrixRoomId(),
           ex.getMessage());
+      return false;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
@@ -1,0 +1,295 @@
+package de.caritas.cob.userservice.api.facade;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.teamdiscussion.TeamDiscussionFeatureGate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * US#473 / ADR-016: the Team-Besprechung — a team-only Matrix side room attached to one open
+ * Agency-Counselling enquiry. Guardrail: team coordination never happens in the client's room; the
+ * advice seeker is never invited to (and cannot discover) this room. The discussion closes
+ * permanently at acceptance ({@link #archiveDiscussionIfPresent(Session)}) and stays reachable
+ * read-only. Participation right = enquiry visibility right — exactly the consultants of the
+ * enquiry's agency, no separate permission layer.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamDiscussionFacade {
+
+  /** events_default above the member level (0) — nobody but the operator can post any more. */
+  static final int ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL = 50;
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull TeamDiscussionParticipantRepository participantRepository;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
+  private final @NonNull TeamDiscussionFeatureGate featureGate;
+
+  /** Read model returned to the controller. */
+  public record TeamDiscussionView(
+      String matrixRoomId, TeamDiscussion.Status status, LocalDateTime archiveDate) {}
+
+  /**
+   * Returns the enquiry's Team-Besprechung, creating room + record on first use. Joining the caller
+   * into the room happens on every call so a colleague opening the panel later gets access. Only
+   * OPEN discussions can be created; an ARCHIVED one is returned read-only.
+   */
+  public TeamDiscussionView getOrCreateDiscussion(Long sessionId, String consultantId) {
+    featureGate.requireEnabled();
+    Session session = loadSession(sessionId);
+    Consultant consultant = requireEligibleConsultant(session, consultantId);
+
+    Optional<TeamDiscussion> existing = teamDiscussionRepository.findBySessionId(sessionId);
+    if (existing.isPresent()) {
+      TeamDiscussion discussion = existing.get();
+      joinConsultantBestEffort(discussion, session, consultant);
+      return toView(discussion);
+    }
+
+    requireOpenEnquiry(session);
+
+    String roomId = createDiscussionRoom(session);
+    TeamDiscussion discussion =
+        teamDiscussionRepository.save(
+            TeamDiscussion.builder()
+                .sessionId(session.getId())
+                .matrixRoomId(roomId)
+                .status(TeamDiscussion.Status.OPEN)
+                .createDate(LocalDateTime.now())
+                .createdByConsultantId(consultant.getId())
+                .tenantId(session.getTenantId())
+                .build());
+    joinConsultantBestEffort(discussion, session, consultant);
+    return toView(discussion);
+  }
+
+  /** Returns the discussion if one exists — also ARCHIVED ones (read-only archive access). */
+  public Optional<TeamDiscussionView> getDiscussion(Long sessionId, String consultantId) {
+    featureGate.requireEnabled();
+    Session session = loadSession(sessionId);
+    requireEligibleConsultant(session, consultantId);
+    return teamDiscussionRepository.findBySessionId(sessionId).map(this::toView);
+  }
+
+  /**
+   * ADR-016 hard close: called from the enquiry-accept path. Best-effort by contract — it never
+   * throws, because a discussion problem must degrade to "the discussion stays open a little
+   * longer", never to "the counsellor cannot accept the case" (same contract as {@code
+   * attachStandingSupervisorIfAssigned}).
+   */
+  public void archiveDiscussionIfPresent(Session session) {
+    try {
+      if (session == null || session.getId() == null) {
+        return;
+      }
+      Optional<TeamDiscussion> discussionOpt =
+          teamDiscussionRepository.findBySessionId(session.getId());
+      if (discussionOpt.isEmpty()
+          || discussionOpt.get().getStatus() == TeamDiscussion.Status.ARCHIVED) {
+        return;
+      }
+      TeamDiscussion discussion = discussionOpt.get();
+      discussion.setStatus(TeamDiscussion.Status.ARCHIVED);
+      discussion.setArchiveDate(LocalDateTime.now());
+      teamDiscussionRepository.save(discussion);
+
+      makeRoomReadOnlyBestEffort(session, discussion);
+      log.info(
+          "Archived team discussion for session {} (room {})",
+          session.getId(),
+          discussion.getMatrixRoomId());
+    } catch (Exception ex) {
+      log.error(
+          "Failed to archive team discussion for session {}: {}",
+          session != null ? session.getId() : null,
+          ex.getMessage());
+    }
+  }
+
+  private Session loadSession(Long sessionId) {
+    return sessionRepository
+        .findById(sessionId)
+        .orElseThrow(() -> new NotFoundException("Session %s not found", sessionId));
+  }
+
+  private Consultant requireEligibleConsultant(Session session, String consultantId) {
+    Consultant consultant =
+        consultantRepository
+            .findById(consultantId)
+            .orElseThrow(() -> new ForbiddenException("Consultant not found"));
+    if (session.getAgencyId() == null
+        || !consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+            consultant.getId(), session.getAgencyId())) {
+      throw new ForbiddenException(
+          "Consultant is not a member of the enquiry's agency and may not access its team"
+              + " discussion");
+    }
+    return consultant;
+  }
+
+  private void requireOpenEnquiry(Session session) {
+    boolean openEnquiry =
+        session.getStatus() == SessionStatus.NEW
+            && session.getRegistrationType() == RegistrationType.REGISTERED
+            && session.getConsultant() == null;
+    if (!openEnquiry) {
+      throw new BadRequestException(
+          "A team discussion can only be started on an open, unassigned registered enquiry"
+              + " (ADR-016: it closes at acceptance)");
+    }
+  }
+
+  private String createDiscussionRoom(Session session) {
+    String agencyToken = loginAgencyOperator(session);
+    String alias =
+        "team_discussion_"
+            + session.getId()
+            + "_"
+            + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String name = "Team-Besprechung – Enquiry " + session.getId();
+    org.springframework.http.ResponseEntity<
+            de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO>
+        response;
+    try {
+      response = matrixSynapseService.createRoom(name, alias, agencyToken);
+    } catch (Exception ex) {
+      throw new InternalServerErrorException(
+          "Matrix room creation for team discussion failed (session "
+              + session.getId()
+              + "): "
+              + ex.getMessage());
+    }
+    if (response == null
+        || response.getBody() == null
+        || response.getBody().getRoomId() == null
+        || response.getBody().getRoomId().isBlank()) {
+      throw new InternalServerErrorException(
+          "Matrix room creation for team discussion failed (session " + session.getId() + ")");
+    }
+    return response.getBody().getRoomId();
+  }
+
+  /**
+   * Invite + join the consultant and record them as participant. Best-effort: an already-joined
+   * consultant or a transient Matrix error must not break opening the panel.
+   */
+  private void joinConsultantBestEffort(
+      TeamDiscussion discussion, Session session, Consultant consultant) {
+    try {
+      if (consultant.getMatrixUserId() == null || consultant.getMatrixUserId().isBlank()) {
+        return;
+      }
+      String agencyToken = loginAgencyOperator(session);
+      try {
+        matrixSynapseService.inviteUserToRoom(
+            discussion.getMatrixRoomId(), consultant.getMatrixUserId(), agencyToken);
+      } catch (Exception inviteEx) {
+        log.debug(
+            "Invite to team discussion room {} skipped: {}",
+            discussion.getMatrixRoomId(),
+            inviteEx.getMessage());
+      }
+      String consultantToken =
+          matrixSynapseService.loginAsUserAccessToken(consultant.getMatrixUserId());
+      if (consultantToken != null) {
+        matrixSynapseService.joinRoom(discussion.getMatrixRoomId(), consultantToken);
+      }
+    } catch (Exception ex) {
+      log.warn(
+          "Could not join consultant {} into team discussion room {}: {}",
+          consultant.getId(),
+          discussion.getMatrixRoomId(),
+          ex.getMessage());
+    }
+    recordParticipant(discussion, consultant.getId());
+  }
+
+  private void recordParticipant(TeamDiscussion discussion, String consultantId) {
+    if (participantRepository.existsByTeamDiscussionIdAndConsultantId(
+        discussion.getId(), consultantId)) {
+      return;
+    }
+    participantRepository.save(
+        TeamDiscussionParticipant.builder()
+            .teamDiscussionId(discussion.getId())
+            .consultantId(consultantId)
+            .joinDate(LocalDateTime.now())
+            .build());
+  }
+
+  private void makeRoomReadOnlyBestEffort(Session session, TeamDiscussion discussion) {
+    try {
+      String agencyToken = loginAgencyOperator(session);
+      matrixSynapseService.setRoomEventsDefaultPowerLevel(
+          discussion.getMatrixRoomId(), ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL, agencyToken);
+    } catch (Exception ex) {
+      log.error(
+          "Could not set team discussion room {} read-only: {}",
+          discussion.getMatrixRoomId(),
+          ex.getMessage());
+    }
+  }
+
+  private String loginAgencyOperator(Session session) {
+    AgencyMatrixCredentialsDTO credentials =
+        matrixCredentialClient
+            .fetchMatrixCredentials(session.getAgencyId())
+            .orElseThrow(
+                () ->
+                    new InternalServerErrorException(
+                        "No Matrix service account for agency " + session.getAgencyId()));
+    if (credentials.getMatrixUserId() == null
+        || credentials.getMatrixUserId().isBlank()
+        || credentials.getMatrixPassword() == null
+        || credentials.getMatrixPassword().isBlank()) {
+      throw new InternalServerErrorException(
+          "Matrix service account for agency " + session.getAgencyId() + " is incomplete");
+    }
+    String token =
+        matrixSynapseService.loginUser(
+            extractLocalPart(credentials.getMatrixUserId()), credentials.getMatrixPassword());
+    if (token == null || token.isBlank()) {
+      throw new InternalServerErrorException(
+          "Matrix service account login failed for agency " + session.getAgencyId());
+    }
+    return token;
+  }
+
+  private String extractLocalPart(String matrixUserId) {
+    String value = matrixUserId.startsWith("@") ? matrixUserId.substring(1) : matrixUserId;
+    int colon = value.indexOf(':');
+    return colon > 0 ? value.substring(0, colon) : value;
+  }
+
+  private TeamDiscussionView toView(TeamDiscussion discussion) {
+    return new TeamDiscussionView(
+        discussion.getMatrixRoomId(), discussion.getStatus(), discussion.getArchiveDate());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
 import de.caritas.cob.userservice.api.facade.RocketChatFacade;
 import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
+import de.caritas.cob.userservice.api.facade.TeamDiscussionFacade;
 import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
@@ -82,6 +83,8 @@ public class AssignEnquiryFacade {
    */
   private final @NonNull SessionSupervisorFacade sessionSupervisorFacade;
 
+  private final @NonNull TeamDiscussionFacade teamDiscussionFacade;
+
   /**
    * Assigns the given {@link Session} session to the given {@link Consultant}. Remove all other
    * consultants from the Rocket.Chat group which don't have the right to view this session anymore.
@@ -106,6 +109,9 @@ public class AssignEnquiryFacade {
     // The case is now committed to this counsellor (assignEnquiry rolls back and rethrows on any
     // failure), so it is safe to layer standing supervision on top. This call never throws.
     sessionSupervisorFacade.attachStandingSupervisorIfAssigned(session.getId(), consultant);
+    // ADR-016 hard close: the pre-acceptance Team-Besprechung archives the moment the case is
+    // accepted. Best-effort by the same contract — never blocks the acceptance.
+    teamDiscussionFacade.archiveDiscussionIfPresent(session);
     liveEventNotificationService.sendAcceptAnonymousEnquiryEventToUser(
         session.getUser().getUserId());
     eventNotificationService.createInquiryAcceptedNotification(session, consultant);

--- a/src/main/java/de/caritas/cob/userservice/api/model/NotificationRoomLevel.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/NotificationRoomLevel.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Server-side mirror of the per-conversation notification level (decided 2026-07-18: All / Mentions
+ * only / Muted / Snoozed-with-auto-revert). The authoritative user-facing copy lives in Matrix
+ * account data (FE #420); the producers here cannot read that, so the frontend mirrors the level
+ * via {@code PATCH /users/event-notifications/conversation-level} and the fan-out honours it. A
+ * snooze is expressed as {@code snoozedUntil} in the future — after that moment the stored level
+ * applies again (auto-revert without any cleanup job).
+ */
+@Entity
+@Table(name = "notification_room_level")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class NotificationRoomLevel {
+
+  public enum Level {
+    ALL,
+    MENTIONS,
+    MUTED
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "user_id", nullable = false, length = 64)
+  private String userId;
+
+  @Column(name = "room_id", nullable = false, length = 255)
+  private String roomId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "notification_level", nullable = false, length = 20)
+  @Builder.Default
+  private Level level = Level.ALL;
+
+  @Column(name = "snoozed_until")
+  private LocalDateTime snoozedUntil;
+
+  @Column(name = "update_date", nullable = false)
+  private LocalDateTime updateDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussion.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussion.java
@@ -74,6 +74,15 @@ public class TeamDiscussion implements TenantAware {
   @Builder.Default
   private boolean firstNotified = false;
 
+  /**
+   * Whether the protocol-level read-only switch (events_default raise) has actually been applied to
+   * the Matrix room after archiving. False after a failed Matrix call — retried lazily on next
+   * access instead of being forgotten.
+   */
+  @Column(name = "is_read_only_applied", nullable = false)
+  @Builder.Default
+  private boolean readOnlyApplied = false;
+
   @Column(name = "tenant_id")
   private Long tenantId;
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussion.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussion.java
@@ -1,0 +1,79 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+/**
+ * US#473 / ADR-016: the Team-Besprechung side room attached to one open enquiry. The room lives
+ * entirely outside the client's conversation; it is archived (hard close) the moment the enquiry is
+ * accepted and is reachable read-only afterwards.
+ */
+@Entity
+@Table(name = "team_discussion")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+@FilterDef(
+    name = "tenantFilter",
+    parameters = {@ParamDef(name = "tenantId", type = Long.class)})
+@Filter(
+    name = "tenantFilter",
+    condition = "(tenant_id = :tenantId OR (:tenantId = 1 AND tenant_id IS NULL))")
+public class TeamDiscussion implements TenantAware {
+
+  public enum Status {
+    OPEN,
+    ARCHIVED
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false, unique = true)
+  private Long sessionId;
+
+  @Column(name = "matrix_room_id", nullable = false, length = 255)
+  private String matrixRoomId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "discussion_status", nullable = false, length = 20)
+  @Builder.Default
+  private Status status = Status.OPEN;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @Column(name = "archive_date")
+  private LocalDateTime archiveDate;
+
+  @Column(name = "created_by_consultant_id", length = 36)
+  private String createdByConsultantId;
+
+  @Column(name = "is_first_notified", nullable = false)
+  @Builder.Default
+  private boolean firstNotified = false;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussionParticipant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/TeamDiscussionParticipant.java
@@ -1,0 +1,44 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * A consultant who opened or posted in a Team-Besprechung. Drives the hybrid notification rule:
+ * after the first post only participants (plus mentioned colleagues) are notified.
+ */
+@Entity
+@Table(name = "team_discussion_participant")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class TeamDiscussionParticipant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "team_discussion_id", nullable = false)
+  private Long teamDiscussionId;
+
+  @Column(name = "consultant_id", nullable = false, length = 36)
+  private String consultantId;
+
+  @Column(name = "join_date", nullable = false)
+  private LocalDateTime joinDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/NotificationRoomLevelRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/NotificationRoomLevelRepository.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.NotificationRoomLevel;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRoomLevelRepository
+    extends JpaRepository<NotificationRoomLevel, Long> {
+
+  Optional<NotificationRoomLevel> findByUserIdAndRoomId(String userId, String roomId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionParticipantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionParticipantRepository.java
@@ -1,0 +1,13 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamDiscussionParticipantRepository
+    extends JpaRepository<TeamDiscussionParticipant, Long> {
+
+  List<TeamDiscussionParticipant> findByTeamDiscussionId(Long teamDiscussionId);
+
+  boolean existsByTeamDiscussionIdAndConsultantId(Long teamDiscussionId, String consultantId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
@@ -1,0 +1,12 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamDiscussionRepository extends JpaRepository<TeamDiscussion, Long> {
+
+  Optional<TeamDiscussion> findBySessionId(Long sessionId);
+
+  Optional<TeamDiscussion> findByMatrixRoomId(String matrixRoomId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -904,6 +904,14 @@ public class EventNotificationService {
     return value.startsWith("enc.") || value.matches("^[A-Za-z0-9+/=]{25,}$");
   }
 
+  /**
+   * Public room-level probe for sibling producers (US#473 team-discussion fan-out): true when the
+   * recipient is actively viewing the room and the notification should be dropped.
+   */
+  public boolean isNotificationSuppressed(String recipientUserId, String roomId) {
+    return shouldSuppressNotification(recipientUserId, roomId, null);
+  }
+
   private boolean shouldSuppressNotification(
       String recipientUserId, String roomId, String threadRootId) {
     ActiveViewState activeView = activeViewByUserId.get(recipientUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationService.java
@@ -76,8 +76,22 @@ public class TeamDiscussionNotificationService {
       return;
     }
     Session session = sessionOpt.get();
+    if (session.getConsultant() != null) {
+      // Create/accept race guard: once the case is accepted, an OPEN row must not keep
+      // notifying — the facade lazily archives it on next access.
+      return;
+    }
 
     Set<String> eligible = eligibleConsultantIds(session.getAgencyId());
+    if (!eligible.contains(senderUserId)) {
+      // Sender-eligibility guard: the endpoint is reachable for askers too. A caller outside
+      // the eligible circle must neither trigger a broadcast nor flip firstNotified.
+      log.warn(
+          "Ignoring team discussion notification from ineligible sender {} for room {}",
+          senderUserId,
+          roomId);
+      return;
+    }
     Set<String> mentioned = sanitizedMentions(mentionedUserIds, eligible);
 
     Set<String> recipients;

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationService.java
@@ -1,0 +1,222 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.NotificationRoomLevel;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.NotificationRoomLevelRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Fan-out for Team-Besprechung posts (US#473, decided 2026-07-18).
+ *
+ * <p><b>Hybrid rule:</b> the first post in a discussion notifies the whole eligible circle (every
+ * consultant of the enquiry's agency — "the team is discussing this enquiry"); every later post
+ * notifies only participants (who opened or wrote) plus explicitly mentioned colleagues.
+ *
+ * <p><b>Level respect:</b> each recipient's per-conversation notification level (server mirror in
+ * {@code notification_room_level}) is honoured — MUTED and active snoozes drop the notification,
+ * MENTIONS only lets mentions through. Active-view suppression applies on top: whoever has the
+ * discussion open gets nothing.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamDiscussionNotificationService {
+
+  static final String EVENT_TYPE_TEAM_DISCUSSION_NEW = "team.discussion.new";
+
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull TeamDiscussionParticipantRepository participantRepository;
+  private final @NonNull NotificationRoomLevelRepository notificationRoomLevelRepository;
+  private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull EventNotificationService eventNotificationService;
+  private final ObjectMapper paramsObjectMapper = new ObjectMapper();
+
+  /**
+   * Called from the frontend's post-send producer ({@code POST
+   * /users/event-notifications/message-events} with {@code teamDiscussion=true}). The sender
+   * becomes a participant; recipients follow the hybrid rule.
+   */
+  @Transactional
+  public void createTeamDiscussionNotification(
+      String roomId, String senderUserId, String senderDisplayName, List<String> mentionedUserIds) {
+    if (roomId == null || roomId.isBlank() || senderUserId == null) {
+      return;
+    }
+    Optional<TeamDiscussion> discussionOpt = teamDiscussionRepository.findByMatrixRoomId(roomId);
+    if (discussionOpt.isEmpty()) {
+      return;
+    }
+    TeamDiscussion discussion = discussionOpt.get();
+    if (discussion.getStatus() == TeamDiscussion.Status.ARCHIVED) {
+      return;
+    }
+    Optional<Session> sessionOpt = sessionRepository.findById(discussion.getSessionId());
+    if (sessionOpt.isEmpty() || sessionOpt.get().getAgencyId() == null) {
+      return;
+    }
+    Session session = sessionOpt.get();
+
+    Set<String> eligible = eligibleConsultantIds(session.getAgencyId());
+    Set<String> mentioned = sanitizedMentions(mentionedUserIds, eligible);
+
+    Set<String> recipients;
+    if (!discussion.isFirstNotified()) {
+      recipients = new HashSet<>(eligible);
+      discussion.setFirstNotified(true);
+      teamDiscussionRepository.save(discussion);
+    } else {
+      recipients =
+          new HashSet<>(
+              participantRepository.findByTeamDiscussionId(discussion.getId()).stream()
+                  .map(TeamDiscussionParticipant::getConsultantId)
+                  .filter(eligible::contains)
+                  .toList());
+      recipients.addAll(mentioned);
+    }
+    recipients.remove(senderUserId);
+
+    recordSenderAsParticipant(discussion, senderUserId, eligible);
+
+    for (String recipientId : recipients) {
+      if (dropForConversationLevel(recipientId, roomId, mentioned.contains(recipientId))) {
+        continue;
+      }
+      if (eventNotificationService.isNotificationSuppressed(recipientId, roomId)) {
+        continue;
+      }
+      eventNotificationService.createEvent(
+          recipientId,
+          EVENT_TYPE_TEAM_DISCUSSION_NEW,
+          EventNotificationService.CATEGORY_MESSAGE,
+          "Team discussion",
+          buildText(senderDisplayName),
+          buildParams(session, discussion, senderDisplayName, mentioned.contains(recipientId)),
+          buildActionPath(session, discussion),
+          session.getId(),
+          session.getTenantId());
+    }
+  }
+
+  /** Upserts the server-side mirror of the per-conversation level for one user and room. */
+  @Transactional
+  public void updateConversationLevel(
+      String userId, String roomId, NotificationRoomLevel.Level level, LocalDateTime snoozedUntil) {
+    NotificationRoomLevel entry =
+        notificationRoomLevelRepository
+            .findByUserIdAndRoomId(userId, roomId)
+            .orElseGet(() -> NotificationRoomLevel.builder().userId(userId).roomId(roomId).build());
+    entry.setLevel(level != null ? level : NotificationRoomLevel.Level.ALL);
+    entry.setSnoozedUntil(snoozedUntil);
+    entry.setUpdateDate(LocalDateTime.now());
+    notificationRoomLevelRepository.save(entry);
+  }
+
+  private Set<String> eligibleConsultantIds(Long agencyId) {
+    List<ConsultantAgency> consultantAgencies =
+        consultantAgencyRepository.findByAgencyIdAndDeleteDateIsNull(agencyId);
+    Set<String> ids = new HashSet<>();
+    for (ConsultantAgency consultantAgency : consultantAgencies) {
+      if (consultantAgency.getConsultant() != null
+          && consultantAgency.getConsultant().getId() != null) {
+        ids.add(consultantAgency.getConsultant().getId());
+      }
+    }
+    return ids;
+  }
+
+  private Set<String> sanitizedMentions(List<String> mentionedUserIds, Set<String> eligible) {
+    Set<String> mentioned = new HashSet<>();
+    if (mentionedUserIds != null) {
+      for (String userId : mentionedUserIds) {
+        if (userId != null && eligible.contains(userId)) {
+          mentioned.add(userId);
+        }
+      }
+    }
+    return mentioned;
+  }
+
+  private void recordSenderAsParticipant(
+      TeamDiscussion discussion, String senderUserId, Set<String> eligible) {
+    if (!eligible.contains(senderUserId)) {
+      return;
+    }
+    if (participantRepository.existsByTeamDiscussionIdAndConsultantId(
+        discussion.getId(), senderUserId)) {
+      return;
+    }
+    participantRepository.save(
+        TeamDiscussionParticipant.builder()
+            .teamDiscussionId(discussion.getId())
+            .consultantId(senderUserId)
+            .joinDate(LocalDateTime.now())
+            .build());
+  }
+
+  /** True when the recipient's per-conversation level says: drop this notification. */
+  private boolean dropForConversationLevel(String recipientId, String roomId, boolean isMentioned) {
+    Optional<NotificationRoomLevel> levelOpt =
+        notificationRoomLevelRepository.findByUserIdAndRoomId(recipientId, roomId);
+    if (levelOpt.isEmpty()) {
+      return false;
+    }
+    NotificationRoomLevel entry = levelOpt.get();
+    if (entry.getSnoozedUntil() != null && entry.getSnoozedUntil().isAfter(LocalDateTime.now())) {
+      return true;
+    }
+    return switch (entry.getLevel()) {
+      case MUTED -> true;
+      case MENTIONS -> !isMentioned;
+      case ALL -> false;
+    };
+  }
+
+  private String buildText(String senderDisplayName) {
+    return senderDisplayName != null && !senderDisplayName.isBlank()
+        ? senderDisplayName + " posted in the team discussion"
+        : "New post in the team discussion";
+  }
+
+  private String buildParams(
+      Session session, TeamDiscussion discussion, String senderDisplayName, boolean mentioned) {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("sessionId", session.getId());
+    params.put("roomId", discussion.getMatrixRoomId());
+    params.put("senderDisplayName", senderDisplayName != null ? senderDisplayName : "");
+    params.put("mentioned", mentioned);
+    try {
+      return paramsObjectMapper.writeValueAsString(params);
+    } catch (JsonProcessingException ex) {
+      log.warn("Could not serialize team discussion params: {}", ex.getMessage());
+      return null;
+    }
+  }
+
+  private String buildActionPath(Session session, TeamDiscussion discussion) {
+    return "/sessions/consultant/sessionPreview?sessionId="
+        + session.getId()
+        + "&teamDiscussion=1&roomId="
+        + discussion.getMatrixRoomId();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGate.java
@@ -1,0 +1,30 @@
+package de.caritas.cob.userservice.api.service.teamdiscussion;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Enforces the Team-Besprechung feature toggle at the backend boundary (US#473 / ADR-016).
+ *
+ * <p>Currently a deploy-level property ({@code team-discussion.enabled}). The decided target is a
+ * tenant-level setting following the {@code GroupChatFeatureGate} pattern; that needs a companion
+ * TenantService settings field first and is tracked as a follow-up on the epic (FE#512). This gate
+ * is the single seam where that check will slot in — callers stay unchanged.
+ */
+@Service
+public class TeamDiscussionFeatureGate {
+
+  @Value("${team-discussion.enabled:true}")
+  private boolean teamDiscussionEnabled;
+
+  public void requireEnabled() {
+    if (!teamDiscussionEnabled) {
+      throw new ForbiddenException("Team discussion is disabled");
+    }
+  }
+
+  public boolean isEnabled() {
+    return teamDiscussionEnabled;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -365,3 +365,6 @@ debug.redis.message.mirror.keyPrefix=${DEBUG_REDIS_MESSAGE_MIRROR_KEY_PREFIX:deb
 privacy.notificationPreviewMode=${PRIVACY_NOTIFICATION_PREVIEW_MODE:NONE}
 # IP privacy mode: STANDARD (default) or STRICT
 privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}
+
+# US#473 Team-Besprechung (ADR-016). Deploy-level gate; tenant-level flag is a follow-up.
+team-discussion.enabled=true

--- a/src/main/resources/db/changelog/changeset/0070_team_discussion/0070_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0070_team_discussion/0070_changeSet.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <changeSet id="0070-team-discussion" author="frank">
+    <sqlFile
+      path="db/changelog/changeset/0070_team_discussion/migrate.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sql>DROP TABLE IF EXISTS notification_room_level;</sql>
+      <sql>DROP TABLE IF EXISTS team_discussion_participant;</sql>
+      <sql>DROP TABLE IF EXISTS team_discussion;</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0070_team_discussion/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0070_team_discussion/migrate.sql
@@ -1,0 +1,40 @@
+-- US#473 / ADR-016: Team-Besprechung — team-only discussion room per open enquiry.
+-- Idempotent DDL following the 0056/0067 pattern.
+
+CREATE TABLE IF NOT EXISTS team_discussion (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  session_id BIGINT NOT NULL,
+  matrix_room_id VARCHAR(255) NOT NULL,
+  discussion_status VARCHAR(20) NOT NULL DEFAULT 'OPEN',
+  create_date DATETIME NOT NULL,
+  archive_date DATETIME NULL,
+  created_by_consultant_id VARCHAR(36) NULL,
+  is_first_notified TINYINT(1) NOT NULL DEFAULT 0,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_team_discussion_session (session_id),
+  KEY idx_team_discussion_room (matrix_room_id)
+);
+
+CREATE TABLE IF NOT EXISTS team_discussion_participant (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  team_discussion_id BIGINT NOT NULL,
+  consultant_id VARCHAR(36) NOT NULL,
+  join_date DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_td_participant (team_discussion_id, consultant_id)
+);
+
+-- Server-side mirror of the per-conversation notification level (All / Mentions / Muted
+-- + timed snooze). Written by the frontend 4-state menu so the fan-out producer can
+-- honour Muted/Snoozed server-side (the Matrix-account-data copy is unreadable here).
+CREATE TABLE IF NOT EXISTS notification_room_level (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  user_id VARCHAR(64) NOT NULL,
+  room_id VARCHAR(255) NOT NULL,
+  notification_level VARCHAR(20) NOT NULL DEFAULT 'ALL',
+  snoozed_until DATETIME NULL,
+  update_date DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_notification_room_level (user_id, room_id)
+);

--- a/src/main/resources/db/changelog/changeset/0070_team_discussion/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0070_team_discussion/migrate.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS team_discussion (
   archive_date DATETIME NULL,
   created_by_consultant_id VARCHAR(36) NULL,
   is_first_notified TINYINT(1) NOT NULL DEFAULT 0,
+  is_read_only_applied TINYINT(1) NOT NULL DEFAULT 0,
   tenant_id BIGINT NULL,
   PRIMARY KEY (id),
   UNIQUE KEY uk_team_discussion_session (session_id),

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -112,6 +112,8 @@
     file="db/changelog/changeset/0068_consultant_assigned_supervisor/0068_changeSet.xml" />
   <include
     file="db/changelog/changeset/0069_case_handover_notification_templates/0069_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0070_team_discussion/0070_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.TeamDiscussionNotificationService;
 import jakarta.validation.constraints.Min;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.springframework.http.HttpStatus;
 class EventNotificationControllerTest {
 
   @Mock private EventNotificationService eventNotificationService;
+  @Mock private TeamDiscussionNotificationService teamDiscussionNotificationService;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private RedisMessageMirrorService redisMessageMirrorService;
 
@@ -36,10 +38,16 @@ class EventNotificationControllerTest {
   void setUp() {
     controllerWithMirror =
         new EventNotificationController(
-            eventNotificationService, authenticatedUser, Optional.of(redisMessageMirrorService));
+            eventNotificationService,
+            teamDiscussionNotificationService,
+            authenticatedUser,
+            Optional.of(redisMessageMirrorService));
     controllerWithoutMirror =
         new EventNotificationController(
-            eventNotificationService, authenticatedUser, Optional.empty());
+            eventNotificationService,
+            teamDiscussionNotificationService,
+            authenticatedUser,
+            Optional.empty());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
@@ -1,0 +1,246 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.api.service.teamdiscussion.TeamDiscussionFeatureGate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.ResponseEntity;
+
+/** US#473 / ADR-016 — Team-Besprechung lifecycle. */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TeamDiscussionFacadeTest {
+
+  private static final Long SESSION_ID = 42L;
+  private static final Long AGENCY_ID = 7L;
+  private static final String CONSULTANT_ID = "consultant-1";
+  private static final String ROOM_ID = "!discussion:oriso";
+
+  @InjectMocks private TeamDiscussionFacade facade;
+
+  @Mock private SessionRepository sessionRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private ConsultantAgencyRepository consultantAgencyRepository;
+  @Mock private TeamDiscussionRepository teamDiscussionRepository;
+  @Mock private TeamDiscussionParticipantRepository participantRepository;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
+  @Mock private TeamDiscussionFeatureGate featureGate;
+
+  private Session session;
+  private Consultant consultant;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    session = new Session();
+    session.setId(SESSION_ID);
+    session.setAgencyId(AGENCY_ID);
+    session.setStatus(SessionStatus.NEW);
+    session.setRegistrationType(RegistrationType.REGISTERED);
+    session.setTenantId(3L);
+
+    consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    consultant.setMatrixUserId("@consultant1:oriso");
+
+    when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultantRepository.findById(CONSULTANT_ID)).thenReturn(Optional.of(consultant));
+    when(consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+            CONSULTANT_ID, AGENCY_ID))
+        .thenReturn(true);
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.empty());
+    when(teamDiscussionRepository.save(any(TeamDiscussion.class)))
+        .thenAnswer(
+            invocation -> {
+              TeamDiscussion d = invocation.getArgument(0);
+              d.setId(99L);
+              return d;
+            });
+
+    var credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId("@agency7:oriso");
+    credentials.setMatrixPassword("secret");
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+    when(matrixSynapseService.loginUser("agency7", "secret")).thenReturn("agency-token");
+    when(matrixSynapseService.loginAsUserAccessToken("@consultant1:oriso"))
+        .thenReturn("consultant-token");
+
+    var body = new MatrixCreateRoomResponseDTO();
+    body.setRoomId(ROOM_ID);
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq("agency-token")))
+        .thenReturn(ResponseEntity.ok(body));
+  }
+
+  @Test
+  void getOrCreateDiscussion_shouldCreateRoomWithAgencyOperatorAndRecordParticipant()
+      throws Exception {
+    var view = facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    assertThat(view.matrixRoomId()).isEqualTo(ROOM_ID);
+    assertThat(view.status()).isEqualTo(TeamDiscussion.Status.OPEN);
+    verify(matrixSynapseService).createRoom(anyString(), anyString(), eq("agency-token"));
+    verify(matrixSynapseService).inviteUserToRoom(ROOM_ID, "@consultant1:oriso", "agency-token");
+    verify(matrixSynapseService).joinRoom(ROOM_ID, "consultant-token");
+    verify(participantRepository).save(any());
+  }
+
+  @Test
+  void getOrCreateDiscussion_shouldReuseExistingDiscussionWithoutCreatingRoom() throws Exception {
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID))
+        .thenReturn(
+            Optional.of(
+                TeamDiscussion.builder()
+                    .id(99L)
+                    .sessionId(SESSION_ID)
+                    .matrixRoomId(ROOM_ID)
+                    .status(TeamDiscussion.Status.OPEN)
+                    .build()));
+
+    var view = facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    assertThat(view.matrixRoomId()).isEqualTo(ROOM_ID);
+    verify(matrixSynapseService, never()).createRoom(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void getOrCreateDiscussion_shouldRejectAssignedSession() {
+    session.setConsultant(consultant);
+
+    assertThatThrownBy(() -> facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void getOrCreateDiscussion_shouldRejectForeignAgencyConsultant() {
+    when(consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+            CONSULTANT_ID, AGENCY_ID))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void getOrCreateDiscussion_shouldRespectFeatureGate() throws Exception {
+    doThrow(new ForbiddenException("Team discussion is disabled"))
+        .when(featureGate)
+        .requireEnabled();
+
+    assertThatThrownBy(() -> facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID))
+        .isInstanceOf(ForbiddenException.class);
+    verify(matrixSynapseService, never()).createRoom(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void archiveDiscussionIfPresent_shouldArchiveAndSetRoomReadOnly() {
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.OPEN)
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+
+    facade.archiveDiscussionIfPresent(session);
+
+    assertThat(discussion.getStatus()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
+    assertThat(discussion.getArchiveDate()).isNotNull();
+    verify(teamDiscussionRepository).save(discussion);
+    verify(matrixSynapseService)
+        .setRoomEventsDefaultPowerLevel(
+            ROOM_ID, TeamDiscussionFacade.ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL, "agency-token");
+  }
+
+  @Test
+  void archiveDiscussionIfPresent_shouldNeverThrow() {
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID))
+        .thenReturn(
+            Optional.of(
+                TeamDiscussion.builder()
+                    .id(99L)
+                    .sessionId(SESSION_ID)
+                    .matrixRoomId(ROOM_ID)
+                    .status(TeamDiscussion.Status.OPEN)
+                    .build()));
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenThrow(new IllegalStateException("agency service down"));
+
+    assertThatCode(() -> facade.archiveDiscussionIfPresent(session)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void archiveDiscussionIfPresent_shouldIgnoreAlreadyArchived() {
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.ARCHIVED)
+            .archiveDate(LocalDateTime.now().minusDays(1))
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+
+    facade.archiveDiscussionIfPresent(session);
+
+    verify(teamDiscussionRepository, never()).save(any());
+    verify(matrixSynapseService, never())
+        .setRoomEventsDefaultPowerLevel(anyString(), anyInt(), anyString());
+  }
+
+  @Test
+  void getDiscussion_shouldReturnArchivedDiscussionForReadOnlyAccess() {
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID))
+        .thenReturn(
+            Optional.of(
+                TeamDiscussion.builder()
+                    .id(99L)
+                    .sessionId(SESSION_ID)
+                    .matrixRoomId(ROOM_ID)
+                    .status(TeamDiscussion.Status.ARCHIVED)
+                    .archiveDate(LocalDateTime.now())
+                    .build()));
+
+    var view = facade.getDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    assertThat(view).isPresent();
+    assertThat(view.get().status()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
+    assertThat(view.get().archiveDate()).isNotNull();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
@@ -243,4 +243,91 @@ class TeamDiscussionFacadeTest {
     assertThat(view.get().status()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
     assertThat(view.get().archiveDate()).isNotNull();
   }
+
+  @Test
+  void getDiscussion_shouldLazilyArchiveOpenDiscussionOnAssignedSession() {
+    // Review finding F2 (create/accept race): an OPEN row on an accepted case reconciles on access.
+    session.setConsultant(consultant);
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.OPEN)
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+    when(matrixSynapseService.setRoomEventsDefaultPowerLevel(anyString(), anyInt(), anyString()))
+        .thenReturn(true);
+
+    var view = facade.getDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    assertThat(view).isPresent();
+    assertThat(view.get().status()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
+    assertThat(discussion.getStatus()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
+    verify(teamDiscussionRepository, org.mockito.Mockito.atLeastOnce()).save(discussion);
+  }
+
+  @Test
+  void archiveDiscussionIfPresent_shouldTrackFailedReadOnlyForRetry() {
+    // Review finding F3 (archive ordering): a failed power-level call must not be forgotten.
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.OPEN)
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+    when(matrixSynapseService.setRoomEventsDefaultPowerLevel(anyString(), anyInt(), anyString()))
+        .thenReturn(false);
+
+    facade.archiveDiscussionIfPresent(session);
+
+    assertThat(discussion.getStatus()).isEqualTo(TeamDiscussion.Status.ARCHIVED);
+    assertThat(discussion.isReadOnlyApplied()).isFalse();
+  }
+
+  @Test
+  void getDiscussion_shouldRetryReadOnlyOnArchivedDiscussionUntilApplied() {
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.ARCHIVED)
+            .archiveDate(LocalDateTime.now())
+            .readOnlyApplied(false)
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+    when(matrixSynapseService.setRoomEventsDefaultPowerLevel(
+            eq(ROOM_ID), eq(TeamDiscussionFacade.ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL), anyString()))
+        .thenReturn(true);
+
+    facade.getDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    assertThat(discussion.isReadOnlyApplied()).isTrue();
+    verify(matrixSynapseService)
+        .setRoomEventsDefaultPowerLevel(
+            ROOM_ID, TeamDiscussionFacade.ARCHIVED_EVENTS_DEFAULT_POWER_LEVEL, "agency-token");
+    verify(teamDiscussionRepository).save(discussion);
+  }
+
+  @Test
+  void getDiscussion_shouldNotRetryReadOnlyWhenAlreadyApplied() {
+    var discussion =
+        TeamDiscussion.builder()
+            .id(99L)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.ARCHIVED)
+            .archiveDate(LocalDateTime.now())
+            .readOnlyApplied(true)
+            .build();
+    when(teamDiscussionRepository.findBySessionId(SESSION_ID)).thenReturn(Optional.of(discussion));
+
+    facade.getDiscussion(SESSION_ID, CONSULTANT_ID);
+
+    verify(matrixSynapseService, never())
+        .setRoomEventsDefaultPowerLevel(anyString(), anyInt(), anyString());
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -112,6 +112,7 @@ class AssignEnquiryFacadeTest {
   @Mock LiveEventNotificationService liveEventNotificationService;
   @Mock EventNotificationService eventNotificationService;
   @Mock de.caritas.cob.userservice.api.facade.SessionSupervisorFacade sessionSupervisorFacade;
+  @Mock de.caritas.cob.userservice.api.facade.TeamDiscussionFacade teamDiscussionFacade;
 
   private LogbackCaptor logCaptor;
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationServiceTest.java
@@ -1,0 +1,338 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.NotificationRoomLevel;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
+import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.NotificationRoomLevelRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * US#473 hybrid notification rule: first post → whole eligible circle; later posts → participants
+ * plus mentioned; per-conversation levels (Muted / Snoozed / Mentions-only) are honoured.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TeamDiscussionNotificationServiceTest {
+
+  private static final String ROOM_ID = "!discussion:oriso";
+  private static final Long SESSION_ID = 42L;
+  private static final Long AGENCY_ID = 7L;
+  private static final Long DISCUSSION_ID = 99L;
+  private static final String SENDER = "consultant-sender";
+  private static final String COLLEAGUE_A = "consultant-a";
+  private static final String COLLEAGUE_B = "consultant-b";
+
+  @InjectMocks private TeamDiscussionNotificationService service;
+
+  @Mock private TeamDiscussionRepository teamDiscussionRepository;
+  @Mock private TeamDiscussionParticipantRepository participantRepository;
+  @Mock private NotificationRoomLevelRepository notificationRoomLevelRepository;
+  @Mock private ConsultantAgencyRepository consultantAgencyRepository;
+  @Mock private SessionRepository sessionRepository;
+  @Mock private EventNotificationService eventNotificationService;
+
+  private TeamDiscussion discussion;
+  private Session session;
+
+  @BeforeEach
+  void setUp() {
+    discussion =
+        TeamDiscussion.builder()
+            .id(DISCUSSION_ID)
+            .sessionId(SESSION_ID)
+            .matrixRoomId(ROOM_ID)
+            .status(TeamDiscussion.Status.OPEN)
+            .firstNotified(false)
+            .build();
+    session = new Session();
+    session.setId(SESSION_ID);
+    session.setAgencyId(AGENCY_ID);
+    session.setTenantId(3L);
+
+    when(teamDiscussionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(discussion));
+    when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultantAgencyRepository.findByAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(
+            List.of(
+                consultantAgency(SENDER),
+                consultantAgency(COLLEAGUE_A),
+                consultantAgency(COLLEAGUE_B)));
+    when(participantRepository.findByTeamDiscussionId(DISCUSSION_ID)).thenReturn(List.of());
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+    when(eventNotificationService.isNotificationSuppressed(anyString(), anyString()))
+        .thenReturn(false);
+  }
+
+  private ConsultantAgency consultantAgency(String consultantId) {
+    var consultant = new Consultant();
+    consultant.setId(consultantId);
+    var ca = new ConsultantAgency();
+    ca.setConsultant(consultant);
+    ca.setAgencyId(AGENCY_ID);
+    return ca;
+  }
+
+  private TeamDiscussionParticipant participant(String consultantId) {
+    return TeamDiscussionParticipant.builder()
+        .teamDiscussionId(DISCUSSION_ID)
+        .consultantId(consultantId)
+        .joinDate(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  void firstPost_shouldNotifyWholeEligibleCircleExceptSender() {
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_A),
+            eq("team.discussion.new"),
+            eq(EventNotificationService.CATEGORY_MESSAGE),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            eq(SESSION_ID),
+            eq(3L));
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_B),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+    verify(eventNotificationService, never())
+        .createEvent(
+            eq(SENDER),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+    assertThat(discussion.isFirstNotified()).isTrue();
+    verify(teamDiscussionRepository).save(discussion);
+  }
+
+  @Test
+  void laterPost_shouldNotifyOnlyParticipantsAndMentioned() {
+    discussion.setFirstNotified(true);
+    when(participantRepository.findByTeamDiscussionId(DISCUSSION_ID))
+        .thenReturn(List.of(participant(SENDER), participant(COLLEAGUE_A)));
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", List.of(COLLEAGUE_B));
+
+    // participant
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_A),
+            eq("team.discussion.new"),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+    // mentioned non-participant
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_B),
+            eq("team.discussion.new"),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void laterPost_shouldNotNotifyNonParticipants() {
+    discussion.setFirstNotified(true);
+    when(participantRepository.findByTeamDiscussionId(DISCUSSION_ID))
+        .thenReturn(List.of(participant(SENDER)));
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void mutedRecipient_shouldBeSkipped() {
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(COLLEAGUE_A, ROOM_ID))
+        .thenReturn(
+            Optional.of(
+                NotificationRoomLevel.builder()
+                    .userId(COLLEAGUE_A)
+                    .roomId(ROOM_ID)
+                    .level(NotificationRoomLevel.Level.MUTED)
+                    .build()));
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            eq(COLLEAGUE_A),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void activeSnooze_shouldBeSkipped_andExpiredSnoozeDelivers() {
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(COLLEAGUE_A, ROOM_ID))
+        .thenReturn(
+            Optional.of(
+                NotificationRoomLevel.builder()
+                    .userId(COLLEAGUE_A)
+                    .roomId(ROOM_ID)
+                    .level(NotificationRoomLevel.Level.ALL)
+                    .snoozedUntil(LocalDateTime.now().plusHours(1))
+                    .build()));
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(COLLEAGUE_B, ROOM_ID))
+        .thenReturn(
+            Optional.of(
+                NotificationRoomLevel.builder()
+                    .userId(COLLEAGUE_B)
+                    .roomId(ROOM_ID)
+                    .level(NotificationRoomLevel.Level.ALL)
+                    .snoozedUntil(LocalDateTime.now().minusHours(1))
+                    .build()));
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            eq(COLLEAGUE_A),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_B),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void mentionsOnlyRecipient_shouldOnlyReceiveWhenMentioned() {
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(COLLEAGUE_A, ROOM_ID))
+        .thenReturn(
+            Optional.of(
+                NotificationRoomLevel.builder()
+                    .userId(COLLEAGUE_A)
+                    .roomId(ROOM_ID)
+                    .level(NotificationRoomLevel.Level.MENTIONS)
+                    .build()));
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", List.of(COLLEAGUE_A));
+    verify(eventNotificationService)
+        .createEvent(
+            eq(COLLEAGUE_A),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void archivedDiscussion_shouldProduceNothing() {
+    discussion.setStatus(TeamDiscussion.Status.ARCHIVED);
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
+
+  @Test
+  void senderBecomesParticipant() {
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(participantRepository).save(any(TeamDiscussionParticipant.class));
+  }
+
+  @Test
+  void updateConversationLevel_shouldUpsert() {
+    when(notificationRoomLevelRepository.findByUserIdAndRoomId(COLLEAGUE_A, ROOM_ID))
+        .thenReturn(Optional.empty());
+
+    service.updateConversationLevel(COLLEAGUE_A, ROOM_ID, NotificationRoomLevel.Level.MUTED, null);
+
+    verify(notificationRoomLevelRepository).save(any(NotificationRoomLevel.class));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/TeamDiscussionNotificationServiceTest.java
@@ -335,4 +335,48 @@ class TeamDiscussionNotificationServiceTest {
 
     verify(notificationRoomLevelRepository).save(any(NotificationRoomLevel.class));
   }
+
+  @Test
+  void ineligibleSender_shouldProduceNothingAndNotFlipFirstNotified() {
+    // Review finding F1: /users/event-notifications/** is reachable for USER_DEFAULT too —
+    // a caller outside the eligible circle must never trigger (or suppress) the broadcast.
+    service.createTeamDiscussionNotification(ROOM_ID, "outsider-or-asker", "Spoof", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+    assertThat(discussion.isFirstNotified()).isFalse();
+    verify(teamDiscussionRepository, never()).save(any());
+    verify(participantRepository, never()).save(any());
+  }
+
+  @Test
+  void assignedSession_shouldProduceNothingEvenWhileDiscussionStillOpen() {
+    // Review finding F2 (race): once the case is accepted, an OPEN row must not keep notifying.
+    var acceptingConsultant = new Consultant();
+    acceptingConsultant.setId(COLLEAGUE_A);
+    session.setConsultant(acceptingConsultant);
+
+    service.createTeamDiscussionNotification(ROOM_ID, SENDER, "Kim", null);
+
+    verify(eventNotificationService, never())
+        .createEvent(
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any());
+  }
 }


### PR DESCRIPTION
## Why

**ADR-016** (2026-07-18 design session): counsellor teams want to coordinate on an incoming enquiry before anyone accepts it — invisible to the advice seeker. Matrix cannot hide messages inside the client's room, so the Team-Besprechung is a **separate side room per open enquiry**, generalizing the shipped ADR-008 side-room principle to the pre-assignment phase. It closes permanently ("hard close") the moment the enquiry is accepted; afterwards it is reachable read-only from the archive. Coordination on active cases stays Supervision / Case Handover.

## What

**Domain + persistence**
- `TeamDiscussion` (per-session, tenant-filtered) + `TeamDiscussionParticipant` + `NotificationRoomLevel` entities; Liquibase `0070_team_discussion` (idempotent `CREATE TABLE IF NOT EXISTS`, wired in master).

**Lifecycle (`TeamDiscussionFacade`)**
- Lazy room creation on first open: operator = **agency Matrix service account** (`private_chat` preset — the advice seeker is never invited and cannot join), alias `team_discussion_<sessionId>_<rnd>`.
- **Participation right = enquiry visibility right**: `ConsultantAgency` membership check, no new permission layer. Join-on-open keeps late colleagues in.
- Discussions can only be **created** on an open, unassigned, registered enquiry; existing ones (incl. ARCHIVED) are returned read-only.
- **Hard close at accept**: hooked into `AssignEnquiryFacade.assignRegisteredEnquiry` right next to `attachStandingSupervisorIfAssigned`, same **best-effort never-throws contract** — a discussion problem can never block acceptance.
- Protocol-level read-only on archive: new `MatrixRoomClient.setRoomEventsDefaultPowerLevel` raises `events_default` to 50 (members are level 0 → nobody can post; reading stays possible).

**Notifications (`TeamDiscussionNotificationService`)**
- New event type `team.discussion.new` through the existing `event_notification` pipeline (dedup writer, active-view suppression, text-free params per ADR-AT-01).
- **Hybrid rule** (decided 2026-07-18): first post → whole eligible circle; later posts → participants (opened or wrote) + `m.mentions`-mentioned colleagues (validated against eligibility).
- **Per-conversation level honoured server-side**: `notification_room_level` mirrors the 4-state menu (ALL / MENTIONS / MUTED + timed snooze via `snoozedUntil`, auto-revert without a cleanup job). Written by the frontend via new `PATCH /users/event-notifications/conversation-level`. Integration-point decision (as requested by the issue): **server-side mirror**, because Matrix account data (FE#420's store) is unreadable for the producers; documented in `NotificationRoomLevel` javadoc.

**API**
- `POST/GET /users/sessions/{sessionId}/team-discussion` (consultant-guarded in `SecurityConfig`, mirroring the supervisor matchers).
- `POST /users/event-notifications/message-events` extended with `teamDiscussion` + `mentionedUserIds`.
- Feature gate `team-discussion.enabled` (deploy-level; the tenant-level flag needs a TenantService settings field first — follow-up documented in `TeamDiscussionFeatureGate`).

## Verification

- TDD: 19 new unit tests — facade lifecycle (create with agency operator, reuse, foreign-agency Forbidden, assigned-session BadRequest, feature gate, archive + read-only, **never-throws archive**, archived read access) and fan-out (first-post circle, later-post participants+mentions, muted/snoozed/mentions-only filtering, expired snooze delivers, archived silent, sender-becomes-participant, level upsert).
- Full unit suite: **3610 tests, 0 failures** (JDK21 runner; note: local JDK25 breaks Mockito/JaCoCo instrumentation — unrelated to this change).
- `spotless:apply` clean.

**Not in this PR** (per epic plan): the frontend panel/badge/read-only view (OpenResilienceInitiative/ORISO-Frontend#514) and the ⋮-menu level dialog (OpenResilienceInitiative/ORISO-Frontend#420).

Closes OpenResilienceInitiative/ORISO-UserService#473
Refs OpenResilienceInitiative/ORISO-Frontend#512 (Team-Besprechung epic) · ADR-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
