### PR TITLE
fix: create consultants with agencies and topics atomically

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -1246,6 +1246,13 @@ components:
             type: integer
             format: int64
           example: [3, 7, 12]
+        agencyIds:
+          type: array
+          description: ids of agencies assigned atomically with the consultant
+          items:
+            type: integer
+            format: int64
+          example: [5, 9]
         publicSlug:
           type: string
           example: nikunj-rohit

--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -131,6 +131,15 @@ public class ConsultantAdminFacade {
    *     ConsultantAdminResponseDTO}
    */
   public ConsultantAdminResponseDTO createNewConsultant(CreateConsultantDTO createConsultantDTO) {
+    if (createConsultantDTO != null && createConsultantDTO.getAgencyIds() != null) {
+      var requestedAgencies =
+          createConsultantDTO.getAgencyIds().stream()
+              .filter(java.util.Objects::nonNull)
+              .distinct()
+              .map(agencyId -> new CreateConsultantAgencyDTO().agencyId(agencyId))
+              .collect(Collectors.toList());
+      checkPermissionsToAssignedAgencies(requestedAgencies);
+    }
     return this.consultantAdminService.createNewConsultant(createConsultantDTO);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/ConsultantCreationInput.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/ConsultantCreationInput.java
@@ -47,4 +47,8 @@ interface ConsultantCreationInput {
   default List<Long> getTopicIds() {
     return null;
   }
+
+  default List<Long> getAgencyIds() {
+    return null;
+  }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapter.java
@@ -151,4 +151,14 @@ public class CreateConsultantDTOCreationInputAdapter implements ConsultantCreati
   public List<Long> getTopicIds() {
     return this.createConsultantDTO.getTopicIds();
   }
+
+  /**
+   * Provides the agencies assigned as part of consultant creation.
+   *
+   * @return the agency ids
+   */
+  @Override
+  public List<Long> getAgencyIds() {
+    return this.createConsultantDTO.getAgencyIds();
+  }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
@@ -16,11 +16,14 @@ import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NotificationsSettingsDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.ConsultantResponseDTOBuilder;
 import de.caritas.cob.userservice.api.admin.service.consultant.TransactionalStep;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation.ConsultantAgencyRelationCreatorService;
+import de.caritas.cob.userservice.api.admin.service.consultant.validation.ConsultantTopicAgencyCompatibilityValidator;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.CreateConsultantDTOAbsenceInputAdapter;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantAdminService;
@@ -71,6 +74,10 @@ public class CreateConsultantSaga {
   private final @NonNull UserAccountInputValidator userAccountInputValidator;
   private final @NonNull TenantAdminService tenantAdminService;
   private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull ConsultantAgencyRelationCreatorService
+      consultantAgencyRelationCreatorService;
+  private final @NonNull ConsultantTopicAgencyCompatibilityValidator
+      consultantTopicAgencyCompatibilityValidator;
 
   private final @NonNull RollbackFacade rollbackFacade;
 
@@ -93,6 +100,13 @@ public class CreateConsultantSaga {
     setCurrentTenant(createConsultantDTO);
     validateTenantId(createConsultantDTO);
     ensureTenantIdResolved(createConsultantDTO);
+    if (createConsultantDTO.getAgencyIds() != null
+        && !createConsultantDTO.getAgencyIds().isEmpty()) {
+      consultantTopicAgencyCompatibilityValidator.validateGrantTopicsAgainstSelectedAgencies(
+          createConsultantDTO.getTopicIds(),
+          createConsultantDTO.getAgencyIds(),
+          createConsultantDTO.getTenantId());
+    }
 
     assertLicensesNotExceeded(createConsultantDTO);
 
@@ -262,8 +276,27 @@ public class CreateConsultantSaga {
         createConsultantInMariaDBOrRollback(
             consultantCreationInput, keycloakUserId, rocketChatUserId, matrixUserId);
 
+    assignAgenciesOrRollback(consultant, consultantCreationInput.getAgencyIds());
     tryAssignConsultantToExistingSessions(consultant);
     return consultant;
+  }
+
+  private void assignAgenciesOrRollback(Consultant consultant, List<Long> agencyIds) {
+    if (agencyIds == null) {
+      return;
+    }
+    try {
+      agencyIds.stream()
+          .filter(java.util.Objects::nonNull)
+          .distinct()
+          .forEach(
+              agencyId ->
+                  consultantAgencyRelationCreatorService.createNewConsultantAgency(
+                      consultant.getId(), new CreateConsultantAgencyDTO().agencyId(agencyId)));
+    } catch (RuntimeException e) {
+      rollbackCreateNewConsultant(consultant);
+      throw e;
+    }
   }
 
   private void tryAssignConsultantToExistingSessions(Consultant consultant) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
@@ -67,12 +67,11 @@ public class ConsultantTopicAgencyCompatibilityValidator {
   private void validateTopicsCoveredByAgencies(
       Collection<Long> topicIds, Collection<Long> agencyIds, Long tenantId) {
     var selectedTopicIds = normalizedIds(topicIds);
-    if (selectedTopicIds.isEmpty()) {
-      return;
-    }
-
     var selectedAgencyIds = normalizedIds(agencyIds);
     if (selectedAgencyIds.isEmpty()) {
+      if (selectedTopicIds.isEmpty()) {
+        return;
+      }
       throw new BadRequestException(
           String.format(
               "Consultant topic ids %s are not covered by any selected agency", selectedTopicIds));
@@ -81,6 +80,10 @@ public class ConsultantTopicAgencyCompatibilityValidator {
     var agencies = agenciesFor(selectedAgencyIds);
     assertAllSelectedAgenciesResolved(selectedAgencyIds, agencies);
     assertAgenciesBelongToTenant(agencies, tenantId);
+
+    if (selectedTopicIds.isEmpty()) {
+      return;
+    }
 
     // Offline agencies count towards topic coverage on purpose: a freshly created agency is
     // offline until it has an assigned consultant, so filtering them out here would make it

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantFilter;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSearchResultDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.Sort;
 import de.caritas.cob.userservice.api.adapters.web.dto.Sort.FieldEnum;
 import de.caritas.cob.userservice.api.admin.service.agency.ConsultantAgencyAdminService;
@@ -96,6 +97,18 @@ class ConsultantAdminFacadeTest {
     this.consultantAdminFacade.createNewConsultant(null);
 
     verify(this.consultantAdminService).createNewConsultant(null);
+  }
+
+  @Test
+  void createNewConsultant_Should_RejectUnauthorizedAgenciesBeforeCreatingIdentity() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(adminUserFacade.findAdminUserAgencyIds("admin-1")).thenReturn(List.of(1L));
+    CreateConsultantDTO dto = new CreateConsultantDTO().agencyIds(List.of(2L));
+
+    assertThrows(ForbiddenException.class, () -> consultantAdminFacade.createNewConsultant(dto));
+
+    verify(consultantAdminService, never()).createNewConsultant(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantDTOCreationInputAdapterTest.java
@@ -28,6 +28,7 @@ class CreateConsultantDTOCreationInputAdapterTest {
     dto.setFormalLanguage(true);
     dto.setTenantId(3L);
     dto.setTopicIds(List.of(10L, 20L));
+    dto.setAgencyIds(List.of(30L, 40L));
 
     ConsultantCreationInput input = new CreateConsultantDTOCreationInputAdapter(dto);
 
@@ -44,6 +45,7 @@ class CreateConsultantDTOCreationInputAdapterTest {
     assertThat(input.isLanguageFormal(), is(true));
     assertThat(input.getTenantId(), is(3L));
     assertThat(input.getTopicIds(), is(List.of(10L, 20L)));
+    assertThat(input.getAgencyIds(), is(List.of(30L, 40L)));
     assertThat(input.getCreateDate(), notNullValue());
     assertThat(input.getUpdateDate(), notNullValue());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
@@ -11,8 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,8 +23,11 @@ import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserRe
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation.ConsultantAgencyRelationCreatorService;
+import de.caritas.cob.userservice.api.admin.service.consultant.validation.ConsultantTopicAgencyCompatibilityValidator;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantAdminService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -44,6 +49,7 @@ import de.caritas.cob.userservice.tenantadminservice.generated.web.model.Licensi
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Set;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.junit.jupiter.api.AfterEach;
@@ -81,6 +87,11 @@ class CreateConsultantSagaTest {
 
   @Mock private TenantAdminService tenantAdminService;
   @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private ConsultantAgencyRelationCreatorService consultantAgencyRelationCreatorService;
+
+  @Mock
+  private ConsultantTopicAgencyCompatibilityValidator consultantTopicAgencyCompatibilityValidator;
+
   @Mock private RollbackFacade rollbackFacade;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private AppointmentService appointmentService;
@@ -111,6 +122,70 @@ class CreateConsultantSagaTest {
     assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
     verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
     verify(appointmentService, never()).createConsultant(any());
+  }
+
+  @Test
+  void createNewConsultant_Should_AssignAllRequestedAgenciesBeforeReturning() throws Exception {
+    stubHappyPath();
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setAgencyIds(List.of(5L, 9L));
+
+    createConsultantSaga.createNewConsultant(dto);
+
+    ArgumentCaptor<CreateConsultantAgencyDTO> agencyCaptor =
+        ArgumentCaptor.forClass(CreateConsultantAgencyDTO.class);
+    verify(consultantAgencyRelationCreatorService, times(2))
+        .createNewConsultantAgency(eq(KEYCLOAK_USER_ID), agencyCaptor.capture());
+    assertThat(
+        agencyCaptor.getAllValues().stream().map(CreateConsultantAgencyDTO::getAgencyId).toList(),
+        is(List.of(5L, 9L)));
+  }
+
+  @Test
+  void createNewConsultant_Should_ValidateAgencyAndTopicTopologyBeforeCreatingIdentity() {
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTenantId(3L);
+    dto.setTopicIds(List.of(7L));
+    dto.setAgencyIds(List.of(5L));
+    doThrow(new BadRequestException("invalid topology"))
+        .when(consultantTopicAgencyCompatibilityValidator)
+        .validateGrantTopicsAgainstSelectedAgencies(List.of(7L), List.of(5L), 3L);
+
+    assertThrows(BadRequestException.class, () -> createConsultantSaga.createNewConsultant(dto));
+
+    verify(identityClient, never()).createKeycloakUser(any(), anyString(), anyString());
+  }
+
+  @Test
+  void createNewConsultant_Should_PreserveLegacyTopicOnlyRequestsWithoutAgencyIds()
+      throws Exception {
+    stubHappyPath();
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setTopicIds(List.of(7L));
+
+    createConsultantSaga.createNewConsultant(dto);
+
+    verify(consultantTopicAgencyCompatibilityValidator, never())
+        .validateGrantTopicsAgainstSelectedAgencies(any(), any(), any());
+  }
+
+  @Test
+  void createNewConsultant_Should_RollBackIdentityWhenAgencyAssignmentFails() throws Exception {
+    stubKeycloakUserCreation();
+    when(rocketChatService.getUserID(anyString(), anyString(), anyBoolean()))
+        .thenReturn(ROCKET_CHAT_USER_ID);
+    when(consultantService.saveConsultant(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    CreateConsultantDTO dto = validCreateConsultantDto();
+    dto.setAgencyIds(List.of(5L));
+    doThrow(new BadRequestException("relation failed"))
+        .when(consultantAgencyRelationCreatorService)
+        .createNewConsultantAgency(eq(KEYCLOAK_USER_ID), any(CreateConsultantAgencyDTO.class));
+
+    assertThrows(BadRequestException.class, () -> createConsultantSaga.createNewConsultant(dto));
+
+    verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
+    verify(sessionService, never()).getRegisteredEnquiriesForConsultant(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
@@ -70,6 +70,20 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
   }
 
   @Test
+  void validateGrantTopicsAgainstSelectedAgencies_RejectsForeignAgencyWithoutTopics() {
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+        .thenReturn(List.of(agency(10L, 2L, false, List.of())));
+
+    var exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                validator.validateGrantTopicsAgainstSelectedAgencies(List.of(), List.of(10L), 1L));
+
+    assertTrue(exception.getMessage().contains("tenant 1"));
+  }
+
+  @Test
   void validateCurrentTopicsAgainstSelectedAgencies_UsesPersistedConsultantTopics() {
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant-id"))
         .thenReturn(Optional.of(consultant("consultant-id", 1L)));


### PR DESCRIPTION
## Summary

- extend consultant creation with optional `agencyIds` alongside `topicIds`
- reject missing, foreign-tenant, topic-incompatible, or unauthorized agencies before creating external identities
- persist agency relations inside the existing transactional create saga
- invoke the existing consultant rollback workflow when relation assignment fails, covering MariaDB, Keycloak, Matrix, and legacy chat cleanup
- keep legacy topic-only requests compatible during the staged Admin/backend rollout

## Verification

- TDD regression reproduced: requested agencies were previously ignored and unauthorized agencies reached identity creation
- `./mvnw -Dtest=CreateConsultantSagaTest,CreateConsultantDTOCreationInputAdapterTest,ConsultantAdminFacadeTest,ConsultantTopicAgencyCompatibilityValidatorTest,ConsultantAgencyRelationCreatorServiceTest,UserAdminControllerTest test` on Java 21 — 121 tests passed
- `ConsultantAdminFacadeIT` and `CreateConsultantSagaTenantAwareIT` passed locally
- `CreateConsultantSagaIT` still contains four pre-existing expectations that contradict current production behavior (Rocket.Chat creation is now intentionally non-fatal, and imports require a password); these failures are unrelated to this change and are documented for follow-up
- `git diff --check` — passed

Closes OpenResilienceInitiative/ORISO-UserService#521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
