### PR TITLE
fix(livechat): accept cross-tenant anonymous enquiries — 404 on accept (#774)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacade.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.transaction.Transactional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -24,19 +25,39 @@ public class AcceptAnonymousEnquiryFacade {
    * Accepts the anonymous enquiry with the given session id and assigns the session to the current
    * authenticated consultant.
    *
+   * <p>#774: anonymous Live Chat enquiries are deliberately cross-tenant — the asker's session
+   * lives in its own tenant while the accepting consultant is in another (the queue makes them
+   * visible across tenants). The assignment therefore runs with the Hibernate tenant filter
+   * disabled (technical context), the same mechanism {@link
+   * de.caritas.cob.userservice.api.conversation.provider.AnonymousEnquiryConversationListProvider}
+   * uses to list them. Without it {@code getSessionForUpdate} cannot find the cross-tenant session
+   * and the accept fails with 404. The caller's tenant is always restored afterwards so no other
+   * work in the request leaks.
+   *
    * @param sessionId the id of the anonymous session
    */
   @Transactional
   public void acceptAnonymousEnquiry(Long sessionId) {
-    var session =
-        sessionService
-            .getSessionForUpdate(sessionId)
-            .orElseThrow(
-                () -> new NotFoundException("Session with id %s does not exist", sessionId));
+    var callerTenant = TenantContext.getCurrentTenant();
+    try {
+      TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
 
-    var consultant = this.userAccountProvider.retrieveValidatedConsultant();
-    this.assignEnquiryFacade.assignAnonymousEnquiry(session, consultant);
-    this.liveEventNotificationService.sendAcceptAnonymousEnquiryEventToUser(
-        session.getUser().getUserId());
+      var session =
+          sessionService
+              .getSessionForUpdate(sessionId)
+              .orElseThrow(
+                  () -> new NotFoundException("Session with id %s does not exist", sessionId));
+
+      var consultant = this.userAccountProvider.retrieveValidatedConsultant();
+      this.assignEnquiryFacade.assignAnonymousEnquiry(session, consultant);
+      this.liveEventNotificationService.sendAcceptAnonymousEnquiryEventToUser(
+          session.getUser().getUserId());
+    } finally {
+      if (callerTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenant(callerTenant);
+      }
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/facade/AcceptAnonymousEnquiryFacadeTest.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.conversation.facade;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -13,8 +14,11 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,6 +37,32 @@ class AcceptAnonymousEnquiryFacadeTest {
   @Mock private SessionService sessionService;
 
   @Mock private UserAccountService userAccountService;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void
+      acceptAnonymousEnquiry_Should_loadSessionCrossTenant_And_restoreCallerTenant_When_multiTenant() {
+    TenantContext.setCurrentTenant(5L);
+    Session session = new EasyRandom().nextObject(Session.class);
+    var tenantDuringLoad = new AtomicReference<Long>();
+    when(this.sessionService.getSessionForUpdate(session.getId()))
+        .thenAnswer(
+            invocation -> {
+              tenantDuringLoad.set(TenantContext.getCurrentTenant());
+              return Optional.of(session);
+            });
+
+    this.acceptAnonymousEnquiryFacade.acceptAnonymousEnquiry(session.getId());
+
+    // The cross-tenant session is loaded with the tenant filter disabled (technical tenant)...
+    assertEquals(TenantContext.TECHNICAL_TENANT_ID, tenantDuringLoad.get());
+    // ...and the caller's tenant is restored afterwards so nothing else in the request leaks.
+    assertEquals(5L, TenantContext.getCurrentTenant());
+  }
 
   @Test
   void acceptAnonymousEnquiry_Should_useServicesCorrectly_When_sessionExists() {


### PR DESCRIPTION
Follow-up to #741 (merged). The open fix landed and the accept button now appears and fires, but accepting still fails: `PUT /service/conversations/askers/anonymous/{id}/accept → 404`. (The accept-fix commit was pushed just after #741 merged, so it never made it into that PR — hence this one.)

## Cause
`acceptAnonymousEnquiry` loads the session via `getSessionForUpdate` → `findByIdForUpdate` (a JPQL query, so the Hibernate tenant `@Filter` applies). Anonymous Live Chat enquiries are deliberately cross-tenant — the askers session lives in its own tenant, the accepting consultant is in another. On multi-tenant dev (`multitenancyEnabled: true`) the filtered lookup finds nothing → `NotFoundException` → **404**. Same cross-tenant gap the open fix (#741) closed for the read path, now on the accept/write path.

Confirmed the route exists on the deployed backend: dev already runs the #741 open fix (open works), and the accept route predates it by months — so the 404 is the handler, not a missing route.

## Fix
Run the accept in technical-tenant context (tenant filter disabled) — the exact mechanism `AnonymousEnquiryConversationListProvider` uses to list these sessions — restoring the callers tenant afterwards. Wrapping the whole accept (not just the load) means every tenant-scoped query in the assignment chain also resolves cross-tenant.

## Tests
New unit test asserts the session is loaded under technical tenant and the callers tenant is restored. Full unit suite: **3780 passing, 0 failures**.

## Needs live verification after deploy
The accept is a cross-tenant **write** (assign consultant, status, Matrix room, async RocketChat which captures tenant context). Unit tests prove the load/restore; one live accept after deploy confirms the full chain. Follow-on question: after acceptance the session keeps the askers tenant — whether the consultant then sees it in their own tenants "My Sessions" may need product input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)