### PR TITLE
Fix own-email rejection during consultant 2FA setup

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -69,7 +69,7 @@ public class IdentityManager implements IdentityManaging {
     var user = identityClient.findUserByEmail(email);
 
     return user.isEmpty()
-        || user.get("encodedUsername").equals(username)
-        || user.get("decodedUsername").equals(usernameTranscoder.decodeUsername(username));
+        || username.equals(user.get("encodedUsername"))
+        || usernameTranscoder.decodeUsername(username).equals(user.get("decodedUsername"));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api;
 
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class IdentityManager implements IdentityManaging {
 
   private final IdentityClient identityClient;
+  private final UsernameTranscoder usernameTranscoder;
 
   @Override
   public Optional<String> setUpOneTimePassword(String username, String email) {
@@ -68,6 +70,6 @@ public class IdentityManager implements IdentityManaging {
 
     return user.isEmpty()
         || user.get("encodedUsername").equals(username)
-        || user.get("decodedUsername").equals(username);
+        || user.get("decodedUsername").equals(usernameTranscoder.decodeUsername(username));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityManagerTest {
+
+  private static final String RAW_USERNAME = "consultant2fa";
+  private static final String ENCODED_USERNAME = "enc.MNXW443VNR2GC3TUGJTGC...";
+  private static final String EMAIL = "consultant@example.org";
+
+  @Mock private IdentityClient identityClient;
+  @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
+
+  @InjectMocks private IdentityManager identityManager;
+
+  @Test
+  void isEmailAvailableOrOwnShouldAcceptRawKeycloakUsernameForEncodedConsultant() {
+    when(identityClient.findUserByEmail(EMAIL))
+        .thenReturn(
+            Map.of(
+                "encodedUsername", RAW_USERNAME,
+                "decodedUsername", RAW_USERNAME,
+                "email", EMAIL));
+
+    assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
+  }
+
+  @Test
+  void isEmailAvailableOrOwnShouldAcceptEncodedKeycloakUsernameForEncodedConsultant() {
+    when(identityClient.findUserByEmail(EMAIL))
+        .thenReturn(
+            Map.of(
+                "encodedUsername", ENCODED_USERNAME,
+                "decodedUsername", RAW_USERNAME,
+                "email", EMAIL));
+
+    assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
+  }
+
+  @Test
+  void isEmailAvailableOrOwnShouldRejectEmailOwnedByDifferentUser() {
+    when(identityClient.findUserByEmail(EMAIL))
+        .thenReturn(
+            Map.of(
+                "encodedUsername", "other-user",
+                "decodedUsername", "other-user",
+                "email", EMAIL));
+
+    assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
+  }
+
+  @Test
+  void isEmailAvailableOrOwnShouldAcceptUnusedEmail() {
+    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of());
+
+    assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -67,4 +67,11 @@ class IdentityManagerTest {
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
+
+  @Test
+  void isEmailAvailableOrOwnShouldRejectIncompleteOwnerDataWithoutThrowing() {
+    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of("email", EMAIL));
+
+    assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController2faE2EIT.java
@@ -229,8 +229,7 @@ class UserController2faE2EIT {
 
   @Test
   @WithMockUser(authorities = AuthorityValue.CONSULTANT_DEFAULT)
-  void startTwoFactorAuthByEmailSetupShouldRespondWithNoContentIfEmailIsOwnedByUser()
-      throws Exception {
+  void startTwoFactorAuthByEmailSetupShouldAcceptOwnEmailForRawKeycloakUsername() throws Exception {
     givenAValidConsultant();
     givenAValidEmailDTO();
     givenKeycloakFoundOwnEmailInUse();
@@ -840,7 +839,7 @@ class UserController2faE2EIT {
   private void givenKeycloakFoundOwnEmailInUse() {
     var usernameTranscoder = new UsernameTranscoder();
     var userRepresentation = new UserRepresentation();
-    var username = usernameTranscoder.encodeUsername(consultant.getUsername());
+    var username = usernameTranscoder.decodeUsername(consultant.getUsername());
     userRepresentation.setUsername(username);
     userRepresentation.setEmail(emailDTO.getEmail());
     var userRepresentationList = new ArrayList<UserRepresentation>(1);


### PR DESCRIPTION
## Why

Admin-created consultants have a raw username in Keycloak and an encoded username in UserService. The email ownership check compared only identical representations, so the consultant’s existing email was rejected as already in use during email 2FA setup.

## What changed

- Decode the authenticated username before comparing it with Keycloak’s decoded owner username.
- Preserve the legacy encoded-username path and rejection of another account’s email.
- Add focused manager coverage and make the controller E2E fixture reflect the current raw Keycloak username model.

## Verification

- Red: raw Keycloak username regression returned `false` before the fix.
- Green: `IdentityManagerTest` + `UserTwoFactorAuthControllerDelegateTest`: 20 passed.
- Full unit suite: 3,713 passed, 0 failed, 7 skipped.
- Spotless check: passed under Java 21.
- The legacy `UserController2faE2EIT` harness currently returns 401 for every protected scenario locally, including unchanged tests, before application logic; this is separate from the product behavior.

Closes OpenResilienceInitiative/ORISO-UserService#507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email ownership checks when usernames are encoded or decoded, ensuring users can correctly retain their own email address.
  * Updated the two-factor authentication email flow for accounts using raw Keycloak usernames.

* **Tests**
  * Added coverage for available emails, matching encoded and raw usernames, and emails belonging to other users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->