### PR TITLE
fix: persist live chat availability in Redis

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,18 +11,6 @@ jobs:
   validate:
     name: test, build and Docker validation
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-        - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-    env:
-      ORISO_LOCAL_REDIS_IT: true
 
     steps:
     # OBS-P10 PoC (ORISO-Helm#62): capture job start time so the final step
@@ -137,6 +125,36 @@ jobs:
           -d "${payload}" \
           || echo "::warning::Failed to POST CI health metrics to SigNoz (non-blocking, telemetry only)"
         true
+
+  redis-contract:
+    name: Redis availability contract
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+        - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      ORISO_LOCAL_REDIS_IT: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up JDK and Maven
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+
+    - name: Verify Redis-backed availability contract
+      run: ./mvnw -B -Dtest=ConsultantActivityRegistryRedisIT test
 
   # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
   # Runs `mvnw -B verify`, which reaches the surefire `integration-tests` execution

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,6 +11,18 @@ jobs:
   validate:
     name: test, build and Docker validation
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+        - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      ORISO_LOCAL_REDIS_IT: true
 
     steps:
     # OBS-P10 PoC (ORISO-Helm#62): capture job start time so the final step

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
@@ -56,11 +56,12 @@ public class ConsultantLiveAvailabilityController {
 
   /** Refreshes only an existing availability key; it never enables a disabled consultant. */
   @PostMapping("/conversations/consultants/availability/heartbeat")
-  public ResponseEntity<Void> heartbeatLiveChatAvailability() {
+  public ResponseEntity<ConsultantLiveAvailabilityResponseDTO> heartbeatLiveChatAvailability() {
+    boolean available = false;
     if (authenticatedUser.isConsultant() && authenticatedUser.getUserId() != null) {
-      consultantActivityRegistry.refreshIfAvailable(authenticatedUser.getUserId());
+      available = consultantActivityRegistry.refreshIfAvailable(authenticatedUser.getUserId());
     }
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok(new ConsultantLiveAvailabilityResponseDTO(available));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,6 +51,15 @@ public class ConsultantLiveAvailabilityController {
       }
     }
 
+    return ResponseEntity.noContent().build();
+  }
+
+  /** Refreshes only an existing availability key; it never enables a disabled consultant. */
+  @PostMapping("/conversations/consultants/availability/heartbeat")
+  public ResponseEntity<Void> heartbeatLiveChatAvailability() {
+    if (authenticatedUser.isConsultant() && authenticatedUser.getUserId() != null) {
+      consultantActivityRegistry.refreshIfAvailable(authenticatedUser.getUserId());
+    }
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptor.java
@@ -31,8 +31,7 @@ public class ConsultantActivityInterceptor implements HandlerInterceptor {
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
     try {
-      if ("GET".equalsIgnoreCase(request.getMethod())
-          && AVAILABILITY_PATH.equals(request.getRequestURI())) {
+      if (request.getRequestURI().startsWith(AVAILABILITY_PATH)) {
         return true;
       }
       AuthenticatedUser user = authenticatedUser.getIfAvailable();

--- a/src/main/java/de/caritas/cob/userservice/api/service/availability/AvailabilityStoreException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/availability/AvailabilityStoreException.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.service.availability;
+
+/** Signals that Redis could not acknowledge a consultant availability state change. */
+public class AvailabilityStoreException extends RuntimeException {
+
+  public AvailabilityStoreException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
@@ -1,68 +1,142 @@
 package de.caritas.cob.userservice.api.service.availability;
 
-import java.time.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * Tracks which consultants are currently available for live chat. Availability is driven by
- * explicit events from the consultant app (Live Chat toggle on/off, logout) and kept alive by a
- * heartbeat while the app stays open, so a crashed/closed browser auto-expires after the configured
- * window.
- *
- * <p>Matrix presence is unreliable for this: a consultant waiting for a new anonymous enquiry has
- * no open chat and therefore generates no Matrix activity.
- */
+/** Redis-backed source of truth for consultants currently available for live chat. */
 @Component
+@Slf4j
 public class ConsultantActivityRegistry {
 
-  private final ConcurrentHashMap<String, Long> availableSince = new ConcurrentHashMap<>();
-  private final Clock clock;
+  static final String STORE_METRIC = "oriso.live_chat.availability.store.operations";
+  private static final String AVAILABLE_VALUE = "1";
 
-  public ConsultantActivityRegistry() {
-    this.clock = Clock.systemUTC();
+  private final StringRedisTemplate redisTemplate;
+  private final MeterRegistry meterRegistry;
+  private final Duration ttl;
+  private final String keyPrefix;
+
+  @Autowired
+  public ConsultantActivityRegistry(
+      StringRedisTemplate redisTemplate,
+      MeterRegistry meterRegistry,
+      @Value("${consultant.availability.redis.ttlSeconds:120}") long ttlSeconds,
+      @Value("${consultant.availability.redis.keyPrefix:livechat:consultant:available:}")
+          String keyPrefix) {
+    this(redisTemplate, meterRegistry, Duration.ofSeconds(ttlSeconds), keyPrefix);
   }
 
-  ConsultantActivityRegistry(Clock clock) {
-    this.clock = clock;
+  ConsultantActivityRegistry(
+      StringRedisTemplate redisTemplate,
+      MeterRegistry meterRegistry,
+      Duration ttl,
+      String keyPrefix) {
+    this.redisTemplate = redisTemplate;
+    this.meterRegistry = meterRegistry;
+    this.ttl = ttl;
+    this.keyPrefix = keyPrefix;
   }
 
-  /** Marks the consultant available now (Live Chat enabled). Adds them if not present. */
+  /** Explicit enable. The request fails when Redis cannot acknowledge the state change. */
   public void markAvailable(String consultantId) {
-    if (consultantId != null && !consultantId.isBlank()) {
-      availableSince.put(consultantId, clock.millis());
+    if (!isValid(consultantId)) {
+      return;
+    }
+    try {
+      redisTemplate.opsForValue().set(key(consultantId), AVAILABLE_VALUE, ttl);
+      record("enable", "success");
+    } catch (RuntimeException ex) {
+      throw storeFailure("enable", ex);
     }
   }
 
-  /** Marks the consultant unavailable immediately (Live Chat disabled or logout). */
+  /** Explicit disable/logout. The Redis key is removed immediately. */
   public void markUnavailable(String consultantId) {
-    if (consultantId != null) {
-      availableSince.remove(consultantId);
+    if (!isValid(consultantId)) {
+      return;
+    }
+    try {
+      redisTemplate.delete(key(consultantId));
+      record("disable", "success");
+    } catch (RuntimeException ex) {
+      throw storeFailure("disable", ex);
+    }
+  }
+
+  /** Heartbeat: EXPIRE refreshes only an existing key and can never enable a consultant. */
+  public void refreshIfAvailable(String consultantId) {
+    if (!isValid(consultantId)) {
+      return;
+    }
+    try {
+      Boolean refreshed = redisTemplate.expire(key(consultantId), ttl);
+      record("refresh", Boolean.TRUE.equals(refreshed) ? "success" : "missing");
+    } catch (RuntimeException ex) {
+      throw storeFailure("refresh", ex);
     }
   }
 
   /**
-   * Heartbeat keep-alive: refreshes the timestamp only for consultants already marked available.
-   * Never adds a consultant, so generic requests can't keep a disabled consultant counted.
+   * Returns only IDs with a live Redis key. Redis TTL is authoritative; {@code windowMs} remains in
+   * the signature while existing callers migrate from the former process-local timestamp store. Any
+   * Redis read failure fails closed, so no consultant is falsely routed.
    */
-  public void refreshIfAvailable(String consultantId) {
-    if (consultantId != null) {
-      availableSince.computeIfPresent(consultantId, (id, ts) -> clock.millis());
+  public Set<String> filterActive(Collection<String> consultantIds, long windowMs) {
+    if (consultantIds == null || consultantIds.isEmpty()) {
+      return Collections.emptySet();
+    }
+    List<String> distinctIds = consultantIds.stream().filter(this::isValid).distinct().toList();
+    if (distinctIds.isEmpty()) {
+      return Collections.emptySet();
+    }
+    List<String> keys = distinctIds.stream().map(this::key).toList();
+    try {
+      List<String> values = redisTemplate.opsForValue().multiGet(keys);
+      if (values == null) {
+        record("read", "success");
+        return Collections.emptySet();
+      }
+      Set<String> active = new LinkedHashSet<>();
+      int resultSize = Math.min(distinctIds.size(), values.size());
+      for (int index = 0; index < resultSize; index++) {
+        if (AVAILABLE_VALUE.equals(values.get(index))) {
+          active.add(distinctIds.get(index));
+        }
+      }
+      record("read", "success");
+      return active;
+    } catch (RuntimeException ex) {
+      record("read", "failure");
+      log.warn("Live-chat availability Redis read failed; routing fails closed", ex);
+      return Collections.emptySet();
     }
   }
 
-  /** Returns the subset of the given consultant IDs marked available within the window (in ms). */
-  public Set<String> filterActive(Collection<String> consultantIds, long windowMs) {
-    long cutoff = clock.millis() - windowMs;
-    return consultantIds.stream()
-        .filter(
-            consultantId -> {
-              Long lastSeen = availableSince.get(consultantId);
-              return lastSeen != null && lastSeen >= cutoff;
-            })
-        .collect(Collectors.toSet());
+  private AvailabilityStoreException storeFailure(String operation, RuntimeException cause) {
+    record(operation, "failure");
+    log.warn("Live-chat availability Redis {} failed", operation, cause);
+    return new AvailabilityStoreException("Live-chat availability store operation failed", cause);
+  }
+
+  private void record(String operation, String outcome) {
+    meterRegistry.counter(STORE_METRIC, "operation", operation, "outcome", outcome).increment();
+  }
+
+  private boolean isValid(String consultantId) {
+    return consultantId != null && !consultantId.isBlank();
+  }
+
+  private String key(String consultantId) {
+    return keyPrefix + consultantId;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistry.java
@@ -74,13 +74,14 @@ public class ConsultantActivityRegistry {
   }
 
   /** Heartbeat: EXPIRE refreshes only an existing key and can never enable a consultant. */
-  public void refreshIfAvailable(String consultantId) {
+  public boolean refreshIfAvailable(String consultantId) {
     if (!isValid(consultantId)) {
-      return;
+      return false;
     }
     try {
       Boolean refreshed = redisTemplate.expire(key(consultantId), ttl);
       record("refresh", Boolean.TRUE.equals(refreshed) ? "success" : "missing");
+      return Boolean.TRUE.equals(refreshed);
     } catch (RuntimeException ex) {
       throw storeFailure("refresh", ex);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,8 @@ spring.liquibase.contexts=local,seed
 spring.data.redis.host=${SPRING_DATA_REDIS_HOST:${SPRING_REDIS_HOST:localhost}}
 spring.data.redis.port=${SPRING_DATA_REDIS_PORT:${SPRING_REDIS_PORT:6379}}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD:${SPRING_REDIS_PASSWORD:}}
+consultant.availability.redis.ttlSeconds=${CONSULTANT_AVAILABILITY_REDIS_TTL_SECONDS:120}
+consultant.availability.redis.keyPrefix=${CONSULTANT_AVAILABILITY_REDIS_KEY_PREFIX:livechat:consultant:available:}
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerIT.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -110,5 +111,17 @@ class ConsultantLiveAvailabilityControllerIT {
     verify(consultantActivityRegistry).filterActive(anyCollection(), anyLong());
     verify(consultantActivityRegistry, never()).refreshIfAvailable(any());
     verify(consultantActivityRegistry, never()).markAvailable(any());
+  }
+
+  @Test
+  void heartbeat_Should_ReturnAuthoritativeFalse_WhenLeaseHasExpired() throws Exception {
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantActivityRegistry.refreshIfAvailable(CONSULTANT_ID)).thenReturn(false);
+
+    this.mockMvc
+        .perform(post(AVAILABILITY_PATH + "/heartbeat"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.available").value(false));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerTest.java
@@ -65,12 +65,26 @@ class ConsultantLiveAvailabilityControllerTest {
   void heartbeat_Should_RefreshExistingAvailabilityWithoutEnablingConsultant() {
     when(authenticatedUser.isConsultant()).thenReturn(true);
     when(authenticatedUser.getUserId()).thenReturn("consultant-2");
+    when(consultantActivityRegistry.refreshIfAvailable("consultant-2")).thenReturn(true);
 
     var response = controller.heartbeatLiveChatAvailability();
 
-    assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(true, response.getBody().getAvailable());
     verify(consultantActivityRegistry).refreshIfAvailable("consultant-2");
     verify(consultantActivityRegistry, never()).markAvailable("consultant-2");
+  }
+
+  @Test
+  void heartbeat_Should_ReturnUnavailable_WhenLeaseAlreadyExpired() {
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("consultant-2");
+    when(consultantActivityRegistry.refreshIfAvailable("consultant-2")).thenReturn(false);
+
+    var response = controller.heartbeatLiveChatAvailability();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(false, response.getBody().getAvailable());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConsultantLiveAvailabilityControllerTest.java
@@ -62,6 +62,18 @@ class ConsultantLiveAvailabilityControllerTest {
   }
 
   @Test
+  void heartbeat_Should_RefreshExistingAvailabilityWithoutEnablingConsultant() {
+    when(authenticatedUser.isConsultant()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("consultant-2");
+
+    var response = controller.heartbeatLiveChatAvailability();
+
+    assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    verify(consultantActivityRegistry).refreshIfAvailable("consultant-2");
+    verify(consultantActivityRegistry, never()).markAvailable("consultant-2");
+  }
+
+  @Test
   void setLiveChatAvailability_consultantAndAvailableNull_marksUnavailable() {
     // Business reason: null availability payload should fail safe to unavailable to avoid stale
     // live

--- a/src/test/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/ConsultantActivityInterceptorTest.java
@@ -54,15 +54,14 @@ class ConsultantActivityInterceptorTest {
   }
 
   @Test
-  void preHandle_Should_refreshTtl_When_putAvailabilityPath() {
-    givenAuthenticatedConsultant();
+  void preHandle_Should_notRefreshTtl_When_putAvailabilityPathOwnsMutation() {
     var request =
         new MockHttpServletRequest("PUT", ConsultantActivityInterceptor.AVAILABILITY_PATH);
     var response = new MockHttpServletResponse();
 
     interceptor.preHandle(request, response, new Object());
 
-    verify(consultantActivityRegistry).refreshIfAvailable(CONSULTANT_ID);
+    verify(consultantActivityRegistry, never()).refreshIfAvailable(CONSULTANT_ID);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryRedisIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryRedisIT.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.userservice.api.service.availability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/** Local Docker contract test against the ORISO Redis container on localhost:6379. */
+@EnabledIfEnvironmentVariable(named = "ORISO_LOCAL_REDIS_IT", matches = "true")
+class ConsultantActivityRegistryRedisIT {
+
+  private LettuceConnectionFactory connectionFactory;
+  private StringRedisTemplate redisTemplate;
+  private String keyPrefix;
+
+  @BeforeEach
+  void setUp() {
+    connectionFactory = new LettuceConnectionFactory("localhost", 6379);
+    connectionFactory.afterPropertiesSet();
+    redisTemplate = new StringRedisTemplate(connectionFactory);
+    redisTemplate.afterPropertiesSet();
+    keyPrefix = "test:livechat:" + UUID.randomUUID() + ":";
+  }
+
+  @AfterEach
+  void tearDown() {
+    redisTemplate.delete(redisTemplate.keys(keyPrefix + "*"));
+    connectionFactory.destroy();
+  }
+
+  @Test
+  void availabilitySurvivesRegistryReconstructionExpiresAndHeartbeatCannotEnable() {
+    var ttl = Duration.ofSeconds(2);
+    var first =
+        new ConsultantActivityRegistry(redisTemplate, new SimpleMeterRegistry(), ttl, keyPrefix);
+    var reconstructed =
+        new ConsultantActivityRegistry(redisTemplate, new SimpleMeterRegistry(), ttl, keyPrefix);
+
+    first.markAvailable("consultant-1");
+    assertThat(reconstructed.filterActive(List.of("consultant-1"), ttl.toMillis()))
+        .containsExactly("consultant-1");
+
+    reconstructed.markUnavailable("consultant-1");
+    reconstructed.refreshIfAvailable("consultant-1");
+    assertThat(first.filterActive(List.of("consultant-1"), ttl.toMillis())).isEmpty();
+
+    first.markAvailable("consultant-1");
+    await()
+        .atMost(Duration.ofSeconds(4))
+        .untilAsserted(
+            () ->
+                assertThat(reconstructed.filterActive(List.of("consultant-1"), ttl.toMillis()))
+                    .isEmpty());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
@@ -1,141 +1,137 @@
 package de.caritas.cob.userservice.api.service.availability;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Clock;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
+@ExtendWith(MockitoExtension.class)
 class ConsultantActivityRegistryTest {
 
+  private static final Duration TTL = Duration.ofSeconds(120);
+  private static final String PREFIX = "livechat:consultant:available:";
+
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOperations;
+
+  private SimpleMeterRegistry meterRegistry;
   private ConsultantActivityRegistry registry;
 
   @BeforeEach
   void setUp() {
-    registry = new ConsultantActivityRegistry();
+    meterRegistry = new SimpleMeterRegistry();
+    registry = new ConsultantActivityRegistry(redisTemplate, meterRegistry, TTL, PREFIX);
+  }
+
+  private void givenValueOperations() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
   }
 
   @Test
-  void markAvailable_Should_AddConsultant() {
+  void markAvailable_Should_WriteRedisKeyWithConfiguredTtl() {
+    givenValueOperations();
     registry.markAvailable("consultant-1");
 
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).containsExactly("consultant-1");
+    verify(valueOperations).set(PREFIX + "consultant-1", "1", TTL);
   }
 
   @Test
-  void markAvailable_Should_IgnoreNullId() {
-    registry.markAvailable(null);
-
-    Set<String> active = registry.filterActive(List.of(), 60_000);
-    assertThat(active).isEmpty();
-  }
-
-  @Test
-  void markAvailable_Should_IgnoreBlankId() {
-    registry.markAvailable("   ");
-
-    Set<String> active = registry.filterActive(List.of("   "), 60_000);
-    assertThat(active).isEmpty();
-  }
-
-  @Test
-  void markUnavailable_Should_RemoveConsultant() {
+  void newRegistryInstance_Should_ReadAvailabilityWrittenByPreviousInstance() {
+    givenValueOperations();
     registry.markAvailable("consultant-1");
+    when(valueOperations.multiGet(List.of(PREFIX + "consultant-1"))).thenReturn(List.of("1"));
+
+    var reconstructedRegistry =
+        new ConsultantActivityRegistry(redisTemplate, meterRegistry, TTL, PREFIX);
+
+    assertThat(reconstructedRegistry.filterActive(List.of("consultant-1"), TTL.toMillis()))
+        .containsExactly("consultant-1");
+  }
+
+  @Test
+  void filterActive_Should_ExcludeExpiredRedisKey() {
+    givenValueOperations();
+    when(valueOperations.multiGet(List.of(PREFIX + "consultant-1")))
+        .thenReturn(java.util.Collections.singletonList(null));
+
+    assertThat(registry.filterActive(List.of("consultant-1"), TTL.toMillis())).isEmpty();
+  }
+
+  @Test
+  void refreshIfAvailable_Should_OnlyExtendExistingKeyAndNeverCreateOne() {
+    when(redisTemplate.expire(PREFIX + "consultant-1", TTL)).thenReturn(false);
+
+    registry.refreshIfAvailable("consultant-1");
+
+    verify(redisTemplate).expire(PREFIX + "consultant-1", TTL);
+    verify(valueOperations, never()).set(any(), any(), any(Duration.class));
+  }
+
+  @Test
+  void markUnavailable_Should_DeleteRedisKeyImmediately() {
     registry.markUnavailable("consultant-1");
 
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).isEmpty();
+    verify(redisTemplate).delete(PREFIX + "consultant-1");
   }
 
   @Test
-  void markUnavailable_Should_IgnoreNullId() {
-    registry.markAvailable("consultant-1");
+  void filterActive_Should_FailClosedAndExposeMetric_WhenRedisReadFails() {
+    givenValueOperations();
+    when(valueOperations.multiGet(List.of(PREFIX + "consultant-1")))
+        .thenThrow(new RedisConnectionFailureException("redis unavailable"));
+
+    assertThat(registry.filterActive(List.of("consultant-1"), TTL.toMillis())).isEmpty();
+    assertThat(
+            meterRegistry
+                .get(ConsultantActivityRegistry.STORE_METRIC)
+                .tag("operation", "read")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void markAvailable_Should_RejectEnableAndExposeMetric_WhenRedisWriteFails() {
+    givenValueOperations();
+    org.mockito.Mockito.doThrow(new RedisConnectionFailureException("redis unavailable"))
+        .when(valueOperations)
+        .set(PREFIX + "consultant-1", "1", TTL);
+
+    assertThatThrownBy(() -> registry.markAvailable("consultant-1"))
+        .isInstanceOf(AvailabilityStoreException.class);
+    assertThat(
+            meterRegistry
+                .get(ConsultantActivityRegistry.STORE_METRIC)
+                .tag("operation", "enable")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void invalidIds_Should_NotAccessRedis() {
+    registry.markAvailable(" ");
     registry.markUnavailable(null);
-
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).containsExactly("consultant-1");
-  }
-
-  @Test
-  void markUnavailable_Should_NotFailWhenConsultantNotPresent() {
-    registry.markUnavailable("non-existent");
-
-    Set<String> active = registry.filterActive(List.of("non-existent"), 60_000);
-    assertThat(active).isEmpty();
-  }
-
-  @Test
-  void refreshIfAvailable_Should_KeepConsultantActive() throws InterruptedException {
-    registry.markAvailable("consultant-1");
-    Thread.sleep(10);
-    registry.refreshIfAvailable("consultant-1");
-
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).containsExactly("consultant-1");
-  }
-
-  @Test
-  void refreshIfAvailable_Should_NotAddUnavailableConsultant() {
-    registry.refreshIfAvailable("consultant-1");
-
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).isEmpty();
-  }
-
-  @Test
-  void refreshIfAvailable_Should_IgnoreNullId() {
-    registry.markAvailable("consultant-1");
     registry.refreshIfAvailable(null);
 
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).containsExactly("consultant-1");
-  }
-
-  @Test
-  void filterActive_Should_ReturnOnlyActiveWithinWindow() {
-    Clock clock = mock(Clock.class);
-    ConsultantActivityRegistry timedRegistry = new ConsultantActivityRegistry(clock);
-
-    when(clock.millis()).thenReturn(1000L);
-    timedRegistry.markAvailable("consultant-1");
-
-    when(clock.millis()).thenReturn(1200L);
-    timedRegistry.markAvailable("consultant-2");
-
-    // cutoff = 1200 - 150 = 1050; consultant-1 (1000) excluded, consultant-2 (1200) included
-    Set<String> active = timedRegistry.filterActive(List.of("consultant-1", "consultant-2"), 150);
-    assertThat(active).containsExactly("consultant-2");
-  }
-
-  @Test
-  void filterActive_Should_ReturnEmptyWhenNoConsultantsGiven() {
-    registry.markAvailable("consultant-1");
-
-    Set<String> active = registry.filterActive(List.of(), 60_000);
-    assertThat(active).isEmpty();
-  }
-
-  @Test
-  void filterActive_Should_OnlyReturnSubsetMatchingGivenIds() {
-    registry.markAvailable("consultant-1");
-    registry.markAvailable("consultant-2");
-
-    Set<String> active = registry.filterActive(List.of("consultant-1"), 60_000);
-    assertThat(active).containsExactly("consultant-1");
-  }
-
-  @Test
-  void multipleConsultants_Should_TrackIndependently() {
-    registry.markAvailable("c1");
-    registry.markAvailable("c2");
-    registry.markUnavailable("c1");
-
-    Set<String> active = registry.filterActive(List.of("c1", "c2"), 60_000);
-    assertThat(active).containsExactly("c2");
+    verify(valueOperations, never()).set(any(), any(), any(Duration.class));
+    verify(redisTemplate, never()).delete(any(String.class));
+    verify(redisTemplate, never()).expire(any(String.class), any(Duration.class));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/availability/ConsultantActivityRegistryTest.java
@@ -75,10 +75,17 @@ class ConsultantActivityRegistryTest {
   void refreshIfAvailable_Should_OnlyExtendExistingKeyAndNeverCreateOne() {
     when(redisTemplate.expire(PREFIX + "consultant-1", TTL)).thenReturn(false);
 
-    registry.refreshIfAvailable("consultant-1");
+    assertThat(registry.refreshIfAvailable("consultant-1")).isFalse();
 
     verify(redisTemplate).expire(PREFIX + "consultant-1", TTL);
     verify(valueOperations, never()).set(any(), any(), any(Duration.class));
+  }
+
+  @Test
+  void refreshIfAvailable_Should_ReturnTrue_WhenLeaseWasExtended() {
+    when(redisTemplate.expire(PREFIX + "consultant-1", TTL)).thenReturn(true);
+
+    assertThat(registry.refreshIfAvailable("consultant-1")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- make Redis with a 120-second TTL the shared source of truth for consultant live-chat availability
- add a refresh-only heartbeat endpoint that cannot recreate disabled or expired availability
- fail closed on Redis reads, reject unacknowledged writes, and emit low-cardinality store-operation metrics
- keep generic consultant activity as refresh-only and prevent the availability endpoints from being mutated twice by the interceptor

## Verification

- 50 focused registry, interceptor, controller, integration, and routing tests passed
- local Docker Redis integration test passed (`ORISO_LOCAL_REDIS_IT=true ./mvnw -Dtest=ConsultantActivityRegistryRedisIT test`)
- Spring application context test passed (`./mvnw -Dtest=UserServiceApplicationIT test`)
- Spotless and `git diff --check` passed

The repository currently pins Testcontainers 1.17.6, which cannot negotiate with the local Docker 29 daemon. The opt-in integration test therefore uses the existing local `redis:7-alpine` container and remains skipped unless explicitly enabled.

Closes #522
Parent: #520
Frontend consumer: OpenResilienceInitiative/ORISO-Frontend#563

🤖 Generated with [Claude Code](https://claude.com/claude-code)