### PR TITLE
fix: make RCToken header optional on consultant enquiry endpoints

### DIFF
--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -28,7 +28,7 @@ paths:
             type: integer
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
       responses:
@@ -72,7 +72,7 @@ paths:
             type: integer
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
       responses:

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationControllerIT.java
@@ -90,6 +90,22 @@ class ConversationControllerIT {
   }
 
   @Test
+  void getAnonymousEnquiries_Should_returnOk_When_rcTokenHeaderIsMissing() throws Exception {
+    // Matrix-only consultants have no Rocket.Chat token; the queue must still answer
+    // (enrichment is failure-tolerant). Regression: required RCToken caused a bare 400.
+    this.mvc
+        .perform(get(GET_ANONYMOUS_ENQUIRIES_PATH).param("offset", "0").param("count", "10"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void getRegisteredEnquiries_Should_returnOk_When_rcTokenHeaderIsMissing() throws Exception {
+    this.mvc
+        .perform(get(GET_REGISTERED_ENQUIRIES_PATH).param("offset", "0").param("count", "10"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
   void getAnonymousEnquiries_Should_returnBadRequest_When_offsetIsMissing() throws Exception {
     this.mvc
         .perform(


### PR DESCRIPTION
## Problem

`GET /conversations/consultants/enquiries/anonymous` (and `…/registered`) answer a bare `400` (empty body) when the `RCToken` header is missing:

```
jakarta.validation.ConstraintViolationException: getAnonymousEnquiries.rcToken: darf nicht null sein
```

Matrix-only consultant sessions have no Rocket.Chat token cookie, so the frontend request carries no `RCToken` header — the enquiry list (including the anonymous live-chat topic queue) can then never load. Found while root-causing "consultant does not see live-chat requests" on pre-dev (2026-07-19).

## Root cause

`api/conversationservice.yaml` declares the `RCToken` header `required: true` for both enquiry endpoints. The generated interface therefore adds `@NotNull` + `@RequestHeader(required = true)`, and method validation rejects the call before the controller runs — although `ConversationController` already declares the header as `required = false` and `AnonymousEnquiryConversationListProvider` only uses the token for failure-tolerant enrichment (the queue stays servable without it).

## Fix

- Spec change only: `required: false` for `RCToken` on `/conversations/consultants/enquiries/registered` and `…/anonymous`. Archive endpoints keep their current contract.
- WebMvc regression tests: both enquiry endpoints answer `200` without the header.

Note: the local `ConversationControllerIT` context boot currently fails for ALL its tests on a pre-existing spring-plugin/hateoas classpath clash (`NoSuchMethodError: PluginRegistryFactoryBean.setBeanFactory`) unrelated to this change — please rely on CI for the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
