### PR TITLE
Preserve Matrix access, deletion cascades, and DPA delivery

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreator.java
@@ -9,7 +9,9 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import java.time.Instant;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class ChatReCreator {
   private final ChatService chatService;
   private final MatrixSynapseService matrixSynapseService;
   private final MatrixChatShutdownService matrixChatShutdownService;
+  private final GroupChatMembershipService groupChatMembershipService;
 
   /**
    * Resets the given chat to its next occurrence: the new Matrix room id is persisted both as
@@ -65,7 +68,29 @@ public class ChatReCreator {
    * @return the id of the newly created Matrix room
    */
   public String recreateMessengerChat(Chat chat) {
+    var oldRoomId = groupChatMembershipService.resolveMatrixRoomId(chat);
+    var humanMembers = groupChatMembershipService.resolveHumanMembers(oldRoomId);
+    if (humanMembers.isEmpty()) {
+      throw new InternalServerErrorException(
+          String.format(
+              "Could not resolve members of repetitive group chat %s before re-creating room",
+              chat.getId()));
+    }
+
     var newRoomId = createMatrixRoom(chat);
+    var ownerMatrixUserId = chat.getChatOwner().getMatrixUserId();
+    for (var member : humanMembers) {
+      if (Objects.equals(ownerMatrixUserId, member.matrixUserId())) {
+        continue;
+      }
+      if (!groupChatMembershipService.addMemberToRoom(
+          newRoomId, ownerMatrixUserId, member.matrixUserId())) {
+        throw new InternalServerErrorException(
+            String.format(
+                "Could not carry member %s into next occurrence of group chat %s",
+                member.matrixUserId(), chat.getId()));
+      }
+    }
     matrixChatShutdownService.shutdownRoom(chat);
 
     return newRoomId;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
@@ -77,7 +77,7 @@ public class KeycloakAuthClient {
   }
 
   public boolean verifyIgnoringOtp(String username, String password) {
-    var entity = loginRequest(username, password);
+    var entity = loginRequest(usernameTranscoder.decodeUsername(username), password);
     var url = identityClientConfig.getOpenIdConnectUrl(ENDPOINT_OPENID_CONNECT_LOGIN);
 
     ResponseEntity<KeycloakLoginResponseDTO> loginResponse;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/DpaForwardEmailController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/DpaForwardEmailController.java
@@ -1,0 +1,47 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.service.accountinvite.DpaForwardEmailService;
+import de.caritas.cob.userservice.api.service.accountinvite.DpaForwardEmailService.DpaForwardEmailCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/useradmin/dpa-invites")
+public class DpaForwardEmailController {
+
+  private static final String ADMIN_AUTH =
+      "hasAnyAuthority('AUTHORIZATION_TENANT_ADMIN', 'AUTHORIZATION_USER_ADMIN')";
+
+  private final @NonNull DpaForwardEmailService dpaForwardEmailService;
+
+  @PreAuthorize(ADMIN_AUTH)
+  @PostMapping("/email")
+  public ResponseEntity<Void> forwardSigningLink(
+      @Valid @RequestBody DpaForwardEmailRequest request) {
+    dpaForwardEmailService.sendSigningLink(
+        new DpaForwardEmailCommand(
+            request.tenantId, request.recipientEmail, request.signLink, request.expiresAt));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Data
+  public static class DpaForwardEmailRequest {
+    @NotNull private Long tenantId;
+    @NotBlank @Email private String recipientEmail;
+    @NotBlank private String signLink;
+    @NotNull private LocalDateTime expiresAt;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
@@ -53,6 +54,7 @@ public class ConsultantAdminService {
 
   private final @NonNull SessionRepository sessionRepository;
   private final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
+  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
 
   private final @NonNull AuthenticatedUser authenticatedUser;
 
@@ -215,6 +217,7 @@ public class ConsultantAdminService {
         .forEach(
             session -> {
               caseHandoverRequestRepository.deleteAllBySessionId(session.getId());
+              sessionSupervisorRepository.deleteAllBySessionId(session.getId());
               sessionRepository.delete(session);
             });
   }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminService.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -37,6 +38,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Service class for admin operations on {@link Consultant} objects. */
 @Service
@@ -50,6 +52,7 @@ public class ConsultantAdminService {
   private final @NonNull ConsultantPreDeletionService consultantPreDeletionService;
 
   private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
 
   private final @NonNull AuthenticatedUser authenticatedUser;
 
@@ -153,6 +156,7 @@ public class ConsultantAdminService {
    * @param consultantId the consultant id
    * @param forceDeleteSessions
    */
+  @Transactional
   public void markConsultantForDeletion(String consultantId, Boolean forceDeleteSessions) {
     var consultant =
         this.consultantRepository
@@ -208,6 +212,10 @@ public class ConsultantAdminService {
   private void deleteSessionsInProgressOrArchived(Consultant consultant) {
     sessionRepository
         .findByConsultantAndStatusIn(consultant, Lists.newArrayList(IN_PROGRESS, IN_ARCHIVE))
-        .forEach(sessionRepository::delete);
+        .forEach(
+            session -> {
+              caseHandoverRequestRepository.deleteAllBySessionId(session.getId());
+              sessionRepository.delete(session);
+            });
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
@@ -4,6 +4,9 @@ import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CaseHandoverRequestRepository extends JpaRepository<CaseHandoverRequest, Long> {
 
@@ -20,4 +23,8 @@ public interface CaseHandoverRequestRepository extends JpaRepository<CaseHandove
   List<CaseHandoverRequest> findByRequesterConsultantId(String requesterConsultantId);
 
   List<CaseHandoverRequest> findByPreviousConsultantId(String previousConsultantId);
+
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("delete from CaseHandoverRequest request where request.session.id = :sessionId")
+  int deleteAllBySessionId(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.model.SessionSupervisor;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -58,4 +59,8 @@ public interface SessionSupervisorRepository extends JpaRepository<SessionSuperv
    * @return count of active supervisors
    */
   long countBySessionIdAndIsActiveTrue(Long sessionId);
+
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("delete from SessionSupervisor supervisor where supervisor.session.id = :sessionId")
+  int deleteAllBySessionId(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -70,13 +70,13 @@ public class CaseHandoverService {
           "COUNSELLOR_ASKED_FOR_ADVICE",
           Map.of(
               "de",
-              "Du hast zugestimmt: {{newAdvisor}} kann dieses Gespräch zeitweise mitlesen, um deine Berater:in fachlich zu unterstützen. Deine Berater:in bleibt für dich zuständig.",
+              "Du hast der Fallübergabe zugestimmt. {{newAdvisor}} hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.",
               "en",
-              "You have given your consent: {{newAdvisor}} can temporarily read this conversation to support your counsellor professionally. Your counsellor remains responsible for you.",
+              "You agreed to the case handover. {{newAdvisor}} has taken over your case and will continue your counselling from now on.",
               "tr",
-              "Onay verdiniz: {{newAdvisor}}, danışmanınıza mesleki destek sağlamak için bu görüşmeyi geçici olarak okuyabilir. Danışmanınız sizin için sorumlu olmaya devam eder.",
+              "Vaka devrine onay verdiniz. {{newAdvisor}} vakanızı devraldı ve bundan sonra danışmanlığınızı sürdürecek.",
               "uk",
-              "Ви надали згоду: {{newAdvisor}} може тимчасово читати цю розмову, щоб професійно підтримати вашого консультанта. Ваш консультант і надалі відповідає за вас."),
+              "Ви погодилися на передачу справи. {{newAdvisor}} перейняв(-ла) вашу справу й відтепер продовжуватиме консультування."),
           "COUNSELLOR_ON_HOLIDAY",
           Map.of(
               "de",
@@ -894,6 +894,17 @@ public class CaseHandoverService {
     if (!joined) {
       throw new InternalServerErrorException(
           "Failed to join case handover requester to Matrix room");
+    }
+
+    // A completed takeover transfers access; it must not leave the previous
+    // counsellor joined at the transport layer after the application curtain
+    // has hidden the conversation. Removing the old member only after the new
+    // member joined keeps the room reachable if the join itself fails.
+    boolean previousConsultantLeft =
+        matrixSynapseService.leaveRoom(roomId, previousConsultantToken);
+    if (!previousConsultantLeft) {
+      throw new InternalServerErrorException(
+          "Failed to remove previous consultant from Matrix room after case handover");
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ChatService.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatParticipantReconciliationService;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +60,7 @@ public class ChatService {
   private final @NonNull UserChatRepository userChatRepository;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull GroupChatParticipantRepository groupChatParticipantRepository;
+  private final @NonNull GroupChatParticipantReconciliationService participantReconciliationService;
 
   private final @NonNull AgencyService agencyService;
 
@@ -303,8 +306,7 @@ public class ChatService {
               var displayName =
                   consultantService
                       .getConsultant(participant.getConsultantId())
-                      .map(Consultant::getDisplayName)
-                      .filter(name -> name != null && !name.isBlank())
+                      .map(this::resolveParticipantDisplayName)
                       .orElse(participant.getConsultantId());
               return new GroupChatParticipantDTO()
                   .consultantId(participant.getConsultantId())
@@ -312,6 +314,23 @@ public class ChatService {
                   .displayName(displayName);
             })
         .toList();
+  }
+
+  private String resolveParticipantDisplayName(Consultant consultant) {
+    if (consultant.getDisplayName() != null && !consultant.getDisplayName().isBlank()) {
+      return consultant.getDisplayName();
+    }
+    var fullName =
+        Stream.of(consultant.getFirstName(), consultant.getLastName())
+            .filter(name -> name != null && !name.isBlank())
+            .collect(Collectors.joining(" "));
+    if (!fullName.isBlank()) {
+      return fullName;
+    }
+    if (consultant.getUsername() != null && !consultant.getUsername().isBlank()) {
+      return consultant.getUsername();
+    }
+    return consultant.getId();
   }
 
   private Set<ChatAgency> loadChatAgencies(Long chatId) {
@@ -437,6 +456,7 @@ public class ChatService {
    * @param authenticatedUser {@link AuthenticatedUser}
    * @return {@link UpdateChatResponseDTO}
    */
+  @Transactional
   public UpdateChatResponseDTO updateChat(
       Long chatId, ChatDTO chatDTO, AuthenticatedUser authenticatedUser) {
 
@@ -497,6 +517,7 @@ public class ChatService {
     chat.setGroupChatRulesTranslations(chatDTO.getGroupChatRulesTranslations());
 
     this.saveChat(chat);
+    participantReconciliationService.reconcile(chat, chatDTO.getConsultantIds());
 
     return new UpdateChatResponseDTO().groupId(chat.getGroupId());
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/DpaForwardEmailService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/DpaForwardEmailService.java
@@ -1,0 +1,84 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.service.notification.DpaSigningEmailDispatchService;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DpaForwardEmailService {
+
+  private final TenantService tenantService;
+  private final DpaSigningEmailDispatchService dpaSigningEmailDispatchService;
+  private final URI permittedAppOrigin;
+
+  public DpaForwardEmailService(
+      @NonNull TenantService tenantService,
+      @NonNull DpaSigningEmailDispatchService dpaSigningEmailDispatchService,
+      @Value("${dpa.sign.frontend.base-url:https://app.oriso.org}") String appBaseUrl) {
+    this.tenantService = tenantService;
+    this.dpaSigningEmailDispatchService = dpaSigningEmailDispatchService;
+    this.permittedAppOrigin = parseUri(appBaseUrl, "appBaseUrl");
+  }
+
+  public void sendSigningLink(DpaForwardEmailCommand command) {
+    if (command == null
+        || command.tenantId() == null
+        || isBlank(command.recipientEmail())
+        || command.expiresAt() == null) {
+      throw new BadRequestException("tenantId, recipientEmail and expiresAt are required");
+    }
+
+    URI signLink = parseUri(command.signLink(), "signLink");
+    if (!hasSameOrigin(signLink, permittedAppOrigin)
+        || signLink.getPath() == null
+        || !signLink.getPath().startsWith("/dpa-sign/")) {
+      throw new BadRequestException("signLink must use the configured ORISO App origin");
+    }
+
+    var tenant = tenantService.getRestrictedTenantData(command.tenantId());
+    String tenantName =
+        tenant == null || isBlank(tenant.getName()) ? "Ihrer Organisation" : tenant.getName();
+    dpaSigningEmailDispatchService.send(
+        command.recipientEmail().trim(), tenantName, signLink.toString(), command.expiresAt());
+  }
+
+  private static URI parseUri(String value, String field) {
+    if (isBlank(value)) {
+      throw new BadRequestException(field + " is required");
+    }
+    try {
+      URI uri = URI.create(value.trim());
+      if (isBlank(uri.getScheme()) || isBlank(uri.getHost())) {
+        throw new IllegalArgumentException("absolute URI required");
+      }
+      return uri;
+    } catch (IllegalArgumentException exception) {
+      throw new BadRequestException(field + " is invalid");
+    }
+  }
+
+  private static boolean hasSameOrigin(URI left, URI right) {
+    return left.getScheme().equalsIgnoreCase(right.getScheme())
+        && left.getHost().equalsIgnoreCase(right.getHost())
+        && effectivePort(left) == effectivePort(right)
+        && Objects.equals(left.getUserInfo(), right.getUserInfo());
+  }
+
+  private static int effectivePort(URI uri) {
+    if (uri.getPort() >= 0) {
+      return uri.getPort();
+    }
+    return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+  }
+
+  public record DpaForwardEmailCommand(
+      Long tenantId, String recipientEmail, String signLink, LocalDateTime expiresAt) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
@@ -1,0 +1,108 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Keeps a chat Series' explicit consultant selection and Matrix room membership in sync. */
+@Service
+@RequiredArgsConstructor
+public class GroupChatParticipantReconciliationService {
+
+  private final GroupChatParticipantRepository participantRepository;
+  private final ConsultantRepository consultantRepository;
+  private final GroupChatMembershipService membershipService;
+
+  /**
+   * Reconciles co-moderators only when the client explicitly supplies {@code consultantIds}. A null
+   * value preserves legacy clients' existing participants.
+   */
+  @Transactional
+  public void reconcile(Chat series, List<String> consultantIds) {
+    if (consultantIds == null) {
+      return;
+    }
+
+    var participants = participantRepository.findBySeriesIdForUpdate(series.getId());
+    var ownerId = series.getChatOwner().getId();
+    var desiredIds = new LinkedHashSet<>(consultantIds);
+    desiredIds.remove(ownerId);
+    desiredIds.removeIf(id -> id == null || id.isBlank());
+
+    var participantsByConsultantId =
+        participants.stream()
+            .collect(
+                Collectors.toMap(
+                    GroupChatParticipant::getConsultantId,
+                    Function.identity(),
+                    (left, right) -> left));
+
+    for (var existing : participants) {
+      if (existing.getRole() == ParticipantRole.CO_MODERATOR
+          && !desiredIds.contains(existing.getConsultantId())) {
+        consultantRepository
+            .findByIdAndDeleteDateIsNull(existing.getConsultantId())
+            .ifPresent(
+                consultant ->
+                    membershipService.removeLeavingMemberFromRoom(
+                        series, consultant.getMatrixUserId()));
+        participantRepository.delete(existing);
+      }
+    }
+
+    var sessionId =
+        participants.stream()
+            .map(GroupChatParticipant::getChatId)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new ConflictException(
+                        "Chat Series has no owner participation and cannot be updated"));
+
+    for (var consultantId : desiredIds) {
+      var existing = participantsByConsultantId.get(consultantId);
+      if (existing != null) {
+        if (existing.getRole() == ParticipantRole.PARTICIPANT) {
+          existing.setRole(ParticipantRole.CO_MODERATOR);
+          participantRepository.save(existing);
+        }
+        continue;
+      }
+
+      var consultant =
+          consultantRepository
+              .findByIdAndDeleteDateIsNull(consultantId)
+              .orElseThrow(
+                  () -> new BadRequestException("Consultant " + consultantId + " does not exist"));
+      if (!Objects.equals(series.getChatOwner().getTenantId(), consultant.getTenantId())) {
+        throw new BadRequestException("Consultant does not belong to the chat owner's tenant");
+      }
+      if (!membershipService.addMemberToRoom(series, consultant.getMatrixUserId())) {
+        throw new InternalServerErrorException(
+            "Consultant " + consultantId + " could not join the Matrix room");
+      }
+
+      participantRepository.save(
+          GroupChatParticipant.builder()
+              .chatId(sessionId)
+              .seriesId(series.getId())
+              .consultantId(consultantId)
+              .role(ParticipantRole.CO_MODERATOR)
+              .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/GroupChatMembershipService.java
@@ -69,6 +69,16 @@ public class GroupChatMembershipService {
     var matrixRoomId = resolveMatrixRoomId(chat);
     var ownerMatrixUserId =
         chat == null || chat.getChatOwner() == null ? null : chat.getChatOwner().getMatrixUserId();
+    return addMemberToRoom(matrixRoomId, ownerMatrixUserId, memberMatrixUserId);
+  }
+
+  /**
+   * Invites and joins a member when the target room is not yet persisted on the {@link Chat}.
+   * Repetitive chats use this while constructing their next occurrence, before the old room is
+   * replaced in the database.
+   */
+  public boolean addMemberToRoom(
+      String matrixRoomId, String ownerMatrixUserId, String memberMatrixUserId) {
     if (isBlank(matrixRoomId) || isBlank(memberMatrixUserId) || isBlank(ownerMatrixUserId)) {
       return false;
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/DefaultDpaSigningEmailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/DefaultDpaSigningEmailDispatchService.java
@@ -1,0 +1,60 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class DefaultDpaSigningEmailDispatchService implements DpaSigningEmailDispatchService {
+
+  private final RestTemplate restTemplate;
+  private final SecurityHeaderSupplier securityHeaderSupplier;
+  private final TenantHeaderSupplier tenantHeaderSupplier;
+  private final String consultingTypeServiceApiUrl;
+
+  public DefaultDpaSigningEmailDispatchService(
+      @NonNull RestTemplate restTemplate,
+      @NonNull SecurityHeaderSupplier securityHeaderSupplier,
+      @NonNull TenantHeaderSupplier tenantHeaderSupplier,
+      @Value("${consulting.type.service.api.url:}") String consultingTypeServiceApiUrl) {
+    this.restTemplate = restTemplate;
+    this.securityHeaderSupplier = securityHeaderSupplier;
+    this.tenantHeaderSupplier = tenantHeaderSupplier;
+    this.consultingTypeServiceApiUrl = consultingTypeServiceApiUrl;
+  }
+
+  @Override
+  public void send(
+      String recipientEmail, String tenantName, String signLink, LocalDateTime expiresAt) {
+    if (isBlank(consultingTypeServiceApiUrl)) {
+      throw new IllegalStateException("DPA email dispatch endpoint is not configured");
+    }
+    var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+    tenantHeaderSupplier.addTenantHeader(headers);
+    Map<String, Object> payload =
+        Map.of(
+            "recipientEmail", recipientEmail,
+            "tenantName", tenantName,
+            "signLink", signLink,
+            "expiresAt", expiresAt.toString());
+    restTemplate.exchange(
+        normalizeBaseUrl(consultingTypeServiceApiUrl) + "/settingsadmin/dpa-signing-emails",
+        HttpMethod.POST,
+        new HttpEntity<>(payload, headers),
+        Void.class);
+  }
+
+  private static String normalizeBaseUrl(String value) {
+    String trimmed = value.trim();
+    return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/DpaSigningEmailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/DpaSigningEmailDispatchService.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import java.time.LocalDateTime;
+
+public interface DpaSigningEmailDispatchService {
+  void send(String recipientEmail, String tenantName, String signLink, LocalDateTime expiresAt);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
@@ -58,19 +58,18 @@ public class UserAccountService {
     return this.consultantService.findConsultantByEmail(email);
   }
 
-  /**
-   * Tries to retrieve the user of the current {@link AuthenticatedUser} and throws an 500 - Server
-   * Error if {@link User} is not present.
-   *
-   * @return the validated {@link User}
-   */
+  /** Tries to retrieve the active user of the current {@link AuthenticatedUser}. */
   public User retrieveValidatedUser() {
-    return this.userService
-        .getUser(this.authenticatedUser.getUserId())
-        .orElseThrow(
-            () ->
-                new InternalServerErrorException(
-                    String.format("User with id %s not found", authenticatedUser.getUserId())));
+    String userId = this.authenticatedUser.getUserId();
+    Optional<User> active = this.userService.getUser(userId);
+    if (active.isPresent()) {
+      return active.get();
+    }
+    if (this.userService.findDeletedById(userId).isPresent()) {
+      throw new ForbiddenException(
+          String.format("User with id %s is flagged for deletion and cannot log in", userId));
+    }
+    throw new InternalServerErrorException(String.format("User with id %s not found", userId));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import org.springframework.stereotype.Component;
 
@@ -18,9 +19,14 @@ public class DeleteAskerRoomsAndSessionsAction extends DeleteRoomsAndSessionActi
       SessionRepository sessionRepository,
       SessionDataRepository sessionDataRepository,
       RocketChatService rocketChatService,
-      CaseHandoverRequestRepository caseHandoverRequestRepository) {
+      CaseHandoverRequestRepository caseHandoverRequestRepository,
+      SessionSupervisorRepository sessionSupervisorRepository) {
     super(
-        sessionRepository, sessionDataRepository, rocketChatService, caseHandoverRequestRepository);
+        sessionRepository,
+        sessionDataRepository,
+        rocketChatService,
+        caseHandoverRequestRepository,
+        sessionSupervisorRepository);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import java.util.List;
@@ -25,6 +26,7 @@ abstract class DeleteRoomsAndSessionAction {
   protected final @NonNull SessionDataRepository sessionDataRepository;
   protected final @NonNull RocketChatService rocketChatService;
   protected final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
+  protected final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
 
   void deleteRocketChatGroup(String rcGroupId, List<DeletionWorkflowError> workflowErrors) {
     if (isNotBlank(rcGroupId)) {
@@ -63,9 +65,7 @@ abstract class DeleteRoomsAndSessionAction {
 
   void deleteCaseHandoverRequests(Session session, List<DeletionWorkflowError> workflowErrors) {
     try {
-      var caseHandoverRequests =
-          this.caseHandoverRequestRepository.findBySessionId(session.getId());
-      this.caseHandoverRequestRepository.deleteAll(caseHandoverRequests);
+      this.caseHandoverRequestRepository.deleteAllBySessionId(session.getId());
     } catch (Exception e) {
       log.error("UserService delete workflow error: ", e);
       workflowErrors.add(
@@ -74,6 +74,22 @@ abstract class DeleteRoomsAndSessionAction {
               .deletionTargetType(DeletionTargetType.DATABASE)
               .identifier(String.valueOf(session.getId()))
               .reason("Unable to delete case handover requests for session")
+              .timestamp(nowInUtc())
+              .build());
+    }
+  }
+
+  void deleteSessionSupervisors(Session session, List<DeletionWorkflowError> workflowErrors) {
+    try {
+      this.sessionSupervisorRepository.deleteAllBySessionId(session.getId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      workflowErrors.add(
+          DeletionWorkflowError.builder()
+              .deletionSourceType(ASKER)
+              .deletionTargetType(DeletionTargetType.DATABASE)
+              .identifier(String.valueOf(session.getId()))
+              .reason("Unable to delete supervisors for session")
               .timestamp(nowInUtc())
               .build());
     }
@@ -99,6 +115,7 @@ abstract class DeleteRoomsAndSessionAction {
 
     deleteRocketChatGroup(session.getGroupId(), workflowErrors);
     deleteSessionData(session, workflowErrors);
+    deleteSessionSupervisors(session, workflowErrors);
     deleteCaseHandoverRequests(session, workflowErrors);
     deleteSession(session, workflowErrors);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.SessionDeletionWorkflowDTO;
 import org.springframework.stereotype.Component;
 
@@ -25,9 +26,14 @@ public class DeleteSingleRoomAndSessionAction extends DeleteRoomsAndSessionActio
       SessionRepository sessionRepository,
       SessionDataRepository sessionDataRepository,
       RocketChatService rocketChatService,
-      CaseHandoverRequestRepository caseHandoverRequestRepository) {
+      CaseHandoverRequestRepository caseHandoverRequestRepository,
+      SessionSupervisorRepository sessionSupervisorRepository) {
     super(
-        sessionRepository, sessionDataRepository, rocketChatService, caseHandoverRequestRepository);
+        sessionRepository,
+        sessionDataRepository,
+        rocketChatService,
+        caseHandoverRequestRepository,
+        sessionSupervisorRepository);
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,7 @@ server.port=8082
 server.host=http://localhost
 app.base.url=http://localhost:8082
 system.notification.frontend.base-url=${SYSTEM_NOTIFICATION_FRONTEND_BASE_URL:https://app.oriso.org}
+dpa.sign.frontend.base-url=${DPA_SIGN_FRONTEND_BASE_URL:https://app.oriso.org}
 # Self-service password reset link base URL. No default on purpose: when unset the feature is
 # disabled (fail closed) rather than emailing a hardcoded production URL. Set per environment.
 password.reset.frontend.base-url=${PASSWORD_RESET_FRONTEND_BASE_URL:}

--- a/src/test/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/chat/ChatReCreatorTest.java
@@ -4,10 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -21,7 +24,11 @@ import de.caritas.cob.userservice.api.model.Chat.ChatInterval;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService.ResolvedRoomMember;
 import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,6 +52,15 @@ class ChatReCreatorTest {
 
   @Mock private MatrixChatShutdownService matrixChatShutdownService;
 
+  @Mock private GroupChatMembershipService groupChatMembershipService;
+
+  @BeforeEach
+  void resolveRoomIdFromChatFixture() {
+    lenient()
+        .when(groupChatMembershipService.resolveMatrixRoomId(any(Chat.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0, Chat.class).getMatrixRoomId());
+  }
+
   @Test
   void recreateShouldCreateMatrixRoomAsChatOwnerAndShutDownOldRoomAfterwards()
       throws MatrixCreateRoomException {
@@ -54,6 +70,11 @@ class ChatReCreatorTest {
     when(matrixSynapseService.createRoomAsMatrixUser(
             eq("topic"), startsWith("group_chat_"), eq(OWNER_MATRIX_USER_ID)))
         .thenReturn(ResponseEntity.ok(response));
+    when(groupChatMembershipService.resolveHumanMembers(OLD_MATRIX_ROOM_ID))
+        .thenReturn(
+            List.of(
+                new ResolvedRoomMember(
+                    OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner Owner", true)));
 
     var newRoomId = chatReCreator.recreateMessengerChat(chat);
 
@@ -66,9 +87,74 @@ class ChatReCreatorTest {
   }
 
   @Test
+  void recreateShouldCarryEveryHumanMemberIntoNewRoomBeforeShuttingDownOldRoom()
+      throws MatrixCreateRoomException {
+    var chat = buildRepetitiveChat(OWNER_MATRIX_USER_ID);
+    var coModeratorMatrixId = "@co-moderator:matrix.local";
+    var askerMatrixId = "@asker:matrix.local";
+    var response = new MatrixCreateRoomResponseDTO();
+    response.setRoomId(NEW_MATRIX_ROOM_ID);
+    when(groupChatMembershipService.resolveHumanMembers(OLD_MATRIX_ROOM_ID))
+        .thenReturn(
+            List.of(
+                new ResolvedRoomMember(
+                    OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner Owner", true),
+                new ResolvedRoomMember(coModeratorMatrixId, "co-id", "co", "Co Moderator", true),
+                new ResolvedRoomMember(askerMatrixId, "asker-id", "asker", "asker", false)));
+    when(matrixSynapseService.createRoomAsMatrixUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.ok(response));
+    when(groupChatMembershipService.addMemberToRoom(
+            NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, coModeratorMatrixId))
+        .thenReturn(true);
+    when(groupChatMembershipService.addMemberToRoom(
+            NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, askerMatrixId))
+        .thenReturn(true);
+
+    chatReCreator.recreateMessengerChat(chat);
+
+    verify(groupChatMembershipService, never())
+        .addMemberToRoom(NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, OWNER_MATRIX_USER_ID);
+    var order = inOrder(groupChatMembershipService, matrixChatShutdownService);
+    order
+        .verify(groupChatMembershipService)
+        .addMemberToRoom(NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, coModeratorMatrixId);
+    order
+        .verify(groupChatMembershipService)
+        .addMemberToRoom(NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, askerMatrixId);
+    order.verify(matrixChatShutdownService).shutdownRoom(chat);
+  }
+
+  @Test
+  void recreateShouldKeepOldRoomAliveWhenAnyHumanMemberCannotJoinNewRoom()
+      throws MatrixCreateRoomException {
+    var chat = buildRepetitiveChat(OWNER_MATRIX_USER_ID);
+    var askerMatrixId = "@asker:matrix.local";
+    var response = new MatrixCreateRoomResponseDTO();
+    response.setRoomId(NEW_MATRIX_ROOM_ID);
+    when(groupChatMembershipService.resolveHumanMembers(OLD_MATRIX_ROOM_ID))
+        .thenReturn(
+            List.of(
+                new ResolvedRoomMember(
+                    OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner Owner", true),
+                new ResolvedRoomMember(askerMatrixId, "asker-id", "asker", "asker", false)));
+    when(matrixSynapseService.createRoomAsMatrixUser(anyString(), anyString(), anyString()))
+        .thenReturn(ResponseEntity.ok(response));
+    when(groupChatMembershipService.addMemberToRoom(
+            NEW_MATRIX_ROOM_ID, OWNER_MATRIX_USER_ID, askerMatrixId))
+        .thenReturn(false);
+
+    assertThrows(
+        InternalServerErrorException.class, () -> chatReCreator.recreateMessengerChat(chat));
+
+    verifyNoInteractions(matrixChatShutdownService);
+  }
+
+  @Test
   void recreateShouldFailAndKeepOldRoomAliveWhenMatrixRoomCreationFails()
       throws MatrixCreateRoomException {
     var chat = buildRepetitiveChat(OWNER_MATRIX_USER_ID);
+    when(groupChatMembershipService.resolveHumanMembers(OLD_MATRIX_ROOM_ID))
+        .thenReturn(ownerRoomMembers());
     when(matrixSynapseService.createRoomAsMatrixUser(anyString(), anyString(), anyString()))
         .thenThrow(new MatrixCreateRoomException("Synapse unavailable"));
 
@@ -82,6 +168,8 @@ class ChatReCreatorTest {
   @Test
   void recreateShouldFailWhenMatrixResponseContainsNoRoomId() throws MatrixCreateRoomException {
     var chat = buildRepetitiveChat(OWNER_MATRIX_USER_ID);
+    when(groupChatMembershipService.resolveHumanMembers(OLD_MATRIX_ROOM_ID))
+        .thenReturn(ownerRoomMembers());
     when(matrixSynapseService.createRoomAsMatrixUser(anyString(), anyString(), anyString()))
         .thenReturn(ResponseEntity.ok(new MatrixCreateRoomResponseDTO()));
 
@@ -146,5 +234,10 @@ class ChatReCreatorTest {
     chat.setGroupId(OLD_MATRIX_ROOM_ID);
     chat.setMatrixRoomId(OLD_MATRIX_ROOM_ID);
     return chat;
+  }
+
+  private List<ResolvedRoomMember> ownerRoomMembers() {
+    return List.of(
+        new ResolvedRoomMember(OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner Owner", true));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommandTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/chat/StopChatActionCommandTest.java
@@ -40,6 +40,9 @@ import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService.ResolvedRoomMember;
+import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -305,6 +308,7 @@ class StopChatActionCommandTest {
             mock(RocketChatCredentialsProvider.class),
             mock(RocketChatConfig.class),
             mock(RocketChatMapper.class));
+    var membershipService = mock(GroupChatMembershipService.class);
     var command =
         new StopChatActionCommand(
             chatService,
@@ -312,9 +316,15 @@ class StopChatActionCommandTest {
             new ChatReCreator(
                 chatService,
                 matrixSynapseService,
-                new MatrixChatShutdownService(matrixSynapseService)),
+                new MatrixChatShutdownService(matrixSynapseService),
+                membershipService),
             new MatrixChatShutdownService(matrixSynapseService));
     var repetitiveChat = buildRepetitiveChatWithMatrixRoom();
+    when(membershipService.resolveMatrixRoomId(repetitiveChat)).thenReturn(MATRIX_ROOM_ID);
+    when(membershipService.resolveHumanMembers(MATRIX_ROOM_ID))
+        .thenReturn(
+            List.of(
+                new ResolvedRoomMember(OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner", true)));
 
     var newRoomResponse = new MatrixCreateRoomResponseDTO();
     newRoomResponse.setRoomId(NEW_MATRIX_ROOM_ID);
@@ -343,6 +353,7 @@ class StopChatActionCommandTest {
             mock(RocketChatCredentialsProvider.class),
             mock(RocketChatConfig.class),
             mock(RocketChatMapper.class));
+    var membershipService = mock(GroupChatMembershipService.class);
     var command =
         new StopChatActionCommand(
             chatService,
@@ -350,9 +361,15 @@ class StopChatActionCommandTest {
             new ChatReCreator(
                 chatService,
                 matrixSynapseService,
-                new MatrixChatShutdownService(matrixSynapseService)),
+                new MatrixChatShutdownService(matrixSynapseService),
+                membershipService),
             new MatrixChatShutdownService(matrixSynapseService));
     var repetitiveChat = buildRepetitiveChatWithMatrixRoom();
+    when(membershipService.resolveMatrixRoomId(repetitiveChat)).thenReturn(MATRIX_ROOM_ID);
+    when(membershipService.resolveHumanMembers(MATRIX_ROOM_ID))
+        .thenReturn(
+            List.of(
+                new ResolvedRoomMember(OWNER_MATRIX_USER_ID, "owner-id", "owner", "Owner", true)));
 
     when(matrixSynapseService.createRoomAsMatrixUser(anyString(), anyString(), anyString()))
         .thenThrow(new MatrixCreateRoomException("Synapse unavailable"));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -25,13 +26,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
@@ -93,6 +97,26 @@ class KeycloakAuthClientTest {
         .thenThrow(exception);
 
     assertTrue(keycloakAuthClient.verifyIgnoringOtp(USERNAME, PASSWORD));
+  }
+
+  @Test
+  void verifyIgnoringOtp_ShouldDecodeEncodedUsernameBeforeKeycloakLogin() {
+    var loginResponse = mock(KeycloakLoginResponseDTO.class);
+    when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
+    var encodedUsername =
+        new de.caritas.cob.userservice.api.helper.UsernameTranscoder()
+            .encodeUsername("blinky.fish@oriso.org");
+
+    assertTrue(keycloakAuthClient.verifyIgnoringOtp(encodedUsername, PASSWORD));
+
+    @SuppressWarnings("rawtypes")
+    var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate, atLeastOnce())
+        .postForEntity(anyString(), requestCaptor.capture(), eq(KeycloakLoginResponseDTO.class));
+    @SuppressWarnings("unchecked")
+    var body = (MultiValueMap<String, String>) requestCaptor.getValue().getBody();
+    assertThat(body.getFirst("username"), is("blinky.fish@oriso.org"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/DpaForwardEmailControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/DpaForwardEmailControllerTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.service.accountinvite.DpaForwardEmailService;
+import de.caritas.cob.userservice.api.service.accountinvite.DpaForwardEmailService.DpaForwardEmailCommand;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class DpaForwardEmailControllerTest {
+
+  @Mock private DpaForwardEmailService dpaForwardEmailService;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(new DpaForwardEmailController(dpaForwardEmailService))
+            .build();
+  }
+
+  @Test
+  void forwardSigningLink_validRequest_returnsNoContent() throws Exception {
+    mockMvc
+        .perform(
+            post("/useradmin/dpa-invites/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "tenantId": 84,
+                      "recipientEmail": "bart.simpson@oriso.org",
+                      "signLink": "https://app.oriso-dev.site/dpa-sign/single-use-token",
+                      "expiresAt": "2026-08-03T13:27:28.243207790"
+                    }
+                    """))
+        .andExpect(status().isNoContent());
+
+    ArgumentCaptor<DpaForwardEmailCommand> command =
+        ArgumentCaptor.forClass(DpaForwardEmailCommand.class);
+    verify(dpaForwardEmailService).sendSigningLink(command.capture());
+    assertThat(command.getValue().tenantId()).isEqualTo(84L);
+    assertThat(command.getValue().recipientEmail()).isEqualTo("bart.simpson@oriso.org");
+    assertThat(command.getValue().signLink())
+        .isEqualTo("https://app.oriso-dev.site/dpa-sign/single-use-token");
+    assertThat(command.getValue().expiresAt())
+        .isEqualTo(LocalDateTime.parse("2026-08-03T13:27:28.243207790"));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -54,9 +54,15 @@ import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.*;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
+import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
+import de.caritas.cob.userservice.api.service.chat.ChatOccurrenceCommandService;
+import de.caritas.cob.userservice.api.service.chat.ChatOccurrenceQueryService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatFeatureGate;
+import de.caritas.cob.userservice.api.service.chat.GroupChatRoleService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -256,6 +262,12 @@ class UserControllerIT {
   @Autowired private MockMvc mvc;
 
   @MockitoBean private UserAccountService userAccountService;
+  @MockitoBean private PasswordResetService passwordResetService;
+  @MockitoBean private AccountInviteService accountInviteService;
+  @MockitoBean private GroupChatFeatureGate groupChatFeatureGate;
+  @MockitoBean private ChatOccurrenceCommandService chatOccurrenceCommandService;
+  @MockitoBean private ChatOccurrenceQueryService chatOccurrenceQueryService;
+  @MockitoBean private GroupChatRoleService groupChatRoleService;
   @MockitoBean private SessionService sessionService;
   @MockitoBean private AuthenticatedUser authenticatedUser;
   @MockitoBean private CreateEnquiryMessageFacade createEnquiryMessageFacade;
@@ -342,6 +354,7 @@ class UserControllerIT {
   private UserDtoMapper userDtoMapper;
 
   @MockitoBean private ConsultantService consultantService;
+  @MockitoBean private ConsultantPublicSlugService consultantPublicSlugService;
 
   @MockitoBean
   @SuppressWarnings("unused")
@@ -1266,6 +1279,22 @@ class UserControllerIT {
                 .cookie(RC_TOKEN_COOKIE)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is(HttpStatus.INTERNAL_SERVER_ERROR.value()));
+  }
+
+  @Test
+  void getUserData_ForSoftDeletedUser_Should_ReturnForbidden() throws Exception {
+    when(authenticatedUser.getRoles()).thenReturn(ROLES_WITH_USER);
+    when(authenticatedUser.getGrantedAuthorities())
+        .thenReturn(new HashSet<>(Authority.getAuthoritiesByUserRole(UserRole.USER)));
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userAccountService.retrieveValidatedUser()).thenThrow(new ForbiddenException(""));
+
+    mvc.perform(
+            get(PATH_USER_DATA)
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(RC_TOKEN_COOKIE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminServiceTest.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
@@ -59,6 +60,8 @@ public class ConsultantAdminServiceTest {
   @Mock private SessionRepository sessionRepository;
 
   @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
 
   @Mock private AuthenticatedUser authenticatedUser;
 
@@ -188,8 +191,10 @@ public class ConsultantAdminServiceTest {
 
     consultantAdminService.markConsultantForDeletion("c-1", true);
 
-    var deletionOrder = inOrder(caseHandoverRequestRepository, sessionRepository);
+    var deletionOrder =
+        inOrder(caseHandoverRequestRepository, sessionSupervisorRepository, sessionRepository);
     deletionOrder.verify(caseHandoverRequestRepository).deleteAllBySessionId(session.getId());
+    deletionOrder.verify(sessionSupervisorRepository).deleteAllBySessionId(session.getId());
     deletionOrder.verify(sessionRepository).delete(session);
     verify(deletionLifecycleService).beginConsultantDeletion(any(), any());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/ConsultantAdminServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,6 +21,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -55,6 +57,8 @@ public class ConsultantAdminServiceTest {
   @Mock private AppointmentService appointmentService;
 
   @Mock private SessionRepository sessionRepository;
+
+  @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
 
   @Mock private AuthenticatedUser authenticatedUser;
 
@@ -184,7 +188,9 @@ public class ConsultantAdminServiceTest {
 
     consultantAdminService.markConsultantForDeletion("c-1", true);
 
-    verify(sessionRepository).delete(session);
+    var deletionOrder = inOrder(caseHandoverRequestRepository, sessionRepository);
+    deletionOrder.verify(caseHandoverRequestRepository).deleteAllBySessionId(session.getId());
+    deletionOrder.verify(sessionRepository).delete(session);
     verify(deletionLifecycleService).beginConsultantDeletion(any(), any());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -3,8 +3,10 @@ package de.caritas.cob.userservice.api.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.CaseHandoverReasonPolicy;
 import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
@@ -106,6 +109,7 @@ class CaseHandoverServiceTest {
         .thenReturn(List.of());
     when(caseHandoverRequestRepository.save(any(CaseHandoverRequest.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
+    when(matrixSynapseService.leaveRoom(anyString(), anyString())).thenReturn(true);
   }
 
   @Test
@@ -132,12 +136,37 @@ class CaseHandoverServiceTest {
     when(matrixSynapseService.loginAsUserAccessToken("@requester:matrix"))
         .thenReturn("requester-token");
     when(matrixSynapseService.joinRoom("!room:matrix", "requester-token")).thenReturn(true);
+    when(matrixSynapseService.leaveRoom("!room:matrix", "previous-token")).thenReturn(true);
 
     caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
 
     verify(matrixSynapseService)
         .inviteUserToRoom("!room:matrix", "@requester:matrix", "previous-token");
     verify(matrixSynapseService).joinRoom("!room:matrix", "requester-token");
+    verify(matrixSynapseService).leaveRoom("!room:matrix", "previous-token");
+  }
+
+  @Test
+  void requestAccess_doesNotActivateRequester_WhenPreviousConsultantCannotLeaveMatrixRoom()
+      throws Exception {
+    session.setMatrixRoomId("!room:matrix");
+    requester.setMatrixUserId("@requester:matrix");
+    previous.setMatrixUserId("@previous:matrix");
+    when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
+        .thenReturn("previous-token");
+    when(matrixSynapseService.loginAsUserAccessToken("@requester:matrix"))
+        .thenReturn("requester-token");
+    when(matrixSynapseService.joinRoom("!room:matrix", "requester-token")).thenReturn(true);
+    when(matrixSynapseService.leaveRoom("!room:matrix", "previous-token")).thenReturn(false);
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () ->
+            caseHandoverService.requestAccess(
+                123L, "OTHER_EMERGENCY", "Colleague is unavailable."));
+
+    assertEquals(previous, session.getConsultant());
+    verify(sessionRepository, never()).save(session);
   }
 
   @Test
@@ -283,6 +312,27 @@ class CaseHandoverServiceTest {
     assertEquals(CaseHandoverRequest.Status.GRANTED, request.getStatus());
     assertEquals("ACCESS_GRANTED", request.getAuditOutcome());
     verify(sessionRepository).save(session);
+  }
+
+  @Test
+  void resolveClientConsent_describesOwnershipTransferInsteadOfTemporarySupervision() {
+    CaseHandoverRequest request = pendingConsentRequest();
+    when(caseHandoverRequestRepository.findByIdAndSessionId(88L, 123L))
+        .thenReturn(Optional.of(request));
+    ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
+
+    caseHandoverService.resolveClientConsent(123L, 88L, true);
+
+    verify(matrixSessionSystemMessageService)
+        .postCaseHandoverGrantedMessage(
+            org.mockito.ArgumentMatchers.eq(session),
+            org.mockito.ArgumentMatchers.eq("Requesting Counsellor"),
+            org.mockito.ArgumentMatchers.eq("Counsellor asked for advice"),
+            org.mockito.ArgumentMatchers.eq("Need a second opinion."),
+            description.capture());
+    assertTrue(description.getValue().contains("hat deinen Fall übernommen"));
+    assertFalse(description.getValue().contains("zeitweise mitlesen"));
+    assertFalse(description.getValue().contains("bleibt für dich zuständig"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ChatServiceTest.java
@@ -49,6 +49,7 @@ import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.chat.GroupChatParticipantReconciliationService;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -78,6 +79,8 @@ class ChatServiceTest {
   @Mock private ConsultantService consultantService;
 
   @Mock private GroupChatParticipantRepository groupChatParticipantRepository;
+
+  @Mock private GroupChatParticipantReconciliationService participantReconciliationService;
 
   @Mock private AgencyService agencyService;
 
@@ -270,6 +273,28 @@ class ChatServiceTest {
   }
 
   @Test
+  void getChatsForUserId_Should_FallBackToFirstAndLastName_WhenDisplayNameIsEmpty() {
+    Chat series = activeChatWithAgency();
+    when(chatRepository.findAssignedByUserId(USER_ID)).thenReturn(List.of(series));
+    when(groupChatParticipantRepository.findBySeriesId(series.getId()))
+        .thenReturn(
+            List.of(
+                GroupChatParticipant.builder()
+                    .consultantId("co-moderator")
+                    .role(ParticipantRole.CO_MODERATOR)
+                    .build()));
+    Consultant coModerator = Mockito.mock(Consultant.class);
+    when(coModerator.getFirstName()).thenReturn("Carlo");
+    when(coModerator.getLastName()).thenReturn("Co-Moderator");
+    when(consultantService.getConsultant("co-moderator")).thenReturn(Optional.of(coModerator));
+
+    List<UserSessionResponseDTO> result = chatService.getChatsForUserId(USER_ID);
+
+    assertEquals(
+        "Carlo Co-Moderator", result.get(0).getChat().getParticipants().get(0).getDisplayName());
+  }
+
+  @Test
   void
       getChatsForUserId_Should_ReturnListOfUserSessionResponseDTOWithChats_When_AssignedChatIsFound() {
     when(chatRepository.findAssignedByUserId(USER_ID)).thenReturn(singletonList(CHAT_V2));
@@ -455,6 +480,7 @@ class ChatServiceTest {
     ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
     verify(chatRepository, times(1)).save(chatArgumentCaptor.capture());
     assertEquals(CHAT_HINT_MESSAGE, chatArgumentCaptor.getValue().getHintMessage());
+    verify(participantReconciliationService).reconcile(inactiveChat, CHAT_DTO.getConsultantIds());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/DpaForwardEmailServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/DpaForwardEmailServiceTest.java
@@ -1,0 +1,73 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.service.notification.DpaSigningEmailDispatchService;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DpaForwardEmailServiceTest {
+
+  @Mock private TenantService tenantService;
+  @Mock private DpaSigningEmailDispatchService dpaSigningEmailDispatchService;
+
+  private DpaForwardEmailService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new DpaForwardEmailService(
+            tenantService, dpaSigningEmailDispatchService, "https://app.oriso-dev.site");
+  }
+
+  @Test
+  void sendSigningLink_validRequest_deliversAgreementInvitation() {
+    when(tenantService.getRestrictedTenantData(84L))
+        .thenReturn(new RestrictedTenantDTO().id(84L).name("E2E Full Gate 202607191747"));
+
+    service.sendSigningLink(
+        new DpaForwardEmailService.DpaForwardEmailCommand(
+            84L,
+            "bart.simpson@oriso.org",
+            "https://app.oriso-dev.site/dpa-sign/single-use-token",
+            LocalDateTime.parse("2026-08-03T13:27:28.243207790")));
+
+    verify(dpaSigningEmailDispatchService)
+        .send(
+            "bart.simpson@oriso.org",
+            "E2E Full Gate 202607191747",
+            "https://app.oriso-dev.site/dpa-sign/single-use-token",
+            LocalDateTime.parse("2026-08-03T13:27:28.243207790"));
+  }
+
+  @Test
+  void sendSigningLink_foreignOrigin_rejectsWithoutSending() {
+    assertThatThrownBy(
+            () ->
+                service.sendSigningLink(
+                    new DpaForwardEmailService.DpaForwardEmailCommand(
+                        84L,
+                        "bart.simpson@oriso.org",
+                        "https://attacker.example/dpa-sign/stolen-token",
+                        LocalDateTime.parse("2026-08-03T13:27:28.243207790"))))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("signLink");
+
+    verifyNoInteractions(tenantService);
+    verify(dpaSigningEmailDispatchService, org.mockito.Mockito.never())
+        .send(anyString(), anyString(), anyString(), any(LocalDateTime.class));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
@@ -1,0 +1,153 @@
+package de.caritas.cob.userservice.api.service.chat;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant;
+import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
+import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupChatParticipantReconciliationServiceTest {
+
+  @Mock private GroupChatParticipantRepository participantRepository;
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private GroupChatMembershipService membershipService;
+
+  private GroupChatParticipantReconciliationService service;
+  private Chat series;
+  private GroupChatParticipant owner;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new GroupChatParticipantReconciliationService(
+            participantRepository, consultantRepository, membershipService);
+    var ownerConsultant = consultant("owner", "@owner:matrix");
+    series = Mockito.mock(Chat.class);
+    Mockito.lenient().when(series.getId()).thenReturn(42L);
+    Mockito.lenient().when(series.getChatOwner()).thenReturn(ownerConsultant);
+    owner = participant(7L, "owner", ParticipantRole.OWNER);
+  }
+
+  @Test
+  void reconcile_ShouldPreserveParticipants_WhenIdsAreOmitted() {
+    service.reconcile(series, null);
+
+    verifyNoInteractions(participantRepository, consultantRepository, membershipService);
+  }
+
+  @Test
+  void reconcile_ShouldInviteAndPersistNewCoModerator_WithoutDuplicatingOwner() {
+    var coModerator = consultant("co-moderator", "@co-moderator:matrix");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("co-moderator"))
+        .thenReturn(Optional.of(coModerator));
+    when(membershipService.addMemberToRoom(series, "@co-moderator:matrix")).thenReturn(true);
+
+    service.reconcile(series, List.of("owner", "co-moderator", "co-moderator"));
+
+    var saved = ArgumentCaptor.forClass(GroupChatParticipant.class);
+    verify(participantRepository).save(saved.capture());
+    verify(membershipService).addMemberToRoom(series, "@co-moderator:matrix");
+    var participant = saved.getValue();
+    org.junit.jupiter.api.Assertions.assertEquals(7L, participant.getChatId());
+    org.junit.jupiter.api.Assertions.assertEquals(42L, participant.getSeriesId());
+    org.junit.jupiter.api.Assertions.assertEquals("co-moderator", participant.getConsultantId());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        ParticipantRole.CO_MODERATOR, participant.getRole());
+  }
+
+  @Test
+  void reconcile_ShouldRemoveDeselectedCoModerator_ButNeverOwner() {
+    var removed = participant(7L, "removed", ParticipantRole.CO_MODERATOR);
+    var removedConsultant = consultant("removed", "@removed:matrix");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, removed));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
+        .thenReturn(Optional.of(removedConsultant));
+
+    service.reconcile(series, List.of());
+
+    verify(membershipService).removeLeavingMemberFromRoom(series, "@removed:matrix");
+    verify(participantRepository).delete(removed);
+    verify(participantRepository, never()).delete(owner);
+  }
+
+  @Test
+  void reconcile_ShouldPreserveDeselectedRegularParticipant() {
+    var participant = participant(7L, "participant", ParticipantRole.PARTICIPANT);
+    when(participantRepository.findBySeriesIdForUpdate(42L))
+        .thenReturn(List.of(owner, participant));
+
+    service.reconcile(series, List.of());
+
+    verify(participantRepository, never()).delete(participant);
+    verifyNoInteractions(consultantRepository, membershipService);
+  }
+
+  @Test
+  void reconcile_ShouldRejectConsultantFromAnotherTenant() {
+    var coModerator = consultant("co-moderator", "@co-moderator:matrix");
+    when(series.getChatOwner().getTenantId()).thenReturn(84L);
+    when(coModerator.getTenantId()).thenReturn(1L);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("co-moderator"))
+        .thenReturn(Optional.of(coModerator));
+
+    assertThrows(
+        BadRequestException.class, () -> service.reconcile(series, List.of("co-moderator")));
+
+    verifyNoInteractions(membershipService);
+  }
+
+  @Test
+  void reconcile_ShouldFailWithoutPersisting_WhenMatrixJoinFails() {
+    var coModerator = consultant("co-moderator", "@co-moderator:matrix");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("co-moderator"))
+        .thenReturn(Optional.of(coModerator));
+    when(membershipService.addMemberToRoom(series, "@co-moderator:matrix")).thenReturn(false);
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> service.reconcile(series, List.of("co-moderator")));
+
+    verify(participantRepository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  private GroupChatParticipant participant(
+      Long sessionId, String consultantId, ParticipantRole role) {
+    return GroupChatParticipant.builder()
+        .id("owner".equals(consultantId) ? 1L : 2L)
+        .chatId(sessionId)
+        .seriesId(42L)
+        .consultantId(consultantId)
+        .role(role)
+        .build();
+  }
+
+  private Consultant consultant(String id, String matrixUserId) {
+    var consultant = Mockito.mock(Consultant.class);
+    Mockito.lenient().when(consultant.getId()).thenReturn(id);
+    Mockito.lenient().when(consultant.getMatrixUserId()).thenReturn(matrixUserId);
+    return consultant;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/DefaultDpaSigningEmailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/DefaultDpaSigningEmailDispatchServiceTest.java
@@ -1,0 +1,71 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withNoContent;
+
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultDpaSigningEmailDispatchServiceTest {
+
+  @Mock private SecurityHeaderSupplier securityHeaderSupplier;
+  @Mock private TenantHeaderSupplier tenantHeaderSupplier;
+
+  private MockRestServiceServer server;
+  private DefaultDpaSigningEmailDispatchService service;
+
+  @BeforeEach
+  void setUp() {
+    RestTemplate restTemplate = new RestTemplate();
+    server = MockRestServiceServer.bindTo(restTemplate).build();
+    service =
+        new DefaultDpaSigningEmailDispatchService(
+            restTemplate,
+            securityHeaderSupplier,
+            tenantHeaderSupplier,
+            "http://consulting-type.example/service");
+  }
+
+  @Test
+  void send_forwardsAuthenticatedFixedDpaPayload() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth("tenant-admin-token");
+    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+    server
+        .expect(
+            requestTo("http://consulting-type.example/service/settingsadmin/dpa-signing-emails"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header("Authorization", "Bearer tenant-admin-token"))
+        .andExpect(jsonPath("$.recipientEmail").value("bart.simpson@oriso.org"))
+        .andExpect(jsonPath("$.tenantName").value("E2E Full Gate 202607191747"))
+        .andExpect(
+            jsonPath("$.signLink").value("https://app.oriso-dev.site/dpa-sign/single-use-token"))
+        .andExpect(jsonPath("$.expiresAt").value("2026-08-03T13:27:28.243207790"))
+        .andRespond(withNoContent());
+
+    service.send(
+        "bart.simpson@oriso.org",
+        "E2E Full Gate 202607191747",
+        "https://app.oriso-dev.site/dpa-sign/single-use-token",
+        LocalDateTime.parse("2026-08-03T13:27:28.243207790"));
+
+    verify(tenantHeaderSupplier).addTenantHeader(headers);
+    server.verify();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
@@ -128,6 +128,16 @@ public class UserAccountServiceTest {
   }
 
   @Test
+  public void retrieveValidatedUser_Should_Throw_ForbiddenException_When_UserIsSoftDeleted() {
+    User deletedUser = mock(User.class);
+    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(userService.getUser(USER_ID)).thenReturn(Optional.empty());
+    when(userService.findDeletedById(USER_ID)).thenReturn(Optional.of(deletedUser));
+
+    assertThrows(ForbiddenException.class, () -> accountProvider.retrieveValidatedUser());
+  }
+
+  @Test
   public void retrieveValidatedConsultant_Should_ReturnConsultant_When_ConsultantIsPresent() {
     Consultant consultantMock = mock(Consultant.class);
     when(consultantService.getConsultant(any())).thenReturn(Optional.of(consultantMock));

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
@@ -52,6 +53,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
   @Mock private RocketChatService rocketChatService;
 
   @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
 
   private LogbackCaptor logCaptor;
 
@@ -92,8 +95,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     verify(this.rocketChatService, times(1)).deleteGroupAsTechnicalUser(any());
     verify(this.sessionDataRepository, times(1)).findBySessionId(session.getId());
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
-    verify(this.caseHandoverRequestRepository, times(1)).findBySessionId(session.getId());
-    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(any());
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAllBySessionId(session.getId());
+    verify(this.sessionSupervisorRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionRepository, times(1)).delete(session);
   }
 
@@ -106,7 +109,12 @@ class DeleteAskerRoomsAndSessionsActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
-    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    doThrow(new RuntimeException())
+        .when(this.caseHandoverRequestRepository)
+        .deleteAllBySessionId(any());
+    doThrow(new RuntimeException())
+        .when(this.sessionSupervisorRepository)
+        .deleteAllBySessionId(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -114,8 +122,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(4));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(4);
+    assertThat(workflowErrors, hasSize(5));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(5);
   }
 
   @Test
@@ -128,7 +136,12 @@ class DeleteAskerRoomsAndSessionsActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
-    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    doThrow(new RuntimeException())
+        .when(this.caseHandoverRequestRepository)
+        .deleteAllBySessionId(any());
+    doThrow(new RuntimeException())
+        .when(this.sessionSupervisorRepository)
+        .deleteAllBySessionId(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -136,8 +149,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(12));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(12);
+    assertThat(workflowErrors, hasSize(15));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(15);
   }
 
   @Test
@@ -187,7 +200,9 @@ class DeleteAskerRoomsAndSessionsActionTest {
   void execute_Should_returnExpectedWorkflowError_When_caseHandoverRequestDeletionFails() {
     Session session = new EasyRandom().nextObject(Session.class);
     when(this.sessionRepository.findByUser(any())).thenReturn(singletonList(session));
-    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    doThrow(new RuntimeException())
+        .when(this.caseHandoverRequestRepository)
+        .deleteAllBySessionId(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.api.workflow.delete.model.SessionDeletionWorkflowDTO;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
@@ -48,6 +49,8 @@ class DeleteSingleRoomAndSessionActionTest {
 
   @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
 
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+
   private LogbackCaptor logCaptor;
 
   @BeforeEach
@@ -74,8 +77,8 @@ class DeleteSingleRoomAndSessionActionTest {
     verify(this.rocketChatService, times(1)).deleteGroupAsTechnicalUser(any());
     verify(this.sessionDataRepository, times(1)).findBySessionId(session.getId());
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
-    verify(this.caseHandoverRequestRepository, times(1)).findBySessionId(session.getId());
-    verify(this.caseHandoverRequestRepository, times(1)).deleteAll(any());
+    verify(this.caseHandoverRequestRepository, times(1)).deleteAllBySessionId(session.getId());
+    verify(this.sessionSupervisorRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionRepository, times(1)).delete(session);
   }
 
@@ -87,7 +90,12 @@ class DeleteSingleRoomAndSessionActionTest {
         .when(this.rocketChatService)
         .deleteGroupAsTechnicalUser(any());
     doThrow(new RuntimeException()).when(this.sessionDataRepository).deleteAll(any());
-    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    doThrow(new RuntimeException())
+        .when(this.caseHandoverRequestRepository)
+        .deleteAllBySessionId(any());
+    doThrow(new RuntimeException())
+        .when(this.sessionSupervisorRepository)
+        .deleteAllBySessionId(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     SessionDeletionWorkflowDTO workflowDTO =
         new SessionDeletionWorkflowDTO(session, new ArrayList<>());
@@ -95,8 +103,8 @@ class DeleteSingleRoomAndSessionActionTest {
     this.deleteSingleRoomAndSessionAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(4));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(4);
+    assertThat(workflowErrors, hasSize(5));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(5);
   }
 
   @Test
@@ -143,7 +151,9 @@ class DeleteSingleRoomAndSessionActionTest {
   @Test
   void execute_Should_returnExpectedWorkflowError_When_caseHandoverRequestDeletionFails() {
     Session session = new EasyRandom().nextObject(Session.class);
-    doThrow(new RuntimeException()).when(this.caseHandoverRequestRepository).deleteAll(any());
+    doThrow(new RuntimeException())
+        .when(this.caseHandoverRequestRepository)
+        .deleteAllBySessionId(any());
     SessionDeletionWorkflowDTO workflowDTO =
         new SessionDeletionWorkflowDTO(session, new ArrayList<>());
 
@@ -159,6 +169,23 @@ class DeleteSingleRoomAndSessionActionTest {
         workflowErrors.get(0).getReason(),
         is("Unable to delete case handover requests for session"));
     assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
+  }
+
+  @Test
+  void execute_Should_returnExpectedWorkflowError_When_sessionSupervisorDeletionFails() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    doThrow(new RuntimeException())
+        .when(this.sessionSupervisorRepository)
+        .deleteAllBySessionId(any());
+    SessionDeletionWorkflowDTO workflowDTO =
+        new SessionDeletionWorkflowDTO(session, new ArrayList<>());
+
+    this.deleteSingleRoomAndSessionAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
+    assertThat(
+        workflowDTO.getDeletionWorkflowErrors().get(0).getReason(),
+        is("Unable to delete supervisors for session"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- reconcile all participant roles when recurring Circle rooms are recreated
- leave the previous consultant only after the new case owner joins Matrix
- delete handover and supervision dependants before forced session removal
- enforce the asker account-deletion lifecycle and preserve the deferred hard-delete path
- forward DPA signing links through the configured mail service

## Verification

- 3,742 tests passed, 7 skipped, 0 failures
- Hot PreDev v22/v23 browser and database proof confirms successful C1/C2 force-deletion scheduling after both foreign-key ordering repairs
- DPA delivery, membership, handover and deletion evidence is attached to the linked issues

Refs OpenResilienceInitiative/ORISO-UserService#518
Closes OpenResilienceInitiative/ORISO-UserService#530

## Known follow-up

- This PR does not fix OpenResilienceInitiative/ORISO-UserService#531: a soft-deleted asker can still leave an invisible open enquiry that blocks later tenant cleanup until the scheduled hard delete runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
