### PR TITLE
feat(tutorial): versioned tutorial-progress persistence and own-progress API (TOUR-03)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressController.java
@@ -1,0 +1,45 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.TutorialProgressItem;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.UpsertTutorialProgressRequest;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Versioned tutorial progress of the authenticated user (epic TOUR-03). Reads and writes are always
+ * scoped to the caller — there is no way to address another user's progress.
+ */
+@RestController
+@RequestMapping("/users/tutorials/progress")
+@RequiredArgsConstructor
+public class TutorialProgressController {
+
+  private final @NonNull TutorialProgressService tutorialProgressService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  @GetMapping
+  public ResponseEntity<List<TutorialProgressItem>> getOwnProgress(
+      @RequestParam(defaultValue = "frontend") String surface) {
+    return ResponseEntity.ok(
+        tutorialProgressService.getOwnProgress(authenticatedUser.getUserId(), surface));
+  }
+
+  @PutMapping
+  public ResponseEntity<TutorialProgressItem> upsertOwnProgress(
+      @RequestBody UpsertTutorialProgressRequest request) {
+    return ResponseEntity.ok(
+        tutorialProgressService.upsertOwnProgress(
+            authenticatedUser.getUserId(), TenantContext.getCurrentTenant(), request));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -181,6 +181,13 @@ public class SecurityConfig {
                     "/matrix/**",
                     "/service/matrix/**")
                 .hasAnyAuthority(USER_DEFAULT, CONSULTANT_DEFAULT)
+                .requestMatchers("/users/tutorials/progress", "/users/tutorials/progress/**")
+                .hasAnyAuthority(
+                    USER_DEFAULT,
+                    CONSULTANT_DEFAULT,
+                    SINGLE_TENANT_ADMIN,
+                    TENANT_ADMIN,
+                    RESTRICTED_AGENCY_ADMIN)
                 .requestMatchers("/users/system-notification-emails/test")
                 .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT, TENANT_ADMIN, SINGLE_TENANT_ADMIN)
                 .requestMatchers("/users/chat/{chatId:[0-9]+}/verify")

--- a/src/main/java/de/caritas/cob/userservice/api/model/TutorialProgress.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/TutorialProgress.java
@@ -1,0 +1,95 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+/**
+ * Versioned tutorial progress per user, application surface, tour id and tour version (epic
+ * TOUR-03). Only identifiers, status and timestamps are persisted — never rendered tour text,
+ * visited URLs or arbitrary UI payloads.
+ */
+@Entity
+@Table(name = "tutorial_progress")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+@FilterDef(
+    name = "tenantFilter",
+    parameters = {@ParamDef(name = "tenantId", type = Long.class)})
+@Filter(
+    name = "tenantFilter",
+    condition = "(tenant_id = :tenantId OR (:tenantId = 1 AND tenant_id IS NULL))")
+public class TutorialProgress implements TenantAware {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "user_id", nullable = false, length = 64)
+  private String userId;
+
+  @Column(name = "surface", nullable = false, length = 16)
+  private String surface;
+
+  @Column(name = "tour_id", nullable = false, length = 64)
+  private String tourId;
+
+  @Column(name = "tour_version", nullable = false)
+  private Integer tourVersion;
+
+  @Column(name = "status", nullable = false, length = 16)
+  private String status;
+
+  @Column(name = "current_step_id", length = 64)
+  private String currentStepId;
+
+  @Column(name = "started_at")
+  private LocalDateTime startedAt;
+
+  @Column(name = "completed_at")
+  private LocalDateTime completedAt;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date", nullable = false)
+  private LocalDateTime updateDate;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TutorialProgress that)) {
+      return false;
+    }
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TutorialProgressRepository extends CrudRepository<TutorialProgress, Long> {
+
+  Optional<TutorialProgress> findByUserIdAndSurfaceAndTourIdAndTourVersion(
+      String userId, String surface, String tourId, Integer tourVersion);
+
+  List<TutorialProgress> findByUserIdAndSurface(String userId, String surface);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
@@ -1,0 +1,139 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Versioned tutorial progress for the authenticated user (epic TOUR-03). Writes are always scoped
+ * to the caller's own user id — no client can write another user's progress. Identifiers are
+ * strictly validated so only ids, status and timestamps are ever persisted.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TutorialProgressService {
+
+  private static final Set<String> SURFACES = Set.of("frontend", "admin");
+  private static final Set<String> STATUSES =
+      Set.of("not_started", "in_progress", "completed", "skipped");
+  private static final Pattern IDENTIFIER = Pattern.compile("^[a-z0-9][a-z0-9_-]{0,63}$");
+
+  private final @NonNull TutorialProgressRepository tutorialProgressRepository;
+
+  @Transactional
+  public TutorialProgressItem upsertOwnProgress(
+      String userId, Long tenantId, UpsertTutorialProgressRequest request) {
+    validate(request);
+
+    var now = LocalDateTime.now();
+    var progress =
+        tutorialProgressRepository
+            .findByUserIdAndSurfaceAndTourIdAndTourVersion(
+                userId, request.getSurface(), request.getTourId(), request.getTourVersion())
+            .orElseGet(
+                () ->
+                    TutorialProgress.builder()
+                        .userId(userId)
+                        .surface(request.getSurface())
+                        .tourId(request.getTourId())
+                        .tourVersion(request.getTourVersion())
+                        .createDate(now)
+                        .startedAt(now)
+                        .tenantId(tenantId)
+                        .build());
+
+    progress.setStatus(request.getStatus());
+    progress.setCurrentStepId(request.getCurrentStepId());
+    progress.setUpdateDate(now);
+    if (isTerminal(request.getStatus())) {
+      progress.setCompletedAt(now);
+    } else {
+      progress.setCompletedAt(null);
+    }
+
+    return toItem(tutorialProgressRepository.save(progress));
+  }
+
+  @Transactional(readOnly = true)
+  public List<TutorialProgressItem> getOwnProgress(String userId, String surface) {
+    if (!SURFACES.contains(surface)) {
+      throw new BadRequestException("unknown tutorial surface");
+    }
+    return tutorialProgressRepository.findByUserIdAndSurface(userId, surface).stream()
+        .map(this::toItem)
+        .toList();
+  }
+
+  private static boolean isTerminal(String status) {
+    return "completed".equals(status) || "skipped".equals(status);
+  }
+
+  private void validate(UpsertTutorialProgressRequest request) {
+    if (request == null) {
+      throw new BadRequestException("missing tutorial progress payload");
+    }
+    if (request.getSurface() == null || !SURFACES.contains(request.getSurface())) {
+      throw new BadRequestException("unknown tutorial surface");
+    }
+    if (request.getStatus() == null || !STATUSES.contains(request.getStatus())) {
+      throw new BadRequestException("unknown tutorial status");
+    }
+    if (request.getTourId() == null || !IDENTIFIER.matcher(request.getTourId()).matches()) {
+      throw new BadRequestException("tourId must be a short lowercase identifier");
+    }
+    if (request.getCurrentStepId() != null
+        && !IDENTIFIER.matcher(request.getCurrentStepId()).matches()) {
+      throw new BadRequestException("currentStepId must be a short lowercase identifier");
+    }
+    if (request.getTourVersion() == null || request.getTourVersion() < 1) {
+      throw new BadRequestException("tourVersion must be a positive integer");
+    }
+  }
+
+  private TutorialProgressItem toItem(TutorialProgress progress) {
+    return TutorialProgressItem.builder()
+        .tourId(progress.getTourId())
+        .tourVersion(progress.getTourVersion())
+        .surface(progress.getSurface())
+        .status(progress.getStatus())
+        .currentStepId(progress.getCurrentStepId())
+        .startedAt(progress.getStartedAt())
+        .completedAt(progress.getCompletedAt())
+        .build();
+  }
+
+  @Getter
+  @Setter
+  public static class UpsertTutorialProgressRequest {
+    private String surface;
+    private String tourId;
+    private Integer tourVersion;
+    private String status;
+    private String currentStepId;
+  }
+
+  @Getter
+  @Builder
+  public static class TutorialProgressItem {
+    private final String tourId;
+    private final Integer tourVersion;
+    private final String surface;
+    private final String status;
+    private final String currentStepId;
+    private final LocalDateTime startedAt;
+    private final LocalDateTime completedAt;
+  }
+}

--- a/src/main/resources/db/changelog/changeset/0071_tutorial_progress/0071_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0071_tutorial_progress/0071_changeSet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <changeSet id="0071-tutorial-progress" author="frank">
+    <sqlFile
+      path="db/changelog/changeset/0071_tutorial_progress/migrate.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sql>DROP TABLE IF EXISTS userservice.tutorial_progress;</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0071_tutorial_progress/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0071_tutorial_progress/migrate.sql
@@ -1,0 +1,19 @@
+CREATE TABLE userservice.tutorial_progress (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  user_id VARCHAR(64) NOT NULL,
+  surface VARCHAR(16) NOT NULL,
+  tour_id VARCHAR(64) NOT NULL,
+  tour_version INT NOT NULL,
+  status VARCHAR(16) NOT NULL,
+  current_step_id VARCHAR(64) NULL,
+  started_at DATETIME NULL,
+  completed_at DATETIME NULL,
+  create_date DATETIME NOT NULL,
+  update_date DATETIME NOT NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT uq_tutorial_progress_scope UNIQUE (user_id, surface, tour_id, tour_version)
+);
+
+CREATE INDEX idx_tutorial_progress_user_surface ON userservice.tutorial_progress (user_id, surface);
+CREATE INDEX idx_tutorial_progress_tour ON userservice.tutorial_progress (tour_id, tour_version, status);

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -114,6 +114,8 @@
     file="db/changelog/changeset/0069_case_handover_notification_templates/0069_changeSet.xml" />
   <include
     file="db/changelog/changeset/0070_team_discussion/0070_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0071_tutorial_progress/0071_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerE2EIT.java
@@ -1,0 +1,110 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import jakarta.servlet.http.Cookie;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Real-slice regression for the versioned tutorial-progress API (TOUR-03): JWT-authenticated
+ * MockMvc against the running Spring context and the JPA persistence layer.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("testing")
+class TutorialProgressControllerE2EIT {
+
+  private static final String CSRF_HEADER = "X-CSRF-Token";
+  private static final String CSRF_VALUE = "test";
+  private static final Cookie CSRF_COOKIE = new Cookie("CSRF-TOKEN", CSRF_VALUE);
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private TutorialProgressRepository tutorialProgressRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+
+  @AfterEach
+  void cleanUp() {
+    tutorialProgressRepository.deleteAll();
+  }
+
+  @Test
+  void tutorialProgress_requiresAuthentication() throws Exception {
+    mockMvc
+        .perform(get("/users/tutorials/progress").param("surface", "frontend"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void tutorialProgress_roundTripsOwnVersionedProgress() throws Exception {
+    org.mockito.Mockito.when(authenticatedUser.getUserId()).thenReturn("tutorial-user-1");
+    var payload =
+        Map.of(
+            "surface", "frontend",
+            "tourId", "consultant-walkthrough",
+            "tourVersion", 1,
+            "status", "completed",
+            "currentStepId", "profile");
+
+    mockMvc
+        .perform(
+            put("/users/tutorials/progress")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status", is("completed")));
+
+    mockMvc
+        .perform(
+            get("/users/tutorials/progress")
+                .param("surface", "frontend")
+                .with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].tourId", is("consultant-walkthrough")))
+        .andExpect(jsonPath("$[0].tourVersion", is(1)))
+        .andExpect(jsonPath("$[0].status", is("completed")));
+  }
+
+  @Test
+  void tutorialProgress_rejectsUnknownStatusWithBadRequest() throws Exception {
+    org.mockito.Mockito.when(authenticatedUser.getUserId()).thenReturn("tutorial-user-1");
+    var payload =
+        Map.of(
+            "surface", "frontend",
+            "tourId", "consultant-walkthrough",
+            "tourVersion", 1,
+            "status", "finished");
+
+    mockMvc
+        .perform(
+            put("/users/tutorials/progress")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerTest.java
@@ -1,0 +1,55 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.TutorialProgressItem;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.UpsertTutorialProgressRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class TutorialProgressControllerTest {
+
+  @Mock private TutorialProgressService tutorialProgressService;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private TutorialProgressController controller;
+
+  @Test
+  void getOwnProgress_delegatesWithTheAuthenticatedUserId() {
+    // Business reason: clients can only ever read their own tutorial history —
+    // the user id comes from the token, never from the request.
+    var item = TutorialProgressItem.builder().tourId("consultant-walkthrough").build();
+    when(authenticatedUser.getUserId()).thenReturn("user-1");
+    when(tutorialProgressService.getOwnProgress("user-1", "frontend")).thenReturn(List.of(item));
+
+    var response = controller.getOwnProgress("frontend");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).containsExactly(item);
+  }
+
+  @Test
+  void upsertOwnProgress_delegatesWithTheAuthenticatedUserId() {
+    var request = new UpsertTutorialProgressRequest();
+    request.setSurface("frontend");
+    var item = TutorialProgressItem.builder().status("in_progress").build();
+    when(authenticatedUser.getUserId()).thenReturn("user-1");
+    when(tutorialProgressService.upsertOwnProgress("user-1", null, request)).thenReturn(item);
+
+    var response = controller.upsertOwnProgress(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(item);
+    verify(tutorialProgressService).upsertOwnProgress("user-1", null, request);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
@@ -1,0 +1,164 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.UpsertTutorialProgressRequest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TutorialProgressServiceTest {
+
+  @Mock private TutorialProgressRepository tutorialProgressRepository;
+
+  @InjectMocks private TutorialProgressService service;
+
+  private UpsertTutorialProgressRequest request(String status) {
+    var req = new UpsertTutorialProgressRequest();
+    req.setSurface("frontend");
+    req.setTourId("consultant-walkthrough");
+    req.setTourVersion(1);
+    req.setStatus(status);
+    req.setCurrentStepId("enquiries");
+    return req;
+  }
+
+  @Test
+  void upsertOwnProgress_createsScopedRecordForTheAuthenticatedUser() {
+    // Business reason: progress is keyed by user, surface, tour and version so
+    // multiple tutorials and audiences can track state independently.
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            "user-1", "frontend", "consultant-walkthrough", 1))
+        .thenReturn(Optional.empty());
+    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var item = service.upsertOwnProgress("user-1", 1L, request("in_progress"));
+
+    var captor = ArgumentCaptor.forClass(TutorialProgress.class);
+    verify(tutorialProgressRepository).save(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo("user-1");
+    assertThat(captor.getValue().getSurface()).isEqualTo("frontend");
+    assertThat(captor.getValue().getTourId()).isEqualTo("consultant-walkthrough");
+    assertThat(captor.getValue().getTourVersion()).isEqualTo(1);
+    assertThat(captor.getValue().getStatus()).isEqualTo("in_progress");
+    assertThat(item.getStatus()).isEqualTo("in_progress");
+  }
+
+  @Test
+  void upsertOwnProgress_overwritesExistingScopeIdempotently() {
+    // Business reason: restarting or re-running a tour updates the same
+    // versioned scope instead of piling up rows.
+    var existing =
+        TutorialProgress.builder()
+            .id(7L)
+            .userId("user-1")
+            .surface("frontend")
+            .tourId("consultant-walkthrough")
+            .tourVersion(1)
+            .status("completed")
+            .createDate(LocalDateTime.now())
+            .build();
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            "user-1", "frontend", "consultant-walkthrough", 1))
+        .thenReturn(Optional.of(existing));
+    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    service.upsertOwnProgress("user-1", 1L, request("in_progress"));
+
+    var captor = ArgumentCaptor.forClass(TutorialProgress.class);
+    verify(tutorialProgressRepository).save(captor.capture());
+    assertThat(captor.getValue().getId()).isEqualTo(7L);
+    assertThat(captor.getValue().getStatus()).isEqualTo("in_progress");
+  }
+
+  @Test
+  void upsertOwnProgress_completedSetsCompletionTimestamp() {
+    // Business reason: completion requires an explicit final-step write and is
+    // observable through the completedAt timestamp.
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            any(), any(), any(), any()))
+        .thenReturn(Optional.empty());
+    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var item = service.upsertOwnProgress("user-1", 1L, request("completed"));
+
+    assertThat(item.getCompletedAt()).isNotNull();
+  }
+
+  @Test
+  void upsertOwnProgress_skippedIsStoredAsSkippedNotCompleted() {
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            any(), any(), any(), any()))
+        .thenReturn(Optional.empty());
+    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var item = service.upsertOwnProgress("user-1", 1L, request("skipped"));
+
+    assertThat(item.getStatus()).isEqualTo("skipped");
+    assertThat(item.getCompletedAt()).isNotNull();
+  }
+
+  @Test
+  void upsertOwnProgress_rejectsUnknownStatus() {
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, request("finished")))
+        .isInstanceOf(BadRequestException.class);
+    verify(tutorialProgressRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertOwnProgress_rejectsUnknownSurface() {
+    var req = request("in_progress");
+    req.setSurface("mobile-app");
+
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void upsertOwnProgress_rejectsFreeTextIdentifiers() {
+    // Business reason: only identifiers, status and timestamps are persisted —
+    // never rendered text, URLs or arbitrary UI payloads.
+    var req = request("in_progress");
+    req.setTourId("Hier finden Sie eine Übersicht über alle offenen Anfragen!");
+
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void getOwnProgress_returnsOnlyTheRequestedSurfaceOfTheOwnUser() {
+    var row =
+        TutorialProgress.builder()
+            .userId("user-1")
+            .surface("frontend")
+            .tourId("consultant-walkthrough")
+            .tourVersion(2)
+            .status("in_progress")
+            .currentStepId("archive")
+            .build();
+    when(tutorialProgressRepository.findByUserIdAndSurface("user-1", "frontend"))
+        .thenReturn(List.of(row));
+
+    var items = service.getOwnProgress("user-1", "frontend");
+
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getTourId()).isEqualTo("consultant-walkthrough");
+    assertThat(items.get(0).getTourVersion()).isEqualTo(2);
+    assertThat(items.get(0).getCurrentStepId()).isEqualTo("archive");
+  }
+}


### PR DESCRIPTION
Closes #484

Part of epic OpenResilienceInitiative/ORISO-Frontend#521 (React Joyride product tours). Frontend/Admin counterparts: OpenResilienceInitiative/ORISO-Frontend#524, OpenResilienceInitiative/ORISO-Admin#390.

**Problem:** tutorial state is a single `walkThroughEnabled` boolean and cannot express multiple tutorials, versions, per-step progress or audiences.

**What changed**

- `tutorial_progress` table (Liquibase changeset 0071): user × surface × tour_id × tour_version with unique scope constraint, status, current_step_id, timestamps, tenant_id.
- `TutorialProgress` entity (tenant-filtered) + `TutorialProgressRepository`.
- `TutorialProgressService`: idempotent upsert per versioned scope, strict identifier/surface/status validation — only identifiers, status and timestamps are ever persisted (no rendered text/URLs/payloads). Terminal states stamp `completedAt`; skipped is never stored as completed.
- `TutorialProgressController`: `GET`/`PUT /users/tutorials/progress`, always scoped to the authenticated user's token id — no client can address another user's progress. SecurityConfig grants user/consultant/admin authorities.
- Legacy `walkThroughEnabled` + `toggleWalkThrough` stay untouched (compatibility until TOUR-04/05 switch the clients).

**Out of scope:** aggregate statistics (TOUR-06, #485).

**Verification:** red-first TDD (8 service + 2 controller unit tests) · JWT MockMvc integration slice (401 unauthenticated, PUT/GET round-trip against JPA, 400 on invalid status) · `DatabaseChangelogDriftIT` green against a fresh MariaDB 10.11 (Liquibase applies 0071, Hibernate validates all entities; the two pre-existing 0067 drift findings are noted on #458) · full suite `mvn test`: 3685 passed · spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
