### PR TITLE
fix(db): include orphaned 0067_consultant_public_slug changeset in master changelog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.idea/
+*.iml
+node_modules/

--- a/.understand-anything/STALE-SEE-SERVER.md
+++ b/.understand-anything/STALE-SEE-SERVER.md
@@ -1,0 +1,16 @@
+# ⚠️ STALE — do not read this graph
+
+The `knowledge-graph.json` in this local `.understand-anything/` folder is a
+**stale local checkout** (June 2026) and is NOT the source of truth. Reading it
+will report an out-of-date picture of the platform.
+
+**Source of truth = the Understand-Anything server**, not this Mac clone:
+- Live boards: https://understand.oriso.org (all 10 repos + cross-repo super-graph)
+- Server: `oriso-understand-dev-1` (49.13.11.37), `/opt/oriso-understand/<Repo>/.understand-anything/`
+- The server graphs are rebuilt from current `dev`/`main` by the committed pipeline
+  in `ORISO-Docs/tools/understand-anything/` (nightly cron + `ua-generate.mjs`).
+
+These local files are git-tracked and left untouched on purpose (they sit on
+active feature branches). Just do not treat them as current.
+
+— note added 2026-07-16

--- a/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml
@@ -3,6 +3,13 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
   <changeSet author="oriso" id="consultantPublicSlug">
+    <!-- Environments that got the slug schema applied manually (pre-dev runs with
+         Liquibase disabled) must not fail on the non-idempotent ALTERs below. -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="consultant" columnName="public_slug"/>
+      </not>
+    </preConditions>
     <rollback>
       <sqlFile path="db/changelog/changeset/0067_consultant_public_slug/consultant-public-slug-rollback.sql"
         stripComments="true"/>

--- a/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/consultant-public-slug.sql
+++ b/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/consultant-public-slug.sql
@@ -11,7 +11,7 @@ CREATE TABLE reserved_public_slug (
   id BIGINT NOT NULL AUTO_INCREMENT,
   slug VARCHAR(128) NOT NULL,
   reason VARCHAR(512) NULL,
-  active TINYINT NOT NULL DEFAULT 1,
+  active TINYINT(1) NOT NULL DEFAULT 1,
   created_by VARCHAR(64) NULL,
   created_at DATETIME NULL,
   updated_by VARCHAR(64) NULL,

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -107,6 +107,8 @@
   <include
     file="db/changelog/changeset/0066_consultant_message_stat/0066_changeSet.xml" />
   <include
+    file="db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml" />
+  <include
     file="db/changelog/changeset/0067_session_supervision_opt_out/0067_changeSet.xml" />
   <include
     file="db/changelog/changeset/0068_consultant_assigned_supervisor/0068_changeSet.xml" />


### PR DESCRIPTION
## Problem
`0067_consultant_public_slug` was never referenced from `userservice-master.xml`, so a database created solely by Liquibase lacks the consultant slug columns and Hibernate schema validation kills the service on boot. `reserved_public_slug.active` was also created as plain `TINYINT`, which fails boolean validation.

## Changes
- Include the changeset in `userservice-master.xml` (after 0066).
- Guard it with a `MARK_RAN` precondition on `consultant.public_slug` so manually-patched environments (pre-dev runs with Liquibase disabled) don't fail on the non-idempotent ALTERs.
- `active TINYINT` → `TINYINT(1)`.

## Verification
- Dropped the local `userservice` schema; service boots healthy with the schema created solely by Liquibase (compose stack).
- Full unit suite green (3683 tests).

Closes OpenResilienceInitiative/ORISO-UserService#488

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by preventing database updates from failing when changes have already been applied.
  * Refined database handling for boolean status values to improve consistency across environments.

* **Chores**
  * Reduced unnecessary files included in container builds, helping keep build contexts cleaner and more efficient.

* **Documentation**
  * Added guidance clarifying which knowledge-graph information is authoritative and where to find current data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->