### PR TITLE
chore: pin dependabot updates to pre-dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: pre-dev
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: pre-dev
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so dependabot targets `pre-dev` instead of `main`.
- Recent dep bumps (#535–#542) opened against `main` because dependabot was running from the org-level default config, which uses the repo default branch.
- I already retargeted those 8 open PRs to `pre-dev` via `gh pr edit`; this PR prevents recurrence.

## Why this PR targets main (not pre-dev)
Dependabot only reads its config from the repo's default branch (currently `main`). The file itself has to live there for the pin to take effect. After merge, every future dep-bump PR dependabot opens will target `pre-dev` automatically.

## Test plan
- [ ] Merge
- [ ] Confirm the next dependabot run opens PRs against `pre-dev`