### PR TITLE
fix(db): restore public slug changelog precondition

### DIFF
--- a/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml
@@ -3,6 +3,11 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
   <changeSet author="oriso" id="consultantPublicSlug">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="consultant" columnName="public_slug"/>
+      </not>
+    </preConditions>
     <rollback>
       <sqlFile path="db/changelog/changeset/0067_consultant_public_slug/consultant-public-slug-rollback.sql"
         stripComments="true"/>

--- a/src/test/java/de/caritas/cob/userservice/api/ConsultantPublicSlugChangelogContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/ConsultantPublicSlugChangelogContractTest.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.w3c.dom.Document;
+
+class ConsultantPublicSlugChangelogContractTest {
+
+  private static final String CHANGELOG =
+      "db/changelog/changeset/0067_consultant_public_slug/0067_changeSet.xml";
+
+  @Test
+  void manuallyAppliedPublicSlugSchemaShouldMarkChangesetAsRan() throws Exception {
+    Document changelog = readChangelog();
+    var xpath = XPathFactory.newInstance().newXPath();
+    String changeSet =
+        "/*[local-name()='databaseChangeLog']"
+            + "/*[local-name()='changeSet' and @id='consultantPublicSlug']";
+
+    String onFail =
+        xpath.evaluate(changeSet + "/*[local-name()='preConditions']/@onFail", changelog);
+    Double matchingColumnGuard =
+        (Double)
+            xpath.evaluate(
+                "count("
+                    + changeSet
+                    + "/*[local-name()='preConditions']"
+                    + "/*[local-name()='not']"
+                    + "/*[local-name()='columnExists'"
+                    + " and @tableName='consultant'"
+                    + " and @columnName='public_slug'])",
+                changelog,
+                XPathConstants.NUMBER);
+
+    assertThat(onFail).isEqualTo("MARK_RAN");
+    assertThat(matchingColumnGuard).isEqualTo(1.0);
+  }
+
+  private Document readChangelog() throws Exception {
+    try (InputStream input = new ClassPathResource(CHANGELOG).getInputStream()) {
+      var factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      return factory.newDocumentBuilder().parse(input);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The regular `pre-dev` UserService image built from merge commit `9d2e7859` crashes on PreDev because Liquibase re-runs the non-idempotent public-slug `ALTER TABLE` against an already provisioned schema.

## Fix

- restore the `MARK_RAN` precondition when `consultant.public_slug` already exists
- add a regression contract test so the guard cannot disappear unnoticed again

## TDD and verification

- RED: the focused test observed no `MARK_RAN` guard
- GREEN: the focused test passes after restoring the precondition
- full suite: 3,772 tests, 0 failures, 0 errors, 7 skipped
- production package and Spotless: green under JDK 21
- `git diff --check`: green

## Deployment impact

PreDev is temporarily restored to the last browser-proven regular UserService digest `sha256:6792b0cb1de46c841a228e9153fcbe8506f5486020c766919b09e13f8f163898`. After human approval and merge, deploy only the new regular immutable digest and verify startup before the next natural account-deletion scheduler run.

No database row, schema object, Liquibase bookkeeping row, or scheduler configuration was modified as part of this repair.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
