### PR TITLE
fix(db): register orphaned 0067_consultant_public_slug changeset

### DIFF
--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -107,6 +107,8 @@
   <include
     file="db/changelog/changeset/0066_consultant_message_stat/0066_changeSet.xml" />
   <include
+    file="db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml" />
+  <include
     file="db/changelog/changeset/0067_session_supervision_opt_out/0067_changeSet.xml" />
   <include
     file="db/changelog/changeset/0068_consultant_assigned_supervisor/0068_changeSet.xml" />


### PR DESCRIPTION
## Problem

`0067_consultant_public_slug` exists on disk but was **never registered** in `userservice-master.xml`, so **Liquibase never runs it**.

The consultant public-slug feature is already fully merged in code:
- `model/ReservedPublicSlug.java`, `model/PublicSlugStatus.java`
- `port/out/ReservedPublicSlugRepository.java`
- `service/ConsultantPublicSlugService.java`

…and ORISO-Frontend ships the matching UI (consultant public slug management / consultant-slug registration flow).

But the table and columns it depends on are created **nowhere**:
- ❌ not created by Liquibase — the changeset was unregistered
- ❌ not in the Helm MariaDB baseline (`charts/mariadb/sql-schemas/userservice-schema.sql`)

Result: the public-slug feature fails at runtime (and can fail startup under `ddl-auto=validate`).

## Fix

Register the include so the migration runs:

```xml
<include
  file="db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml" />
```

Placed in numeric order, directly after `0066_consultant_message_stat` and before `0067_session_supervision_opt_out`. The two `0067_*` changesets touch different tables, so relative order between them is not significant.

## Notes

- The changeset itself is unchanged and already valid (id `consultantPublicSlug`, author `oriso`, with a rollback via `consultant-public-slug-rollback.sql`).
- Forward migration is **additive** — `CREATE TABLE` / `ADD COLUMN` / `INSERT`. The `DROP` statements exist only in the rollback file, which does not run on a forward deploy.
- Master changelog XML validated as well-formed.
- Unrelated: `0057_adr008_supervision_sideroom_migration` is also unregistered, but it is a dead leftover superseded by the registered `0058_adr008_supervision_sideroom_migration` and already present on `dev`. Intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)