### PR TITLE
feat(team-discussion): gate on per-tenant flag, fall back to deploy property

### DIFF
--- a/services/tenantservice.yaml
+++ b/services/tenantservice.yaml
@@ -98,6 +98,9 @@ components:
         featureGroupChatV2Enabled:
           type: boolean
           default: false
+        featureTeamDiscussionEnabled:
+          type: boolean
+          default: false
     Licensing:
       type: object
       required:

--- a/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacade.java
@@ -62,8 +62,8 @@ public class TeamDiscussionFacade {
    * OPEN discussions can be created; an ARCHIVED one is returned read-only.
    */
   public TeamDiscussionView getOrCreateDiscussion(Long sessionId, String consultantId) {
-    featureGate.requireEnabled();
     Session session = loadSession(sessionId);
+    featureGate.requireEnabled(session.getTenantId());
     Consultant consultant = requireEligibleConsultant(session, consultantId);
 
     Optional<TeamDiscussion> existing = teamDiscussionRepository.findBySessionId(sessionId);
@@ -97,8 +97,8 @@ public class TeamDiscussionFacade {
 
   /** Returns the discussion if one exists — also ARCHIVED ones (read-only archive access). */
   public Optional<TeamDiscussionView> getDiscussion(Long sessionId, String consultantId) {
-    featureGate.requireEnabled();
     Session session = loadSession(sessionId);
+    featureGate.requireEnabled(session.getTenantId());
     requireEligibleConsultant(session, consultantId);
     return teamDiscussionRepository
         .findBySessionId(sessionId)

--- a/src/main/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGate.java
@@ -1,30 +1,49 @@
 package de.caritas.cob.userservice.api.service.teamdiscussion;
 
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
  * Enforces the Team-Besprechung feature toggle at the backend boundary (US#473 / ADR-016).
  *
- * <p>Currently a deploy-level property ({@code team-discussion.enabled}). The decided target is a
- * tenant-level setting following the {@code GroupChatFeatureGate} pattern; that needs a companion
- * TenantService settings field first and is tracked as a follow-up on the epic (FE#512). This gate
- * is the single seam where that check will slot in — callers stay unchanged.
+ * <p>The per-tenant setting {@code featureTeamDiscussionEnabled} (TenantService) takes precedence.
+ * When there is no tenant context — single-tenant deploy, or TenantService returns no settings —
+ * the gate falls back to the deploy property {@code team-discussion.enabled} (default true). This
+ * mirrors {@code GroupChatFeatureGate} but fails <em>open to the property</em> rather than closed,
+ * so single-tenant installations keep working without a tenant settings document.
  */
 @Service
+@RequiredArgsConstructor
 public class TeamDiscussionFeatureGate {
+
+  private final @NonNull TenantService tenantService;
 
   @Value("${team-discussion.enabled:true}")
   private boolean teamDiscussionEnabled;
 
-  public void requireEnabled() {
-    if (!teamDiscussionEnabled) {
+  public void requireEnabled(Long tenantId) {
+    if (!isEnabled(tenantId)) {
       throw new ForbiddenException("Team discussion is disabled");
     }
   }
 
-  public boolean isEnabled() {
-    return teamDiscussionEnabled;
+  public boolean isEnabled(Long tenantId) {
+    Boolean tenantValue = resolveTenantValue(tenantId);
+    return tenantValue != null ? tenantValue : teamDiscussionEnabled;
+  }
+
+  private Boolean resolveTenantValue(Long tenantId) {
+    if (tenantId == null) {
+      return null;
+    }
+    var tenant = tenantService.getRestrictedTenantDataFresh(tenantId);
+    if (tenant == null || tenant.getSettings() == null) {
+      return null;
+    }
+    return tenant.getSettings().getFeatureTeamDiscussionEnabled();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/TeamDiscussionFacadeTest.java
@@ -160,7 +160,7 @@ class TeamDiscussionFacadeTest {
   void getOrCreateDiscussion_shouldRespectFeatureGate() throws Exception {
     doThrow(new ForbiddenException("Team discussion is disabled"))
         .when(featureGate)
-        .requireEnabled();
+        .requireEnabled(org.mockito.ArgumentMatchers.any());
 
     assertThatThrownBy(() -> facade.getOrCreateDiscussion(SESSION_ID, CONSULTANT_ID))
         .isInstanceOf(ForbiddenException.class);

--- a/src/test/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/teamdiscussion/TeamDiscussionFeatureGateTest.java
@@ -1,0 +1,79 @@
+package de.caritas.cob.userservice.api.service.teamdiscussion;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantSettings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * US#473 / ADR-016 — the Team-Besprechung gate prefers the per-tenant flag and falls back to the
+ * deploy property when there is no tenant context (single-tenant deploy).
+ */
+@ExtendWith(MockitoExtension.class)
+class TeamDiscussionFeatureGateTest {
+
+  @Mock private TenantService tenantService;
+
+  private TeamDiscussionFeatureGate gateWithProperty(boolean deployDefault) {
+    var gate = new TeamDiscussionFeatureGate(tenantService);
+    ReflectionTestUtils.setField(gate, "teamDiscussionEnabled", deployDefault);
+    return gate;
+  }
+
+  private RestrictedTenantDTO tenant(Long id, Boolean flag) {
+    return new RestrictedTenantDTO()
+        .id(id)
+        .name("Tenant")
+        .settings(new RestrictedTenantSettings().featureTeamDiscussionEnabled(flag));
+  }
+
+  @Test
+  void tenantFlagTrue_enables_evenIfDeployPropertyFalse() {
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant(7L, true));
+    var gate = gateWithProperty(false);
+    assertThatCode(() -> gate.requireEnabled(7L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void tenantFlagFalse_disables_evenIfDeployPropertyTrue() {
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant(7L, false));
+    var gate = gateWithProperty(true);
+    assertThatThrownBy(() -> gate.requireEnabled(7L)).isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void noTenantContext_fallsBackToDeployProperty_enabled() {
+    var gate = gateWithProperty(true);
+    assertThatCode(() -> gate.requireEnabled(null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void noTenantContext_fallsBackToDeployProperty_disabled() {
+    var gate = gateWithProperty(false);
+    assertThatThrownBy(() -> gate.requireEnabled(null)).isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void tenantWithoutSettings_fallsBackToDeployProperty() {
+    when(tenantService.getRestrictedTenantDataFresh(7L))
+        .thenReturn(new RestrictedTenantDTO().id(7L).name("Tenant").settings(null));
+    var gate = gateWithProperty(true);
+    assertThatCode(() -> gate.requireEnabled(7L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void isEnabled_reflectsTenantFlag() {
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant(7L, false));
+    var gate = gateWithProperty(true);
+    org.assertj.core.api.Assertions.assertThat(gate.isEnabled(7L)).isFalse();
+  }
+}


### PR DESCRIPTION
## Why

Team-Besprechung (ADR-016) gated on a deploy-only property. With the tenant flag now in TenantService (OpenResilienceInitiative/ORISO-TenantService#98), the gate should honour the **per-tenant** setting so an admin can toggle it — while single-tenant deploys keep working.

## What

- `TeamDiscussionFeatureGate`: injects `TenantService`; `requireEnabled(tenantId)` / `isEnabled(tenantId)` read `featureTeamDiscussionEnabled`. **Precedence:** tenant flag wins; when there is no tenant context (tenantId null, or TenantService returns no settings) it **falls back to the deploy property** `team-discussion.enabled` (default true). Deliberately fails *open to the property* rather than closed (unlike `GroupChatFeatureGate`), so single-tenant installs need no tenant settings document.
- `services/tenantservice.yaml`: `featureTeamDiscussionEnabled` on `RestrictedTenantSettings`.
- `TeamDiscussionFacade`: loads the session before the gate and passes its `tenantId`.

## Verification

TDD: `TeamDiscussionFeatureGateTest` — tenant-true enables over property-false, tenant-false disables over property-true, no-tenant falls back both directions, null-settings falls back. Full suite **3703 green** on JDK21 (JDK25 breaks Mockito/JaCoCo locally), spotless clean.

**Depends on** OpenResilienceInitiative/ORISO-TenantService#98 (must deploy first, else the field is absent → gate falls back to the property = today's behaviour, so no hard ordering requirement).

Refs OpenResilienceInitiative/ORISO-Frontend#512 · ADR-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
