### PR TITLE
fix: load Matrix mobile recipients transactionally

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/mobilepushmessage/MobilePushNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/mobilepushmessage/MobilePushNotificationService.java
@@ -14,6 +14,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Collects all relevant mobile tokens and fires push notifications via the {@link
@@ -32,6 +33,7 @@ public class MobilePushNotificationService {
    *
    * @param userIds user ids to send push notifications
    */
+  @Transactional(readOnly = true)
   public void triggerMobilePushNotification(List<String> userIds) {
     userIds.forEach(this::sendPushNotificationForUser);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -1169,7 +1169,7 @@ class MatrixEventListenerServiceTest {
   }
 
   @Test
-  void handleRoomMessage_shouldStillCreateNotificationRow_whenLiveSendFails() {
+  void handleRoomMessage_shouldStillPersistNotificationAndStatistic_whenLiveOrPushSendFails() {
     // The live STOMP push is an optimisation; the persisted feed entry is the
     // source of truth for the Zeitstrahl. A live-send failure (e.g. the
     // request-scoped AuthenticatedUser being unavailable on the sync-loop
@@ -1177,19 +1177,22 @@ class MatrixEventListenerServiceTest {
     var service = newServiceWithSyncExecutor();
     service.registerRoom(33L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
 
-    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID))
-        .thenReturn(Optional.of(userWithId(ASKER_DOMAIN_ID)));
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultantWithId(CONSULTANT_DOMAIN_ID)));
 
-    org.mockito.Mockito.doThrow(new IllegalStateException("No thread-bound request found"))
+    org.mockito.Mockito.doThrow(new IllegalStateException("mobile push failed"))
         .when(liveEventNotificationService)
         .sendLiveDirectMessageEventToUsers(MATRIX_ROOM_ID);
 
-    var event = messageEvent(SENDER_MATRIX_ID, "m.text", "hello", "$evt-live-down");
+    var event = messageEvent(CONSULTANT_MATRIX_ID, "m.text", "hello", "$evt-live-or-push-down");
     invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event);
 
     verify(eventNotificationService)
         .createMessageNotificationFromRoom(
-            eq(MATRIX_ROOM_ID), eq(ASKER_DOMAIN_ID), eq(true), any(PrivacyEnvelope.class));
+            eq(MATRIX_ROOM_ID), eq(CONSULTANT_DOMAIN_ID), eq(true), any(PrivacyEnvelope.class));
+    verify(consultantMessageStatService).recordMessageSent(CONSULTANT_DOMAIN_ID, 33L);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/mobilepushmessage/MobilePushNotificationServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/mobilepushmessage/MobilePushNotificationServiceIT.java
@@ -1,0 +1,58 @@
+package de.caritas.cob.userservice.api.service.mobilepushmessage;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.model.ConsultantMobileToken;
+import de.caritas.cob.userservice.api.port.out.ConsultantMobileTokenRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+class MobilePushNotificationServiceIT {
+
+  private static final String MOBILE_TOKEN = "matrix-background-mobile-token";
+
+  @Autowired private MobilePushNotificationService mobilePushNotificationService;
+  @Autowired private ConsultantRepository consultantRepository;
+  @Autowired private ConsultantMobileTokenRepository consultantMobileTokenRepository;
+  @Autowired private TransactionTemplate transactionTemplate;
+
+  @MockitoBean private FirebasePushMessageService firebasePushMessageService;
+
+  private String consultantId;
+
+  @BeforeEach
+  void persistConsultantMobileToken() {
+    consultantMobileTokenRepository.deleteAll();
+    consultantId = consultantRepository.findAll().getFirst().getId();
+    transactionTemplate.executeWithoutResult(
+        ignored -> {
+          var consultant = consultantRepository.findById(consultantId).orElseThrow();
+          var token = new ConsultantMobileToken();
+          token.setConsultant(consultant);
+          token.setMobileAppToken(MOBILE_TOKEN);
+          consultantMobileTokenRepository.save(token);
+        });
+  }
+
+  @Test
+  void triggerMobilePushNotificationLoadsLazyTokensInsideItsPublicBoundary() {
+    assertDoesNotThrow(
+        () -> mobilePushNotificationService.triggerMobilePushNotification(List.of(consultantId)));
+
+    verify(firebasePushMessageService).pushNewMessageEvent(MOBILE_TOKEN);
+  }
+}


### PR DESCRIPTION
## Summary

- keep lazy user/consultant mobile-token collections inside the public mobile-notification service read-only transaction
- preserve the existing Matrix failure-domain split so a live/mobile push failure cannot suppress persisted notification or consultant statistics effects
- add a persistence-backed consultant-token regression test without wrapping the test itself in a transaction
- retain metadata-only notifications; no plaintext message preview or device token is added

## TDD evidence

Before the transaction boundary, `MobilePushNotificationServiceIT` failed with `LazyInitializationException` for `Consultant.consultantMobileTokens`. The same persistence-backed test now passes.

## Verification

- 112 focused mobile-push, live-event, Matrix-listener, and persistence-backed tests passed
- failure-isolation test proves persisted notification and consultant statistics still execute when the live/mobile push boundary throws
- Spotless passed

Closes #523
Parent: #520
Related existing Matrix access repair: #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)