### PR TITLE
Fix email 2FA completion for encoded Admin usernames

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -33,7 +33,7 @@ public class IdentityManager implements IdentityManaging {
     var validationResult = identityClient.finishEmailVerification(username, code);
     if (validationResult.get("created").equals("true")) {
       var email = validationResult.get("email");
-      identityClient.changeEmailAddress(username, email);
+      identityClient.changeEmailAddress(usernameTranscoder.decodeUsername(username), email);
     }
 
     return validationResult;

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
@@ -24,6 +25,31 @@ class IdentityManagerTest {
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
+
+  @Test
+  void validateOneTimePasswordShouldUseRawUsernameForKeycloakEmailUpdate() {
+    var encodedUsername = usernameTranscoder.encodeUsername(RAW_USERNAME);
+    var validationResult = Map.of("created", "true", "email", EMAIL);
+    when(identityClient.finishEmailVerification(encodedUsername, "123456"))
+        .thenReturn(validationResult);
+
+    assertThat(identityManager.validateOneTimePassword(encodedUsername, "123456"))
+        .isEqualTo(validationResult);
+
+    verify(identityClient).finishEmailVerification(encodedUsername, "123456");
+    verify(identityClient).changeEmailAddress(RAW_USERNAME, EMAIL);
+  }
+
+  @Test
+  void validateOneTimePasswordShouldKeepAlreadyRawUsernameForKeycloakEmailUpdate() {
+    var validationResult = Map.of("created", "true", "email", EMAIL);
+    when(identityClient.finishEmailVerification(RAW_USERNAME, "123456"))
+        .thenReturn(validationResult);
+
+    identityManager.validateOneTimePassword(RAW_USERNAME, "123456");
+
+    verify(identityClient).changeEmailAddress(RAW_USERNAME, EMAIL);
+  }
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptRawKeycloakUsernameForEncodedConsultant() {


### PR DESCRIPTION
## Why

Email-based 2FA verification succeeded in the identity provider but UserService then searched Keycloak with the encoded OTP-SPI username. Keycloak stores this Admin identity under the raw username, so the empty search result caused an `IndexOutOfBoundsException`. The active marker was never written and the mandatory 2FA setup gate appeared again.

## What changed

- Keep the encoded username for OTP verification.
- Decode the username only for the subsequent Keycloak email update.
- Cover both encoded and already-raw usernames with regression tests.

## Verification

- Red: the new encoded-username regression failed because `changeEmailAddress` received the encoded value.
- Green focused suite: 23 tests passed.
- Full Java 21 unit suite: 3,747 tests, 0 failures, 0 errors, 7 skipped.
- Spotless and `git diff --check`: passed.
- PreDev hotfix image: `docker.io/storypapst/oriso-e2e@sha256:3d287644f7fa84a76c3231ca9c3d540a25ba4ba90f02b42d601aa3c4a9f60eba` (`linux/amd64`).
- Managed Test Access run `13377183-ab35-4216-a98a-109baac116be` passed with Simpson identity Herb Powell (`herb.powell@oriso.org`).
- Runtime flow: reset factor → request email OTP (204) → retrieve OTP through Test Access → validate (204) → reload.
- Persisted readback after reload: `isEnabled=true`, `isActive=true`, `isToEncourage=true`, `type=EMAIL`; no mandatory setup dialog.
- UserService logs contained no `IndexOutOfBoundsException` or email-2FA completion error during the passing run.

Closes #727
