### PR TITLE
fix(tutorial): reject unknown tours and cap progress rows per user

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
@@ -11,4 +11,7 @@ public interface TutorialProgressRepository extends CrudRepository<TutorialProgr
       String userId, String surface, String tourId, Integer tourVersion);
 
   List<TutorialProgress> findByUserIdAndSurface(String userId, String surface);
+
+  /** Number of progress rows a user owns — used to cap per-user row growth. */
+  long countByUserId(String userId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestExceptio
 import de.caritas.cob.userservice.api.model.TutorialProgress;
 import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -13,6 +14,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,27 +35,51 @@ public class TutorialProgressService {
 
   private final @NonNull TutorialProgressRepository tutorialProgressRepository;
 
+  /**
+   * Tours that may be written per surface. Without this allowlist any authenticated user could
+   * invent tour ids — including on a surface they never see — and those rows would show up in the
+   * tenant admin's aggregate dashboard with attacker-chosen labels (found in gate run
+   * e2e-20260720-1507, probe S6). Configured rather than hardcoded so enabling a new tour stays a
+   * deployment concern; the frontends remain the source of truth for tour content.
+   */
+  @Value("${tutorial.tours.frontend:consultant-walkthrough}")
+  private String[] frontendTours = {"consultant-walkthrough"};
+
+  @Value("${tutorial.tours.admin:}")
+  private String[] adminTours = {};
+
+  /**
+   * Upper bound of progress rows a single account may own. Rows are only ever created by their own
+   * user, but nothing else bounded how many distinct tour/version combinations one account could
+   * create (probe S7). Updates of existing rows are never blocked by this cap.
+   */
+  @Value("${tutorial.max-rows-per-user:50}")
+  private int maxRowsPerUser = 50;
+
   @Transactional
   public TutorialProgressItem upsertOwnProgress(
       String userId, Long tenantId, UpsertTutorialProgressRequest request) {
     validate(request);
 
     var now = LocalDateTime.now();
+    var existing =
+        tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            userId, request.getSurface(), request.getTourId(), request.getTourVersion());
+    if (existing.isEmpty() && tutorialProgressRepository.countByUserId(userId) >= maxRowsPerUser) {
+      throw new BadRequestException("tutorial progress row limit reached for this user");
+    }
     var progress =
-        tutorialProgressRepository
-            .findByUserIdAndSurfaceAndTourIdAndTourVersion(
-                userId, request.getSurface(), request.getTourId(), request.getTourVersion())
-            .orElseGet(
-                () ->
-                    TutorialProgress.builder()
-                        .userId(userId)
-                        .surface(request.getSurface())
-                        .tourId(request.getTourId())
-                        .tourVersion(request.getTourVersion())
-                        .createDate(now)
-                        .startedAt(now)
-                        .tenantId(tenantId)
-                        .build());
+        existing.orElseGet(
+            () ->
+                TutorialProgress.builder()
+                    .userId(userId)
+                    .surface(request.getSurface())
+                    .tourId(request.getTourId())
+                    .tourVersion(request.getTourVersion())
+                    .createDate(now)
+                    .startedAt(now)
+                    .tenantId(tenantId)
+                    .build());
 
     progress.setStatus(request.getStatus());
     progress.setCurrentStepId(request.getCurrentStepId());
@@ -101,6 +127,14 @@ public class TutorialProgressService {
     if (request.getTourVersion() == null || request.getTourVersion() < 1) {
       throw new BadRequestException("tourVersion must be a positive integer");
     }
+    if (!isEnabledTour(request.getSurface(), request.getTourId())) {
+      throw new BadRequestException("unknown tour for this surface");
+    }
+  }
+
+  private boolean isEnabledTour(String surface, String tourId) {
+    var enabled = "admin".equals(surface) ? adminTours : frontendTours;
+    return enabled != null && Arrays.stream(enabled).map(String::trim).anyMatch(tourId::equals);
   }
 
   private TutorialProgressItem toItem(TutorialProgress progress) {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialProgressControllerE2EIT.java
@@ -88,6 +88,51 @@ class TutorialProgressControllerE2EIT {
   }
 
   @Test
+  void tutorialProgress_rejectsATourThatIsNotEnabledOnThatSurface() throws Exception {
+    // Hardening (gate run e2e-20260720-1507, probe S6): a consultant must not be
+    // able to invent admin-surface tours that then appear in the tenant admin's
+    // aggregate dashboard.
+    org.mockito.Mockito.when(authenticatedUser.getUserId()).thenReturn("tutorial-user-1");
+    var payload =
+        Map.of(
+            "surface", "admin",
+            "tourId", "consultant-walkthrough",
+            "tourVersion", 1,
+            "status", "completed");
+
+    mockMvc
+        .perform(
+            put("/users/tutorials/progress")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void tutorialProgress_rejectsAnUnknownTourId() throws Exception {
+    org.mockito.Mockito.when(authenticatedUser.getUserId()).thenReturn("tutorial-user-1");
+    var payload =
+        Map.of(
+            "surface", "frontend",
+            "tourId", "zz-invented-tour",
+            "tourVersion", 1,
+            "status", "completed");
+
+    mockMvc
+        .perform(
+            put("/users/tutorials/progress")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .with(jwt().authorities(() -> AuthorityValue.CONSULTANT_DEFAULT))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void tutorialProgress_rejectsUnknownStatusWithBadRequest() throws Exception {
     org.mockito.Mockito.when(authenticatedUser.getUserId()).thenReturn("tutorial-user-1");
     var payload =

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
@@ -38,6 +38,65 @@ class TutorialProgressServiceTest {
     return req;
   }
 
+  /* --- hardening (gate run e2e-20260720-1507): unknown tours and unbounded rows --- */
+
+  @Test
+  void upsertOwnProgress_rejectsATourThatIsNotEnabledOnThatSurface() {
+    // A consultant could otherwise write surface=admin rows that surface in the
+    // tenant admin's aggregate dashboard with attacker-chosen labels.
+    var req = request("completed");
+    req.setSurface("admin");
+
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
+        .isInstanceOf(BadRequestException.class);
+    verify(tutorialProgressRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertOwnProgress_rejectsAnUnknownTourId() {
+    var req = request("completed");
+    req.setTourId("zz-invented-tour");
+
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
+        .isInstanceOf(BadRequestException.class);
+    verify(tutorialProgressRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertOwnProgress_rejectsNewRowsBeyondThePerUserCap() {
+    var req = request("in_progress");
+    req.setTourVersion(7);
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            "user-1", "frontend", "consultant-walkthrough", 7))
+        .thenReturn(Optional.empty());
+    when(tutorialProgressRepository.countByUserId("user-1")).thenReturn(50L);
+
+    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
+        .isInstanceOf(BadRequestException.class);
+    verify(tutorialProgressRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertOwnProgress_stillUpdatesAnExistingRowWhenTheCapIsReached() {
+    var req = request("completed");
+    var existing =
+        TutorialProgress.builder()
+            .userId("user-1")
+            .surface("frontend")
+            .tourId("consultant-walkthrough")
+            .tourVersion(1)
+            .status("in_progress")
+            .build();
+    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            "user-1", "frontend", "consultant-walkthrough", 1))
+        .thenReturn(Optional.of(existing));
+    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var item = service.upsertOwnProgress("user-1", 1L, req);
+
+    assertThat(item.getStatus()).isEqualTo("completed");
+  }
+
   @Test
   void upsertOwnProgress_createsScopedRecordForTheAuthenticatedUser() {
     // Business reason: progress is keyed by user, surface, tour and version so


### PR DESCRIPTION
Found during E2E gate run `e2e-20260720-1507` (security probes against the deployed Pre-Dev, regular `:pre-dev` images). Part of epic OpenResilienceInitiative/ORISO-Frontend#521; hardens the API added in #491 and consumed by #501/ORISO-Admin#400.

**Problem**

Two live-verified weaknesses in the tutorial-progress write path, both reachable with an ordinary consultant token:

1. **Invented tours on any surface.** `PUT /users/tutorials/progress` validated shape only (surface enum, status enum, identifier regex, positive version) but never that the tour exists. A consultant could write `surface=admin, tourId=zz-probe-fake-tour, tourVersion=999` → `200 OK`. Those rows are aggregated by the tenant/platform admin statistics view, so a normal user could inject attacker-chosen labels into an admin's dashboard. Not an XSS vector (identifier regex + React escaping), but a data-integrity/spoofing issue.
2. **No per-account row cap.** 25 consecutive writes with distinct tour ids all succeeded; nothing bounded row growth in `tutorial_progress`, and each invented row also lands in the admin aggregate.

Probes that passed and are unchanged by this PR: unauthenticated 401 on both endpoints, consultant 403 on the statistics endpoint, tenant-header spoofing rejected (token/subdomain cross-validation), no user identifiers in any payload, injection/oversize payloads rejected with 400, CSRF double-submit enforced on writes.

**What changed**

- Per-surface allowlist of enabled tours (`tutorial.tours.frontend`, default `consultant-walkthrough`; `tutorial.tours.admin`, default empty). Unknown surface/tour combinations are rejected with 400. Configured rather than hardcoded so enabling a tour stays a deployment concern while the frontends remain the source of truth for tour content.
- Per-user row cap (`tutorial.max-rows-per-user`, default 50). It blocks only the creation of NEW rows — an existing row always updates, so nobody can be locked out of finishing a tour they already started.

**Verification:** red-first — 4 new unit tests (both rejection cases, cap blocks a new row, cap still updates an existing row) and 2 new JWT integration tests through the real slice; full unit suite green. The live probes will be re-run against the deployed image after merge.

**Related finding, deliberately not fixed here:** the tutorial statistics have no small-cell suppression, while the sibling `AdminDashboardStatisticsService` enforces `SMALL_CELL_MINIMUM_COUNSELORS = 5` (fail-closed on prod) exactly to prevent re-identification. In a tenant with one consultant, `completed: 1` is that identifiable person's behaviour. Whether tutorial telemetry needs the same bar as counselling data is a product/legal call and changes the response shape plus the Admin rendering, so it is tracked separately rather than smuggled into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
