### PR TITLE
feat(auth): support Admin password reset links

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -95,7 +95,8 @@ class UserRegistrationControllerDelegate {
   }
 
   ResponseEntity<Void> requestPasswordReset(PasswordResetRequestDTO requestDTO) {
-    passwordResetService.requestPasswordReset(requestDTO.getUsername(), requestDTO.getLocale());
+    passwordResetService.requestPasswordReset(
+        requestDTO.getUsername(), requestDTO.getLocale(), requestDTO.getApplication());
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetApplication.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetApplication.java
@@ -1,0 +1,6 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+public enum PasswordResetApplication {
+  APP,
+  ADMIN
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/PasswordResetRequestDTO.java
@@ -8,4 +8,5 @@ public class PasswordResetRequestDTO {
 
   @NotBlank private String username;
   private String locale;
+  private PasswordResetApplication application = PasswordResetApplication.APP;
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -71,6 +71,8 @@ public interface AdminRepository
 
   List<Admin> findAllByIdIn(Set<String> adminIds);
 
+  Optional<Admin> findFirstByUsernameIgnoreCaseOrEmailIgnoreCase(String username, String email);
+
   @Query("SELECT a.id FROM Admin a WHERE a.id IN :ids")
   Set<String> findExistingIdsByIdIn(@Param("ids") Collection<String> ids);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -5,10 +5,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetApplication;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import jakarta.annotation.PostConstruct;
@@ -60,6 +63,7 @@ public class PasswordResetService {
 
   private final @NonNull UserService userService;
   private final @NonNull ConsultantService consultantService;
+  private final @NonNull AdminRepository adminRepository;
   private final @NonNull KeycloakService keycloakService;
   private final @NonNull RestTemplate restTemplate;
 
@@ -103,6 +107,9 @@ public class PasswordResetService {
   @Value("${password.reset.frontend.base-url:}")
   private String passwordResetFrontendBaseUrl;
 
+  @Value("${password.reset.admin.frontend.base-url:}")
+  private String passwordResetAdminFrontendBaseUrl;
+
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
 
@@ -114,6 +121,13 @@ public class PasswordResetService {
               + "'password.reset.frontend.base-url' (env PASSWORD_RESET_FRONTEND_BASE_URL) is unset. "
               + "Reset emails will not be sent until it is configured.");
     }
+    if (isBlank(passwordResetAdminFrontendBaseUrl)) {
+      log.warn(
+          "Admin password reset is DISABLED: required property "
+              + "'password.reset.admin.frontend.base-url' "
+              + "(env PASSWORD_RESET_ADMIN_FRONTEND_BASE_URL) is unset. "
+              + "Admin reset emails will not be sent until it is configured.");
+    }
   }
 
   /**
@@ -121,15 +135,23 @@ public class PasswordResetService {
    * If an eligible account is found, a reset email is sent best-effort.
    */
   public void requestPasswordReset(String usernameInput, String locale) {
+    requestPasswordReset(usernameInput, locale, PasswordResetApplication.APP);
+  }
+
+  public void requestPasswordReset(
+      String usernameInput, String locale, PasswordResetApplication application) {
     if (isBlank(usernameInput)) {
       return;
     }
 
     String username = usernameInput.trim();
     String resolvedLocale = resolveLocale(locale);
+    PasswordResetApplication resolvedApplication =
+        application == null ? PasswordResetApplication.APP : application;
     try {
       // Dispatch asynchronously so the response time does not reveal whether the account exists.
-      passwordResetExecutor.execute(() -> processPasswordResetRequest(username, resolvedLocale));
+      passwordResetExecutor.execute(
+          () -> processPasswordResetRequest(username, resolvedLocale, resolvedApplication));
     } catch (RejectedExecutionException ex) {
       // Queue saturated (flood/overload): drop the dispatch, keep the response identical so
       // neither existence nor the drop is observable. No PII in the log.
@@ -137,9 +159,10 @@ public class PasswordResetService {
     }
   }
 
-  private void processPasswordResetRequest(String username, String locale) {
+  private void processPasswordResetRequest(
+      String username, String locale, PasswordResetApplication application) {
     try {
-      Optional<AccountResetTarget> accountOptional = resolveAccount(username);
+      Optional<AccountResetTarget> accountOptional = resolveAccount(username, application);
       if (accountOptional.isEmpty()) {
         return;
       }
@@ -150,7 +173,7 @@ public class PasswordResetService {
         return;
       }
 
-      sendPasswordResetEmailSafely(account, locale);
+      sendPasswordResetEmailSafely(account, locale, application);
     } catch (RuntimeException ex) {
       // Never leak PII (account id, email, raw message) — log the exception class only.
       log.warn("Password reset request processing failed ({})", ex.getClass().getSimpleName());
@@ -221,16 +244,34 @@ public class PasswordResetService {
         consultant -> new AccountResetTarget(consultant.getId(), consultant.getEmail()));
   }
 
+  private Optional<AccountResetTarget> resolveAccount(
+      String username, PasswordResetApplication application) {
+    if (application == PasswordResetApplication.ADMIN) {
+      Optional<Admin> adminOptional =
+          adminRepository.findFirstByUsernameIgnoreCaseOrEmailIgnoreCase(username, username);
+      return adminOptional.map(admin -> new AccountResetTarget(admin.getId(), admin.getEmail()));
+    }
+    return resolveAccount(username);
+  }
+
   private String resolveLocale(String locale) {
     return isNotBlank(locale) && EMAIL_CONTENT.containsKey(locale) ? locale : "de";
   }
 
-  private void sendPasswordResetEmailSafely(AccountResetTarget target, String locale) {
+  private void sendPasswordResetEmailSafely(
+      AccountResetTarget target, String locale, PasswordResetApplication application) {
+    String frontendBaseUrl =
+        application == PasswordResetApplication.ADMIN
+            ? passwordResetAdminFrontendBaseUrl
+            : passwordResetFrontendBaseUrl;
+    String frontendBaseUrlProperty =
+        application == PasswordResetApplication.ADMIN
+            ? "password.reset.admin.frontend.base-url"
+            : "password.reset.frontend.base-url";
     // Fail closed: without an explicitly configured frontend base URL we cannot build a usable
     // reset link, so the feature stays disabled instead of emailing a wrong/production URL.
-    if (isBlank(passwordResetFrontendBaseUrl)) {
-      log.warn(
-          "Password reset email not sent: 'password.reset.frontend.base-url' is not configured.");
+    if (isBlank(frontendBaseUrl)) {
+      log.warn("Password reset email not sent: '{}' is not configured.", frontendBaseUrlProperty);
       return;
     }
 
@@ -243,7 +284,7 @@ public class PasswordResetService {
     // Bound the in-memory token map: purge expired entries before inserting a new one.
     cleanupExpiredTokens();
     String oneTimeToken = generateAndStoreToken(target.getKeycloakUserId());
-    String resetUrl = buildResetFrontendUrl(oneTimeToken);
+    String resetUrl = buildResetFrontendUrl(oneTimeToken, frontendBaseUrl);
     EmailContent content = EMAIL_CONTENT.get(locale);
 
     try {
@@ -357,8 +398,8 @@ public class PasswordResetService {
     resetTokens.entrySet().removeIf(entry -> entry.getValue().getExpiresAt().isBefore(now));
   }
 
-  private String buildResetFrontendUrl(String oneTimeToken) {
-    return normalizeBaseUrl(passwordResetFrontendBaseUrl)
+  private String buildResetFrontendUrl(String oneTimeToken, String frontendBaseUrl) {
+    return normalizeBaseUrl(frontendBaseUrl)
         + "/password-reset/confirm?token="
         + URLEncoder.encode(oneTimeToken, StandardCharsets.UTF_8);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetApplication;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetConfirmDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetRequestDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
@@ -363,7 +364,21 @@ class UserRegistrationControllerDelegateTest {
     var response = delegate.requestPasswordReset(request);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-    verify(passwordResetService).requestPasswordReset(USERNAME, "de");
+    verify(passwordResetService).requestPasswordReset(USERNAME, "de", PasswordResetApplication.APP);
+  }
+
+  @Test
+  void requestPasswordReset_delegatesAdminApplicationToService() {
+    var request = new PasswordResetRequestDTO();
+    request.setUsername(USERNAME);
+    request.setLocale("en");
+    request.setApplication(PasswordResetApplication.ADMIN);
+
+    var response = delegate.requestPasswordReset(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(passwordResetService)
+        .requestPasswordReset(USERNAME, "en", PasswordResetApplication.ADMIN);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -11,10 +11,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetApplication;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
+import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.auth.PasswordResetService.PasswordResetMailSender;
 import de.caritas.cob.userservice.api.service.user.UserService;
@@ -40,6 +43,7 @@ class PasswordResetServiceTest {
 
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
+  @Mock private AdminRepository adminRepository;
   @Mock private KeycloakService keycloakService;
   @Mock private RestTemplate restTemplate;
 
@@ -54,6 +58,8 @@ class PasswordResetServiceTest {
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "");
     ReflectionTestUtils.setField(
         passwordResetService, "passwordResetFrontendBaseUrl", "https://app.oriso.org");
+    ReflectionTestUtils.setField(
+        passwordResetService, "passwordResetAdminFrontendBaseUrl", "https://admin.oriso.org/admin");
     // Run dispatch synchronously so request-flow assertions are deterministic.
     ReflectionTestUtils.setField(
         passwordResetService, "passwordResetExecutor", (Executor) Runnable::run);
@@ -142,6 +148,68 @@ class PasswordResetServiceTest {
     assertThat(mail.resetUrl())
         .startsWith("https://app.oriso.org/password-reset/confirm?token=")
         .matches("https://app\\.oriso\\.org/password-reset/confirm\\?token=[0-9a-f]{64}");
+  }
+
+  @Test
+  void requestPasswordReset_Should_SendAdminMailToAdminFrontend_When_ApplicationIsAdmin() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    Admin admin =
+        Admin.builder()
+            .id("admin-keycloak-id")
+            .username("admin@example.com")
+            .firstName("Ada")
+            .lastName("Admin")
+            .email("admin@example.com")
+            .type(Admin.AdminType.SUPER)
+            .build();
+    when(adminRepository.findFirstByUsernameIgnoreCaseOrEmailIgnoreCase(
+            "admin@example.com", "admin@example.com"))
+        .thenReturn(Optional.of(admin));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
+
+    passwordResetService.requestPasswordReset(
+        "admin@example.com", "en", PasswordResetApplication.ADMIN);
+
+    assertThat(sentMails).hasSize(1);
+    assertThat(sentMails.get(0).recipient()).isEqualTo("admin@example.com");
+    assertThat(sentMails.get(0).resetUrl())
+        .matches("https://admin\\.oriso\\.org/admin/password-reset/confirm\\?token=[0-9a-f]{64}");
+    verify(userService, never()).findUserByUsername(anyString());
+    verify(consultantService, never()).findConsultantByUsernameOrEmail(anyString(), anyString());
+  }
+
+  @Test
+  void requestPasswordReset_Should_NotFallBackToAppAccounts_When_AdminIsUnknown() {
+    when(adminRepository.findFirstByUsernameIgnoreCaseOrEmailIgnoreCase("app-user", "app-user"))
+        .thenReturn(Optional.empty());
+
+    passwordResetService.requestPasswordReset("app-user", "de", PasswordResetApplication.ADMIN);
+
+    assertThat(sentMails).isEmpty();
+    verify(userService, never()).findUserByUsername(anyString());
+    verify(consultantService, never()).findConsultantByUsernameOrEmail(anyString(), anyString());
+  }
+
+  @Test
+  void requestPasswordReset_Should_NotSendAdminMail_When_AdminFrontendBaseUrlUnset() {
+    ReflectionTestUtils.setField(passwordResetService, "passwordResetAdminFrontendBaseUrl", "");
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    Admin admin =
+        Admin.builder()
+            .id("admin-keycloak-id")
+            .username("admin")
+            .firstName("Ada")
+            .lastName("Admin")
+            .email("admin@example.com")
+            .type(Admin.AdminType.SUPER)
+            .build();
+    when(adminRepository.findFirstByUsernameIgnoreCaseOrEmailIgnoreCase("admin", "admin"))
+        .thenReturn(Optional.of(admin));
+
+    passwordResetService.requestPasswordReset("admin", "de", PasswordResetApplication.ADMIN);
+
+    assertThat(sentMails).isEmpty();
+    verify(restTemplate, never()).getForObject(anyString(), any());
   }
 
   @Test


### PR DESCRIPTION
## Problem
Admin password recovery currently lands on Keycloak's blocked reset-credentials flow.

## Changes
- Accept an explicit `ADMIN` password-reset application while keeping `APP` as the backward-compatible default.
- Resolve admin accounts only through the admin repository, without falling back to app identities.
- Build reset links from a dedicated server-side admin frontend URL.
- Keep responses enumeration-safe and fail closed when the URL is unset.

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw test` — 3,679 tests passed.

Counterparts: [Admin #394](https://github.com/OpenResilienceInitiative/ORISO-Admin/pull/394), [Helm #103](https://github.com/OpenResilienceInitiative/ORISO-Helm/pull/103).

Closes #492
Refs OpenResilienceInitiative/ORISO-Admin#392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
