### PR TITLE
Fix asker deletion with session topics

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionTopicRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionTopicRepository.java
@@ -1,0 +1,16 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.SessionTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface SessionTopicRepository extends JpaRepository<SessionTopic, Long> {
+
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Transactional
+  @Query("delete from SessionTopic topic where topic.session.id = :sessionId")
+  int deleteAllBySessionId(@Param("sessionId") Long sessionId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsAction.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.SessionTopicRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import org.springframework.stereotype.Component;
 
@@ -20,13 +21,15 @@ public class DeleteAskerRoomsAndSessionsAction extends DeleteRoomsAndSessionActi
       SessionDataRepository sessionDataRepository,
       RocketChatService rocketChatService,
       CaseHandoverRequestRepository caseHandoverRequestRepository,
-      SessionSupervisorRepository sessionSupervisorRepository) {
+      SessionSupervisorRepository sessionSupervisorRepository,
+      SessionTopicRepository sessionTopicRepository) {
     super(
         sessionRepository,
         sessionDataRepository,
         rocketChatService,
         caseHandoverRequestRepository,
-        sessionSupervisorRepository);
+        sessionSupervisorRepository,
+        sessionTopicRepository);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteRoomsAndSessionAction.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.SessionTopicRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import java.util.List;
@@ -27,6 +28,7 @@ abstract class DeleteRoomsAndSessionAction {
   protected final @NonNull RocketChatService rocketChatService;
   protected final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
   protected final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  protected final @NonNull SessionTopicRepository sessionTopicRepository;
 
   void deleteRocketChatGroup(String rcGroupId, List<DeletionWorkflowError> workflowErrors) {
     if (isNotBlank(rcGroupId)) {
@@ -95,6 +97,22 @@ abstract class DeleteRoomsAndSessionAction {
     }
   }
 
+  void deleteSessionTopics(Session session, List<DeletionWorkflowError> workflowErrors) {
+    try {
+      this.sessionTopicRepository.deleteAllBySessionId(session.getId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      workflowErrors.add(
+          DeletionWorkflowError.builder()
+              .deletionSourceType(ASKER)
+              .deletionTargetType(DeletionTargetType.DATABASE)
+              .identifier(String.valueOf(session.getId()))
+              .reason("Unable to delete topics for session")
+              .timestamp(nowInUtc())
+              .build());
+    }
+  }
+
   protected void deleteSession(Session session, List<DeletionWorkflowError> workflowErrors) {
     try {
       this.sessionRepository.delete(session);
@@ -116,6 +134,7 @@ abstract class DeleteRoomsAndSessionAction {
     deleteRocketChatGroup(session.getGroupId(), workflowErrors);
     deleteSessionData(session, workflowErrors);
     deleteSessionSupervisors(session, workflowErrors);
+    deleteSessionTopics(session, workflowErrors);
     deleteCaseHandoverRequests(session, workflowErrors);
     deleteSession(session, workflowErrors);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionAction.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.SessionTopicRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.SessionDeletionWorkflowDTO;
 import org.springframework.stereotype.Component;
 
@@ -27,13 +28,15 @@ public class DeleteSingleRoomAndSessionAction extends DeleteRoomsAndSessionActio
       SessionDataRepository sessionDataRepository,
       RocketChatService rocketChatService,
       CaseHandoverRequestRepository caseHandoverRequestRepository,
-      SessionSupervisorRepository sessionSupervisorRepository) {
+      SessionSupervisorRepository sessionSupervisorRepository,
+      SessionTopicRepository sessionTopicRepository) {
     super(
         sessionRepository,
         sessionDataRepository,
         rocketChatService,
         caseHandoverRequestRepository,
-        sessionSupervisorRepository);
+        sessionSupervisorRepository,
+        sessionTopicRepository);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerRoomsAndSessionsActionTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -26,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.SessionTopicRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,6 +58,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
   @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
 
   @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+
+  @Mock private SessionTopicRepository sessionTopicRepository;
 
   private LogbackCaptor logCaptor;
 
@@ -97,7 +102,11 @@ class DeleteAskerRoomsAndSessionsActionTest {
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
     verify(this.caseHandoverRequestRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionSupervisorRepository, times(1)).deleteAllBySessionId(session.getId());
+    verify(this.sessionTopicRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionRepository, times(1)).delete(session);
+    InOrder dependencyOrder = inOrder(this.sessionTopicRepository, this.sessionRepository);
+    dependencyOrder.verify(this.sessionTopicRepository).deleteAllBySessionId(session.getId());
+    dependencyOrder.verify(this.sessionRepository).delete(session);
   }
 
   @Test
@@ -115,6 +124,7 @@ class DeleteAskerRoomsAndSessionsActionTest {
     doThrow(new RuntimeException())
         .when(this.sessionSupervisorRepository)
         .deleteAllBySessionId(any());
+    doThrow(new RuntimeException()).when(this.sessionTopicRepository).deleteAllBySessionId(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -122,8 +132,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(5));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(5);
+    assertThat(workflowErrors, hasSize(6));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(6);
   }
 
   @Test
@@ -142,6 +152,7 @@ class DeleteAskerRoomsAndSessionsActionTest {
     doThrow(new RuntimeException())
         .when(this.sessionSupervisorRepository)
         .deleteAllBySessionId(any());
+    doThrow(new RuntimeException()).when(this.sessionTopicRepository).deleteAllBySessionId(any());
     doThrow(new RuntimeException()).when(this.sessionRepository).delete(any());
     AskerDeletionWorkflowDTO workflowDTO =
         new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
@@ -149,8 +160,8 @@ class DeleteAskerRoomsAndSessionsActionTest {
     this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
     List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
 
-    assertThat(workflowErrors, hasSize(15));
-    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(15);
+    assertThat(workflowErrors, hasSize(18));
+    assertThat(logCaptor.count(Level.ERROR)).isEqualTo(18);
   }
 
   @Test
@@ -217,6 +228,26 @@ class DeleteAskerRoomsAndSessionsActionTest {
     assertThat(
         workflowErrors.get(0).getReason(),
         is("Unable to delete case handover requests for session"));
+    assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
+  }
+
+  @Test
+  void execute_Should_returnExpectedWorkflowError_When_sessionTopicDeletionFails() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    when(this.sessionRepository.findByUser(any())).thenReturn(singletonList(session));
+    doThrow(new RuntimeException()).when(this.sessionTopicRepository).deleteAllBySessionId(any());
+    AskerDeletionWorkflowDTO workflowDTO =
+        new AskerDeletionWorkflowDTO(new User(), new ArrayList<>());
+
+    this.deleteAskerRoomsAndSessionsAction.execute(workflowDTO);
+    List<DeletionWorkflowError> workflowErrors = workflowDTO.getDeletionWorkflowErrors();
+
+    assertThat(workflowErrors, hasSize(1));
+    assertThat(logCaptor.contains(Level.ERROR, "UserService delete workflow error")).isTrue();
+    assertThat(workflowErrors.get(0).getDeletionSourceType(), is(ASKER));
+    assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+    assertThat(workflowErrors.get(0).getIdentifier(), is(session.getId().toString()));
+    assertThat(workflowErrors.get(0).getReason(), is("Unable to delete topics for session"));
     assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteSingleRoomAndSessionActionTest.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.SessionTopicRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.api.workflow.delete.model.SessionDeletionWorkflowDTO;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
@@ -51,6 +52,8 @@ class DeleteSingleRoomAndSessionActionTest {
 
   @Mock private SessionSupervisorRepository sessionSupervisorRepository;
 
+  @Mock private SessionTopicRepository sessionTopicRepository;
+
   private LogbackCaptor logCaptor;
 
   @BeforeEach
@@ -79,6 +82,7 @@ class DeleteSingleRoomAndSessionActionTest {
     verify(this.sessionDataRepository, times(1)).deleteAll(any());
     verify(this.caseHandoverRequestRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionSupervisorRepository, times(1)).deleteAllBySessionId(session.getId());
+    verify(this.sessionTopicRepository, times(1)).deleteAllBySessionId(session.getId());
     verify(this.sessionRepository, times(1)).delete(session);
   }
 


### PR DESCRIPTION
## Summary

- delete `session_topic` relations before their parent session in the shared deletion action
- use the same cleanup for full asker deletion and single-session cleanup
- retain a dedicated workflow error when topic deletion fails

## Runtime evidence

The natural 48-hour PreDev run removed the test asker's Keycloak identity but retained its retryable UserService row, session 103442, and one topic relation. The session delete failed on `session_topic_ibfk_1`; no database row was modified directly and the scheduler was not accelerated.

## Verification

- regression test observed red before implementation: topic repository was never invoked
- 16 focused deletion-action tests passed
- full UserService suite: 3,744 tests, 0 failures, 7 skipped
- Spotless check passed
- production package build passed on Java 21
- `git diff --check` passed

## Deployment gate

This PR must receive human approval and green CI before merge. After the regular immutable `pre-dev` image is deployed, the normal account scheduler must retry the retained user row. Browser cleanup then continues with Spider Pig, agency 282, and tenant 84 through the real Admin UI with desktop/mobile screenshot pairs.

Closes #551
Refs OpenResilienceInitiative/ORISO-UserService#531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
