### PR TITLE
fix: refresh Keycloak admin token for OTP requests

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
@@ -192,9 +193,11 @@ public class KeycloakService implements IdentityClient {
 
   @Override
   public OtpInfoDTO getOtpCredential(String userName) {
-    var bearerToken = keycloakClient.getBearerToken();
     var requestUrl = getOtpUrl(ENDPOINT_OTP_INFO, userName);
-    var response = keycloakClient.get(bearerToken, requestUrl, OtpInfoDTO.class);
+    var response =
+        withFreshAdminTokenOnUnauthorized(
+            () ->
+                keycloakClient.get(keycloakClient.getBearerToken(), requestUrl, OtpInfoDTO.class));
 
     return response.getBody();
   }
@@ -202,11 +205,13 @@ public class KeycloakService implements IdentityClient {
   @Override
   public boolean setUpOtpCredential(String userName, String initialCode, String secret) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(initialCode, secret, null);
-    var bearerToken = keycloakClient.getBearerToken();
     var requestUrl = getOtpUrl(ENDPOINT_OTP_SETUP, userName);
 
     try {
-      keycloakClient.putForEntity(bearerToken, requestUrl, otpSetupDTO, OtpInfoDTO.class);
+      withFreshAdminTokenOnUnauthorized(
+          () ->
+              keycloakClient.putForEntity(
+                  keycloakClient.getBearerToken(), requestUrl, otpSetupDTO, OtpInfoDTO.class));
       return true;
     } catch (HttpClientErrorException exception) {
       if (exception.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
@@ -219,19 +224,21 @@ public class KeycloakService implements IdentityClient {
 
   @Override
   public void deleteOtpCredential(String userName) {
-    var bearerToken = keycloakClient.getBearerToken();
     var requestUrl = getOtpUrl(ENDPOINT_OTP_TEARDOWN, userName);
-    keycloakClient.delete(bearerToken, requestUrl, Void.class);
+    withFreshAdminTokenOnUnauthorized(
+        () -> keycloakClient.delete(keycloakClient.getBearerToken(), requestUrl, Void.class));
   }
 
   @Override
   public Optional<String> initiateEmailVerification(String username, String email) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(null, null, email);
-    var bearerToken = keycloakClient.getBearerToken();
     var requestUrl = getOtpUrl(ENDPOINT_OTP_VERIFY_EMAIL, username);
 
     try {
-      keycloakClient.putForEntity(bearerToken, requestUrl, otpSetupDTO, Success.class);
+      withFreshAdminTokenOnUnauthorized(
+          () ->
+              keycloakClient.putForEntity(
+                  keycloakClient.getBearerToken(), requestUrl, otpSetupDTO, Success.class));
       return Optional.empty();
     } catch (RestClientException exception) {
       return Optional.of("Keycloak answered: " + exception.getMessage());
@@ -241,13 +248,17 @@ public class KeycloakService implements IdentityClient {
   @Override
   public Map<String, String> finishEmailVerification(String username, String initialCode) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(initialCode, null, null);
-    var bearerToken = keycloakClient.getBearerToken();
     var requestUrl = getOtpUrl(ENDPOINT_OTP_FINISH_EMAIL, username);
 
     try {
       var response =
-          keycloakClient.postForEntity(
-              bearerToken, requestUrl, otpSetupDTO, SuccessWithEmail.class);
+          withFreshAdminTokenOnUnauthorized(
+              () ->
+                  keycloakClient.postForEntity(
+                      keycloakClient.getBearerToken(),
+                      requestUrl,
+                      otpSetupDTO,
+                      SuccessWithEmail.class));
       return keycloakMapper.mapOf(response);
     } catch (HttpClientErrorException exception) {
       return keycloakMapper.mapOf(exception);
@@ -258,6 +269,22 @@ public class KeycloakService implements IdentityClient {
     var decodedUsername = usernameTranscoder.decodeUsername(username);
     return identityClientConfig.getOtpUrl(
         endpoint, java.util.regex.Matcher.quoteReplacement(decodedUsername));
+  }
+
+  private <T> T withFreshAdminTokenOnUnauthorized(Supplier<T> request) {
+    try {
+      return request.get();
+    } catch (HttpClientErrorException exception) {
+      if (!exception.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
+        throw exception;
+      }
+
+      log.warn(
+          "Keycloak admin session was unauthorized for an OTP provider request, forcing token"
+              + " refresh and retrying once");
+      keycloakClient.refreshAdminSession();
+      return request.get();
+    }
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -320,6 +321,52 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void getOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    var entity = new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK);
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.get(eq("stale-token"), any(), any())).thenThrow(unauthorized);
+    when(keycloakClient.get(eq("fresh-token"), any(), any())).thenReturn(entity);
+
+    assertEquals(OTP_INFO_DTO, keycloakService.getOtpCredential(USERNAME));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).getBearerToken();
+  }
+
+  @Test
+  public void getOtpCredential_Should_RetryOnlyOnce_When_BothRequestsAreUnauthorized() {
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.get(any(), any(), any())).thenThrow(unauthorized);
+
+    assertThrows(
+        org.springframework.web.client.HttpClientErrorException.class,
+        () -> keycloakService.getOtpCredential(USERNAME));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).get(any(), any(), any());
+  }
+
+  @Test
+  public void getOtpCredential_Should_NotRefreshAdminSession_When_RequestFailsWithNon401() {
+    var badRequest =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.BAD_REQUEST);
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    when(keycloakClient.get(any(), any(), any())).thenThrow(badRequest);
+
+    assertThrows(
+        org.springframework.web.client.HttpClientErrorException.class,
+        () -> keycloakService.getOtpCredential(USERNAME));
+
+    verify(keycloakClient, never()).refreshAdminSession();
+    verify(keycloakClient).get(any(), any(), any());
+  }
+
+  @Test
   public void
       setUpOtpCredential_ShouldNot_ThrowInternalServerErrorException_When_RequestWasSuccessfully() {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
@@ -330,11 +377,42 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void setUpOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.putForEntity(eq("stale-token"), any(), any(), any()))
+        .thenThrow(unauthorized);
+    when(keycloakClient.putForEntity(eq("fresh-token"), any(), any(), any()))
+        .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+    assertThat(keycloakService.setUpOtpCredential(USERNAME, "123456", "secret"), is(true));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).getBearerToken();
+  }
+
+  @Test
   public void
       deleteOtpCredential_Should_Not_ThrowBadRequestException_When_RequestWasSuccessfully() {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
 
     assertDoesNotThrow(() -> keycloakService.deleteOtpCredential(USERNAME));
+  }
+
+  @Test
+  public void deleteOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.delete(eq("stale-token"), any(), eq(Void.class))).thenThrow(unauthorized);
+    when(keycloakClient.delete(eq("fresh-token"), any(), eq(Void.class)))
+        .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
+
+    assertDoesNotThrow(() -> keycloakService.deleteOtpCredential(USERNAME));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).getBearerToken();
   }
 
   @Test
@@ -1315,7 +1393,8 @@ public class KeycloakServiceTest {
   @Test
   public void finishEmailVerification_Should_ReturnMappedError_When_KeycloakRejects() {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
-    var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
+    var exception =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.BAD_REQUEST);
     when(keycloakClient.postForEntity(any(), any(), any(), any())).thenThrow(exception);
     var expected = new HashMap<String, String>();
     expected.put("status", "error");
@@ -1324,6 +1403,7 @@ public class KeycloakServiceTest {
     var result = keycloakService.finishEmailVerification(USERNAME, "123456");
 
     assertThat(result, is(expected));
+    verify(keycloakClient, never()).refreshAdminSession();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- refresh the cached Keycloak admin session after the first OTP-provider HTTP 401
- reacquire the bearer token and retry exactly once
- cover OTP info, app setup/removal, and email verification endpoints
- preserve repeated-401 and non-401 behavior

## Why
The real PreDev Consultant 3 flow reproduced a stale cached admin token: UserService returned 401 from `/otp-config/fetch-otp-setup-info/...` until only the unchanged UserService pod was restarted. The same account then completed TOTP enrollment and a fresh password+TOTP login.

## Verification
- TDD red: first 401 was propagated before implementation
- focused retry tests: 5/5 green
- `KeycloakServiceTest`: 97/97 green
- blocking PR CI equivalent: `./mvnw -B test` — 3,770 tests, 0 failures, 0 errors, 7 skipped
- `./mvnw -B package -DskipTests` — green (repository custom lifecycle also reran the 3,770 tests)
- `git diff --check` — green
- full `verify` burn-in remains red on unrelated existing integration-environment failures; this job is explicitly non-blocking in repository CI

Fixes #546
Related: OpenResilienceInitiative/ORISO-E2E#14