### PR TITLE
feat: reject duplicate tenant ids on TENANT_ADMIN invite creation (409)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.service.accountinvite;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -58,7 +59,8 @@ public class AccountInviteService {
     if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN
         && command.tenantId() != null
         && isTenantIdTaken(command.tenantId())) {
-      throw new BadRequestException("tenantId " + command.tenantId() + " is already taken");
+      // 409 — the admin frontend maps CONFLICT to its dedicated "tenant id taken" message.
+      throw new ConflictException("tenantId " + command.tenantId() + " is already taken");
     }
 
     LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -770,12 +771,12 @@ class AccountInviteServiceTest {
             null,
             30L);
 
-    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(ConflictException.class);
     verify(accountInviteRepository, never()).save(any());
   }
 
   @Test
-  void createInvite_Should_ThrowBadRequest_When_TenantAdminTenantIdUsedByActiveInvite() {
+  void createInvite_Should_ThrowConflict_When_TenantAdminTenantIdUsedByActiveInvite() {
     when(tenantService.getRestrictedTenantData(7L))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
     when(accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
@@ -795,7 +796,7 @@ class AccountInviteServiceTest {
             null,
             30L);
 
-    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(ConflictException.class);
     verify(accountInviteRepository, never()).save(any());
   }
 


### PR DESCRIPTION
## Problem
The admin frontend (merged in ORISO-Admin#357) expects a **409 Conflict** when a TENANT_ADMIN invite is created with a `tenantId` that is already taken, to show its dedicated "tenant ID already taken" message. The duplicate-id guard itself already landed on `pre-dev`, but it rejected with **400 Bad Request** — so the FE fell back to a generic error.

## What changed
- `AccountInviteService.createInvite`: taken tenantId (existing tenant or active DRAFT/EMAIL_SENT TENANT_ADMIN invite) now throws `ConflictException` (409) instead of `BadRequestException` (400)
- Guard tests renamed/updated to assert `ConflictException`

Note: the branch originally also carried the guard commit; after rebasing onto `pre-dev` (which already contains it) this PR reduces to the 400→409 contract fix.

## Verification
- `./mvnw -Dtest=AccountInviteServiceTest test` — 55/55 pass (Temurin 21)

Part of OpenResilienceInitiative/ORISO-Admin#309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
