### PR TITLE
ci: add recovery trigger for Pre-Dev image builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,6 +1,7 @@
 name: UserService Build and Publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- add `workflow_dispatch` to the existing UserService main build workflow
- preserve all automatic push triggers for `main`, `dev`, and `pre-dev`
- provide a sanctioned recovery path when GitHub misses a branch push event

## Validation

- Red evidence: dispatching `CI - Main` for `pre-dev` returned HTTP 422 because the workflow had no manual trigger.
- `git diff --check`
- Ruby/Psych workflow YAML parse
- trigger-preservation assertion confirming both `workflow_dispatch` and `push`

No product test is added because this is a one-line GitHub Actions trigger configuration change. The behavioral acceptance check is a successful manual dispatch after merge.

## Deployment impact

This PR does not deploy by itself. After merge, `CI - Main` will be manually dispatched for `pre-dev`; Hassan is included as deployment reviewer. The published digest will then be deployed through `/root/predev-deploy-script/deploy-userservice-dev.sh` and verified with the Dreambau Test Access consultant.

Refs OpenResilienceInitiative/ORISO-UserService#509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
