### PR TITLE
feat(notifications): global Do-Not-Disturb store + email gate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/DoNotDisturbController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/DoNotDisturbController.java
@@ -1,0 +1,42 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Global per-user Do-Not-Disturb (decided 2026-07-18). Authoritative cross-device store; the
+ * frontend reads it to suppress announcements while active and notification emails are gated on it.
+ * A {@code null} {@code dndUntil} clears DND.
+ */
+@RestController
+@RequestMapping("/users/notifications/do-not-disturb")
+@RequiredArgsConstructor
+public class DoNotDisturbController {
+
+  private final @NonNull DoNotDisturbService doNotDisturbService;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  @GetMapping
+  public ResponseEntity<DoNotDisturbDTO> get() {
+    return ResponseEntity.ok(
+        new DoNotDisturbDTO(doNotDisturbService.getDndUntil(authenticatedUser.getUserId())));
+  }
+
+  @PutMapping
+  public ResponseEntity<DoNotDisturbDTO> put(@RequestBody DoNotDisturbDTO request) {
+    LocalDateTime until = request != null ? request.dndUntil() : null;
+    doNotDisturbService.setDndUntil(authenticatedUser.getUserId(), until);
+    return ResponseEntity.ok(new DoNotDisturbDTO(until));
+  }
+
+  public record DoNotDisturbDTO(LocalDateTime dndUntil) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -171,6 +171,7 @@ public class SecurityConfig {
                     "/users/drafts/**",
                     "/users/event-notifications",
                     "/users/event-notifications/**",
+                    "/users/notifications/do-not-disturb",
                     "/users/chat/{chatId:[0-9]+}",
                     "/users/chat/e2e",
                     "/users/chat/{chatId:[0-9]+}/join",

--- a/src/main/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacade.java
@@ -61,6 +61,8 @@ public class EmailNotificationFacade {
   private String rocketChatSystemUserId;
 
   private final @NonNull MailService mailService;
+  private final @NonNull de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService
+      doNotDisturbService;
   private final @NonNull SessionService sessionService;
   private final @NonNull ConsultantAgencyService consultantAgencyService;
   private final @NonNull ConsultantService consultantService;
@@ -168,6 +170,7 @@ public class EmailNotificationFacade {
               .multiTenancyEnabled(multiTenancyEnabled)
               .messageClient(messageClient)
               .releaseToggleService(releaseToggleService)
+              .doNotDisturbService(doNotDisturbService)
               .build();
       sendMailTasksToMailService(newMessageMails);
 

--- a/src/main/java/de/caritas/cob/userservice/api/model/UserDoNotDisturb.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/UserDoNotDisturb.java
@@ -1,0 +1,39 @@
+package de.caritas.cob.userservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Global per-user Do-Not-Disturb (decided 2026-07-18). While {@code dndUntil} is in the future,
+ * announcements (toast/sound/push) and notification emails are suppressed; the persisted activity
+ * feed still fills. Auto-reverts when the timestamp passes — no cleanup job.
+ */
+@Entity
+@Table(name = "user_do_not_disturb")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+public class UserDoNotDisturb {
+
+  @Id
+  @Column(name = "user_id", nullable = false, length = 64)
+  private String userId;
+
+  @Column(name = "dnd_until")
+  private LocalDateTime dndUntil;
+
+  @Column(name = "update_date", nullable = false)
+  private LocalDateTime updateDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/UserDoNotDisturbRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/UserDoNotDisturbRepository.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.UserDoNotDisturb;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDoNotDisturbRepository extends JpaRepository<UserDoNotDisturb, String> {
+
+  Optional<UserDoNotDisturb> findByUserId(String userId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/donotdisturb/DoNotDisturbService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/donotdisturb/DoNotDisturbService.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.service.donotdisturb;
+
+import de.caritas.cob.userservice.api.model.UserDoNotDisturb;
+import de.caritas.cob.userservice.api.port.out.UserDoNotDisturbRepository;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Global per-user Do-Not-Disturb (decided 2026-07-18). Authoritative, server-readable and
+ * cross-device: the frontend suppresses toast/sound/push while active, and notification emails are
+ * gated on it. Active while {@code dndUntil} is in the future; auto-reverts when it passes.
+ */
+@Service
+@RequiredArgsConstructor
+public class DoNotDisturbService {
+
+  private final @NonNull UserDoNotDisturbRepository repository;
+
+  public boolean isInDoNotDisturb(String userId) {
+    LocalDateTime until = getDndUntil(userId);
+    return until != null && until.isAfter(LocalDateTime.now());
+  }
+
+  public LocalDateTime getDndUntil(String userId) {
+    if (userId == null || userId.isBlank()) {
+      return null;
+    }
+    return repository.findByUserId(userId).map(UserDoNotDisturb::getDndUntil).orElse(null);
+  }
+
+  @Transactional
+  public void setDndUntil(String userId, LocalDateTime until) {
+    if (userId == null || userId.isBlank()) {
+      return;
+    }
+    UserDoNotDisturb entry =
+        repository
+            .findByUserId(userId)
+            .orElseGet(() -> UserDoNotDisturb.builder().userId(userId).build());
+    entry.setDndUntil(until);
+    entry.setUpdateDate(LocalDateTime.now());
+    repository.save(entry);
+  }
+
+  @Transactional
+  public void clear(String userId) {
+    setDndUntil(userId, null);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplier.java
@@ -61,6 +61,9 @@ public class NewMessageEmailSupplier implements EmailSupplier {
 
   private final ReleaseToggleService releaseToggleService;
 
+  private final de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService
+      doNotDisturbService;
+
   /**
    * Generates new message notification mails sent to regarding consultants when a user has written
    * a new message and to regarding user when a consultant has written a new message.
@@ -108,6 +111,7 @@ public class NewMessageEmailSupplier implements EmailSupplier {
       return consultantList.stream()
           .filter(agency -> checkThatConsultantEmailNotEmpty(agency))
           .filter(agency -> wantsToReceiveNotifications(agency.getConsultant()))
+          .filter(agency -> notInDoNotDisturb(agency.getConsultant()))
           .filter(isConsultantLoggedOut())
           .map(this::toNewConsultantMessageMailDTO)
           .collect(Collectors.toList());
@@ -232,6 +236,18 @@ public class NewMessageEmailSupplier implements EmailSupplier {
     }
 
     return emptyList();
+  }
+
+  private boolean notInDoNotDisturb(Consultant consultant) {
+    if (doNotDisturbService == null) {
+      return true;
+    }
+    var inDnd = doNotDisturbService.isInDoNotDisturb(consultant.getId());
+    if (inDnd) {
+      log.debug(
+          "Skipping email notification: consultant {} is in do-not-disturb", consultant.getId());
+    }
+    return !inDnd;
   }
 
   private Predicate<ConsultantAgency> isConsultantLoggedOut() {

--- a/src/main/resources/db/changelog/changeset/0072_user_do_not_disturb/0072_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0072_user_do_not_disturb/0072_changeSet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+  <changeSet id="0072-user-do-not-disturb" author="frank">
+    <sqlFile
+      path="db/changelog/changeset/0072_user_do_not_disturb/migrate.sql"
+      relativeToChangelogFile="false" splitStatements="true" stripComments="true" endDelimiter=";"/>
+    <rollback><sql>DROP TABLE IF EXISTS user_do_not_disturb;</sql></rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0072_user_do_not_disturb/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0072_user_do_not_disturb/migrate.sql
@@ -1,0 +1,9 @@
+-- Global per-user Do-Not-Disturb (decided 2026-07-18). dnd_until in the future = active;
+-- auto-reverts when the timestamp passes (no cleanup job). Announcements (toast/sound/push)
+-- and notification emails are suppressed while active; the persisted activity feed still fills.
+CREATE TABLE IF NOT EXISTS user_do_not_disturb (
+  user_id VARCHAR(64) NOT NULL,
+  dnd_until DATETIME NULL,
+  update_date DATETIME NOT NULL,
+  PRIMARY KEY (user_id)
+);

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -116,6 +116,8 @@
     file="db/changelog/changeset/0070_team_discussion/0070_changeSet.xml" />
   <include
     file="db/changelog/changeset/0071_tutorial_progress/0071_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0072_user_do_not_disturb/0072_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacadeTest.java
@@ -307,6 +307,11 @@ class EmailNotificationFacadeTest {
 
   @Spy private AssignEnquiryEmailSupplier assignEnquiryEmailSupplier;
   @Mock private MailService mailService;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService
+      doNotDisturbService;
+
   @Mock SessionService sessionService;
   @Mock ConsultantAgencyService consultantAgencyService;
   @Mock ConsultantService consultantService;

--- a/src/test/java/de/caritas/cob/userservice/api/service/donotdisturb/DoNotDisturbServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/donotdisturb/DoNotDisturbServiceTest.java
@@ -1,0 +1,105 @@
+package de.caritas.cob.userservice.api.service.donotdisturb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.UserDoNotDisturb;
+import de.caritas.cob.userservice.api.port.out.UserDoNotDisturbRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Global per-user Do-Not-Disturb: active while {@code dndUntil} is in the future, auto-reverts when
+ * it passes (no cleanup job).
+ */
+@ExtendWith(MockitoExtension.class)
+class DoNotDisturbServiceTest {
+
+  private static final String USER = "user-1";
+
+  @InjectMocks private DoNotDisturbService service;
+  @Mock private UserDoNotDisturbRepository repository;
+
+  @Test
+  void isInDoNotDisturb_true_whenDndUntilInFuture() {
+    when(repository.findByUserId(USER))
+        .thenReturn(
+            Optional.of(
+                UserDoNotDisturb.builder()
+                    .userId(USER)
+                    .dndUntil(LocalDateTime.now().plusHours(1))
+                    .build()));
+    assertThat(service.isInDoNotDisturb(USER)).isTrue();
+  }
+
+  @Test
+  void isInDoNotDisturb_false_whenDndUntilInPast_autoReverts() {
+    when(repository.findByUserId(USER))
+        .thenReturn(
+            Optional.of(
+                UserDoNotDisturb.builder()
+                    .userId(USER)
+                    .dndUntil(LocalDateTime.now().minusMinutes(1))
+                    .build()));
+    assertThat(service.isInDoNotDisturb(USER)).isFalse();
+  }
+
+  @Test
+  void isInDoNotDisturb_false_whenNoRecord() {
+    when(repository.findByUserId(USER)).thenReturn(Optional.empty());
+    assertThat(service.isInDoNotDisturb(USER)).isFalse();
+  }
+
+  @Test
+  void isInDoNotDisturb_false_whenDndUntilNull() {
+    when(repository.findByUserId(USER))
+        .thenReturn(Optional.of(UserDoNotDisturb.builder().userId(USER).dndUntil(null).build()));
+    assertThat(service.isInDoNotDisturb(USER)).isFalse();
+  }
+
+  @Test
+  void isInDoNotDisturb_false_whenUserIdBlank() {
+    assertThat(service.isInDoNotDisturb(null)).isFalse();
+    assertThat(service.isInDoNotDisturb(" ")).isFalse();
+  }
+
+  @Test
+  void getDndUntil_returnsStoredValue() {
+    var until = LocalDateTime.now().plusHours(2);
+    when(repository.findByUserId(USER))
+        .thenReturn(Optional.of(UserDoNotDisturb.builder().userId(USER).dndUntil(until).build()));
+    assertThat(service.getDndUntil(USER)).isEqualTo(until);
+  }
+
+  @Test
+  void setDndUntil_upsertsRecord() {
+    when(repository.findByUserId(USER)).thenReturn(Optional.empty());
+    var until = LocalDateTime.now().plusHours(8);
+
+    service.setDndUntil(USER, until);
+
+    verify(repository).save(any(UserDoNotDisturb.class));
+  }
+
+  @Test
+  void clear_setsDndUntilNull() {
+    when(repository.findByUserId(USER))
+        .thenReturn(
+            Optional.of(
+                UserDoNotDisturb.builder()
+                    .userId(USER)
+                    .dndUntil(LocalDateTime.now().plusHours(1))
+                    .build()));
+
+    service.clear(USER);
+
+    verify(repository).save(any(UserDoNotDisturb.class));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
@@ -82,6 +82,10 @@ class NewMessageEmailSupplierTest {
 
   @Mock private ReleaseToggleService releaseToggleService;
 
+  @Mock
+  private de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService
+      doNotDisturbService;
+
   private TestLogAppender testLogAppender;
 
   @BeforeEach
@@ -99,6 +103,7 @@ class NewMessageEmailSupplierTest {
             .emailDummySuffix("dummySuffix")
             .messageClient(messageClient)
             .releaseToggleService(releaseToggleService)
+            .doNotDisturbService(doNotDisturbService)
             .build();
 
     // Attach a custom appender to the logger
@@ -188,6 +193,22 @@ class NewMessageEmailSupplierTest {
     assertThat(templateData.get(1).getValue(), is("1234"));
     assertThat(templateData.get(2).getKey(), is("url"));
     assertThat(templateData.get(2).getValue(), is("app baseurl"));
+  }
+
+  @Test
+  void generateEmails_Should_SkipConsultant_When_ConsultantIsInDoNotDisturb() {
+    when(roles.contains(UserRole.USER.getValue())).thenReturn(true);
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn(USER.getUserId());
+    when(session.getUser()).thenReturn(user);
+    when(session.getStatus()).thenReturn(SessionStatus.IN_PROGRESS);
+    when(session.getConsultant()).thenReturn(CONSULTANT);
+    when(session.getPostcode()).thenReturn("1234");
+    when(doNotDisturbService.isInDoNotDisturb(CONSULTANT.getId())).thenReturn(true);
+
+    List<MailDTO> generatedMails = this.newMessageEmailSupplier.generateEmails();
+
+    assertThat(generatedMails, hasSize(0));
   }
 
   @Test


### PR DESCRIPTION
## Why

Frank's follow-up: a global "Nicht stören" (Do-Not-Disturb) that also pauses **email** notifications, Slack-style. It must be server-readable (email gate lives in the backend) and cross-device, so it is stored authoritatively in UserService; the frontend reads the same source to silence toast/sound/push (ORISO-Frontend PR to follow).

## What

- `UserDoNotDisturb` entity + repo + **Liquibase 0072** (idempotent, `dnd_until` in the future = active, auto-reverts — no cleanup job).
- `DoNotDisturbService`: `isInDoNotDisturb` / `getDndUntil` / `setDndUntil` / `clear`.
- `DoNotDisturbController`: `GET`/`PUT /users/notifications/do-not-disturb` (USER_DEFAULT + CONSULTANT_DEFAULT; `null` clears).
- **Email gate**: `NewMessageEmailSupplier` skips recipients in DND — the high-volume "new message" mail ("Handy brummt bei jeder Nachricht"). The service is reusable; lower-frequency suppliers (enquiry, reassign) can adopt the same one-line filter as a follow-up.

## Verification

TDD: `DoNotDisturbServiceTest` (active/expired/none/null/blank, upsert, clear) and `NewMessageEmailSupplierTest` skip-in-DND. Full suite **3706 green** on JDK21, spotless clean.

Part of the notification follow-ups (Team-Besprechung epic OpenResilienceInitiative/ORISO-Frontend#512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
