### PR TITLE
chore: add AGPL-3.0 license baseline to main

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+ORISO UserService
+Copyright 2025-2026 Open Resilience Initiative
+
+This repository is a modified version of Onlineberatung/onlineBeratung-userService
+(original work Copyright virtualidentity AG and contributors /
+Caritas Deutschland, licensed under AGPL-3.0).
+
+This version has been modified by the Open Resilience Initiative,
+2025-2026. The git history is the record of modifications
+(AGPL-3.0 section 5(a)).


### PR DESCRIPTION
Ports the AGPL-3.0 license baseline from `pre-dev` to `main`.

GitHub reads a repository's license from its **default branch**, so until these files are on `main` this repo publicly shows *no license* ("all rights reserved"). Files are copied **verbatim** from this repo's own `pre-dev` branch — no content changes.

Files: NOTICE

Refs OpenResilienceInitiative/ORISO-Docs#64