### PR TITLE
Fix Keycloak OTP lookups for transcoded usernames

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -193,7 +193,7 @@ public class KeycloakService implements IdentityClient {
   @Override
   public OtpInfoDTO getOtpCredential(String userName) {
     var bearerToken = keycloakClient.getBearerToken();
-    var requestUrl = identityClientConfig.getOtpUrl(ENDPOINT_OTP_INFO, userName);
+    var requestUrl = getOtpUrl(ENDPOINT_OTP_INFO, userName);
     var response = keycloakClient.get(bearerToken, requestUrl, OtpInfoDTO.class);
 
     return response.getBody();
@@ -203,7 +203,7 @@ public class KeycloakService implements IdentityClient {
   public boolean setUpOtpCredential(String userName, String initialCode, String secret) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(initialCode, secret, null);
     var bearerToken = keycloakClient.getBearerToken();
-    var requestUrl = identityClientConfig.getOtpUrl(ENDPOINT_OTP_SETUP, userName);
+    var requestUrl = getOtpUrl(ENDPOINT_OTP_SETUP, userName);
 
     try {
       keycloakClient.putForEntity(bearerToken, requestUrl, otpSetupDTO, OtpInfoDTO.class);
@@ -220,7 +220,7 @@ public class KeycloakService implements IdentityClient {
   @Override
   public void deleteOtpCredential(String userName) {
     var bearerToken = keycloakClient.getBearerToken();
-    var requestUrl = identityClientConfig.getOtpUrl(ENDPOINT_OTP_TEARDOWN, userName);
+    var requestUrl = getOtpUrl(ENDPOINT_OTP_TEARDOWN, userName);
     keycloakClient.delete(bearerToken, requestUrl, Void.class);
   }
 
@@ -228,7 +228,7 @@ public class KeycloakService implements IdentityClient {
   public Optional<String> initiateEmailVerification(String username, String email) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(null, null, email);
     var bearerToken = keycloakClient.getBearerToken();
-    var requestUrl = identityClientConfig.getOtpUrl(ENDPOINT_OTP_VERIFY_EMAIL, username);
+    var requestUrl = getOtpUrl(ENDPOINT_OTP_VERIFY_EMAIL, username);
 
     try {
       keycloakClient.putForEntity(bearerToken, requestUrl, otpSetupDTO, Success.class);
@@ -242,7 +242,7 @@ public class KeycloakService implements IdentityClient {
   public Map<String, String> finishEmailVerification(String username, String initialCode) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(initialCode, null, null);
     var bearerToken = keycloakClient.getBearerToken();
-    var requestUrl = identityClientConfig.getOtpUrl(ENDPOINT_OTP_FINISH_EMAIL, username);
+    var requestUrl = getOtpUrl(ENDPOINT_OTP_FINISH_EMAIL, username);
 
     try {
       var response =
@@ -252,6 +252,10 @@ public class KeycloakService implements IdentityClient {
     } catch (HttpClientErrorException exception) {
       return keycloakMapper.mapOf(exception);
     }
+  }
+
+  private String getOtpUrl(String endpoint, String username) {
+    return identityClientConfig.getOtpUrl(endpoint, usernameTranscoder.decodeUsername(username));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -255,7 +255,9 @@ public class KeycloakService implements IdentityClient {
   }
 
   private String getOtpUrl(String endpoint, String username) {
-    return identityClientConfig.getOtpUrl(endpoint, usernameTranscoder.decodeUsername(username));
+    var decodedUsername = usernameTranscoder.decodeUsername(username);
+    return identityClientConfig.getOtpUrl(
+        endpoint, java.util.regex.Matcher.quoteReplacement(decodedUsername));
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -335,6 +335,29 @@ public class KeycloakServiceTest {
     assertDoesNotThrow(() -> keycloakService.deleteOtpCredential(USERNAME));
   }
 
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void otpRequests_ShouldUseDecodedKeycloakUsername() {
+    var encodedUsername = "enc.ORSXG5BAOVZWK4Q.";
+    when(usernameTranscoder.decodeUsername(encodedUsername)).thenReturn(USERNAME);
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    when(keycloakClient.get(anyString(), any(), any()))
+        .thenReturn(new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK));
+
+    keycloakService.getOtpCredential(encodedUsername);
+    keycloakService.setUpOtpCredential(encodedUsername, "123456", "secret");
+    keycloakService.deleteOtpCredential(encodedUsername);
+    keycloakService.initiateEmailVerification(encodedUsername, "mail@example.com");
+    keycloakService.finishEmailVerification(encodedUsername, "123456");
+
+    verify(identityClientConfig).getOtpUrl("/fetch-otp-setup-info/{username}", USERNAME);
+    verify(identityClientConfig).getOtpUrl("/setup-otp/{username}", USERNAME);
+    verify(identityClientConfig).getOtpUrl("/delete-otp/{username}", USERNAME);
+    verify(identityClientConfig).getOtpUrl("/send-verification-mail/{username}", USERNAME);
+    verify(identityClientConfig).getOtpUrl("/setup-otp-mail/{username}", USERNAME);
+    verify(usernameTranscoder, times(5)).decodeUsername(encodedUsername);
+  }
+
   private void givenAKeycloakLoginUrl() {
     when(identityClientConfig.getOpenIdConnectUrl(anyString()))
         .thenReturn(

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -336,13 +336,12 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public void otpRequests_ShouldUseDecodedKeycloakUsername() {
     var encodedUsername = "enc.ORSXG5BAOVZWK4Q.";
     when(usernameTranscoder.decodeUsername(encodedUsername)).thenReturn(USERNAME);
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
-    when(keycloakClient.get(anyString(), any(), any()))
-        .thenReturn(new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK));
+    when(keycloakClient.get(anyString(), anyString(), eq(OtpInfoDTO.class)))
+        .thenReturn(new ResponseEntity<>(OTP_INFO_DTO, HttpStatus.OK));
 
     keycloakService.getOtpCredential(encodedUsername);
     keycloakService.setUpOtpCredential(encodedUsername, "123456", "secret");

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -37,6 +37,7 @@ import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
@@ -339,6 +340,7 @@ public class KeycloakServiceTest {
   public void otpRequests_ShouldUseDecodedKeycloakUsername() {
     var encodedUsername = "enc.ORSXG5BAOVZWK4Q.";
     when(usernameTranscoder.decodeUsername(encodedUsername)).thenReturn(USERNAME);
+    when(identityClientConfig.getOtpUrl(anyString(), eq(USERNAME))).thenReturn("otp-url");
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
     when(keycloakClient.get(anyString(), anyString(), eq(OtpInfoDTO.class)))
         .thenReturn(new ResponseEntity<>(OTP_INFO_DTO, HttpStatus.OK));


### PR DESCRIPTION
## What changed

- Decode transcoded `enc...` usernames before building Keycloak OTP SPI URLs.
- Apply the same normalization to OTP lookup, app setup, deletion, email verification, and email confirmation.
- Add regression coverage proving every OTP request uses the real Keycloak username.

## Why

Consultant usernames are stored in transcoded form, but UserService forwarded that value directly to Keycloak. The OTP SPI consequently returned `400 Bad Request: username not found`.

## Impact

Once the OTP Helm flags and URL are deployed, consultants can load and manage 2FA without manual database or Keycloak patches.

## Validation

- `./mvnw -Dtest=KeycloakServiceTest test` — 91 tests passed
- `./mvnw spotless:check`
