### PR TITLE
Repair live-chat routing, session identity, and chat authorization

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2124,6 +2124,10 @@ components:
     SessionDataDTO:
       type: object
       properties:
+        displayName:
+          type: string
+          example: Behutsames Pferd Jules
+          description: Session-scoped pseudonym shown to consultants for anonymous live chat
         age:
           type: string
           example: 17
@@ -2614,6 +2618,9 @@ components:
         username:
           type: string
           example: max94
+        displayName:
+          type: string
+          example: Behutsames Pferd Jules
         isDeleted:
           type: boolean
         sessionData:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -539,6 +539,20 @@ public class KeycloakService implements IdentityClient {
    * @param roleName Keycloak role name
    */
   public void updateRole(final String userId, final String roleName) {
+    try {
+      updateRoleOnce(userId, roleName);
+    } catch (NotAuthorizedException e) {
+      log.warn(
+          "Keycloak admin session was unauthorized while assigning role {} to user {}, forcing"
+              + " token refresh and retrying once",
+          roleName,
+          userId);
+      keycloakClient.refreshAdminSession();
+      updateRoleOnce(userId, roleName);
+    }
+  }
+
+  private void updateRoleOnce(final String userId, final String roleName) {
     // Get realm and user resources
     var realmResource = keycloakClient.getRealmResource();
     UsersResource userRessource = realmResource.users();

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -142,7 +142,7 @@ class UserSessionControllerDelegate {
       var rocketChatCredentials = buildUserRocketChatCredentials(user, rcToken);
       groupSessionList =
           sessionListFacade.retrieveChatsForUserByChatIds(
-              singletonList(chatId), rocketChatCredentials);
+              user.getUserId(), singletonList(chatId), rocketChatCredentials);
     }
 
     consultantDataFacade.addConsultantDisplayNameToSessionList(groupSessionList);
@@ -331,7 +331,7 @@ class UserSessionControllerDelegate {
       log.info("Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
       groupSessionList =
           sessionListFacade.retrieveChatsForUserByChatIds(
-              singletonList(sessionId), rocketChatCredentials);
+              user.getUserId(), singletonList(sessionId), rocketChatCredentials);
 
       log.info(
           "Step 2 result: {} chats found",

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/SessionUserDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/SessionUserDTO.java
@@ -21,7 +21,10 @@ public class SessionUserDTO {
   @ApiModelProperty(example = "Username", position = 1)
   private String username;
 
-  @ApiModelProperty(example = "isDeleted", position = 2)
+  @ApiModelProperty(example = "Display name", position = 2)
+  private String displayName;
+
+  @ApiModelProperty(example = "isDeleted", position = 3)
   private boolean isDeleted;
 
   private Map<String, Object> sessionData;

--- a/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
@@ -2,11 +2,14 @@ package de.caritas.cob.userservice.api.config;
 
 import java.util.List;
 import lombok.NonNull;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -14,6 +17,12 @@ import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 @Component
 public class CustomWebMvcConfigurer implements WebMvcConfigurer {
@@ -48,6 +57,30 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
     registry
         .addResourceHandler(docuPath + "/**")
         .addResourceLocations("classpath:/META-INF/resources/");
+  }
+
+  @Override
+  public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+    var module = new SimpleModule("OpenApiJsonNullable");
+    module.addSerializer(JsonNullable.class, new JsonNullableSerializer());
+
+    for (int index = 0; index < converters.size(); index++) {
+      if (converters.get(index) instanceof JacksonJsonHttpMessageConverter converter) {
+        var mapper = (JsonMapper) converter.getMapper().rebuild().addModule(module).build();
+        var replacement = new JacksonJsonHttpMessageConverter(mapper);
+        replacement.setSupportedMediaTypes(converter.getSupportedMediaTypes());
+        converters.set(index, replacement);
+      }
+    }
+  }
+
+  private static class JsonNullableSerializer extends ValueSerializer<JsonNullable> {
+
+    @Override
+    public void serialize(JsonNullable value, JsonGenerator generator, SerializationContext context)
+        throws JacksonException {
+      context.writeValue(generator, value.orElse(null));
+    }
   }
 
   @Bean

--- a/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
@@ -133,9 +133,10 @@ public class SessionListFacade {
   }
 
   public GroupSessionListResponseDTO retrieveChatsForUserByChatIds(
-      List<Long> chatIds, RocketChatCredentials rocketChatCredentials) {
+      String userId, List<Long> chatIds, RocketChatCredentials rocketChatCredentials) {
     var userChatSessions =
-        userSessionListService.retrieveChatsForUserAndChatIds(chatIds, rocketChatCredentials);
+        userSessionListService.retrieveChatsForUserAndChatIds(
+            userId, chatIds, rocketChatCredentials);
     userChatSessions.sort(
         comparing(UserSessionResponseDTO::getLatestMessage, nullsLast(reverseOrder())));
 

--- a/src/main/java/de/caritas/cob/userservice/api/helper/SessionDataKeyRegistration.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/SessionDataKeyRegistration.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SessionDataKeyRegistration {
   AGE("age"),
-  STATE("state");
+  STATE("state"),
+  DISPLAY_NAME("displayName");
 
   private final String key;
 

--- a/src/main/java/de/caritas/cob/userservice/api/helper/SessionDataProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/SessionDataProvider.java
@@ -53,6 +53,13 @@ public class SessionDataProvider {
   public List<SessionData> createSessionDataList(Session session, SessionDataDTO sessionData) {
 
     List<SessionData> sessionDataList = new ArrayList<>();
+    if (!isEmpty(sessionData.getDisplayName())) {
+      sessionDataList.add(
+          obtainSessionData(
+              session,
+              SessionDataKeyRegistration.DISPLAY_NAME.getValue(),
+              sessionData.getDisplayName()));
+    }
     if (getSessionDataInitializing(session.getConsultingTypeId()).isAge()) {
       sessionDataList.add(
           obtainSessionData(

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -201,7 +201,8 @@ public class AgencyInviteLinkService {
       if (InviteLinkChatType.LIVE_CHAT.name().equals(link.getChatType())) {
         var dto = new CreateAnonymousEnquiryDTO(consultingTypeId).mainTopicId(link.getTopicId());
         var session = createAnonymousEnquiryFacade.createAnonymousEnquiry(dto, true);
-        // Link is reusable until expiry date — stay ACTIVE, do not mark USED.
+        // Public Live Chat entry points are reusable until expiry so multiple clients can enter
+        // the shared topic queue through the same published link.
         return new RedeemContext(
             session, link.getTenantId(), null, consultingTypeId, link.getTopicId());
       }

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
@@ -6,11 +6,13 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -48,22 +50,44 @@ public class TopicConsultantRoutingService {
       return Collections.emptyList();
     }
 
-    List<String> topicConsultantIds = consultantTopicRepository.findConsultantIdsByTopicId(topicId);
-    if (topicConsultantIds.isEmpty()) {
-      return Collections.emptyList();
-    }
-
     List<String> activeConsultantIds =
-        consultantRepository.findAllByIdIn(topicConsultantIds).stream()
-            .filter(consultant -> consultant != null && !consultant.isAbsent())
-            .map(Consultant::getId)
-            .collect(Collectors.toList());
+        runCrossTenant(
+            () -> {
+              List<String> topicConsultantIds =
+                  consultantTopicRepository.findConsultantIdsByTopicId(topicId);
+              if (topicConsultantIds.isEmpty()) {
+                return Collections.emptyList();
+              }
+              return consultantRepository.findAllByIdIn(topicConsultantIds).stream()
+                  .filter(consultant -> consultant != null && !consultant.isAbsent())
+                  .map(Consultant::getId)
+                  .collect(Collectors.toList());
+            });
     if (activeConsultantIds.isEmpty()) {
       return Collections.emptyList();
     }
 
     return new ArrayList<>(
         consultantActivityRegistry.filterActive(activeConsultantIds, activeWindowMs));
+  }
+
+  /**
+   * Public topic availability is deliberately cross-tenant: one published Live Chat link feeds a
+   * shared topic queue. Disable the tenant filter only while resolving eligible consultant IDs and
+   * always restore the caller context before applying the in-memory activity filter.
+   */
+  private <T> T runCrossTenant(Supplier<T> lookup) {
+    Long callerTenant = TenantContext.getCurrentTenant();
+    try {
+      TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+      return lookup.get();
+    } finally {
+      if (callerTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenant(callerTenant);
+      }
+    }
   }
 
   public List<String> findEligibleConsultantIds(Long topicId, Integer consultingTypeId) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
@@ -90,7 +90,12 @@ public class SessionMapper {
         new UsernameTranscoder().decodeUsername(session.getUser().getUsername()));
     sessionUserDto.setDeleted(session.getUser().getDeleteDate() != null);
     if (nonNull(session.getSessionData())) {
-      sessionUserDto.setSessionData(buildSessionDataMapFromSession(session));
+      var sessionData = buildSessionDataMapFromSession(session);
+      sessionUserDto.setSessionData(sessionData);
+      var displayName = sessionData.get(SessionDataKeyRegistration.DISPLAY_NAME.getValue());
+      if (displayName instanceof String value) {
+        sessionUserDto.setDisplayName(value);
+      }
     }
     return sessionUserDto;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
 import de.caritas.cob.userservice.api.container.RocketChatRoomInformation;
 import de.caritas.cob.userservice.api.facade.sessionlist.RocketChatRoomInformationProvider;
 import de.caritas.cob.userservice.api.helper.SessionListAnalyser;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
@@ -81,7 +82,7 @@ public class UserSessionListService {
       Set<String> roles) {
 
     var groupIds = new HashSet<>(rcGroupIds);
-    var chats = chatService.getChatSessionsByGroupIds(groupIds);
+    var chats = filterChatsVisibleToUser(userId, chatService.getChatSessionsByGroupIds(groupIds));
     var chatGroupIds =
         chats.stream()
             .map(UserSessionResponseDTO::getChat)
@@ -124,13 +125,35 @@ public class UserSessionListService {
   }
 
   public List<UserSessionResponseDTO> retrieveChatsForUserAndChatIds(
-      List<Long> chatIds, RocketChatCredentials rocketChatCredentials) {
+      String userId, List<Long> chatIds, RocketChatCredentials rocketChatCredentials) {
     var uniqueChatIds = new HashSet<>(chatIds);
-    var chats = chatService.getChatSessionsByIds(uniqueChatIds);
+    var chats = filterChatsVisibleToUser(userId, chatService.getChatSessionsByIds(uniqueChatIds));
     var rocketChatRoomInformation =
         rocketChatRoomInformationProvider.retrieveRocketChatInformation(rocketChatCredentials);
     return updateUserChatValues(
         chats, rocketChatRoomInformation, rocketChatCredentials.getRocketChatUserId());
+  }
+
+  private List<UserSessionResponseDTO> filterChatsVisibleToUser(
+      String userId, List<UserSessionResponseDTO> candidates) {
+    var assignedChatIds =
+        chatService.getChatsForUserId(userId).stream()
+            .map(UserSessionResponseDTO::getChat)
+            .filter(java.util.Objects::nonNull)
+            .map(UserChatDTO::getId)
+            .collect(Collectors.toSet());
+
+    return candidates.stream()
+        .filter(UserSessionListService::hasChat)
+        .filter(
+            candidate ->
+                candidate.getChat().getConversationType() == ConversationType.SELF_HELP
+                    || assignedChatIds.contains(candidate.getChat().getId()))
+        .toList();
+  }
+
+  private static boolean hasChat(UserSessionResponseDTO candidate) {
+    return candidate != null && candidate.getChat() != null;
   }
 
   private List<UserSessionResponseDTO> mergeUserSessionsAndChats(

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -42,6 +42,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.HashMap;
@@ -753,6 +754,38 @@ public class KeycloakServiceTest {
     this.keycloakService.updateRole("user", validRole);
 
     verify(roleScopeResource, times(1)).add(any());
+  }
+
+  @Test
+  public void updateRole_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
+    String validRole = "role";
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(anyString())).thenReturn(userResource);
+    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
+    RoleRepresentation assignedRole = mock(RoleRepresentation.class);
+    when(assignedRole.getName()).thenReturn(validRole);
+    when(roleScopeResource.listAll()).thenReturn(singletonList(assignedRole));
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+    when(userResource.roles()).thenReturn(roleMappingResource);
+    RoleRepresentation roleRepresentation = new EasyRandom().nextObject(RoleRepresentation.class);
+    RoleResource roleResource = mock(RoleResource.class);
+    when(roleResource.toRepresentation()).thenReturn(roleRepresentation);
+    RolesResource rolesResource = mock(RolesResource.class);
+    when(rolesResource.get(any())).thenReturn(roleResource);
+    RealmResource realmResource = mock(RealmResource.class);
+    when(realmResource.users()).thenReturn(usersResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+    when(keycloakClient.getRealmResource())
+        .thenThrow(new NotAuthorizedException("Bearer"))
+        .thenReturn(realmResource);
+
+    keycloakService.updateRole("user", validRole);
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).getRealmResource();
+    verify(roleScopeResource).add(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegateTest.java
@@ -232,7 +232,7 @@ class UserSessionControllerDelegateTest {
     when(sessionListFacade.retrieveSessionsForAuthenticatedUserBySessionIds(
             eq("user-id"), eq(List.of(1L)), any(), eq(Set.of(UserRole.USER.getValue()))))
         .thenReturn(emptySessionList);
-    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq("user-id"), eq(List.of(1L)), any()))
         .thenReturn(chatSessionList);
 
     var response = delegate.getSessionForId(1L, null);
@@ -304,7 +304,7 @@ class UserSessionControllerDelegateTest {
     var responseDto = new GroupSessionListResponseDTO().sessions(List.of());
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithRocketChatId());
-    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq("user-id"), eq(List.of(1L)), any()))
         .thenReturn(responseDto);
 
     var response = delegate.getChatById("rc-token", 1L);
@@ -319,7 +319,7 @@ class UserSessionControllerDelegateTest {
         new GroupSessionListResponseDTO().sessions(List.of(new GroupSessionResponseDTO()));
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(userWithoutRocketChatId());
-    when(sessionListFacade.retrieveChatsForUserByChatIds(eq(List.of(1L)), any()))
+    when(sessionListFacade.retrieveChatsForUserByChatIds(eq("user-id"), eq(List.of(1L)), any()))
         .thenReturn(responseDto);
 
     var response = delegate.getChatById(null, 1L);
@@ -327,7 +327,7 @@ class UserSessionControllerDelegateTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     var credentialsCaptor = ArgumentCaptor.forClass(RocketChatCredentials.class);
     verify(sessionListFacade)
-        .retrieveChatsForUserByChatIds(eq(List.of(1L)), credentialsCaptor.capture());
+        .retrieveChatsForUserByChatIds(eq("user-id"), eq(List.of(1L)), credentialsCaptor.capture());
     assertThat(credentialsCaptor.getValue().getRocketChatUserId()).isEqualTo("dummy-rc-user");
     assertThat(credentialsCaptor.getValue().getRocketChatToken()).isEqualTo("dummy-rc-token");
   }

--- a/src/test/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurerTest.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConversationType;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+
+class CustomWebMvcConfigurerTest {
+
+  @Test
+  void extendMessageConvertersShouldSerializeJsonNullableAsApiValueWithJackson3() throws Exception {
+    var converters = new ArrayList<HttpMessageConverter<?>>();
+    converters.add(new JacksonJsonHttpMessageConverter());
+    var configurer = new CustomWebMvcConfigurer(mock(ObjectProvider.class));
+
+    configurer.extendMessageConverters(converters);
+
+    var converter = (JacksonJsonHttpMessageConverter) converters.getFirst();
+    var json =
+        converter
+            .getMapper()
+            .writeValueAsString(new SessionDTO().conversationType(ConversationType.LIVE_CHAT));
+    assertThat(json)
+        .contains("\"conversationType\":\"LIVE_CHAT\"")
+        .doesNotContain("\"conversationType\":{\"present\":true}");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacadeTest.java
@@ -422,11 +422,13 @@ public class SessionListFacadeTest {
 
   @Test
   public void retrieveChatsForUserByChatIds_Should_ReturnGroupSessionList() {
-    when(userSessionListService.retrieveChatsForUserAndChatIds(Mockito.any(), Mockito.any()))
+    when(userSessionListService.retrieveChatsForUserAndChatIds(
+            Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(new java.util.ArrayList<>());
 
     var result =
-        sessionListFacade.retrieveChatsForUserByChatIds(java.util.List.of(), RC_CREDENTIALS);
+        sessionListFacade.retrieveChatsForUserByChatIds(
+            USER_ID, java.util.List.of(), RC_CREDENTIALS);
 
     assertNotNull(result);
     assertEquals(0, result.getSessions().size());

--- a/src/test/java/de/caritas/cob/userservice/api/helper/SessionDataProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/SessionDataProviderTest.java
@@ -217,6 +217,20 @@ class SessionDataProviderTest {
   }
 
   @Test
+  void createSessionDataList_Should_AlwaysPersistAnonymousDisplayName() {
+    when(consultingTypeManager.getConsultingTypeSettings(CONSULTING_TYPE_ID_U25))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_WITH_NO_SESSION_DATA_ITEMS);
+
+    List<SessionData> result =
+        sessionDataProvider.createSessionDataList(
+            INITIALIZED_SESSION_U25, new SessionDataDTO().displayName("Behutsames Pferd Jules"));
+
+    assertEquals(
+        "Behutsames Pferd Jules",
+        getValueOfKey(result, SessionDataKeyRegistration.DISPLAY_NAME.getValue()));
+  }
+
+  @Test
   void
       createSessionDataList_Should_ReturnCorrectListOfSessionDataItems_WhenSessionDataValuesAreNull() {
     when(consultingTypeManager.getConsultingTypeSettings(CONSULTING_TYPE_ID_SUCHT))

--- a/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
@@ -289,6 +289,10 @@ class AgencyInviteLinkServiceTest {
     assertThat(ctx.getTopicId()).isEqualTo(11L);
     // No agency resolution at entry for a live-chat link.
     assertThat(ctx.getAgencyId()).isNull();
+    assertThat(link.getStatus()).isEqualTo(InviteLinkStatus.ACTIVE.name());
+    assertThat(link.getUsedAt()).isNull();
+    assertThat(link.getUsedBySessionId()).isNull();
+    verify(repository, org.mockito.Mockito.never()).save(link);
     verify(agencyService, org.mockito.Mockito.never()).getAgenciesByConsultingType(anyInt());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.service.availability.ConsultantActivityRegistry;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -129,6 +130,34 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findAvailableConsultantIds(5L);
 
     assertThat(result).containsExactly("c1");
+  }
+
+  @Test
+  void findAvailableConsultantIds_Should_QueryAcrossTenants_AndRestoreCallerContext() {
+    TenantContext.setCurrentTenant(84L);
+    try {
+      when(consultantTopicRepository.findConsultantIdsByTopicId(9L))
+          .thenAnswer(
+              invocation -> {
+                assertThat(TenantContext.getCurrentTenant())
+                    .isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+                return List.of("tenant-84-consultant");
+              });
+      when(consultantRepository.findAllByIdIn(List.of("tenant-84-consultant")))
+          .thenAnswer(
+              invocation -> {
+                assertThat(TenantContext.getCurrentTenant())
+                    .isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+                return List.of(consultant("tenant-84-consultant", false));
+              });
+      when(consultantActivityRegistry.filterActive(List.of("tenant-84-consultant"), 120_000L))
+          .thenReturn(Set.of("tenant-84-consultant"));
+
+      assertThat(service.findAvailableConsultantIds(9L)).containsExactly("tenant-84-consultant");
+      assertThat(TenantContext.getCurrentTenant()).isEqualTo(84L);
+    } finally {
+      TenantContext.clear();
+    }
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsu
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForUserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
+import de.caritas.cob.userservice.api.config.AppConfig;
 import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.SessionData;
@@ -36,6 +37,19 @@ class SessionMapperTest {
     assertThat(
         sessionDTO.getConversationType().get(),
         is(de.caritas.cob.userservice.api.adapters.web.dto.ConversationType.LIVE_CHAT));
+  }
+
+  @Test
+  void convertToSessionDTOShouldSerializeConversationTypeAsApiEnum() throws Exception {
+    Session session = new EasyRandom().nextObject(Session.class);
+    session.setConversationType(ConversationType.LIVE_CHAT);
+
+    SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
+
+    org.assertj.core.api.Assertions.assertThat(
+            new AppConfig().objectMapper().writeValueAsString(sessionDTO))
+        .contains("\"conversationType\":\"LIVE_CHAT\"")
+        .doesNotContain("\"conversationType\":{\"present\":true}");
   }
 
   @Test
@@ -159,6 +173,21 @@ class SessionMapperTest {
 
     assertThat(map, hasEntry("age", "30"));
     assertEquals(1, map.size());
+  }
+
+  @Test
+  void toConsultantSessionDto_Should_ProjectSessionScopedDisplayName() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    session.setRegistrationType(ANONYMOUS);
+    SessionData displayName = new SessionData();
+    displayName.setKey("displayName");
+    displayName.setValue("Behutsames Pferd Jules");
+    session.setSessionData(java.util.List.of(displayName));
+
+    ConsultantSessionResponseDTO dto = new SessionMapper().toConsultantSessionDto(session);
+
+    assertEquals("Behutsames Pferd Jules", dto.getUser().getDisplayName());
+    assertThat(dto.getUser().getSessionData(), hasEntry("displayName", "Behutsames Pferd Jules"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListServiceTest.java
@@ -27,11 +27,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.adapters.web.dto.UserChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
 import de.caritas.cob.userservice.api.container.RocketChatRoomInformation;
 import de.caritas.cob.userservice.api.facade.sessionlist.RocketChatRoomInformationProvider;
 import de.caritas.cob.userservice.api.helper.Helper;
 import de.caritas.cob.userservice.api.helper.SessionListAnalyser;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
@@ -155,6 +157,7 @@ class UserSessionListServiceTest {
     var chatResponse = USER_CHAT_RESPONSE_DTO_LIST.getFirst();
     when(chatService.getChatSessionsByGroupIds(Set.of(RC_GROUP_ID_4)))
         .thenReturn(List.of(chatResponse));
+    when(chatService.getChatsForUserId(USER_ID)).thenReturn(List.of(chatResponse));
     var roomInformation =
         RocketChatRoomInformation.builder()
             .readMessages(MESSAGES_READ_MAP_WITHOUT_UNREADS)
@@ -170,6 +173,79 @@ class UserSessionListServiceTest {
     assertEquals(List.of(chatResponse), result);
     verify(sessionService, Mockito.never())
         .getSessionsByUserAndGroupIds(Mockito.anyString(), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  void retrieveSessionsForGroupIds_Should_NotExposeUnassignedInternalChat() {
+    var internalChat = new UserChatDTO();
+    internalChat.setId(1087L);
+    internalChat.setGroupId("!internal:matrix.example");
+    internalChat.setConversationType(ConversationType.INTERNAL_GROUP);
+    internalChat.setStartDateWithTime(java.time.LocalDateTime.now());
+    var internalResponse = new UserSessionResponseDTO();
+    internalResponse.setChat(internalChat);
+    when(chatService.getChatSessionsByGroupIds(Set.of("!internal:matrix.example")))
+        .thenReturn(List.of(internalResponse));
+    when(chatService.getChatsForUserId(USER_ID)).thenReturn(List.of());
+    when(rocketChatRoomInformationProvider.retrieveRocketChatInformation(RC_CREDENTIALS))
+        .thenReturn(
+            RocketChatRoomInformation.builder()
+                .userRooms(List.of())
+                .readMessages(emptyMap())
+                .lastMessagesRoom(emptyMap())
+                .build());
+
+    var result =
+        userSessionListService.retrieveSessionsForAuthenticatedUserAndGroupIds(
+            USER_ID, List.of("!internal:matrix.example"), RC_CREDENTIALS, Set.of("user"));
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void retrieveChatsForUserAndChatIds_Should_NotExposeUnassignedInternalChat() {
+    var internalChat = new UserChatDTO();
+    internalChat.setId(1087L);
+    internalChat.setGroupId("!internal:matrix.example");
+    internalChat.setConversationType(ConversationType.INTERNAL_GROUP);
+    var internalResponse = new UserSessionResponseDTO();
+    internalResponse.setChat(internalChat);
+    when(chatService.getChatSessionsByIds(Set.of(1087L))).thenReturn(List.of(internalResponse));
+    when(chatService.getChatsForUserId(USER_ID)).thenReturn(List.of());
+    when(rocketChatRoomInformationProvider.retrieveRocketChatInformation(RC_CREDENTIALS))
+        .thenReturn(RocketChatRoomInformation.builder().build());
+
+    var result =
+        userSessionListService.retrieveChatsForUserAndChatIds(
+            USER_ID, List.of(1087L), RC_CREDENTIALS);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void retrieveChatsForUserAndChatIds_Should_KeepPublicSelfHelpDeepLink() {
+    var selfHelpChat = new UserChatDTO();
+    selfHelpChat.setId(1088L);
+    selfHelpChat.setGroupId("!self-help:matrix.example");
+    selfHelpChat.setConversationType(ConversationType.SELF_HELP);
+    selfHelpChat.setStartDateWithTime(java.time.LocalDateTime.now());
+    var selfHelpResponse = new UserSessionResponseDTO();
+    selfHelpResponse.setChat(selfHelpChat);
+    when(chatService.getChatSessionsByIds(Set.of(1088L))).thenReturn(List.of(selfHelpResponse));
+    when(chatService.getChatsForUserId(USER_ID)).thenReturn(List.of());
+    when(rocketChatRoomInformationProvider.retrieveRocketChatInformation(RC_CREDENTIALS))
+        .thenReturn(
+            RocketChatRoomInformation.builder()
+                .userRooms(List.of())
+                .readMessages(emptyMap())
+                .lastMessagesRoom(emptyMap())
+                .build());
+
+    var result =
+        userSessionListService.retrieveChatsForUserAndChatIds(
+            USER_ID, List.of(1088L), RC_CREDENTIALS);
+
+    assertEquals(List.of(selfHelpResponse), result);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- repair public Live Chat routing and session-scoped identity
- enforce group-chat lookup authorisation
- retry expired Keycloak admin sessions during role assignment
- serialize JsonNullable fields through the active converter

## Evidence

![Live Chat consultant conversation](https://github.com/OpenResilienceInitiative/ORISO-E2E/blob/719a815dd6178d8593604c52542a224b302b5767/docs/e2e-runs/e2e-20260719-1711/screenshots/21-live-chat-conversation-consultant-predev-desktop.png?raw=1)

Refs OpenResilienceInitiative/ORISO-UserService#514
Parent run: OpenResilienceInitiative/ORISO-Frontend#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

