### PR TITLE
Expose mandatory platform-admin 2FA policy

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -111,6 +111,9 @@ class UserAccountControllerDelegate {
       enrichConsultantAvailability(partialUserData);
     } else if (isTenantAdmin() || isAgencyAdmin()) {
       partialUserData = keycloakUserDataProvider.retrieveAuthenticatedUserData();
+      if (authenticatedUser.isPlatformAdmin()) {
+        partialUserData.setEncourage2fa(true);
+      }
     } else {
       var user = userAccountProvider.retrieveValidatedUser();
       partialUserData = askerDataProvider.retrieveData(user);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -112,6 +112,25 @@ class UserAccountControllerDelegateTest {
   }
 
   @Test
+  void getUserDataShouldRequireTwoFactorSetupForPlatformAdmins() {
+    var roles = Set.of(UserRole.TENANT_ADMIN.getValue(), UserRole.AGENCY_ADMIN.getValue());
+    var partialUserData = new UserDataResponseDTO();
+    var fullUserData = new UserDataResponseDTO();
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
+    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
+        .thenReturn(fullUserData);
+
+    var response = delegate.getUserData();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(partialUserData.getEncourage2fa()).isTrue();
+  }
+
+  @Test
   void patchUserShouldRejectMagicLinkLoginWhenConsultantHasDummyEmail() {
     var patchUserDTO = new PatchUserDTO();
     patchUserDTO.setMagicLinkLoginEnabled(true);


### PR DESCRIPTION
Closes #516\n\nRequired by OpenResilienceInitiative/ORISO-Admin#419.\n\n## What\n- marks authenticated platform admins with encourage2fa=true in user data\n- preserves existing role-based OTP availability\n- adds controller regression coverage\n\n## Verification\n- Java 21 compilation passed\n- UserAccountControllerDelegateTest: 38 passed\n- Spotless check passed with Java 21