### PR TITLE
feat(support): Global Support Admin identity — role, admin type, own listing, 2FA gate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportAdminController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportAdminController.java
@@ -1,0 +1,43 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.AdminSearchResultDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.AdminDtoMapper;
+import de.caritas.cob.userservice.api.admin.service.admin.SupportAdminUserService;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Global-Support-Admin listing (ADR-018). Response shape matches the other admin searches so the
+ * Admin panel's shared table plumbing parses it unchanged.
+ */
+@RestController
+@RequestMapping("/useradmin/supportadmins")
+@RequiredArgsConstructor
+public class SupportAdminController {
+
+  private final @NonNull SupportAdminUserService supportAdminUserService;
+  private final @NonNull AdminDtoMapper adminDtoMapper;
+
+  @GetMapping("/search")
+  public ResponseEntity<AdminSearchResultDTO> searchSupportAdmins(
+      @RequestParam(defaultValue = "*") String query,
+      @RequestParam(defaultValue = "1") Integer page,
+      @RequestParam(defaultValue = "20") Integer perPage,
+      @RequestParam(defaultValue = "FIRSTNAME") String field,
+      @RequestParam(defaultValue = "ASC") String order) {
+    var decodedInfix = URLDecoder.decode(query, StandardCharsets.UTF_8).trim();
+    var resultMap =
+        supportAdminUserService.findSupportAdminsByInfix(
+            decodedInfix, PageRequest.of(page - 1, perPage));
+    return ResponseEntity.ok(
+        adminDtoMapper.adminSearchResultOf(resultMap, query, page, perPage, field, order));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportRoomController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportRoomController.java
@@ -1,0 +1,38 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.support.SupportRoomService;
+import de.caritas.cob.userservice.api.service.support.SupportRoomService.SupportRoomItem;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Temporary Support Access rooms (ADR-018 §2). Listing is always scoped to the caller; only the
+ * room's Berater*in may terminate early — enforcement lives in {@link SupportRoomService}.
+ */
+@RestController
+@RequestMapping("/users/support-rooms")
+@RequiredArgsConstructor
+public class SupportRoomController {
+
+  private final @NonNull SupportRoomService supportRoomService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  @GetMapping("/active")
+  public ResponseEntity<List<SupportRoomItem>> active() {
+    return ResponseEntity.ok(supportRoomService.activeFor(authenticatedUser));
+  }
+
+  @PostMapping("/{roomId}/terminate")
+  public ResponseEntity<Void> terminate(@PathVariable String roomId) {
+    supportRoomService.terminate(authenticatedUser, roomId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapper.java
@@ -188,6 +188,8 @@ public class AdminDtoMapper implements DtoMapperUtils {
         return "Tenant Admin";
       case AGENCY:
         return "Agency Admin";
+      case SUPPORT:
+        return "Support Admin";
       default:
         return null;
     }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/SupportAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/SupportAdminUserService.java
@@ -1,0 +1,51 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import com.google.common.collect.Lists;
+import de.caritas.cob.userservice.api.UserServiceMapper;
+import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Admin.AdminBase;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * Listing of Global Support Admins (ADR-018): an additive support identity with its OWN table —
+ * never mixed into the tenant- or agency-admin listings. Mirrors the tenant-admin search shape so
+ * the Admin panel parses all admin tables identically.
+ */
+@Service
+@RequiredArgsConstructor
+public class SupportAdminUserService {
+
+  private final @NonNull RetrieveAdminService retrieveAdminService;
+  private final @NonNull UserServiceMapper userServiceMapper;
+  private final @NonNull ConsultantRepository consultantRepository;
+
+  public Map<String, Object> findSupportAdminsByInfix(String infix, PageRequest pageRequest) {
+    Page<AdminBase> adminsPage =
+        retrieveAdminService.findAllByInfix(infix, Admin.AdminType.SUPPORT, pageRequest);
+    var adminIds = adminsPage.stream().map(AdminBase::getId).collect(Collectors.toSet());
+    var fullAdmins = retrieveAdminService.findAllById(adminIds);
+
+    Set<String> idsWithConsultantIdentity =
+        adminIds.isEmpty()
+            ? Collections.emptySet()
+            : consultantRepository.findActiveIdsByIdIn(adminIds);
+
+    return userServiceMapper.mapOfAdmin(
+        adminsPage,
+        fullAdmins,
+        Lists.newArrayList(),
+        Lists.newArrayList(),
+        Collections.emptyMap(),
+        idsWithConsultantIdentity);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/Authority.java
@@ -57,7 +57,9 @@ public enum Authority {
   RESTRICTED_AGENCY_ADMIN(
       UserRole.RESTRICTED_AGENCY_ADMIN, singletonList(AuthorityValue.RESTRICTED_AGENCY_ADMIN)),
   SUPERVISOR_CONSULTANT(
-      UserRole.SUPERVISOR_CONSULTANT, List.of(CONSULTANT_DEFAULT, VIEW_AGENCY_CONSULTANTS));
+      UserRole.SUPERVISOR_CONSULTANT, List.of(CONSULTANT_DEFAULT, VIEW_AGENCY_CONSULTANTS)),
+  GLOBAL_SUPPORT_ADMIN(
+      UserRole.GLOBAL_SUPPORT_ADMIN, singletonList(AuthorityValue.GLOBAL_SUPPORT_ADMIN));
 
   private final UserRole userRole;
   private final List<String> grantedAuthorities;
@@ -97,5 +99,6 @@ public enum Authority {
     public static final String SINGLE_TENANT_ADMIN = PREFIX + "SINGLE_TENANT_ADMIN";
     public static final String TENANT_ADMIN = PREFIX + "TENANT_ADMIN";
     public static final String RESTRICTED_AGENCY_ADMIN = PREFIX + "RESTRICTED_AGENCY_ADMIN";
+    public static final String GLOBAL_SUPPORT_ADMIN = PREFIX + "GLOBAL_SUPPORT_ADMIN";
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -185,6 +185,8 @@ public class SecurityConfig {
                 // per-purpose role pairs + fresh-credential checks are enforced in the service.
                 .requestMatchers("/users/handshakes", "/users/handshakes/**")
                 .authenticated()
+                .requestMatchers("/users/support-rooms", "/users/support-rooms/**")
+                .authenticated()
                 .requestMatchers("/users/tutorials/progress", "/users/tutorials/progress/**")
                 .hasAnyAuthority(
                     USER_DEFAULT,

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -298,6 +298,8 @@ public class SecurityConfig {
                     "/users/chat/{chatId:[0-9]+}/update",
                     "/users/{chatUserId:[0-9A-Za-z]+}/chat/{chatId:[0-9]+}/ban")
                 .hasAuthority(UPDATE_CHAT)
+                .requestMatchers(HttpMethod.GET, "/useradmin/supportadmins/search")
+                .hasAnyAuthority(USER_ADMIN, GLOBAL_SUPPORT_ADMIN)
                 .requestMatchers(HttpMethod.GET, "/useradmin/tenantadmins/search")
                 .hasAnyAuthority(TENANT_ADMIN, USER_ADMIN)
                 .requestMatchers("/useradmin/tenantadmins/", "/useradmin/tenantadmins/**")

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/UserRole.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/UserRole.java
@@ -21,7 +21,8 @@ public enum UserRole {
   TOPIC_ADMIN("topic-admin"),
   NOTIFICATIONS_TECHNICAL("notifications-technical"),
   RESTRICTED_CONSULTANT_ADMIN("restricted-consultant-admin"),
-  SUPERVISOR_CONSULTANT("supervisor-consultant");
+  SUPERVISOR_CONSULTANT("supervisor-consultant"),
+  GLOBAL_SUPPORT_ADMIN("global-support-admin");
 
   private final String value;
 

--- a/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Admin.java
@@ -57,7 +57,9 @@ public class Admin implements TenantAware {
   public enum AdminType {
     AGENCY,
     TENANT,
-    SUPER
+    SUPER,
+    /** Global Support Admin (ADR-018) — additive support identity, separate from Platform Admin. */
+    SUPPORT
   }
 
   @Id

--- a/src/main/java/de/caritas/cob/userservice/api/model/SupportRoom.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/SupportRoom.java
@@ -1,0 +1,72 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One temporary support session room (ADR-018 §2): a fresh encrypted 1:1 Matrix room between a
+ * Global Support Admin and a Berater*in, hard-limited to four hours and never reused — every
+ * further help cycle starts completely from scratch.
+ */
+@Entity
+@Table(name = "support_room")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupportRoom {
+
+  public enum SupportRoomStatus {
+    ACTIVE,
+    CLOSED
+  }
+
+  @Id
+  @Column(name = "id", length = 36, nullable = false)
+  private String id;
+
+  @Column(name = "handshake_id", length = 36, nullable = false)
+  private String handshakeId;
+
+  @Column(name = "matrix_room_id", length = 255, nullable = false)
+  private String matrixRoomId;
+
+  @Column(name = "support_admin_id", length = 36, nullable = false)
+  private String supportAdminId;
+
+  @Column(name = "support_admin_matrix_id", length = 255)
+  private String supportAdminMatrixId;
+
+  @Column(name = "consultant_id", length = 36, nullable = false)
+  private String consultantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", length = 16, nullable = false)
+  private SupportRoomStatus status;
+
+  @Column(name = "close_reason", length = 16)
+  private String closeReason;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @Column(name = "expiry_date", nullable = false)
+  private LocalDateTime expiryDate;
+
+  @Column(name = "closed_date")
+  private LocalDateTime closedDate;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SupportRoomRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SupportRoomRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.repository.CrudRepository;
 public interface SupportRoomRepository extends CrudRepository<SupportRoom, String> {
 
   List<SupportRoom> findAllByStatusAndExpiryDateBefore(
-      SupportRoomStatus status, LocalDateTime before);
+      SupportRoomStatus status,
+      LocalDateTime before,
+      org.springframework.data.domain.Pageable page);
 
   List<SupportRoom> findAllByStatusAndConsultantIdOrStatusAndSupportAdminId(
       SupportRoomStatus consultantStatus,

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SupportRoomRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SupportRoomRepository.java
@@ -1,0 +1,19 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.SupportRoom;
+import de.caritas.cob.userservice.api.model.SupportRoom.SupportRoomStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SupportRoomRepository extends CrudRepository<SupportRoom, String> {
+
+  List<SupportRoom> findAllByStatusAndExpiryDateBefore(
+      SupportRoomStatus status, LocalDateTime before);
+
+  List<SupportRoom> findAllByStatusAndConsultantIdOrStatusAndSupportAdminId(
+      SupportRoomStatus consultantStatus,
+      String consultantId,
+      SupportRoomStatus supportAdminStatus,
+      String supportAdminId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/handshake/HandshakeService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/handshake/HandshakeService.java
@@ -42,7 +42,11 @@ public class HandshakeService {
   private final @NonNull HandshakeSessionRepository handshakeSessionRepository;
   private final @NonNull HandshakeAuditEventRepository handshakeAuditEventRepository;
   private final @NonNull KeycloakAuthClient keycloakAuthClient;
+  private final @NonNull de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
   private final @NonNull List<HandshakeCompletionHandler> completionHandlers;
+
+  private final de.caritas.cob.userservice.api.helper.UsernameTranscoder usernameTranscoder =
+      new de.caritas.cob.userservice.api.helper.UsernameTranscoder();
 
   @Value("${handshake.ttl-seconds:300}")
   private long ttlSeconds;
@@ -64,6 +68,7 @@ public class HandshakeService {
     if (initiator.getUserId().equals(request.getCounterpartId())) {
       throw new BadRequestException("A handshake requires two distinct people");
     }
+    requireActiveSecondFactorForSupportAdmin(initiator);
     if (!keycloakAuthClient.verifyWithOtp(
         initiator.getUsername(), request.getPassword(), request.getOtp())) {
       throw new ForbiddenException(
@@ -164,6 +169,38 @@ public class HandshakeService {
   public void purgeOldAuditEvents() {
     handshakeAuditEventRepository.deleteAllByCreateDateBefore(
         LocalDateTime.now().minusMonths(auditRetentionMonths));
+  }
+
+  /**
+   * ADR-018: a Global Support Admin cannot become active without completed 2FA enrollment. Fails
+   * closed — an unreachable OTP state never lets a support admin through.
+   */
+  private void requireActiveSecondFactorForSupportAdmin(AuthenticatedUser initiator) {
+    var roles = initiator.getRoles();
+    if (roles == null
+        || !roles.contains(
+            de.caritas.cob.userservice.api.config.auth.UserRole.GLOBAL_SUPPORT_ADMIN.getValue())) {
+      return;
+    }
+    boolean otpActive;
+    try {
+      var otpInfo =
+          identityClient.getOtpCredential(
+              usernameTranscoder.encodeUsername(initiator.getUsername()));
+      otpActive = otpInfo != null && Boolean.TRUE.equals(otpInfo.getOtpSetup());
+    } catch (Exception e) {
+      log.warn(
+          "Could not read OTP state for support admin {}; failing closed",
+          initiator.getUserId(),
+          e);
+      otpActive = false;
+    }
+    if (!otpActive) {
+      throw new ForbiddenException(
+          String.format(
+              "Support admin %s must complete 2FA enrollment before initiating a handshake",
+              initiator.getUserId()));
+    }
   }
 
   private void expire(HandshakeSession session) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/support/SupportAccessCompletionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/support/SupportAccessCompletionHandler.java
@@ -1,0 +1,30 @@
+package de.caritas.cob.userservice.api.service.support;
+
+import de.caritas.cob.userservice.api.model.HandshakeSession;
+import de.caritas.cob.userservice.api.service.handshake.HandshakeCompletionHandler;
+import de.caritas.cob.userservice.api.service.handshake.HandshakePurpose;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * First real handshake consumer (ADR-018 §2): a confirmed SUPPORT_ACCESS handshake creates the
+ * fresh encrypted 1:1 support room. Runs inside the confirm transaction — if room creation fails,
+ * the handshake does not count as confirmed.
+ */
+@Component
+@RequiredArgsConstructor
+public class SupportAccessCompletionHandler implements HandshakeCompletionHandler {
+
+  private final @NonNull SupportRoomService supportRoomService;
+
+  @Override
+  public boolean supports(HandshakePurpose purpose) {
+    return purpose == HandshakePurpose.SUPPORT_ACCESS;
+  }
+
+  @Override
+  public void onConfirmed(HandshakeSession session) {
+    supportRoomService.createForConfirmedHandshake(session);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/support/SupportRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/support/SupportRoomService.java
@@ -1,0 +1,228 @@
+package de.caritas.cob.userservice.api.service.support;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.HandshakeAuditEvent;
+import de.caritas.cob.userservice.api.model.HandshakeSession;
+import de.caritas.cob.userservice.api.model.SupportRoom;
+import de.caritas.cob.userservice.api.model.SupportRoom.SupportRoomStatus;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.HandshakeAuditEventRepository;
+import de.caritas.cob.userservice.api.port.out.SupportRoomRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Temporary Support Access room lifecycle (ADR-018 §2). The room is created only after both
+ * handshake popups completed; it contains exactly the Support Admin and the Berater*in, carries
+ * zero pre-existing data, dies hard at four hours (or earlier on the Berater*in's termination) and
+ * is never reused — "komplett von vorne" on every cycle.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SupportRoomService {
+
+  private static final String EVENT_ROOM_CREATED = "SUPPORT_ROOM_CREATED";
+  private static final String EVENT_ROOM_CLOSED = "SUPPORT_ROOM_CLOSED";
+  private static final String REASON_EXPIRED = "EXPIRED";
+  private static final String REASON_TERMINATED = "TERMINATED";
+
+  private final @NonNull SupportRoomRepository supportRoomRepository;
+  private final @NonNull HandshakeAuditEventRepository handshakeAuditEventRepository;
+  private final @NonNull AdminRepository adminRepository;
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull MatrixConfig matrixConfig;
+
+  @Value("${support.room-ttl-hours:4}")
+  private long roomTtlHours;
+
+  /**
+   * Creates the fresh encrypted 1:1 room for a confirmed SUPPORT_ACCESS handshake. Any failure here
+   * propagates — the handshake confirmation rolls back and no half-created lease remains.
+   */
+  @Transactional
+  public SupportRoom createForConfirmedHandshake(HandshakeSession session) {
+    var supportAdmin =
+        adminRepository
+            .findById(session.getInitiatorId())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Support admin %s of handshake %s not found"
+                            .formatted(session.getInitiatorId(), session.getId())));
+    var consultant =
+        consultantRepository
+            .findByIdAndDeleteDateIsNull(session.getCounterpartId())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Consultant %s of handshake %s not found"
+                            .formatted(session.getCounterpartId(), session.getId())));
+    var consultantMatrixId = consultant.getMatrixUserId();
+    if (consultantMatrixId == null || consultantMatrixId.isBlank()) {
+      throw new IllegalStateException(
+          "Consultant %s has no Matrix identity; support room impossible"
+              .formatted(consultant.getId()));
+    }
+
+    try {
+      var supportAdminMatrixId = resolveSupportAdminMatrixId(supportAdmin);
+      var supportAdminToken = matrixSynapseService.loginAsUserAccessToken(supportAdminMatrixId);
+      // Confidentiality-neutral room name: no names, no topic, no category (ADR-012 §9 spirit).
+      var roomResponse = matrixSynapseService.createRoom("Support", null, supportAdminToken);
+      var roomId = roomResponse.getBody() != null ? roomResponse.getBody().getRoomId() : null;
+      if (roomId == null) {
+        throw new IllegalStateException(
+            "Matrix room creation returned no room id for handshake %s".formatted(session.getId()));
+      }
+      matrixSynapseService.inviteUserToRoom(roomId, consultantMatrixId, supportAdminToken);
+      var consultantToken = matrixSynapseService.loginAsUserAccessToken(consultantMatrixId);
+      matrixSynapseService.joinRoom(roomId, consultantToken);
+
+      var now = LocalDateTime.now();
+      var room =
+          SupportRoom.builder()
+              .id(UUID.randomUUID().toString())
+              .handshakeId(session.getId())
+              .matrixRoomId(roomId)
+              .supportAdminId(supportAdmin.getId())
+              .supportAdminMatrixId(supportAdminMatrixId)
+              .consultantId(consultant.getId())
+              .status(SupportRoomStatus.ACTIVE)
+              .createDate(now)
+              .expiryDate(now.plusHours(roomTtlHours))
+              .tenantId(session.getTenantId())
+              .build();
+      room = supportRoomRepository.save(room);
+      audit(room, EVENT_ROOM_CREATED, null);
+      return room;
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Support room creation failed for handshake %s".formatted(session.getId()), e);
+    }
+  }
+
+  /** The Berater*in ends the session early — same hard close as the four-hour cutoff. */
+  @Transactional
+  public void terminate(AuthenticatedUser caller, String roomId) {
+    var room =
+        supportRoomRepository
+            .findById(roomId)
+            .orElseThrow(
+                () -> new BadRequestException(String.format("Unknown support room %s", roomId)));
+    if (!room.getConsultantId().equals(caller.getUserId())) {
+      throw new ForbiddenException(
+          String.format("User %s may not terminate support room %s", caller.getUserId(), roomId));
+    }
+    if (room.getStatus() != SupportRoomStatus.ACTIVE) {
+      throw new BadRequestException(String.format("Support room %s is not active", roomId));
+    }
+    close(room, REASON_TERMINATED, caller.getUserId());
+  }
+
+  @Transactional(readOnly = true)
+  public List<SupportRoomItem> activeFor(AuthenticatedUser caller) {
+    return supportRoomRepository
+        .findAllByStatusAndConsultantIdOrStatusAndSupportAdminId(
+            SupportRoomStatus.ACTIVE,
+            caller.getUserId(),
+            SupportRoomStatus.ACTIVE,
+            caller.getUserId())
+        .stream()
+        .map(SupportRoomItem::of)
+        .toList();
+  }
+
+  /** ADR-018 hard cutoff: at four hours the lease ends even if the homeserver hiccups. */
+  @Scheduled(fixedDelayString = "${support.room-sweep-delay-ms:60000}")
+  @Transactional
+  public void sweepExpired() {
+    supportRoomRepository
+        .findAllByStatusAndExpiryDateBefore(SupportRoomStatus.ACTIVE, LocalDateTime.now())
+        .forEach(room -> close(room, REASON_EXPIRED, null));
+  }
+
+  private void close(SupportRoom room, String reason, String actorId) {
+    try {
+      var supportAdminToken =
+          matrixSynapseService.loginAsUserAccessToken(room.getSupportAdminMatrixId());
+      matrixSynapseService.leaveRoom(room.getMatrixRoomId(), supportAdminToken);
+    } catch (Exception e) {
+      log.error(
+          "Could not remove support admin from Matrix room {} while closing support room {} — closing the lease anyway",
+          room.getMatrixRoomId(),
+          room.getId(),
+          e);
+    }
+    room.setStatus(SupportRoomStatus.CLOSED);
+    room.setCloseReason(reason);
+    room.setClosedDate(LocalDateTime.now());
+    supportRoomRepository.save(room);
+    audit(room, EVENT_ROOM_CLOSED, actorId);
+  }
+
+  private String resolveSupportAdminMatrixId(Admin supportAdmin) throws Exception {
+    var localpart = supportAdmin.getUsername().toLowerCase();
+    if (!matrixSynapseService.userExists(localpart)) {
+      var response =
+          matrixSynapseService.createUser(
+              supportAdmin.getUsername(),
+              UUID.randomUUID().toString(),
+              supportAdmin.getFirstName() + " " + supportAdmin.getLastName());
+      if (response.getBody() != null && response.getBody().getUserId() != null) {
+        return response.getBody().getUserId();
+      }
+    }
+    return "@" + localpart + ":" + matrixConfig.getServerName();
+  }
+
+  private void audit(SupportRoom room, String event, String actorId) {
+    handshakeAuditEventRepository.save(
+        HandshakeAuditEvent.builder()
+            .handshakeId(room.getHandshakeId())
+            .purpose("SUPPORT_ACCESS")
+            .event(event)
+            .actorId(actorId)
+            .counterpartId(room.getConsultantId())
+            .tenantId(room.getTenantId())
+            .createDate(LocalDateTime.now())
+            .build());
+  }
+
+  @Getter
+  public static class SupportRoomItem {
+    private String id;
+    private String matrixRoomId;
+    private String supportAdminId;
+    private String consultantId;
+    private LocalDateTime expiryDate;
+
+    static SupportRoomItem of(SupportRoom room) {
+      var item = new SupportRoomItem();
+      item.id = room.getId();
+      item.matrixRoomId = room.getMatrixRoomId();
+      item.supportAdminId = room.getSupportAdminId();
+      item.consultantId = room.getConsultantId();
+      item.expiryDate = room.getExpiryDate();
+      return item;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/support/SupportRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/support/SupportRoomService.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.userservice.api.service.support;
 
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
@@ -52,6 +54,9 @@ public class SupportRoomService {
   @Value("${support.room-ttl-hours:4}")
   private long roomTtlHours;
 
+  @Value("${support.room-sweep-batch-size:200}")
+  private int sweepBatchSize;
+
   /**
    * Creates the fresh encrypted 1:1 room for a confirmed SUPPORT_ACCESS handshake. Any failure here
    * propagates — the handshake confirmation rolls back and no half-created lease remains.
@@ -95,7 +100,7 @@ public class SupportRoomService {
       var consultantToken = matrixSynapseService.loginAsUserAccessToken(consultantMatrixId);
       matrixSynapseService.joinRoom(roomId, consultantToken);
 
-      var now = LocalDateTime.now();
+      var now = nowInUtc();
       var room =
           SupportRoom.builder()
               .id(UUID.randomUUID().toString())
@@ -156,7 +161,10 @@ public class SupportRoomService {
   @Transactional
   public void sweepExpired() {
     supportRoomRepository
-        .findAllByStatusAndExpiryDateBefore(SupportRoomStatus.ACTIVE, LocalDateTime.now())
+        .findAllByStatusAndExpiryDateBefore(
+            SupportRoomStatus.ACTIVE,
+            nowInUtc(),
+            org.springframework.data.domain.PageRequest.of(0, sweepBatchSize))
         .forEach(room -> close(room, REASON_EXPIRED, null));
   }
 
@@ -174,7 +182,7 @@ public class SupportRoomService {
     }
     room.setStatus(SupportRoomStatus.CLOSED);
     room.setCloseReason(reason);
-    room.setClosedDate(LocalDateTime.now());
+    room.setClosedDate(nowInUtc());
     supportRoomRepository.save(room);
     audit(room, EVENT_ROOM_CLOSED, actorId);
   }
@@ -203,7 +211,7 @@ public class SupportRoomService {
             .actorId(actorId)
             .counterpartId(room.getConsultantId())
             .tenantId(room.getTenantId())
-            .createDate(LocalDateTime.now())
+            .createDate(nowInUtc())
             .build());
   }
 

--- a/src/main/resources/db/changelog/changeset/0073_support_room/0073_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0073_support_room/0073_changeSet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <changeSet id="0073-support-room" author="frank">
+    <sqlFile
+      path="db/changelog/changeset/0073_support_room/migrate.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sql>DROP TABLE IF EXISTS userservice.support_room;</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0073_support_room/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0073_support_room/migrate.sql
@@ -1,0 +1,21 @@
+-- ADR-018 Temporary Support Access: fresh encrypted 1:1 room per confirmed
+-- handshake, hard four-hour lease, never reused.
+CREATE TABLE userservice.support_room (
+  id VARCHAR(36) NOT NULL,
+  handshake_id VARCHAR(36) NOT NULL,
+  matrix_room_id VARCHAR(255) NOT NULL,
+  support_admin_id VARCHAR(36) NOT NULL,
+  support_admin_matrix_id VARCHAR(255) NULL,
+  consultant_id VARCHAR(36) NOT NULL,
+  status VARCHAR(16) NOT NULL,
+  close_reason VARCHAR(16) NULL,
+  create_date DATETIME NOT NULL,
+  expiry_date DATETIME NOT NULL,
+  closed_date DATETIME NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_support_room_status_expiry ON userservice.support_room (status, expiry_date);
+CREATE INDEX idx_support_room_consultant ON userservice.support_room (consultant_id, status);
+CREATE INDEX idx_support_room_support_admin ON userservice.support_room (support_admin_id, status);

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -118,6 +118,8 @@
     file="db/changelog/changeset/0071_tutorial_progress/0071_changeSet.xml" />
   <include
     file="db/changelog/changeset/0072_handshake/0072_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0073_support_room/0073_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportAdminControllerTest.java
@@ -1,0 +1,43 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.AdminSearchResultDTO;
+import de.caritas.cob.userservice.api.adapters.web.mapping.AdminDtoMapper;
+import de.caritas.cob.userservice.api.admin.service.admin.SupportAdminUserService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class SupportAdminControllerTest {
+
+  @Mock private SupportAdminUserService supportAdminUserService;
+  @Mock private AdminDtoMapper adminDtoMapper;
+
+  @InjectMocks private SupportAdminController controller;
+
+  @Test
+  void search_delegatesToTheSupportListingAndMapsLikeTheOtherAdminTables() {
+    // Business reason: the Admin panel reuses one response shape for all admin
+    // tables — the GSA table must parse identically to tenant-admins/search.
+    Map<String, Object> resultMap = Map.of("totalElements", 0);
+    var dto = mock(AdminSearchResultDTO.class);
+    when(supportAdminUserService.findSupportAdminsByInfix("*", PageRequest.of(0, 20)))
+        .thenReturn(resultMap);
+    when(adminDtoMapper.adminSearchResultOf(resultMap, "*", 1, 20, "FIRSTNAME", "ASC"))
+        .thenReturn(dto);
+
+    var response = controller.searchSupportAdmins("*", 1, 20, "FIRSTNAME", "ASC");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(dto);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportRoomControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SupportRoomControllerTest.java
@@ -1,0 +1,47 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.support.SupportRoomService;
+import de.caritas.cob.userservice.api.service.support.SupportRoomService.SupportRoomItem;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class SupportRoomControllerTest {
+
+  @Mock private SupportRoomService supportRoomService;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private SupportRoomController controller;
+
+  @Test
+  void active_returnsOnlyTheCallersRooms() {
+    // Business reason: support rooms are strictly participant-scoped — nobody can
+    // enumerate other people's support sessions.
+    var item = mock(SupportRoomItem.class);
+    when(supportRoomService.activeFor(authenticatedUser)).thenReturn(List.of(item));
+
+    var response = controller.active();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).containsExactly(item);
+  }
+
+  @Test
+  void terminate_delegatesWithTheAuthenticatedCaller() {
+    var response = controller.terminate("sr-1");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(supportRoomService).terminate(authenticatedUser, "sr-1");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/AdminDtoMapperTest.java
@@ -44,6 +44,22 @@ class AdminDtoMapperTest {
     assertThat(result.getEmbedded().get(0).getEmbedded().getAdminRights()).isTrue();
   }
 
+  @Test
+  void adminSearchResultOf_Should_MapSupportAdminRoleInOrg() {
+    // given
+    AdminDtoMapper adminDtoMapper = new AdminDtoMapper(tenantService);
+    ReflectionTestUtils.setField(adminDtoMapper, "multiTenancyEnabled", false);
+    var resultMap = resultMap();
+    ((Map<String, Object>) ((List<?>) resultMap.get("admins")).get(0))
+        .put("type", Admin.AdminType.SUPPORT);
+
+    // when
+    var result = adminDtoMapper.adminSearchResultOf(resultMap, "*", 1, 10, "FIRSTNAME", "ASC");
+
+    // then
+    assertThat(result.getEmbedded().get(0).getEmbedded().getRoleInOrg()).isEqualTo("Support Admin");
+  }
+
   private Map<String, Object> resultMap() {
     Map<String, Object> adminMap = new HashMap<>();
     adminMap.put("id", "admin-id");

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/SupportAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/SupportAdminUserServiceTest.java
@@ -1,0 +1,110 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.UserServiceMapper;
+import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
+import de.caritas.cob.userservice.api.model.Admin;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class SupportAdminUserServiceTest {
+
+  @InjectMocks private SupportAdminUserService supportAdminUserService;
+
+  @Mock private RetrieveAdminService retrieveAdminService;
+
+  @Mock private UserServiceMapper userServiceMapper;
+
+  @Mock private de.caritas.cob.userservice.api.port.out.ConsultantRepository consultantRepository;
+
+  private Admin.AdminBase adminBase(String id) {
+    return new Admin.AdminBase() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public String getFirstName() {
+        return "Sam";
+      }
+
+      @Override
+      public String getLastName() {
+        return "Support";
+      }
+
+      @Override
+      public String getEmail() {
+        return "sam@support.example";
+      }
+
+      @Override
+      public Long getTenantId() {
+        return 0L;
+      }
+
+      @Override
+      public Admin.AdminType getType() {
+        return Admin.AdminType.SUPPORT;
+      }
+
+      @Override
+      public LocalDateTime getUpdateDate() {
+        return null;
+      }
+    };
+  }
+
+  @Test
+  void findSupportAdminsByInfix_Should_QueryTheSupportTypeAndMapWithConsultantIdentities() {
+    // Business reason: Global Support Admins have their OWN table (ADR-018) — the
+    // listing must never mix in tenant or agency admins.
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Page<Admin.AdminBase> page = new PageImpl<>(List.of(adminBase("gsa-1")), pageRequest, 1);
+    Admin fullAdmin = new Admin();
+    fullAdmin.setId("gsa-1");
+    fullAdmin.setType(Admin.AdminType.SUPPORT);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.SUPPORT, pageRequest))
+        .thenReturn(page);
+    when(retrieveAdminService.findAllById(Set.of("gsa-1"))).thenReturn(List.of(fullAdmin));
+    when(consultantRepository.findActiveIdsByIdIn(Set.of("gsa-1"))).thenReturn(Set.of());
+    when(userServiceMapper.mapOfAdmin(any(), any(), any(), any(), any(), any()))
+        .thenReturn(Map.of("totalElements", 1));
+
+    var result = supportAdminUserService.findSupportAdminsByInfix("*", pageRequest);
+
+    assertThat(result).containsEntry("totalElements", 1);
+    verify(retrieveAdminService).findAllByInfix("*", Admin.AdminType.SUPPORT, pageRequest);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Set<String>> identityCaptor =
+        ArgumentCaptor.forClass((Class<Set<String>>) (Class<?>) Set.class);
+    verify(userServiceMapper)
+        .mapOfAdmin(
+            Mockito.eq(page),
+            Mockito.eq(List.of(fullAdmin)),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyMap(),
+            identityCaptor.capture());
+    assertThat(identityCaptor.getValue()).isEmpty();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/handshake/HandshakeServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/handshake/HandshakeServiceTest.java
@@ -38,6 +38,7 @@ class HandshakeServiceTest {
   @Mock private HandshakeAuditEventRepository handshakeAuditEventRepository;
   @Mock private KeycloakAuthClient keycloakAuthClient;
   @Mock private HandshakeCompletionHandler completionHandler;
+  @Mock private de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
 
   private HandshakeService handshakeService;
 
@@ -48,8 +49,12 @@ class HandshakeServiceTest {
             handshakeSessionRepository,
             handshakeAuditEventRepository,
             keycloakAuthClient,
+            identityClient,
             List.of(completionHandler));
     ReflectionTestUtils.setField(handshakeService, "ttlSeconds", 300L);
+    org.mockito.Mockito.lenient()
+        .when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new de.caritas.cob.userservice.api.model.OtpInfoDTO().otpSetup(true));
   }
 
   private AuthenticatedUser supportAdmin() {
@@ -117,6 +122,31 @@ class HandshakeServiceTest {
         .isInstanceOf(ForbiddenException.class);
 
     verify(keycloakAuthClient, never()).verifyWithOtp(anyString(), anyString(), anyString());
+    verify(handshakeSessionRepository, never()).save(any());
+  }
+
+  @Test
+  void initiate_Should_Forbid_When_SupportAdminHasNoActiveSecondFactor() {
+    // ADR-018: a Global Support Admin cannot become active without completed 2FA enrollment.
+    when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new de.caritas.cob.userservice.api.model.OtpInfoDTO().otpSetup(false));
+
+    assertThatThrownBy(() -> handshakeService.initiate(supportAdmin(), supportRequest()))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessageContaining("2FA");
+
+    verify(keycloakAuthClient, never()).verifyWithOtp(anyString(), anyString(), anyString());
+    verify(handshakeSessionRepository, never()).save(any());
+  }
+
+  @Test
+  void initiate_Should_Forbid_When_SupportAdminOtpStateIsUnavailable() {
+    // Fail closed: an unreachable OTP state never lets a support admin through.
+    when(identityClient.getOtpCredential(anyString())).thenThrow(new RuntimeException("SPI down"));
+
+    assertThatThrownBy(() -> handshakeService.initiate(supportAdmin(), supportRequest()))
+        .isInstanceOf(ForbiddenException.class);
+
     verify(handshakeSessionRepository, never()).save(any());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/support/SupportRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/support/SupportRoomServiceTest.java
@@ -1,0 +1,250 @@
+package de.caritas.cob.userservice.api.service.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.HandshakeSession;
+import de.caritas.cob.userservice.api.model.SupportRoom;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.HandshakeAuditEventRepository;
+import de.caritas.cob.userservice.api.port.out.SupportRoomRepository;
+import de.caritas.cob.userservice.api.service.handshake.HandshakePurpose;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SupportRoomServiceTest {
+
+  private static final String GSA_ID = "gsa-1";
+  private static final String CONSULTANT_ID = "consultant-1";
+  private static final String GSA_MXID = "@sam.support:caritas.local";
+  private static final String CONSULTANT_MXID = "@tina.consultant:caritas.local";
+  private static final String ROOM_ID = "!room:caritas.local";
+
+  @InjectMocks private SupportRoomService supportRoomService;
+
+  @Mock private SupportRoomRepository supportRoomRepository;
+  @Mock private HandshakeAuditEventRepository handshakeAuditEventRepository;
+  @Mock private AdminRepository adminRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private MatrixConfig matrixConfig;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(supportRoomService, "roomTtlHours", 4L);
+    lenient().when(matrixConfig.getServerName()).thenReturn("caritas.local");
+  }
+
+  private HandshakeSession confirmedSession() {
+    return HandshakeSession.builder()
+        .id("hs-1")
+        .purpose(HandshakePurpose.SUPPORT_ACCESS)
+        .initiatorId(GSA_ID)
+        .counterpartId(CONSULTANT_ID)
+        .status(HandshakeSession.HandshakeStatus.CONFIRMED)
+        .createDate(LocalDateTime.now())
+        .expiryDate(LocalDateTime.now().plusMinutes(5))
+        .tenantId(1L)
+        .build();
+  }
+
+  private Admin gsa() {
+    return Admin.builder()
+        .id(GSA_ID)
+        .username("sam.support")
+        .firstName("Sam")
+        .lastName("Support")
+        .email("sam@support.example")
+        .type(Admin.AdminType.SUPPORT)
+        .build();
+  }
+
+  private Consultant consultantWithMatrix() {
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    consultant.setMatrixUserId(CONSULTANT_MXID);
+    return consultant;
+  }
+
+  private void stubHappyMatrix() throws Exception {
+    when(matrixSynapseService.userExists("sam.support")).thenReturn(true);
+    when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID)).thenReturn("gsa-token");
+    when(matrixSynapseService.loginAsUserAccessToken(CONSULTANT_MXID))
+        .thenReturn("consultant-token");
+    var roomResponse = new MatrixCreateRoomResponseDTO();
+    roomResponse.setRoomId(ROOM_ID);
+    when(matrixSynapseService.createRoom(anyString(), any(), eq("gsa-token")))
+        .thenReturn(ResponseEntity.ok(roomResponse));
+    when(matrixSynapseService.joinRoom(ROOM_ID, "consultant-token")).thenReturn(true);
+  }
+
+  // --- creation on confirmed handshake ---
+
+  @Test
+  void createForConfirmedHandshake_Should_CreateEncryptedRoomWithBothMembersAndFourHourLease()
+      throws Exception {
+    when(adminRepository.findById(GSA_ID)).thenReturn(Optional.of(gsa()));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultantWithMatrix()));
+    stubHappyMatrix();
+    when(supportRoomRepository.save(any(SupportRoom.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var room = supportRoomService.createForConfirmedHandshake(confirmedSession());
+
+    verify(matrixSynapseService).inviteUserToRoom(ROOM_ID, CONSULTANT_MXID, "gsa-token");
+    verify(matrixSynapseService).joinRoom(ROOM_ID, "consultant-token");
+    assertThat(room.getMatrixRoomId()).isEqualTo(ROOM_ID);
+    assertThat(room.getStatus()).isEqualTo(SupportRoom.SupportRoomStatus.ACTIVE);
+    assertThat(room.getSupportAdminId()).isEqualTo(GSA_ID);
+    assertThat(room.getConsultantId()).isEqualTo(CONSULTANT_ID);
+    assertThat(room.getExpiryDate())
+        .isAfter(LocalDateTime.now().plusHours(3))
+        .isBefore(LocalDateTime.now().plusHours(5));
+    verify(handshakeAuditEventRepository).save(any());
+  }
+
+  @Test
+  void createForConfirmedHandshake_Should_Fail_When_ConsultantHasNoMatrixIdentity() {
+    when(adminRepository.findById(GSA_ID)).thenReturn(Optional.of(gsa()));
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultant));
+
+    assertThatThrownBy(() -> supportRoomService.createForConfirmedHandshake(confirmedSession()))
+        .isInstanceOf(IllegalStateException.class);
+
+    verify(supportRoomRepository, never()).save(any());
+  }
+
+  // --- termination ---
+
+  private SupportRoom activeRoom() {
+    return SupportRoom.builder()
+        .id("sr-1")
+        .handshakeId("hs-1")
+        .matrixRoomId(ROOM_ID)
+        .supportAdminId(GSA_ID)
+        .supportAdminMatrixId(GSA_MXID)
+        .consultantId(CONSULTANT_ID)
+        .status(SupportRoom.SupportRoomStatus.ACTIVE)
+        .createDate(LocalDateTime.now().minusHours(1))
+        .expiryDate(LocalDateTime.now().plusHours(3))
+        .build();
+  }
+
+  @Test
+  void terminate_Should_KickSupportAdminAndCloseRoom_When_CalledByTheRoomsConsultant() {
+    var room = activeRoom();
+    when(supportRoomRepository.findById("sr-1")).thenReturn(Optional.of(room));
+    when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID)).thenReturn("gsa-token");
+    when(matrixSynapseService.leaveRoom(ROOM_ID, "gsa-token")).thenReturn(true);
+    when(supportRoomRepository.save(any(SupportRoom.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    var consultant = new AuthenticatedUser();
+    consultant.setUserId(CONSULTANT_ID);
+
+    supportRoomService.terminate(consultant, "sr-1");
+
+    assertThat(room.getStatus()).isEqualTo(SupportRoom.SupportRoomStatus.CLOSED);
+    assertThat(room.getCloseReason()).isEqualTo("TERMINATED");
+    verify(matrixSynapseService).leaveRoom(ROOM_ID, "gsa-token");
+    verify(handshakeAuditEventRepository).save(any());
+  }
+
+  @Test
+  void terminate_Should_Forbid_When_CallerIsNotTheRoomsConsultant() {
+    when(supportRoomRepository.findById("sr-1")).thenReturn(Optional.of(activeRoom()));
+    var stranger = new AuthenticatedUser();
+    stranger.setUserId("someone-else");
+
+    assertThatThrownBy(() -> supportRoomService.terminate(stranger, "sr-1"))
+        .isInstanceOf(ForbiddenException.class);
+
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), anyString());
+  }
+
+  // --- hard four-hour cutoff ---
+
+  @Test
+  void sweepExpired_Should_KickAndCloseLapsedActiveRooms() {
+    var room = activeRoom();
+    room.setExpiryDate(LocalDateTime.now().minusMinutes(1));
+    when(supportRoomRepository.findAllByStatusAndExpiryDateBefore(
+            eq(SupportRoom.SupportRoomStatus.ACTIVE), any(LocalDateTime.class)))
+        .thenReturn(List.of(room));
+    when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID)).thenReturn("gsa-token");
+    when(matrixSynapseService.leaveRoom(ROOM_ID, "gsa-token")).thenReturn(true);
+    when(supportRoomRepository.save(any(SupportRoom.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    supportRoomService.sweepExpired();
+
+    assertThat(room.getStatus()).isEqualTo(SupportRoom.SupportRoomStatus.CLOSED);
+    assertThat(room.getCloseReason()).isEqualTo("EXPIRED");
+    verify(handshakeAuditEventRepository).save(any());
+  }
+
+  @Test
+  void sweepExpired_Should_CloseRoomEvenIfMatrixKickFails() {
+    // Fail-safe: the lease must end at 4h even when the homeserver hiccups.
+    var room = activeRoom();
+    room.setExpiryDate(LocalDateTime.now().minusMinutes(1));
+    when(supportRoomRepository.findAllByStatusAndExpiryDateBefore(
+            eq(SupportRoom.SupportRoomStatus.ACTIVE), any(LocalDateTime.class)))
+        .thenReturn(List.of(room));
+    when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID))
+        .thenThrow(new RuntimeException("synapse down"));
+    when(supportRoomRepository.save(any(SupportRoom.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    supportRoomService.sweepExpired();
+
+    assertThat(room.getStatus()).isEqualTo(SupportRoom.SupportRoomStatus.CLOSED);
+  }
+
+  // --- listing ---
+
+  @Test
+  void activeFor_Should_ReturnRoomsWhereTheUserIsEitherSide() {
+    var user = new AuthenticatedUser();
+    user.setUserId(CONSULTANT_ID);
+    when(supportRoomRepository.findAllByStatusAndConsultantIdOrStatusAndSupportAdminId(
+            SupportRoom.SupportRoomStatus.ACTIVE,
+            CONSULTANT_ID,
+            SupportRoom.SupportRoomStatus.ACTIVE,
+            CONSULTANT_ID))
+        .thenReturn(List.of(activeRoom()));
+
+    var items = supportRoomService.activeFor(user);
+
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getMatrixRoomId()).isEqualTo(ROOM_ID);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/support/SupportRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/support/SupportRoomServiceTest.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.HandshakeAuditEventRepository;
 import de.caritas.cob.userservice.api.port.out.SupportRoomRepository;
 import de.caritas.cob.userservice.api.service.handshake.HandshakePurpose;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +58,7 @@ class SupportRoomServiceTest {
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(supportRoomService, "roomTtlHours", 4L);
+    ReflectionTestUtils.setField(supportRoomService, "sweepBatchSize", 200);
     lenient().when(matrixConfig.getServerName()).thenReturn("caritas.local");
   }
 
@@ -67,8 +69,8 @@ class SupportRoomServiceTest {
         .initiatorId(GSA_ID)
         .counterpartId(CONSULTANT_ID)
         .status(HandshakeSession.HandshakeStatus.CONFIRMED)
-        .createDate(LocalDateTime.now())
-        .expiryDate(LocalDateTime.now().plusMinutes(5))
+        .createDate(LocalDateTime.now(ZoneOffset.UTC))
+        .expiryDate(LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5))
         .tenantId(1L)
         .build();
   }
@@ -124,8 +126,8 @@ class SupportRoomServiceTest {
     assertThat(room.getSupportAdminId()).isEqualTo(GSA_ID);
     assertThat(room.getConsultantId()).isEqualTo(CONSULTANT_ID);
     assertThat(room.getExpiryDate())
-        .isAfter(LocalDateTime.now().plusHours(3))
-        .isBefore(LocalDateTime.now().plusHours(5));
+        .isAfter(LocalDateTime.now(ZoneOffset.UTC).plusHours(3))
+        .isBefore(LocalDateTime.now(ZoneOffset.UTC).plusHours(5));
     verify(handshakeAuditEventRepository).save(any());
   }
 
@@ -154,8 +156,8 @@ class SupportRoomServiceTest {
         .supportAdminMatrixId(GSA_MXID)
         .consultantId(CONSULTANT_ID)
         .status(SupportRoom.SupportRoomStatus.ACTIVE)
-        .createDate(LocalDateTime.now().minusHours(1))
-        .expiryDate(LocalDateTime.now().plusHours(3))
+        .createDate(LocalDateTime.now(ZoneOffset.UTC).minusHours(1))
+        .expiryDate(LocalDateTime.now(ZoneOffset.UTC).plusHours(3))
         .build();
   }
 
@@ -195,9 +197,11 @@ class SupportRoomServiceTest {
   @Test
   void sweepExpired_Should_KickAndCloseLapsedActiveRooms() {
     var room = activeRoom();
-    room.setExpiryDate(LocalDateTime.now().minusMinutes(1));
+    room.setExpiryDate(LocalDateTime.now(ZoneOffset.UTC).minusMinutes(1));
     when(supportRoomRepository.findAllByStatusAndExpiryDateBefore(
-            eq(SupportRoom.SupportRoomStatus.ACTIVE), any(LocalDateTime.class)))
+            eq(SupportRoom.SupportRoomStatus.ACTIVE),
+            any(LocalDateTime.class),
+            any(org.springframework.data.domain.Pageable.class)))
         .thenReturn(List.of(room));
     when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID)).thenReturn("gsa-token");
     when(matrixSynapseService.leaveRoom(ROOM_ID, "gsa-token")).thenReturn(true);
@@ -215,9 +219,11 @@ class SupportRoomServiceTest {
   void sweepExpired_Should_CloseRoomEvenIfMatrixKickFails() {
     // Fail-safe: the lease must end at 4h even when the homeserver hiccups.
     var room = activeRoom();
-    room.setExpiryDate(LocalDateTime.now().minusMinutes(1));
+    room.setExpiryDate(LocalDateTime.now(ZoneOffset.UTC).minusMinutes(1));
     when(supportRoomRepository.findAllByStatusAndExpiryDateBefore(
-            eq(SupportRoom.SupportRoomStatus.ACTIVE), any(LocalDateTime.class)))
+            eq(SupportRoom.SupportRoomStatus.ACTIVE),
+            any(LocalDateTime.class),
+            any(org.springframework.data.domain.Pageable.class)))
         .thenReturn(List.of(room));
     when(matrixSynapseService.loginAsUserAccessToken(GSA_MXID))
         .thenThrow(new RuntimeException("synapse down"));


### PR DESCRIPTION
## Problem
ADR-018 introduces the Global Support Admin as an additive identity with its own table; the SUPPORT_ACCESS handshake purpose needs its role to exist, and a GSA must never act without completed 2FA.

## Changes
- `UserRole.GLOBAL_SUPPORT_ADMIN` (`global-support-admin`) + authority mapping.
- `Admin.AdminType.SUPPORT`; `roleInOrg` maps to "Support Admin".
- `GET /useradmin/supportadmins/search` (`SupportAdminController` + `SupportAdminUserService`, tenantadmins pattern incl. `hasOtherIdentity`) — same response shape as the other admin tables, consumed by ORISO-Admin#395. SecurityConfig: `USER_ADMIN` or `GLOBAL_SUPPORT_ADMIN`.
- Fail-closed 2FA gate in `HandshakeService.initiate`: a support admin without active OTP enrollment cannot initiate any handshake (unreachable OTP state also denies).

Stacked on #502 (live-handshake primitive). Ops prerequisite: create the `global-support-admin` realm role in Keycloak (`realm.json` in ORISO-Helm) before assigning GSAs.

## Verification
- TDD; 5 new unit tests; full suite green (3714 tests).

Closes OpenResilienceInitiative/ORISO-UserService#496
Refs OpenResilienceInitiative/ORISO-UserService#493

🤖 Generated with [Claude Code](https://claude.com/claude-code)