### PR TITLE
fix: preserve 2FA availability on lookup failure

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -161,10 +161,13 @@ class UserAccountControllerDelegate {
           usernameTranscoder.encodeUsername(authenticatedUser.getUsername()));
     } catch (Exception ex) {
       log.warn(
-          "Could not retrieve OTP credential for authenticated user {}; returning user data without OTP state",
+          "Could not retrieve OTP credential for authenticated user {}; preserving OTP availability without credential state",
           authenticatedUser.getUserId(),
           ex);
-      return null;
+      // A failed Keycloak lookup must not look like role-policy denial. An empty
+      // DTO keeps 2FA enabled in the response while safely reporting no active
+      // credential, so users can still open setup/reset controls.
+      return new OtpInfoDTO();
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -87,7 +87,7 @@ class UserAccountControllerDelegateTest {
   @InjectMocks private UserAccountControllerDelegate delegate;
 
   @Test
-  void getUserDataShouldReturnUserDataWithoutOtpStateWhenOtpLookupFails() {
+  void getUserDataShouldPreserveOtpAvailabilityWhenOtpLookupFails() {
     var roles = Set.of(UserRole.TENANT_ADMIN.getValue());
     var partialUserData = new UserDataResponseDTO();
     var fullUserData = new UserDataResponseDTO();
@@ -99,14 +99,16 @@ class UserAccountControllerDelegateTest {
     when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenThrow(new RuntimeException("OTP down"));
-    when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
+    when(userDtoMapper.userDataOf(
+            eq(partialUserData), any(OtpInfoDTO.class), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
     var response = delegate.getUserData();
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isSameAs(fullUserData);
-    verify(userDtoMapper).userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean());
+    verify(userDtoMapper)
+        .userDataOf(eq(partialUserData), any(OtpInfoDTO.class), anyBoolean(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
## What changed

- Preserve role-based 2FA availability when the Keycloak OTP credential lookup fails.
- Return an empty OTP state instead of `null` for lookup failures.
- Add a regression test covering the degraded lookup path.

## Why

The frontend renders the complete 2FA security section only when `twoFactorAuth.isEnabled` is true. UserService previously returned no OTP state when the Keycloak lookup failed, and the mapper interpreted that exactly like role-policy denial. After deployment, this hid both enable and reset controls from eligible users.

This change keeps authorization policy separate from credential lookup health. Eligible users retain access to the setup/reset UI while the response safely reports no active credential state. OTP operations can still surface their own backend error if Keycloak is genuinely unavailable.

## Validation

- `./mvnw -Dtest=UserAccountControllerDelegateTest test` — 37 tests passed
- `git diff --check`
- `./mvnw test` — 3,698 tests passed, 7 skipped; build successful
