### PR TITLE
fix: stop deadlocking platform admins behind an unsatisfiable 2FA gate

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -111,7 +111,13 @@ class UserAccountControllerDelegate {
       enrichConsultantAvailability(partialUserData);
     } else if (isTenantAdmin() || isAgencyAdmin()) {
       partialUserData = keycloakUserDataProvider.retrieveAuthenticatedUserData();
-      if (authenticatedUser.isPlatformAdmin()) {
+      // Only ask a platform admin to set 2FA up when the OTP role policy would actually
+      // let them finish. Encouraging it unconditionally deadlocks the admin UI: the
+      // client gates on isToEncourage && !isActive, but isActive can never become true
+      // while the policy denies OTP (the credential is never read), and every setup
+      // endpoint rejects the attempt with 409. See assertTwoFactorAuthAllowed in
+      // UserTwoFactorAuthControllerDelegate.
+      if (authenticatedUser.isPlatformAdmin() && isOtpAllowed()) {
         partialUserData.setEncourage2fa(true);
       }
     } else {
@@ -155,8 +161,12 @@ class UserAccountControllerDelegate {
     }
   }
 
+  private boolean isOtpAllowed() {
+    return identityClientConfig.isOtpAllowed(authenticatedUser.getRoles());
+  }
+
   private OtpInfoDTO retrieveOtpCredentialIfAllowed() {
-    if (!identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())) {
+    if (!isOtpAllowed()) {
       return null;
     }
     try {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -131,6 +131,27 @@ class UserAccountControllerDelegateTest {
   }
 
   @Test
+  void getUserDataShouldNotRequireTwoFactorSetupForPlatformAdminsWhenOtpIsNotAllowed() {
+    var roles = Set.of(UserRole.TENANT_ADMIN.getValue(), UserRole.AGENCY_ADMIN.getValue());
+    var partialUserData = new UserDataResponseDTO();
+    var fullUserData = new UserDataResponseDTO();
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(authenticatedUser.getRoles()).thenReturn(roles);
+    when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
+    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
+        .thenReturn(fullUserData);
+
+    var response = delegate.getUserData();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // The setup endpoints would answer 409 for this role, so encouraging 2FA here would
+    // lock the admin UI behind a gate that can never be satisfied.
+    assertThat(partialUserData.getEncourage2fa()).isNull();
+  }
+
+  @Test
   void patchUserShouldRejectMagicLinkLoginWhenConsultantHasDummyEmail() {
     var patchUserDTO = new PatchUserDTO();
     patchUserDTO.setMagicLinkLoginEnabled(true);


### PR DESCRIPTION
Fixes the reported issue where setting up email 2FA on `admin.oriso-dev.site` never activates and the setup prompt returns on every login.

## Root cause

This is not a setup failure. It is a deadlock between the login gate and the OTP role policy — 2FA can never activate for a platform admin while the policy denies OTP for admin roles.

1. **The gate demands 2FA.** `getUserData` set `encourage2fa(true)` for every platform admin, unconditionally.
2. **But the OTP state is never read.** `retrieveOtpCredentialIfAllowed()` returns `null` when the role policy denies OTP, so `UserDtoMapper` skips the block that would set `isEnabled`/`isActive`. The payload is always `{"isToEncourage": true, "isActive": null}`.
3. **The client blocks the app.** `requiresPlatformAdminTwoFactor` (ORISO-Admin) gates on `isToEncourage === true && isActive !== true`, so it renders the setup page instead of `/admin/tenants`.
4. **Setup is rejected.** Both email endpoints call `assertTwoFactorAuthAllowed()`, which throws **409 `"2FA is disabled for user role"`** under the same policy.

Step 1 demands exactly what step 4 forbids, and `isActive` can never flip because the credential is never read.

The client hook writes `isActive: true` into its react-query cache optimistically on success, which is why it can briefly look like it worked until the next real fetch.

## Fix

Encourage 2FA only when `isOtpAllowed()` would let the user finish. Roles that are allowed OTP are entirely unaffected.

## Scope

Reachable wherever the OTP flags are off for admin roles. `values-dev.yaml` and `values-prod.yaml` both set `otpAllowedForTenantSuperAdmins` and `otpAllowedForSingleTenantAdmins` to `"false"`, so this affects **production**, not just dev.

This PR unblocks the lockout. It deliberately does **not** enable admin 2FA — that is a config decision. To actually use email 2FA for admins, `otpAllowedForTenantSuperAdmins` / `otpAllowedForSingleTenantAdmins` also need to be `"true"` in the relevant Helm values.

## Testing

- New regression test `getUserDataShouldNotRequireTwoFactorSetupForPlatformAdminsWhenOtpIsNotAllowed`. The existing platform-admin test only covered `isOtpAllowed == true`, which is why this slipped through.
- Verified the test fails without the production change and passes with it.
- Full suite green locally: `Tests run: 3775, Failures: 0, Errors: 0, Skipped: 7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)