### PR TITLE
Fix platform admin access to inactive-account audit logs

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -19,11 +20,13 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -32,6 +35,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
@@ -370,7 +374,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/users/inactive-accounts/audit-logs",
                     "/service/users/inactive-accounts/audit-logs")
-                .hasAuthority(TECHNICAL_DEFAULT)
+                .access(this::canAccessInactiveAccountAuditLogs)
                 .requestMatchers(
                     "/users/consultants/sessions/{sessionId:[0-9]+}",
                     "/users/sessions/{sessionId:[0-9]+}/archive",
@@ -454,6 +458,39 @@ public class SecurityConfig {
             .collect(Collectors.toSet());
     authorities.addAll(authorityMapper.mapAuthorities(roleAuthorities));
     return authorities;
+  }
+
+  private AuthorizationDecision canAccessInactiveAccountAuditLogs(
+      Supplier<? extends Authentication> authenticationSupplier,
+      RequestAuthorizationContext requestContext) {
+    Authentication authentication = authenticationSupplier.get();
+    boolean isTechnicalAccount =
+        authentication.getAuthorities().stream()
+            .anyMatch(authority -> TECHNICAL_DEFAULT.equals(authority.getAuthority()));
+
+    if (isTechnicalAccount) {
+      return new AuthorizationDecision(true);
+    }
+
+    if (!(authentication instanceof JwtAuthenticationToken jwtAuthentication)) {
+      return new AuthorizationDecision(false);
+    }
+
+    Jwt jwt = jwtAuthentication.getToken();
+    Set<String> roles = extractKeycloakRoles(jwt);
+    boolean hasPlatformAdminRoles =
+        roles.contains(UserRole.AGENCY_ADMIN.getValue())
+            && roles.contains(UserRole.TENANT_ADMIN.getValue());
+
+    return new AuthorizationDecision(hasPlatformAdminRoles && isPlatformTenant(jwt));
+  }
+
+  private boolean isPlatformTenant(Jwt jwt) {
+    Object tenantId = jwt.getClaims().get("tenantId");
+    if (tenantId instanceof Number number) {
+      return number.longValue() == 0L;
+    }
+    return tenantId != null && "0".equals(tenantId.toString());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.HttpTe
 import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.IpPrivacyHeaderFilter;
 import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.StatelessCsrfFilter;
 import de.caritas.cob.userservice.api.config.CsrfSecurityProperties;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -488,7 +489,11 @@ public class SecurityConfig {
   private boolean isPlatformTenant(Jwt jwt) {
     Object tenantId = jwt.getClaims().get("tenantId");
     if (tenantId instanceof Number number) {
-      return number.longValue() == 0L;
+      try {
+        return new BigDecimal(number.toString()).compareTo(BigDecimal.ZERO) == 0;
+      } catch (NumberFormatException ignored) {
+        return false;
+      }
     }
     return tenantId != null && "0".equals(tenantId.toString());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsControllerAuthorizationIT.java
@@ -124,6 +124,24 @@ class InactiveAccountAuditLogsControllerAuthorizationIT {
   }
 
   @Test
+  void listAuditLogs_Should_ReturnForbidden_WhenTenantIdIsFractionalZero() throws Exception {
+    mvc.perform(
+            get(ENDPOINT)
+                .with(
+                    jwt()
+                        .jwt(
+                            token ->
+                                token
+                                    .claim(
+                                        "realm_access",
+                                        Map.of("roles", List.of("agency-admin", "tenant-admin")))
+                                    .claim("tenantId", 0.5))))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(inactiveAccountAuditLogsService);
+  }
+
+  @Test
   void listAuditLogs_Should_ReturnForbidden_WhenTenantAdminLacksAgencyAdminRole() throws Exception {
     mvc.perform(
             get(ENDPOINT)

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/InactiveAccountAuditLogsControllerAuthorizationIT.java
@@ -1,0 +1,141 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue.TECHNICAL_DEFAULT;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService;
+import de.caritas.cob.userservice.api.service.InactiveAccountAuditLogsService.InactiveAccountAuditLogsResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.datasource.url=jdbc:h2:mem:inactive-audit-auth;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=sa",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.sql.init.mode=never",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "keycloak.auth-server-url=https://auth.testing",
+      "keycloak.realm=testing",
+      "keycloak.config.admin-username=admin",
+      "keycloak.config.admin-password=secret",
+      "identity.openid-connect-url=https://auth.testing/realms/testing/protocol/openid-connect",
+      "rocket.technical.username=technical",
+      "rocket.technical.password=secret",
+      "rocket-chat.base-url=https://testing.com/api/v1",
+      "rocket-chat.mongo-url=mongodb://localhost:27017/testing",
+      "consulting.type.service.api.url=https://consulting-type.testing/service",
+      "tenant.service.api.url=https://tenant.testing/service",
+      "matrix.apiUrl=https://matrix.testing",
+      "matrix.registrationSharedSecret=secret"
+    })
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+@ActiveProfiles("testing")
+class InactiveAccountAuditLogsControllerAuthorizationIT {
+
+  private static final String ENDPOINT = "/service/users/inactive-accounts/audit-logs";
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private InactiveAccountAuditLogsService inactiveAccountAuditLogsService;
+
+  @BeforeEach
+  void returnEmptyAuditLogPage() {
+    when(inactiveAccountAuditLogsService.listAuditLogs(anyInt(), anyInt(), isNull(), isNull()))
+        .thenReturn(
+            InactiveAccountAuditLogsResult.builder()
+                .data(List.of())
+                .total(0)
+                .page(1)
+                .perPage(20)
+                .build());
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnUnauthorized_WhenNoAuthentication() throws Exception {
+    mvc.perform(get(ENDPOINT)).andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(inactiveAccountAuditLogsService);
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnOk_WhenTechnicalAccountIsAuthorized() throws Exception {
+    mvc.perform(
+            get(ENDPOINT).with(jwt().authorities(new SimpleGrantedAuthority(TECHNICAL_DEFAULT))))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnOk_WhenPlatformAdminIsAuthorized() throws Exception {
+    mvc.perform(
+            get(ENDPOINT)
+                .with(
+                    jwt()
+                        .jwt(
+                            token ->
+                                token
+                                    .claim(
+                                        "realm_access",
+                                        Map.of("roles", List.of("agency-admin", "tenant-admin")))
+                                    .claim("tenantId", 0))))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnForbidden_WhenTenantScopedAdminUsesPlatformRoles()
+      throws Exception {
+    mvc.perform(
+            get(ENDPOINT)
+                .with(
+                    jwt()
+                        .jwt(
+                            token ->
+                                token
+                                    .claim(
+                                        "realm_access",
+                                        Map.of("roles", List.of("agency-admin", "tenant-admin")))
+                                    .claim("tenantId", 1))))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(inactiveAccountAuditLogsService);
+  }
+
+  @Test
+  void listAuditLogs_Should_ReturnForbidden_WhenTenantAdminLacksAgencyAdminRole() throws Exception {
+    mvc.perform(
+            get(ENDPOINT)
+                .with(
+                    jwt()
+                        .jwt(
+                            token ->
+                                token
+                                    .claim("realm_access", Map.of("roles", List.of("tenant-admin")))
+                                    .claim("tenantId", 0))))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(inactiveAccountAuditLogsService);
+  }
+}


### PR DESCRIPTION
## Summary

- authorize canonical platform admins (`tenantId=0`, `agency-admin`, `tenant-admin`) for inactive-account audit logs
- retain existing technical service-account access
- keep tenant-scoped, fractional-tenant, and incompletely privileged admins forbidden
- add request-level Spring Security regression coverage for all six cases

## Root cause

ORISO Admin correctly exposed the Logs section to platform admins, but UserService protected the backing endpoint with `TECHNICAL_DEFAULT` only. The request therefore failed in Spring Security with HTTP 403 before reaching the controller.

## Verification

- Red: platform-admin MockMvc request expected 200 and received 403 before the fix
- Red/green review hardening: fractional `tenantId=0.5` received 200 before exact-zero comparison and 403 afterward
- Green: `InactiveAccountAuditLogsControllerAuthorizationIT` (6 scenarios)
- Green: `SecurityConfigTest`
- Green: `spotless:check`
- Green: `git diff --check`
- Green: all GitHub CI jobs and CodeRabbit review
- Runtime: browser-tested commit `45c2b286` on disposable Pre-Dev; Abe's Logs page rendered four audit rows at desktop/mobile sizes; regular image restored afterward

Closes OpenResilienceInitiative/ORISO-UserService#725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
