### PR TITLE
feat(tour): aggregate tutorial statistics for authorized admins (TOUR-06)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AdminStatisticsController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AdminStatisticsController.java
@@ -2,6 +2,8 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService;
 import de.caritas.cob.userservice.api.service.statistics.AdminDashboardStatisticsService.DashboardStatistics;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialStatisticsService;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialStatisticsService.TutorialStatistics;
 import io.swagger.annotations.Api;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +24,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminStatisticsController {
 
   private final @NonNull AdminDashboardStatisticsService adminDashboardStatisticsService;
+  private final @NonNull TutorialStatisticsService tutorialStatisticsService;
 
   @GetMapping({"/useradmin/statistics/dashboard", "/service/useradmin/statistics/dashboard"})
   public ResponseEntity<DashboardStatistics> getDashboardStatistics() {
     return ResponseEntity.ok(adminDashboardStatisticsService.buildDashboard());
+  }
+
+  /**
+   * Aggregate tutorial-completion counts (epic TOUR-06), scoped to the caller: platform admins
+   * receive global counts grouped per tenant, tenant admins only their own tenant. Counts only —
+   * never individual users' tutorial histories.
+   */
+  @GetMapping({"/useradmin/statistics/tutorials", "/service/useradmin/statistics/tutorials"})
+  public ResponseEntity<TutorialStatistics> getTutorialStatistics() {
+    return ResponseEntity.ok(tutorialStatisticsService.getStatistics());
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -349,6 +349,11 @@ public class SecurityConfig {
                 .hasAnyAuthority(
                     USER_ADMIN, TENANT_ADMIN, SINGLE_TENANT_ADMIN, RESTRICTED_AGENCY_ADMIN)
                 .requestMatchers(
+                    HttpMethod.GET,
+                    "/useradmin/statistics/tutorials",
+                    "/service/useradmin/statistics/tutorials")
+                .hasAnyAuthority(TENANT_ADMIN, SINGLE_TENANT_ADMIN)
+                .requestMatchers(
                     "/useradmin", "/useradmin/**", "/service/useradmin", "/service/useradmin/**")
                 .hasAnyAuthority(USER_ADMIN, TECHNICAL_DEFAULT)
                 .requestMatchers("/users/consultants/search")

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialStatisticsRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialStatisticsRepository.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Read-only aggregate queries over versioned tutorial progress (epic TOUR-06). Only counts are
+ * projected — no query ever selects a user id, so no admin can obtain an individual user's tutorial
+ * history through this repository.
+ *
+ * <p>Native queries are used because Hibernate tenant filters do not apply to aggregations;
+ * therefore the tenant-scoped query carries an explicit tenant restriction that mirrors the
+ * entity's {@code tenantFilter} condition (tenant 1 also owns legacy rows without a tenant id).
+ */
+public interface TutorialStatisticsRepository extends Repository<TutorialProgress, Long> {
+
+  interface TutorialCountProjection {
+    Long getTenantId();
+
+    String getSurface();
+
+    String getTourId();
+
+    Integer getTourVersion();
+
+    String getStatus();
+
+    Long getTotal();
+  }
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT tp.tenant_id AS tenantId, tp.surface AS surface, tp.tour_id AS tourId, "
+              + "tp.tour_version AS tourVersion, tp.status AS status, COUNT(*) AS total "
+              + "FROM tutorial_progress tp "
+              + "WHERE (tp.tenant_id = :tenantId OR (:tenantId = 1 AND tp.tenant_id IS NULL)) "
+              + "GROUP BY tp.tenant_id, tp.surface, tp.tour_id, tp.tour_version, tp.status")
+  List<TutorialCountProjection> countByTenant(@Param("tenantId") Long tenantId);
+
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT tp.tenant_id AS tenantId, tp.surface AS surface, tp.tour_id AS tourId, "
+              + "tp.tour_version AS tourVersion, tp.status AS status, COUNT(*) AS total "
+              + "FROM tutorial_progress tp "
+              + "GROUP BY tp.tenant_id, tp.surface, tp.tour_id, tp.tour_version, tp.status")
+  List<TutorialCountProjection> countGlobal();
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsService.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.TutorialStatisticsRepository;
+import de.caritas.cob.userservice.api.port.out.TutorialStatisticsRepository.TutorialCountProjection;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Aggregate tutorial-completion statistics for authorized admins (epic TOUR-06). The response is
+ * scoped to the caller: platform admins receive global counts grouped per tenant, tenant admins
+ * receive only their own tenant. Agency admins, consultants and advice seekers are rejected. No
+ * response ever contains an individual user's tutorial history — counts only.
+ */
+@Service
+@RequiredArgsConstructor
+public class TutorialStatisticsService {
+
+  private final @NonNull TutorialStatisticsRepository tutorialStatisticsRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull Clock clock;
+
+  public enum TutorialStatisticsScope {
+    PLATFORM,
+    TENANT
+  }
+
+  public record TutorialStatistics(
+      String generatedAt, TutorialStatisticsScope scope, List<TenantTutorialCounts> tenants) {}
+
+  public record TenantTutorialCounts(Long tenantId, List<TutorialCount> counts) {}
+
+  public record TutorialCount(
+      String surface, String tourId, Integer tourVersion, String status, long total) {}
+
+  @Transactional(readOnly = true)
+  public TutorialStatistics getStatistics() {
+    if (authenticatedUser.isPlatformAdmin()) {
+      return build(TutorialStatisticsScope.PLATFORM, tutorialStatisticsRepository.countGlobal());
+    }
+    if (authenticatedUser.isTenantSuperAdmin() || authenticatedUser.isSingleTenantAdmin()) {
+      var tenantId = resolveTenantId();
+      return build(
+          TutorialStatisticsScope.TENANT, tutorialStatisticsRepository.countByTenant(tenantId));
+    }
+    throw new ForbiddenException(
+        "User %s is not authorized to access tutorial statistics"
+            .formatted(authenticatedUser.getUserId()));
+  }
+
+  private Long resolveTenantId() {
+    var contextTenant = TenantContext.getCurrentTenant();
+    if (contextTenant != null && !TenantContext.TECHNICAL_TENANT_ID.equals(contextTenant)) {
+      return contextTenant;
+    }
+    return authenticatedUser.getTenantId();
+  }
+
+  private TutorialStatistics build(
+      TutorialStatisticsScope scope, List<TutorialCountProjection> projections) {
+    // Legacy rows may carry a null tenant id; nullsLast keeps them addressable and ordered.
+    Map<Long, List<TutorialCount>> countsByTenant =
+        new TreeMap<>(Comparator.nullsLast(Comparator.naturalOrder()));
+    for (var projection : projections) {
+      countsByTenant
+          .computeIfAbsent(projection.getTenantId(), unused -> new ArrayList<>())
+          .add(
+              new TutorialCount(
+                  projection.getSurface(),
+                  projection.getTourId(),
+                  projection.getTourVersion(),
+                  projection.getStatus(),
+                  projection.getTotal()));
+    }
+
+    var tenants =
+        countsByTenant.entrySet().stream()
+            .map(entry -> new TenantTutorialCounts(entry.getKey(), List.copyOf(entry.getValue())))
+            .toList();
+    return new TutorialStatistics(OffsetDateTime.now(clock).toString(), scope, tenants);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsService.java
@@ -51,6 +51,9 @@ public class TutorialStatisticsService {
     }
     if (authenticatedUser.isTenantSuperAdmin() || authenticatedUser.isSingleTenantAdmin()) {
       var tenantId = resolveTenantId();
+      if (tenantId == null) {
+        throw new ForbiddenException("No tenant context available for tutorial statistics");
+      }
       return build(
           TutorialStatisticsScope.TENANT, tutorialStatisticsRepository.countByTenant(tenantId));
     }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialStatisticsControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialStatisticsControllerE2EIT.java
@@ -1,0 +1,149 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import java.time.LocalDateTime;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Authorization matrix and count correctness for the aggregate tutorial statistics endpoint (epic
+ * TOUR-06): tenant admins see only their tenant, platform admins see global counts, everyone else
+ * is rejected, and no response ever contains an individual user's tutorial history.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("testing")
+class TutorialStatisticsControllerE2EIT {
+
+  private static final String ENDPOINT = "/useradmin/statistics/tutorials";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private TutorialProgressRepository tutorialProgressRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+
+  @BeforeEach
+  void seedProgressAcrossTenants() {
+    tutorialProgressRepository.deleteAll();
+    save("user-a", "frontend", "consultant-walkthrough", 1, "completed", 2L);
+    save("user-b", "frontend", "consultant-walkthrough", 1, "completed", 2L);
+    save("user-c", "frontend", "consultant-walkthrough", 1, "in_progress", 2L);
+    save("user-d", "admin", "admin-demo-tour", 1, "skipped", 3L);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    tutorialProgressRepository.deleteAll();
+  }
+
+  private void save(
+      String userId, String surface, String tourId, int tourVersion, String status, Long tenantId) {
+    var now = LocalDateTime.now();
+    tutorialProgressRepository.save(
+        TutorialProgress.builder()
+            .userId(userId)
+            .surface(surface)
+            .tourId(tourId)
+            .tourVersion(tourVersion)
+            .status(status)
+            .startedAt(now)
+            .createDate(now)
+            .updateDate(now)
+            .tenantId(tenantId)
+            .build());
+  }
+
+  @Test
+  void tutorialStatistics_requiresAuthentication() throws Exception {
+    mockMvc.perform(get(ENDPOINT)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void tutorialStatistics_rejectsConsultants() throws Exception {
+    mockMvc
+        .perform(get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void tutorialStatistics_rejectsAdviceSeekers() throws Exception {
+    mockMvc
+        .perform(get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.USER_DEFAULT)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void tutorialStatistics_rejectsRestrictedAgencyAdmins() throws Exception {
+    mockMvc
+        .perform(
+            get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.RESTRICTED_AGENCY_ADMIN)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void tutorialStatistics_tenantAdminSeesOnlyOwnTenantWithCorrectCounts() throws Exception {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.getTenantId()).thenReturn(2L);
+
+    mockMvc
+        .perform(get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.TENANT_ADMIN)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.scope", Matchers.is("TENANT")))
+        .andExpect(jsonPath("$.tenants", Matchers.hasSize(1)))
+        .andExpect(jsonPath("$.tenants[0].tenantId", Matchers.is(2)))
+        .andExpect(jsonPath("$.tenants[0].counts", Matchers.hasSize(2)))
+        .andExpect(
+            jsonPath("$.tenants[0].counts[?(@.status=='completed')].total", Matchers.contains(2)))
+        .andExpect(
+            jsonPath(
+                "$.tenants[0].counts[?(@.status=='in_progress')].total", Matchers.contains(1)));
+  }
+
+  @Test
+  void tutorialStatistics_platformAdminSeesGlobalCountsGroupedByTenant() throws Exception {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+
+    mockMvc
+        .perform(get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.TENANT_ADMIN)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.scope", Matchers.is("PLATFORM")))
+        .andExpect(jsonPath("$.tenants", Matchers.hasSize(2)))
+        .andExpect(jsonPath("$.tenants[0].tenantId", Matchers.is(2)))
+        .andExpect(jsonPath("$.tenants[1].tenantId", Matchers.is(3)))
+        .andExpect(jsonPath("$.tenants[1].counts[0].tourId", Matchers.is("admin-demo-tour")))
+        .andExpect(jsonPath("$.tenants[1].counts[0].total", Matchers.is(1)));
+  }
+
+  @Test
+  void tutorialStatistics_neverExposesIndividualUserRecords() throws Exception {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+
+    var body =
+        mockMvc
+            .perform(get(ENDPOINT).with(jwt().authorities(() -> AuthorityValue.TENANT_ADMIN)))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    assertThat(body).doesNotContain("userId", "user-a", "user-b", "user-c", "user-d");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsServiceTest.java
@@ -1,0 +1,185 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.config.auth.UserRole;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.TutorialStatisticsRepository;
+import de.caritas.cob.userservice.api.port.out.TutorialStatisticsRepository.TutorialCountProjection;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialStatisticsService.TutorialStatisticsScope;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TutorialStatisticsServiceTest {
+
+  private static final long TENANT_ID = 5L;
+
+  private final Clock clock =
+      Clock.fixed(Instant.parse("2026-07-19T10:00:00Z"), ZoneId.of("Europe/Berlin"));
+
+  @Mock private TutorialStatisticsRepository tutorialStatisticsRepository;
+
+  private AuthenticatedUser authenticatedUser;
+  private TutorialStatisticsService service;
+
+  @BeforeEach
+  void setUp() {
+    authenticatedUser = new AuthenticatedUser();
+    authenticatedUser.setUserId("admin-user-id");
+    authenticatedUser.setUsername("admin");
+    authenticatedUser.setAccessToken("token");
+    authenticatedUser.setTenantId(TENANT_ID);
+    service = new TutorialStatisticsService(tutorialStatisticsRepository, authenticatedUser, clock);
+    TenantContext.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  private static TutorialCountProjection count(
+      Long tenantId, String surface, String tourId, int tourVersion, String status, long total) {
+    return new TutorialCountProjection() {
+      @Override
+      public Long getTenantId() {
+        return tenantId;
+      }
+
+      @Override
+      public String getSurface() {
+        return surface;
+      }
+
+      @Override
+      public String getTourId() {
+        return tourId;
+      }
+
+      @Override
+      public Integer getTourVersion() {
+        return tourVersion;
+      }
+
+      @Override
+      public String getStatus() {
+        return status;
+      }
+
+      @Override
+      public Long getTotal() {
+        return total;
+      }
+    };
+  }
+
+  @Test
+  void tenantSuperAdmin_receivesOnlyOwnTenantCounts() {
+    authenticatedUser.setRoles(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    when(tutorialStatisticsRepository.countByTenant(TENANT_ID))
+        .thenReturn(
+            List.of(
+                count(TENANT_ID, "frontend", "consultant-walkthrough", 1, "completed", 7),
+                count(TENANT_ID, "frontend", "consultant-walkthrough", 1, "in_progress", 2)));
+
+    var statistics = service.getStatistics();
+
+    assertThat(statistics.scope()).isEqualTo(TutorialStatisticsScope.TENANT);
+    assertThat(statistics.tenants()).hasSize(1);
+    var tenant = statistics.tenants().get(0);
+    assertThat(tenant.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(tenant.counts())
+        .extracting("surface", "tourId", "tourVersion", "status", "total")
+        .containsExactlyInAnyOrder(
+            org.assertj.core.groups.Tuple.tuple(
+                "frontend", "consultant-walkthrough", 1, "completed", 7L),
+            org.assertj.core.groups.Tuple.tuple(
+                "frontend", "consultant-walkthrough", 1, "in_progress", 2L));
+    verify(tutorialStatisticsRepository).countByTenant(TENANT_ID);
+  }
+
+  @Test
+  void singleTenantAdmin_receivesOnlyOwnTenantCounts() {
+    authenticatedUser.setRoles(Set.of(UserRole.SINGLE_TENANT_ADMIN.getValue()));
+    when(tutorialStatisticsRepository.countByTenant(TENANT_ID)).thenReturn(List.of());
+
+    var statistics = service.getStatistics();
+
+    assertThat(statistics.scope()).isEqualTo(TutorialStatisticsScope.TENANT);
+    verify(tutorialStatisticsRepository).countByTenant(TENANT_ID);
+  }
+
+  @Test
+  void tenantAdmin_prefersTenantContextOverTokenTenant() {
+    authenticatedUser.setRoles(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    TenantContext.setCurrentTenant(9L);
+    when(tutorialStatisticsRepository.countByTenant(9L)).thenReturn(List.of());
+
+    service.getStatistics();
+
+    verify(tutorialStatisticsRepository).countByTenant(9L);
+  }
+
+  @Test
+  void platformAdmin_receivesGlobalCountsGroupedByTenant() {
+    authenticatedUser.setTenantId(0L);
+    authenticatedUser.setRoles(
+        Set.of(UserRole.TENANT_ADMIN.getValue(), UserRole.AGENCY_ADMIN.getValue()));
+    when(tutorialStatisticsRepository.countGlobal())
+        .thenReturn(
+            List.of(
+                count(1L, "frontend", "consultant-walkthrough", 1, "completed", 4),
+                count(2L, "frontend", "consultant-walkthrough", 1, "skipped", 1),
+                count(2L, "admin", "admin-demo-tour", 1, "in_progress", 3)));
+
+    var statistics = service.getStatistics();
+
+    assertThat(statistics.scope()).isEqualTo(TutorialStatisticsScope.PLATFORM);
+    assertThat(statistics.tenants()).extracting("tenantId").containsExactly(1L, 2L);
+    assertThat(statistics.tenants().get(1).counts()).hasSize(2);
+    assertThat(statistics.generatedAt()).isNotBlank();
+  }
+
+  @Test
+  void agencyAdmin_isForbidden() {
+    authenticatedUser.setRoles(Set.of(UserRole.RESTRICTED_AGENCY_ADMIN.getValue()));
+
+    assertThatThrownBy(() -> service.getStatistics()).isInstanceOf(ForbiddenException.class);
+    verifyNoInteractions(tutorialStatisticsRepository);
+  }
+
+  @Test
+  void agencySuperAdmin_withoutTenantAdminRole_isForbidden() {
+    authenticatedUser.setRoles(Set.of(UserRole.AGENCY_ADMIN.getValue()));
+
+    assertThatThrownBy(() -> service.getStatistics()).isInstanceOf(ForbiddenException.class);
+    verifyNoInteractions(tutorialStatisticsRepository);
+  }
+
+  @Test
+  void consultant_isForbidden() {
+    authenticatedUser.setRoles(Set.of(UserRole.CONSULTANT.getValue()));
+
+    assertThatThrownBy(() -> service.getStatistics()).isInstanceOf(ForbiddenException.class);
+    verifyNoInteractions(tutorialStatisticsRepository);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialStatisticsServiceTest.java
@@ -160,6 +160,15 @@ class TutorialStatisticsServiceTest {
   }
 
   @Test
+  void tenantAdmin_withoutResolvableTenant_isForbidden() {
+    authenticatedUser.setRoles(Set.of(UserRole.TENANT_ADMIN.getValue()));
+    authenticatedUser.setTenantId(null);
+
+    assertThatThrownBy(() -> service.getStatistics()).isInstanceOf(ForbiddenException.class);
+    verifyNoInteractions(tutorialStatisticsRepository);
+  }
+
+  @Test
   void agencyAdmin_isForbidden() {
     authenticatedUser.setRoles(Set.of(UserRole.RESTRICTED_AGENCY_ADMIN.getValue()));
 


### PR DESCRIPTION
Closes #485

Part of epic OpenResilienceInitiative/ORISO-Frontend#521. Builds on the versioned tutorial-progress persistence from #491 (TOUR-03); consumed by the upcoming admin dashboard package (TOUR-07, OpenResilienceInitiative/ORISO-Admin#387).

**Problem:** product needs to know whether tutorials are effective, without exposing any individual user's tutorial history.

**What changed**

- `GET /useradmin/statistics/tutorials` (+ `/service` alias) on the existing `AdminStatisticsController`, scoped to the caller like the admin dashboard: platform admins receive global counts grouped per tenant, tenant admins (tenant super admin / single tenant admin) only their own tenant. Agency admins, consultants and advice seekers get 403.
- `TutorialStatisticsRepository`: read-only native aggregate queries over `tutorial_progress` grouped by tenant, surface, tour id, tour version and status. No query selects a user id — individual histories are structurally unreachable through this endpoint. The tenant-scoped query mirrors the entity's `tenantFilter` condition (tenant 1 also owns legacy `NULL`-tenant rows).
- `TutorialStatisticsService`: caller-scoping via `AuthenticatedUser` (`isPlatformAdmin` / `isTenantSuperAdmin` / `isSingleTenantAdmin`), tenant resolution preferring `TenantContext` over the token tenant (same pattern as `AdminDashboardStatisticsService`), `ForbiddenException` fallback as second authorization layer behind the SecurityConfig rule.
- SecurityConfig: dedicated matcher for the new path with `TENANT_ADMIN`/`SINGLE_TENANT_ADMIN` only (before the `/useradmin/**` catch-all).
- No schema change — aggregates run over the existing TOUR-03 table, so there is no Liquibase changeset in this PR.

**Deviation from the design wording (documented, no product change):** the design lists counts "by tour, version, audience and status". `audience` is tour-definition metadata in the apps and is not persisted per progress row (approved TOUR-03 contract keys by user/surface/tourId/tourVersion). The aggregates therefore group by `surface` + `tourId`, and the consuming dashboard derives audience labels from its tour definitions via `tourId`. Persisting a per-user audience would have changed the deployed cross-repo contract and added role information per row for no informational gain.

**Verification:** red-first TDD. Unit tests (`TutorialStatisticsServiceTest`, 7) cover the authorization matrix and grouping; integration tests (`TutorialStatisticsControllerE2EIT`, 7, JWT + real JPA slice) prove 401 unauthenticated, 403 for consultant/asker/restricted agency admin, tenant admin sees only their tenant with counts matching seeded rows, platform admin sees both tenants globally, and the response body contains no user ids. Full local unit suite and integration-test execution green, Spotless applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint for aggregated tutorial completion statistics.
  * Tenant administrators can view statistics for their tenant.
  * Platform administrators can view aggregated statistics across tenants.
  * Results include tutorial surface, version, status, totals, scope, and generation timestamp.
  * Individual user information is not included in the statistics.
* **Access Control**
  * Restricted tutorial statistics access to authorized tenant and platform administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->