### PR TITLE
test(load): exercise seeded mixed read workload

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -261,6 +261,10 @@ A reproducible two-replica variant is:
 bash scripts/load/run-seeded-public-read-replicas.sh
 ```
 
+The runner requires Java 21. It retains an already active Java 21 runtime and
+auto-selects an installed JDK 21 through `java_home` on macOS; unsupported
+runtimes fail before Docker or any dependency state starts.
+
 It packages the real application jar, starts isolated MariaDB 11.0.6 and Redis
 7 containers, starts two distinct UserService JVMs against that shared state,
 seeds the exact integration-test dataset, and sends requests directly to both
@@ -274,18 +278,18 @@ Local two-replica proof on 2026-07-26:
 
 | Scope | Requests | Failures | Response bytes | Mean | p95 | Max |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| Replica one | 700 | 0 | 230,700 | 66.04 ms | 117.29 ms | 245.73 ms |
-| Replica two | 700 | 0 | 174,700 | 43.14 ms | 82.99 ms | 160.69 ms |
-| **Overall** | **1,400** | **0** | **405,400** | **54.59 ms** | **103.98 ms** | **245.73 ms** |
+| Replica one | 700 | 0 | 230,700 | 48.73 ms | 88.95 ms | 218.58 ms |
+| Replica two | 700 | 0 | 174,700 | 34.35 ms | 62.11 ms | 202.77 ms |
+| **Overall** | **1,400** | **0** | **405,400** | **41.54 ms** | **80.83 ms** | **218.58 ms** |
 
-The overall run completed in 2.407 seconds at 581.64 requests/second. The
-slowest named operation was `consultant-profile-peer` at 114.52 ms p95; all six
-operations had zero failures. This proves that the bounded mixed-read scenario
-can run across two real JVMs sharing MariaDB and Redis. It does **not** yet
-prove replica safety for concurrent writes, scheduled jobs, authentication and
-authorization flows, Kubernetes service routing, or deployed PreDev behavior.
-The production replica maximum must therefore remain one until those paths and
-their idempotency/locking contracts are exercised.
+The current rerun completed in 1.829 seconds at 765.46 requests/second. The
+slowest named operation was `consultant-profile-parenting-team` at 102.75 ms
+p95; all six operations had zero failures. This proves that the bounded
+mixed-read scenario can run across two real JVMs sharing MariaDB and Redis. It
+does **not** yet prove replica safety for concurrent writes, scheduled jobs,
+authentication and authorization flows, Kubernetes service routing, or
+deployed PreDev behavior. The production replica maximum must therefore remain
+one until those paths and their idempotency/locking contracts are exercised.
 
 The same seeded workload was also run with AgencyService deliberately
 unavailable. UserService still returned all 1,400 responses through its local

--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -55,7 +55,7 @@ runtime dependency set is:
 | Boundary | Dependencies | Transport |
 | --- | --- | --- |
 | Identity | Keycloak, identity extensions | Keycloak client + HTTP |
-| Chat | Matrix; Rocket.Chat only when explicitly enabled | HTTP long-poll + HTTP; optional MongoDB |
+| Chat | Matrix; residual Rocket.Chat code only when explicitly enabled | HTTP long-poll + HTTP; optional legacy MongoDB |
 | ORISO services | Agency, Tenant, Consulting Type/Topic/Application Settings, Appointment, Message, Mail, Live | HTTP |
 | State/event infrastructure | MariaDB, Redis, RabbitMQ | JDBC, Redis, AMQP |
 
@@ -80,6 +80,16 @@ The Java `HttpClient` used by LiveService and Keycloak's own admin-client
 transport are not covered by the payload interceptor; their higher-level retry
 paths are covered by the explicit retry counter. This is a known measurement
 boundary, not an implied zero.
+
+Rocket.Chat is a removal target, not a supported second transport in the target
+architecture. Matrix/Synapse is the sole messaging backbone, the ORISO frontend
+remains the product surface, and LiveKit plus the controlled Element Call path
+is the target calling stack. The remaining Rocket.Chat configuration, adapters,
+DTOs, database/wire names and optional MongoDB access are migration debt to
+delete after data and contract gates; they must not be preserved merely because
+the current ports can hide them. Jitsi removal is coordinated outside this
+UserService-only stability change across Frontend, call/appointment contracts
+and deployment.
 
 ### Live PreDev baseline before this change
 
@@ -161,10 +171,12 @@ policy cannot leak back into orchestration. The appointment deletion repair
 stays behind `Organizing` and `AppointmentRepository`.
 
 This is a ratcheted incremental modularization, not a claim that all three
-domains are already isolated. The next safe sequence is the remaining identity
-token/create-user DTO decoupling, then the admin controller composition
-boundary, then session-list adapter removal. Each step must add a failing
-boundary contract before moving dependencies.
+domains are already isolated. The next migration-aligned sequence is the
+session-list Rocket.Chat deletion slice, anonymous identity/provisioning
+cleanup, then Admin chat operations. Coordinated wire/database renames follow
+only after a verified Matrix identity and room-ID backfill. Each step must add a
+failing boundary contract before moving dependencies, and a slice is not
+complete while both transports remain reachable behind a cleaner interface.
 
 ## Microservice decision
 
@@ -186,7 +198,7 @@ Reconsider extraction only when PreDev telemetry supplies all of:
 
 ## Load and regression use
 
-Run a bounded load smoke against a deployed environment:
+Run a bounded single-endpoint smoke against a deployed environment:
 
 ```bash
 python3 tests/load/user_service_load_smoke.py \
@@ -201,12 +213,60 @@ python3 tests/load/user_service_load_smoke.py \
 Protected endpoints can receive repeated `--header 'Name: value'` arguments.
 The script reports request count, error rate, response bytes, throughput and
 mean/p50/p95/max latency and exits non-zero when either threshold is exceeded.
-Its concurrent behavior is itself exercised by the required Python CI contract.
 
-Local proof on 2026-07-25 used a real started UserService testing process and
+For a weighted workload, pass `--scenario`. The exit threshold applies to the
+overall result and every named operation, so a slow low-weight endpoint cannot
+hide behind a healthy aggregate. The runner also requires at least one complete
+weight cycle.
+
+The reproducible local seeded read proof is:
+
+```bash
+bash scripts/load/run-seeded-public-read.sh
+```
+
+The runner starts a real UserService testing-profile process with
+`UserServiceDatabase.sql` in an isolated H2 database, starts the deterministic
+AgencyService batch-read stub, waits for liveness, warms every operation, runs
+`tests/load/scenarios/seeded-public-read.json`, and cleans up both processes.
+Defaults are 1,400 requests, concurrency 32, zero tolerated failures and a
+1,000 ms p95 ceiling. Request count, concurrency and ceiling can be overridden
+with `USERSERVICE_LOAD_REQUESTS`, `USERSERVICE_LOAD_CONCURRENCY` and
+`USERSERVICE_LOAD_MAX_P95_MS`.
+
+The six operations exercise three seeded consultant profiles, their
+agency/topic relations, two agency-language aggregations, the generated
+AgencyService HTTP client contract, security/controller/JPA/mapping paths, and
+a small liveness control.
+
+Local healthy-dependency proof on 2026-07-25:
+
+| Operation | Requests | Failures | Response bytes | p95 |
+| --- | ---: | ---: | ---: | ---: |
+| Consultant profile — addiction | 400 | 0 | 148,400 | 128.55 ms |
+| Consultant profile — peer | 300 | 0 | 172,500 | 133.77 ms |
+| Consultant profile — parenting team | 200 | 0 | 75,000 | 163.93 ms |
+| Agency languages — primary | 200 | 0 | 4,000 | 34.89 ms |
+| Agency languages — multi | 200 | 0 | 4,000 | 40.47 ms |
+| Liveness control | 100 | 0 | 1,500 | 31.92 ms |
+| **Overall** | **1,400** | **0** | **405,400** | **114.28 ms** |
+
+The overall run completed in 1.627 seconds at 860.47 requests/second with
+35.69 ms mean latency and 343.82 ms maximum latency. This is a bounded local
+mixed-read regression proof, not a production capacity claim.
+
+The same seeded workload was also run with AgencyService deliberately
+unavailable. UserService still returned all 1,400 responses through its local
+topic fallback at concurrency 32 (121.19 ms p95, 843.2 requests/second).
+However, each failed dependency attempt emitted a WARN stack trace. That proves
+fallback continuity while exposing log amplification as a separate operational
+risk; it is not equivalent to the healthy-dependency result above.
+
+The earlier control proof on 2026-07-25 used a real started UserService testing process and
 500 requests at concurrency 20 against `/actuator/health/liveness`: 0 failures,
 0% error rate, 2,996 requests/second, 6.58 ms mean and 17.84 ms p95 (25.98 ms
-max). This is a bounded smoke baseline, not a production capacity claim. The
+max). It is retained as a liveness control and is superseded by the seeded mixed
+read scenario for application-path evidence. The
 aggregate local health group was `DOWN` because the developer RabbitMQ instance
 did not accept the testing profile's credentials; liveness and readiness were
 both `UP`, and the dedicated Redis contract passed independently.

--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -255,6 +255,38 @@ The overall run completed in 1.627 seconds at 860.47 requests/second with
 35.69 ms mean latency and 343.82 ms maximum latency. This is a bounded local
 mixed-read regression proof, not a production capacity claim.
 
+A reproducible two-replica variant is:
+
+```bash
+bash scripts/load/run-seeded-public-read-replicas.sh
+```
+
+It packages the real application jar, starts isolated MariaDB 11.0.6 and Redis
+7 containers, starts two distinct UserService JVMs against that shared state,
+seeds the exact integration-test dataset, and sends requests directly to both
+replicas in deterministic round-robin order. Scheduling and external chat event
+listeners are disabled so the result isolates the seeded public-read paths. The
+CLI reports and enforces thresholds for the aggregate, each operation, and each
+replica; cleanup removes both JVMs, the dependency containers, the AgencyService
+stub, and the temporary run directory.
+
+Local two-replica proof on 2026-07-26:
+
+| Scope | Requests | Failures | Response bytes | Mean | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Replica one | 700 | 0 | 230,700 | 66.04 ms | 117.29 ms | 245.73 ms |
+| Replica two | 700 | 0 | 174,700 | 43.14 ms | 82.99 ms | 160.69 ms |
+| **Overall** | **1,400** | **0** | **405,400** | **54.59 ms** | **103.98 ms** | **245.73 ms** |
+
+The overall run completed in 2.407 seconds at 581.64 requests/second. The
+slowest named operation was `consultant-profile-peer` at 114.52 ms p95; all six
+operations had zero failures. This proves that the bounded mixed-read scenario
+can run across two real JVMs sharing MariaDB and Redis. It does **not** yet
+prove replica safety for concurrent writes, scheduled jobs, authentication and
+authorization flows, Kubernetes service routing, or deployed PreDev behavior.
+The production replica maximum must therefore remain one until those paths and
+their idempotency/locking contracts are exercised.
+
 The same seeded workload was also run with AgencyService deliberately
 unavailable. UserService still returned all 1,400 responses through its local
 topic fallback at concurrency 32 (121.19 ms p95, 843.2 requests/second).

--- a/scripts/load/ensure-java-21.sh
+++ b/scripts/load/ensure-java-21.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+java_major_version() {
+  local java_command="$1"
+  local version_output
+  version_output="$("${java_command}" -version 2>&1 | head -n 1)" || return 1
+  if [[ "${version_output}" =~ \"([0-9]+)(\.([0-9]+))? ]]; then
+    if [[ "${BASH_REMATCH[1]}" == "1" ]]; then
+      printf '%s\n' "${BASH_REMATCH[3]}"
+    else
+      printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
+    return 0
+  fi
+  return 1
+}
+
+ensure_java_21() {
+  local current_java
+  local current_major=""
+  local current_version="unavailable"
+  current_java="$(command -v java 2>/dev/null || true)"
+  if [[ -n "${current_java}" ]]; then
+    current_major="$(java_major_version "${current_java}" || true)"
+    current_version="$("${current_java}" -version 2>&1 | head -n 1)"
+  fi
+  if [[ "${current_major}" == "21" ]]; then
+    return 0
+  fi
+
+  local resolver="${JAVA_21_HOME_RESOLVER:-}"
+  if [[ -z "${resolver}" && -x /usr/libexec/java_home ]]; then
+    resolver="/usr/libexec/java_home"
+  fi
+  if [[ -n "${resolver}" && -x "${resolver}" ]]; then
+    local java_21_home
+    java_21_home="$("${resolver}" -v 21 2>/dev/null || true)"
+    if [[ -x "${java_21_home}/bin/java" ]] &&
+      [[ "$(java_major_version "${java_21_home}/bin/java" || true)" == "21" ]]; then
+      export JAVA_HOME="${java_21_home}"
+      export PATH="${JAVA_HOME}/bin:${PATH}"
+      return 0
+    fi
+  fi
+
+  echo "UserService requires Java 21; current runtime: ${current_version}" >&2
+  return 1
+}

--- a/scripts/load/run-seeded-public-read-replicas.sh
+++ b/scripts/load/run-seeded-public-read-replicas.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${repo_root}/scripts/load/ensure-java-21.sh"
+ensure_java_21
+
 replica_one_port="${USERSERVICE_REPLICA_ONE_PORT:-18082}"
 replica_two_port="${USERSERVICE_REPLICA_TWO_PORT:-18084}"
 agency_stub_port="${AGENCY_STUB_PORT:-18083}"

--- a/scripts/load/run-seeded-public-read-replicas.sh
+++ b/scripts/load/run-seeded-public-read-replicas.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+replica_one_port="${USERSERVICE_REPLICA_ONE_PORT:-18082}"
+replica_two_port="${USERSERVICE_REPLICA_TWO_PORT:-18084}"
+agency_stub_port="${AGENCY_STUB_PORT:-18083}"
+request_count="${USERSERVICE_LOAD_REQUESTS:-1400}"
+concurrency="${USERSERVICE_LOAD_CONCURRENCY:-32}"
+max_p95_ms="${USERSERVICE_LOAD_MAX_P95_MS:-1000}"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/userservice-replica-load.XXXXXX")"
+run_id="userservice-replica-load-$$"
+mariadb_container="${run_id}-mariadb"
+redis_container="${run_id}-redis"
+userservice_replica_one_pid=""
+userservice_replica_two_pid=""
+agency_stub_pid=""
+
+stop_process() {
+  local process_id="$1"
+  if [[ -n "${process_id}" ]] && kill -0 "${process_id}" 2>/dev/null; then
+    kill "${process_id}" 2>/dev/null || true
+    wait "${process_id}" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  stop_process "${userservice_replica_one_pid}"
+  stop_process "${userservice_replica_two_pid}"
+  stop_process "${agency_stub_pid}"
+  docker rm -f "${mariadb_container}" >/dev/null 2>&1 || true
+  docker rm -f "${redis_container}" >/dev/null 2>&1 || true
+  rm -r "${run_dir}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command in docker curl python3 java; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  fi
+done
+
+docker run --detach \
+  --name "${mariadb_container}" \
+  --env MARIADB_ROOT_PASSWORD=root \
+  --env MARIADB_DATABASE=userservice \
+  --publish 127.0.0.1::3306 \
+  --health-cmd "healthcheck.sh --connect --innodb_initialized" \
+  --health-interval 2s \
+  --health-timeout 5s \
+  --health-retries 30 \
+  mariadb:11.0.6 \
+  >"${run_dir}/mariadb.container"
+
+docker run --detach \
+  --name "${redis_container}" \
+  --publish 127.0.0.1::6379 \
+  --health-cmd "redis-cli ping" \
+  --health-interval 2s \
+  --health-timeout 3s \
+  --health-retries 30 \
+  redis:7-alpine \
+  >"${run_dir}/redis.container"
+
+for container in "${mariadb_container}" "${redis_container}"; do
+  healthy=false
+  for ((attempt = 1; attempt <= 90; attempt += 1)); do
+    if [[ "$(docker inspect --format '{{.State.Health.Status}}' "${container}")" == "healthy" ]]; then
+      healthy=true
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${healthy}" != true ]]; then
+    echo "Container did not become healthy: ${container}" >&2
+    docker logs --tail 120 "${container}" >&2
+    exit 1
+  fi
+done
+
+mariadb_binding="$(docker port "${mariadb_container}" 3306/tcp | head -n 1)"
+redis_binding="$(docker port "${redis_container}" 6379/tcp | head -n 1)"
+mariadb_port="${mariadb_binding##*:}"
+redis_port="${redis_binding##*:}"
+jdbc_url="jdbc:mariadb://127.0.0.1:${mariadb_port}/userservice"
+
+python3 "${repo_root}/tests/load/seeded_agency_stub.py" \
+  --port "${agency_stub_port}" \
+  >"${run_dir}/agency-stub.log" 2>&1 &
+agency_stub_pid="$!"
+
+"${repo_root}/mvnw" -B -DskipTests -Dskip.unit-tests=true -Dskip.integration-tests=true package \
+  >"${run_dir}/package.log" 2>&1
+jar_path="${repo_root}/target/UserService.jar"
+if [[ ! -f "${jar_path}" ]]; then
+  echo "Packaged UserService jar is missing: ${jar_path}" >&2
+  tail -120 "${run_dir}/package.log" >&2
+  exit 1
+fi
+
+start_replica() {
+  local port="$1"
+  local log_file="$2"
+  SPRING_PROFILES_ACTIVE=testing \
+  SERVER_PORT="${port}" \
+  SPRING_DATASOURCE_URL="${jdbc_url}" \
+  SPRING_DATASOURCE_USERNAME=root \
+  SPRING_DATASOURCE_PASSWORD=root \
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver \
+  SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT=org.hibernate.dialect.MariaDBDialect \
+  SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
+  SPRING_LIQUIBASE_ENABLED=true \
+  SPRING_SQL_INIT_MODE=never \
+  SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION=false \
+  SPRING_DATA_REDIS_HOST=127.0.0.1 \
+  SPRING_DATA_REDIS_PORT="${redis_port}" \
+  AGENCY_SERVICE_API_URL="http://127.0.0.1:${agency_stub_port}" \
+  MATRIX_EVENT_LISTENER_ENABLED=false \
+  ROCKET_CHAT_ENABLED=false \
+  SPRING_TASK_SCHEDULING_ENABLED=false \
+  LOGGING_LEVEL_ROOT=WARN \
+  java -jar "${jar_path}" >"${log_file}" 2>&1 &
+}
+
+wait_for_replica() {
+  local port="$1"
+  local process_id="$2"
+  local log_file="$3"
+  local ready=false
+  for ((attempt = 1; attempt <= 180; attempt += 1)); do
+    if curl --fail --silent \
+      "http://127.0.0.1:${port}/actuator/health/liveness" \
+      >/dev/null; then
+      ready=true
+      break
+    fi
+    if ! kill -0 "${process_id}" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${ready}" != true ]]; then
+    echo "UserService replica on port ${port} did not become live:" >&2
+    tail -120 "${log_file}" >&2
+    exit 1
+  fi
+}
+
+start_replica "${replica_one_port}" "${run_dir}/userservice-replica-one.log"
+userservice_replica_one_pid="$!"
+wait_for_replica \
+  "${replica_one_port}" \
+  "${userservice_replica_one_pid}" \
+  "${run_dir}/userservice-replica-one.log"
+
+docker exec --interactive \
+  "${mariadb_container}" \
+  mariadb --user=root --password=root userservice \
+  <"${repo_root}/src/test/resources/database/UserServiceDatabase.sql"
+
+start_replica "${replica_two_port}" "${run_dir}/userservice-replica-two.log"
+userservice_replica_two_pid="$!"
+wait_for_replica \
+  "${replica_two_port}" \
+  "${userservice_replica_two_pid}" \
+  "${run_dir}/userservice-replica-two.log"
+
+python3 "${repo_root}/tests/load/user_service_load_smoke.py" \
+  --base-url "http://127.0.0.1:${replica_one_port}" \
+  --replica-url "http://127.0.0.1:${replica_two_port}" \
+  --scenario "${repo_root}/tests/load/scenarios/seeded-public-read.json" \
+  --requests 14 \
+  --concurrency 2 \
+  --max-error-rate 0 \
+  --max-p95-ms "${max_p95_ms}" \
+  >/dev/null
+
+python3 "${repo_root}/tests/load/user_service_load_smoke.py" \
+  --base-url "http://127.0.0.1:${replica_one_port}" \
+  --replica-url "http://127.0.0.1:${replica_two_port}" \
+  --scenario "${repo_root}/tests/load/scenarios/seeded-public-read.json" \
+  --requests "${request_count}" \
+  --concurrency "${concurrency}" \
+  --max-error-rate 0 \
+  --max-p95-ms "${max_p95_ms}"

--- a/scripts/load/run-seeded-public-read.sh
+++ b/scripts/load/run-seeded-public-read.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+userservice_port="${USERSERVICE_LOAD_PORT:-18082}"
+agency_stub_port="${AGENCY_STUB_PORT:-18083}"
+request_count="${USERSERVICE_LOAD_REQUESTS:-1400}"
+concurrency="${USERSERVICE_LOAD_CONCURRENCY:-32}"
+max_p95_ms="${USERSERVICE_LOAD_MAX_P95_MS:-1000}"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/userservice-seeded-load.XXXXXX")"
+userservice_pid=""
+agency_stub_pid=""
+
+cleanup() {
+  if [[ -n "${userservice_pid}" ]] && kill -0 "${userservice_pid}" 2>/dev/null; then
+    kill "${userservice_pid}" 2>/dev/null || true
+    wait "${userservice_pid}" 2>/dev/null || true
+  fi
+  if [[ -n "${agency_stub_pid}" ]] && kill -0 "${agency_stub_pid}" 2>/dev/null; then
+    kill "${agency_stub_pid}" 2>/dev/null || true
+    wait "${agency_stub_pid}" 2>/dev/null || true
+  fi
+  rm -r "${run_dir}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+python3 "${repo_root}/tests/load/seeded_agency_stub.py" \
+  --port "${agency_stub_port}" \
+  >"${run_dir}/agency-stub.log" 2>&1 &
+agency_stub_pid="$!"
+
+(
+  cd "${repo_root}"
+  SPRING_PROFILES_ACTIVE=testing \
+  SERVER_PORT="${userservice_port}" \
+  SPRING_DATASOURCE_URL="jdbc:h2:mem:userservice-seeded-load;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MariaDB;NON_KEYWORDS=USER,VALUE,DAY" \
+  SPRING_SQL_INIT_DATA_LOCATIONS="file:${repo_root}/src/test/resources/database/UserServiceDatabase.sql" \
+  AGENCY_SERVICE_API_URL="http://127.0.0.1:${agency_stub_port}" \
+  LOGGING_LEVEL_ROOT=WARN \
+  ./mvnw -DskipTests -Dspring-boot.run.useTestClasspath=true spring-boot:run
+) >"${run_dir}/userservice.log" 2>&1 &
+userservice_pid="$!"
+
+ready=false
+for ((attempt = 1; attempt <= 180; attempt += 1)); do
+  if curl --fail --silent \
+    "http://127.0.0.1:${userservice_port}/actuator/health/liveness" \
+    >/dev/null; then
+    ready=true
+    break
+  fi
+  if ! kill -0 "${userservice_pid}" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${ready}" != true ]]; then
+  echo "UserService did not become live; last startup log lines:" >&2
+  tail -120 "${run_dir}/userservice.log" >&2
+  exit 1
+fi
+
+python3 "${repo_root}/tests/load/user_service_load_smoke.py" \
+  --base-url "http://127.0.0.1:${userservice_port}" \
+  --scenario "${repo_root}/tests/load/scenarios/seeded-public-read.json" \
+  --requests 14 \
+  --concurrency 1 \
+  --max-error-rate 0 \
+  --max-p95-ms "${max_p95_ms}" \
+  >/dev/null
+
+python3 "${repo_root}/tests/load/user_service_load_smoke.py" \
+  --base-url "http://127.0.0.1:${userservice_port}" \
+  --scenario "${repo_root}/tests/load/scenarios/seeded-public-read.json" \
+  --requests "${request_count}" \
+  --concurrency "${concurrency}" \
+  --max-error-rate 0 \
+  --max-p95-ms "${max_p95_ms}"

--- a/tests/ci/test_load_smoke.py
+++ b/tests/ci/test_load_smoke.py
@@ -15,6 +15,7 @@ LOAD_SCRIPT = ROOT / "tests/load/user_service_load_smoke.py"
 SEEDED_PUBLIC_READ_SCENARIO = ROOT / "tests/load/scenarios/seeded-public-read.json"
 AGENCY_STUB_SCRIPT = ROOT / "tests/load/seeded_agency_stub.py"
 SEEDED_PUBLIC_READ_RUNNER = ROOT / "scripts/load/run-seeded-public-read.sh"
+SEEDED_REPLICA_RUNNER = ROOT / "scripts/load/run-seeded-public-read-replicas.sh"
 SPEC = importlib.util.spec_from_file_location("user_service_load_smoke", LOAD_SCRIPT)
 LOAD_SMOKE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -40,6 +41,19 @@ class SlowOperationHandler(HealthHandler):
         if self.path == "/slow":
             time.sleep(0.1)
         super().do_GET()
+
+
+class FailingHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = b'{"error":"replica failure"}'
+        self.send_response(500)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format, *_args):
+        pass
 
 
 class LoadSmokeContractTest(unittest.TestCase):
@@ -104,6 +118,52 @@ class LoadSmokeContractTest(unittest.TestCase):
             {"consultant-profile", "agency-languages"},
             {sample.operation for sample in samples},
         )
+
+    def test_weighted_workload_distributes_requests_across_two_replicas(self):
+        first = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        second = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        first_thread = Thread(target=first.serve_forever, daemon=True)
+        second_thread = Thread(target=second.serve_forever, daemon=True)
+        first_thread.start()
+        second_thread.start()
+        first_url = f"http://127.0.0.1:{first.server_port}"
+        second_url = f"http://127.0.0.1:{second.server_port}"
+        try:
+            summary, samples = LOAD_SMOKE.run_workload(
+                [first_url, second_url],
+                request_specs=[
+                    LOAD_SMOKE.RequestSpec(
+                        name="liveness",
+                        path="/actuator/health/liveness",
+                    )
+                ],
+                requests=40,
+                concurrency=8,
+                timeout_seconds=2,
+            )
+        finally:
+            first.shutdown()
+            second.shutdown()
+            first.server_close()
+            second.server_close()
+            first_thread.join(timeout=2)
+            second_thread.join(timeout=2)
+
+        self.assertEqual(20, summary["targets"][first_url]["requests"])
+        self.assertEqual(20, summary["targets"][second_url]["requests"])
+        self.assertEqual({first_url, second_url}, {sample.target for sample in samples})
+
+    def test_weighted_workload_requires_enough_requests_to_reach_every_target(self):
+        with self.assertRaisesRegex(ValueError, "requests must reach every target"):
+            LOAD_SMOKE.run_workload(
+                ["http://127.0.0.1:1", "http://127.0.0.1:2"],
+                request_specs=[
+                    LOAD_SMOKE.RequestSpec(name="liveness", path="/health")
+                ],
+                requests=1,
+                concurrency=1,
+                timeout_seconds=1,
+            )
 
     def test_weighted_workload_requires_one_complete_weight_cycle(self):
         with self.assertRaisesRegex(
@@ -177,6 +237,117 @@ class LoadSmokeContractTest(unittest.TestCase):
         self.assertEqual(
             5, output["summary"]["operations"]["agency-languages"]["requests"]
         )
+        self.assertEqual(
+            f"http://127.0.0.1:{server.server_port}",
+            output["target"],
+        )
+
+    def test_cli_accepts_a_second_replica_and_reports_both_targets(self):
+        first = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        second = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        first_thread = Thread(target=first.serve_forever, daemon=True)
+        second_thread = Thread(target=second.serve_forever, daemon=True)
+        first_thread.start()
+        second_thread.start()
+        first_url = f"http://127.0.0.1:{first.server_port}"
+        second_url = f"http://127.0.0.1:{second.server_port}"
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", encoding="utf-8"
+            ) as scenario:
+                json.dump(
+                    {"requests": [{"name": "liveness", "path": "/health"}]},
+                    scenario,
+                )
+                scenario.flush()
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(LOAD_SCRIPT),
+                        "--base-url",
+                        first_url,
+                        "--replica-url",
+                        second_url,
+                        "--scenario",
+                        scenario.name,
+                        "--requests",
+                        "20",
+                        "--concurrency",
+                        "4",
+                    ],
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=10,
+                )
+        finally:
+            first.shutdown()
+            second.shutdown()
+            first.server_close()
+            second.server_close()
+            first_thread.join(timeout=2)
+            second_thread.join(timeout=2)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(10, output["summary"]["targets"][first_url]["requests"])
+        self.assertEqual(10, output["summary"]["targets"][second_url]["requests"])
+
+    def test_cli_fails_when_one_replica_exceeds_its_error_rate(self):
+        healthy = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        failing = ThreadingHTTPServer(("127.0.0.1", 0), FailingHandler)
+        healthy_thread = Thread(target=healthy.serve_forever, daemon=True)
+        failing_thread = Thread(target=failing.serve_forever, daemon=True)
+        healthy_thread.start()
+        failing_thread.start()
+        healthy_url = f"http://127.0.0.1:{healthy.server_port}"
+        failing_url = f"http://127.0.0.1:{failing.server_port}"
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", encoding="utf-8"
+            ) as scenario:
+                json.dump(
+                    {"requests": [{"name": "liveness", "path": "/health"}]},
+                    scenario,
+                )
+                scenario.flush()
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(LOAD_SCRIPT),
+                        "--base-url",
+                        healthy_url,
+                        "--replica-url",
+                        failing_url,
+                        "--scenario",
+                        scenario.name,
+                        "--requests",
+                        "20",
+                        "--concurrency",
+                        "4",
+                        "--max-error-rate",
+                        "0.6",
+                    ],
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=10,
+                )
+        finally:
+            healthy.shutdown()
+            failing.shutdown()
+            healthy.server_close()
+            failing.server_close()
+            healthy_thread.join(timeout=2)
+            failing_thread.join(timeout=2)
+
+        output = json.loads(result.stdout)
+        self.assertEqual(0.5, output["summary"]["error_rate"])
+        self.assertEqual(
+            1.0,
+            output["summary"]["targets"][failing_url]["error_rate"],
+        )
+        self.assertEqual(1, result.returncode)
 
     def test_scenario_fails_when_a_low_weight_operation_exceeds_its_p95_limit(self):
         server = ThreadingHTTPServer(("127.0.0.1", 0), SlowOperationHandler)
@@ -298,6 +469,31 @@ class LoadSmokeContractTest(unittest.TestCase):
         self.assertIn("trap cleanup EXIT", runner)
         self.assertIn("trap 'exit 130' INT", runner)
         self.assertIn("trap 'exit 143' TERM", runner)
+
+    def test_replica_runner_uses_shared_mariadb_redis_and_two_processes(self):
+        result = subprocess.run(
+            ["bash", "-n", str(SEEDED_REPLICA_RUNNER)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        runner = SEEDED_REPLICA_RUNNER.read_text(encoding="utf-8")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("mariadb:11.0.6", runner)
+        self.assertIn("redis:7-alpine", runner)
+        self.assertIn("jdbc:mariadb://127.0.0.1:", runner)
+        self.assertNotIn("jdbc:h2:mem:", runner)
+        self.assertIn("userservice_replica_one_pid", runner)
+        self.assertIn("userservice_replica_two_pid", runner)
+        self.assertIn("target/UserService.jar", runner)
+        self.assertIn("--replica-url", runner)
+        self.assertIn("UserServiceDatabase.sql", runner)
+        self.assertIn("SPRING_LIQUIBASE_ENABLED=true", runner)
+        self.assertIn("SPRING_TASK_SCHEDULING_ENABLED=false", runner)
+        self.assertIn('docker rm -f "${mariadb_container}"', runner)
+        self.assertIn('docker rm -f "${redis_container}"', runner)
+        self.assertIn("trap cleanup EXIT", runner)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_load_smoke.py
+++ b/tests/ci/test_load_smoke.py
@@ -222,7 +222,9 @@ class LoadSmokeContractTest(unittest.TestCase):
             thread.join(timeout=2)
 
         output = json.loads(result.stdout)
-        self.assertLess(output["summary"]["latency_p95_ms"], 50)
+        self.assertEqual(20, output["summary"]["requests"])
+        self.assertEqual(19, output["summary"]["operations"]["fast-read"]["requests"])
+        self.assertEqual(1, output["summary"]["operations"]["slow-read"]["requests"])
         self.assertGreater(
             output["summary"]["operations"]["slow-read"]["latency_p95_ms"], 50
         )

--- a/tests/ci/test_load_smoke.py
+++ b/tests/ci/test_load_smoke.py
@@ -1,6 +1,7 @@
 import importlib.util
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -16,6 +17,7 @@ SEEDED_PUBLIC_READ_SCENARIO = ROOT / "tests/load/scenarios/seeded-public-read.js
 AGENCY_STUB_SCRIPT = ROOT / "tests/load/seeded_agency_stub.py"
 SEEDED_PUBLIC_READ_RUNNER = ROOT / "scripts/load/run-seeded-public-read.sh"
 SEEDED_REPLICA_RUNNER = ROOT / "scripts/load/run-seeded-public-read-replicas.sh"
+JAVA_21_RUNTIME = ROOT / "scripts/load/ensure-java-21.sh"
 SPEC = importlib.util.spec_from_file_location("user_service_load_smoke", LOAD_SCRIPT)
 LOAD_SMOKE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -57,6 +59,128 @@ class FailingHandler(BaseHTTPRequestHandler):
 
 
 class LoadSmokeContractTest(unittest.TestCase):
+    def test_java_runtime_selects_available_jdk_21(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            current_java = temporary_path / "current-bin" / "java"
+            java_21_home = temporary_path / "jdk-21"
+            java_21 = java_21_home / "bin" / "java"
+            resolver = temporary_path / "resolve-java-home"
+            current_java.parent.mkdir()
+            java_21.parent.mkdir(parents=True)
+            current_java.write_text(
+                "#!/usr/bin/env bash\nprintf 'openjdk version \"25.0.3\"\\n' >&2\n",
+                encoding="utf-8",
+            )
+            java_21.write_text(
+                "#!/usr/bin/env bash\nprintf 'openjdk version \"21.0.11\"\\n' >&2\n",
+                encoding="utf-8",
+            )
+            resolver.write_text(
+                f'#!/usr/bin/env bash\nprintf "%s\\n" "{java_21_home}"\n',
+                encoding="utf-8",
+            )
+            current_java.chmod(0o755)
+            java_21.chmod(0o755)
+            resolver.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = (
+                f"{current_java.parent}{os.pathsep}{environment['PATH']}"
+            )
+            environment["JAVA_21_HOME_RESOLVER"] = str(resolver)
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; ensure_java_21; printf "%s\\n" "$JAVA_HOME"; java -version',
+                    "_",
+                    str(JAVA_21_RUNTIME),
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+                text=True,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(str(java_21_home), result.stdout.strip())
+        self.assertIn('openjdk version "21.0.11"', result.stderr)
+
+    def test_java_runtime_rejects_an_unsupported_jdk_before_work_starts(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            current_java = temporary_path / "current-bin" / "java"
+            resolver = temporary_path / "missing-java-home"
+            current_java.parent.mkdir()
+            current_java.write_text(
+                "#!/usr/bin/env bash\nprintf 'openjdk version \"25.0.3\"\\n' >&2\n",
+                encoding="utf-8",
+            )
+            resolver.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            current_java.chmod(0o755)
+            resolver.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = (
+                f"{current_java.parent}{os.pathsep}{environment['PATH']}"
+            )
+            environment["JAVA_21_HOME_RESOLVER"] = str(resolver)
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; ensure_java_21',
+                    "_",
+                    str(JAVA_21_RUNTIME),
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+                text=True,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("UserService requires Java 21", result.stderr)
+        self.assertIn("25.0.3", result.stderr)
+
+    def test_replica_runner_rejects_wrong_java_before_starting_docker(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            fake_bin = temporary_path / "bin"
+            fake_bin.mkdir()
+            docker_calls = temporary_path / "docker-calls"
+            current_java = fake_bin / "java"
+            fake_docker = fake_bin / "docker"
+            resolver = temporary_path / "missing-java-home"
+            current_java.write_text(
+                "#!/usr/bin/env bash\nprintf 'openjdk version \"25.0.3\"\\n' >&2\n",
+                encoding="utf-8",
+            )
+            fake_docker.write_text(
+                f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >>"{docker_calls}"\nexit 1\n',
+                encoding="utf-8",
+            )
+            resolver.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            current_java.chmod(0o755)
+            fake_docker.chmod(0o755)
+            resolver.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+            environment["JAVA_21_HOME_RESOLVER"] = str(resolver)
+
+            result = subprocess.run(
+                ["bash", str(SEEDED_REPLICA_RUNNER)],
+                capture_output=True,
+                check=False,
+                env=environment,
+                text=True,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("UserService requires Java 21", result.stderr)
+        self.assertFalse(docker_calls.exists())
+
     def test_concurrent_smoke_reports_request_volume_payload_and_latency(self):
         server = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
         thread = Thread(target=server.serve_forever, daemon=True)
@@ -157,9 +281,7 @@ class LoadSmokeContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "requests must reach every target"):
             LOAD_SMOKE.run_workload(
                 ["http://127.0.0.1:1", "http://127.0.0.1:2"],
-                request_specs=[
-                    LOAD_SMOKE.RequestSpec(name="liveness", path="/health")
-                ],
+                request_specs=[LOAD_SMOKE.RequestSpec(name="liveness", path="/health")],
                 requests=1,
                 concurrency=1,
                 timeout_seconds=1,

--- a/tests/ci/test_load_smoke.py
+++ b/tests/ci/test_load_smoke.py
@@ -1,13 +1,20 @@
 import importlib.util
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 from threading import Thread
+import time
 import unittest
-
+from urllib.request import urlopen
 
 ROOT = Path(__file__).resolve().parents[2]
 LOAD_SCRIPT = ROOT / "tests/load/user_service_load_smoke.py"
+SEEDED_PUBLIC_READ_SCENARIO = ROOT / "tests/load/scenarios/seeded-public-read.json"
+AGENCY_STUB_SCRIPT = ROOT / "tests/load/seeded_agency_stub.py"
+SEEDED_PUBLIC_READ_RUNNER = ROOT / "scripts/load/run-seeded-public-read.sh"
 SPEC = importlib.util.spec_from_file_location("user_service_load_smoke", LOAD_SCRIPT)
 LOAD_SMOKE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -26,6 +33,13 @@ class HealthHandler(BaseHTTPRequestHandler):
 
     def log_message(self, _format, *_args):
         pass
+
+
+class SlowOperationHandler(HealthHandler):
+    def do_GET(self):
+        if self.path == "/slow":
+            time.sleep(0.1)
+        super().do_GET()
 
 
 class LoadSmokeContractTest(unittest.TestCase):
@@ -52,6 +66,236 @@ class LoadSmokeContractTest(unittest.TestCase):
         self.assertGreater(summary["requests_per_second"], 0)
         self.assertGreaterEqual(summary["latency_p95_ms"], 0)
         self.assertTrue(all(sample.status == 200 for sample in samples))
+
+    def test_weighted_workload_reports_each_public_read_operation_separately(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            summary, samples = LOAD_SMOKE.run_workload(
+                f"http://127.0.0.1:{server.server_port}",
+                request_specs=[
+                    LOAD_SMOKE.RequestSpec(
+                        name="consultant-profile",
+                        path="/users/consultants/473f7c4b-f011-4fc2-847c-ceb636a5b399",
+                        weight=3,
+                    ),
+                    LOAD_SMOKE.RequestSpec(
+                        name="agency-languages",
+                        path="/users/consultants/languages?agencyId=1",
+                        weight=1,
+                    ),
+                ],
+                requests=40,
+                concurrency=8,
+                timeout_seconds=2,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(40, summary["requests"])
+        self.assertEqual(30, summary["operations"]["consultant-profile"]["requests"])
+        self.assertEqual(10, summary["operations"]["agency-languages"]["requests"])
+        self.assertEqual(0, summary["operations"]["consultant-profile"]["failures"])
+        self.assertEqual(0, summary["operations"]["agency-languages"]["failures"])
+        self.assertEqual(
+            {"consultant-profile", "agency-languages"},
+            {sample.operation for sample in samples},
+        )
+
+    def test_weighted_workload_requires_one_complete_weight_cycle(self):
+        with self.assertRaisesRegex(
+            ValueError, "requests must cover at least one complete weight cycle"
+        ):
+            LOAD_SMOKE.run_workload(
+                "http://127.0.0.1:1",
+                request_specs=[
+                    LOAD_SMOKE.RequestSpec(name="first", path="/first", weight=3),
+                    LOAD_SMOKE.RequestSpec(name="second", path="/second", weight=1),
+                ],
+                requests=3,
+                concurrency=1,
+                timeout_seconds=1,
+            )
+
+    def test_cli_runs_a_json_scenario_and_emits_per_operation_results(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", encoding="utf-8"
+            ) as scenario:
+                json.dump(
+                    {
+                        "requests": [
+                            {
+                                "name": "consultant-profile",
+                                "path": "/users/consultants/473f7c4b-f011-4fc2-847c-ceb636a5b399",
+                                "weight": 3,
+                            },
+                            {
+                                "name": "agency-languages",
+                                "path": "/users/consultants/languages?agencyId=1",
+                                "weight": 1,
+                            },
+                        ]
+                    },
+                    scenario,
+                )
+                scenario.flush()
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(LOAD_SCRIPT),
+                        "--base-url",
+                        f"http://127.0.0.1:{server.server_port}",
+                        "--scenario",
+                        scenario.name,
+                        "--requests",
+                        "20",
+                        "--concurrency",
+                        "4",
+                    ],
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=10,
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(
+            15, output["summary"]["operations"]["consultant-profile"]["requests"]
+        )
+        self.assertEqual(
+            5, output["summary"]["operations"]["agency-languages"]["requests"]
+        )
+
+    def test_scenario_fails_when_a_low_weight_operation_exceeds_its_p95_limit(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), SlowOperationHandler)
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", encoding="utf-8"
+            ) as scenario:
+                json.dump(
+                    {
+                        "requests": [
+                            {"name": "fast-read", "path": "/fast", "weight": 19},
+                            {"name": "slow-read", "path": "/slow", "weight": 1},
+                        ]
+                    },
+                    scenario,
+                )
+                scenario.flush()
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(LOAD_SCRIPT),
+                        "--base-url",
+                        f"http://127.0.0.1:{server.server_port}",
+                        "--scenario",
+                        scenario.name,
+                        "--requests",
+                        "20",
+                        "--concurrency",
+                        "4",
+                        "--max-p95-ms",
+                        "50",
+                    ],
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                    timeout=10,
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        output = json.loads(result.stdout)
+        self.assertLess(output["summary"]["latency_p95_ms"], 50)
+        self.assertGreater(
+            output["summary"]["operations"]["slow-read"]["latency_p95_ms"], 50
+        )
+        self.assertEqual(1, result.returncode)
+
+    def test_repository_scenario_covers_seeded_profiles_relations_and_liveness(self):
+        specs = LOAD_SMOKE.load_request_specs(str(SEEDED_PUBLIC_READ_SCENARIO))
+
+        self.assertEqual(6, len(specs))
+        self.assertEqual(14, sum(spec.weight for spec in specs))
+        self.assertEqual(
+            {
+                "consultant-profile-addiction",
+                "consultant-profile-peer",
+                "consultant-profile-parenting-team",
+                "agency-languages-primary",
+                "agency-languages-multi",
+                "liveness-control",
+            },
+            {spec.name for spec in specs},
+        )
+        self.assertTrue(
+            all(
+                spec.path.startswith("/users/") or spec.path.startswith("/actuator/")
+                for spec in specs
+            )
+        )
+
+    def test_seeded_agency_stub_implements_the_generated_batch_read_contract(self):
+        spec = importlib.util.spec_from_file_location(
+            "seeded_agency_stub", AGENCY_STUB_SCRIPT
+        )
+        stub = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = stub
+        spec.loader.exec_module(stub)
+
+        server = stub.create_server("127.0.0.1", 0)
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with urlopen(
+                f"http://127.0.0.1:{server.server_port}/agencies/1,121",
+                timeout=2,
+            ) as response:
+                payload = json.load(response)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual([1, 121], [agency["id"] for agency in payload])
+        self.assertTrue(all(agency["offline"] is False for agency in payload))
+
+    def test_seeded_runner_wires_seed_dependency_and_mixed_scenario(self):
+        result = subprocess.run(
+            ["bash", "-n", str(SEEDED_PUBLIC_READ_RUNNER)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        runner = SEEDED_PUBLIC_READ_RUNNER.read_text(encoding="utf-8")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("UserServiceDatabase.sql", runner)
+        self.assertIn("seeded_agency_stub.py", runner)
+        self.assertIn("seeded-public-read.json", runner)
+        self.assertIn("spring-boot.run.useTestClasspath=true", runner)
+        self.assertIn("--max-error-rate", runner)
+        self.assertIn("--max-p95-ms", runner)
+        self.assertIn("trap cleanup EXIT", runner)
+        self.assertIn("trap 'exit 130' INT", runner)
+        self.assertIn("trap 'exit 143' TERM", runner)
 
 
 if __name__ == "__main__":

--- a/tests/load/scenarios/seeded-public-read.json
+++ b/tests/load/scenarios/seeded-public-read.json
@@ -1,0 +1,35 @@
+{
+  "description": "Deterministic mixed public-read workload over the testing profile's seeded consultant and agency-relation data.",
+  "requests": [
+    {
+      "name": "consultant-profile-addiction",
+      "path": "/users/consultants/473f7c4b-f011-4fc2-847c-ceb636a5b399",
+      "weight": 4
+    },
+    {
+      "name": "consultant-profile-peer",
+      "path": "/users/consultants/45816eb6-984b-411f-a818-996cd16e1f2a",
+      "weight": 3
+    },
+    {
+      "name": "consultant-profile-parenting-team",
+      "path": "/users/consultants/330dd0a4-6728-453e-a6b7-3aa181cf0c72",
+      "weight": 2
+    },
+    {
+      "name": "agency-languages-primary",
+      "path": "/users/consultants/languages?agencyId=1",
+      "weight": 2
+    },
+    {
+      "name": "agency-languages-multi",
+      "path": "/users/consultants/languages?agencyId=121",
+      "weight": 2
+    },
+    {
+      "name": "liveness-control",
+      "path": "/actuator/health/liveness",
+      "weight": 1
+    }
+  ]
+}

--- a/tests/load/seeded_agency_stub.py
+++ b/tests/load/seeded_agency_stub.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Deterministic AgencyService batch-read stub for the seeded load scenario."""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+
+
+class SeededAgencyHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        prefix = "/agencies/"
+        if not self.path.startswith(prefix):
+            self.send_error(404)
+            return
+
+        raw_ids = self.path.removeprefix(prefix).split("?", 1)[0]
+        try:
+            agency_ids = [int(value) for value in raw_ids.split(",")]
+        except ValueError:
+            self.send_error(400)
+            return
+
+        payload = json.dumps(
+            [
+                {
+                    "id": agency_id,
+                    "name": f"Seeded Agency {agency_id}",
+                    "postcode": "10115",
+                    "city": "Berlin",
+                    "description": "Seeded load-test agency",
+                    "teamAgency": False,
+                    "offline": False,
+                    "consultingType": 1,
+                    "tenantId": 0,
+                    "topicIds": [1, 2],
+                }
+                for agency_id in agency_ids
+            ]
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        pass
+
+
+def create_server(host: str, port: int) -> ThreadingHTTPServer:
+    return ThreadingHTTPServer((host, port), SeededAgencyHandler)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Serve the seeded AgencyService batch-read contract."
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18083)
+    args = parser.parse_args()
+    server = create_server(args.host, args.port)
+    print(f"Seeded AgencyService stub listening on {args.host}:{server.server_port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load/user_service_load_smoke.py
+++ b/tests/load/user_service_load_smoke.py
@@ -24,6 +24,7 @@ class Sample:
     latency_ms: float
     error: str | None = None
     operation: str = "request"
+    target: str = ""
 
 
 @dataclass(frozen=True)
@@ -46,6 +47,7 @@ def request_once(
     timeout_seconds: float,
     headers: dict[str, str],
     operation: str = "request",
+    target: str = "",
 ) -> Sample:
     started = time.perf_counter()
     try:
@@ -58,6 +60,7 @@ def request_once(
                 response_bytes=len(payload),
                 latency_ms=(time.perf_counter() - started) * 1000,
                 operation=operation,
+                target=target,
             )
     except HTTPError as error:
         payload = error.read()
@@ -67,6 +70,7 @@ def request_once(
             latency_ms=(time.perf_counter() - started) * 1000,
             error=f"http-{error.code}",
             operation=operation,
+            target=target,
         )
     except (TimeoutError, URLError, OSError) as error:
         return Sample(
@@ -75,6 +79,7 @@ def request_once(
             latency_ms=(time.perf_counter() - started) * 1000,
             error=type(error).__name__,
             operation=operation,
+            target=target,
         )
 
 
@@ -124,7 +129,7 @@ def run_load(
 
 
 def run_workload(
-    base_url: str,
+    base_url: str | list[str],
     request_specs: list[RequestSpec],
     requests: int,
     concurrency: int,
@@ -135,6 +140,14 @@ def run_workload(
         raise ValueError("request_specs must not be empty")
     if any(spec.weight < 1 for spec in request_specs):
         raise ValueError("request weights must be positive")
+    base_urls = [base_url] if isinstance(base_url, str) else list(base_url)
+    if not base_urls:
+        raise ValueError("base_url must contain at least one target")
+    if requests < len(base_urls):
+        raise ValueError(
+            "requests must reach every target "
+            f"({len(base_urls)} requests)"
+        )
 
     headers = headers or {}
     weighted_specs = [spec for spec in request_specs for _ in range(spec.weight)]
@@ -146,17 +159,25 @@ def run_workload(
     scheduled_specs = [
         weighted_specs[index % len(weighted_specs)] for index in range(requests)
     ]
+    scheduled_requests = [
+        (spec, base_urls[index % len(base_urls)])
+        for index, spec in enumerate(scheduled_specs)
+    ]
     started = time.perf_counter()
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         samples = list(
             executor.map(
-                lambda spec: request_once(
-                    urljoin(base_url.rstrip("/") + "/", spec.path.lstrip("/")),
+                lambda request: request_once(
+                    urljoin(
+                        request[1].rstrip("/") + "/",
+                        request[0].path.lstrip("/"),
+                    ),
                     timeout_seconds,
                     headers,
-                    spec.name,
+                    request[0].name,
+                    request[1],
                 ),
-                scheduled_specs,
+                scheduled_requests,
             )
         )
     elapsed_seconds = time.perf_counter() - started
@@ -170,6 +191,14 @@ def run_workload(
             elapsed_seconds,
         )
         for spec in request_specs
+    }
+    summary["targets"] = {
+        target: summarize_samples(
+            [sample for sample in samples if sample.target == target],
+            concurrency,
+            elapsed_seconds,
+        )
+        for target in base_urls
     }
     return summary, samples
 
@@ -215,6 +244,12 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("USERSERVICE_BASE_URL"),
         required=os.environ.get("USERSERVICE_BASE_URL") is None,
     )
+    parser.add_argument(
+        "--replica-url",
+        action="append",
+        default=[],
+        help="Additional UserService replica URL; may be repeated",
+    )
     parser.add_argument("--path", default="/actuator/health")
     parser.add_argument(
         "--scenario",
@@ -235,15 +270,16 @@ def main() -> int:
         raise ValueError("requests and concurrency must be positive")
     headers = parse_headers(args.header)
     if args.scenario:
+        targets = [args.base_url, *args.replica_url]
         summary, samples = run_workload(
-            args.base_url,
+            targets,
             load_request_specs(args.scenario),
             args.requests,
             args.concurrency,
             args.timeout_seconds,
             headers,
         )
-        target = args.base_url
+        target = targets[0] if len(targets) == 1 else targets
     else:
         target = urljoin(args.base_url.rstrip("/") + "/", args.path.lstrip("/"))
         summary, samples = run_load(
@@ -265,6 +301,9 @@ def main() -> int:
     operations = summary.get("operations")
     if isinstance(operations, dict):
         summaries_to_check.extend(operations.values())
+    targets = summary.get("targets")
+    if isinstance(targets, dict):
+        summaries_to_check.extend(targets.values())
     return int(
         any(
             result["error_rate"] > args.max_error_rate

--- a/tests/load/user_service_load_smoke.py
+++ b/tests/load/user_service_load_smoke.py
@@ -23,6 +23,14 @@ class Sample:
     response_bytes: int
     latency_ms: float
     error: str | None = None
+    operation: str = "request"
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+    name: str
+    path: str
+    weight: int = 1
 
 
 def percentile(values: list[float], quantile: float) -> float:
@@ -33,15 +41,23 @@ def percentile(values: list[float], quantile: float) -> float:
     return ordered[index]
 
 
-def request_once(url: str, timeout_seconds: float, headers: dict[str, str]) -> Sample:
+def request_once(
+    url: str,
+    timeout_seconds: float,
+    headers: dict[str, str],
+    operation: str = "request",
+) -> Sample:
     started = time.perf_counter()
     try:
-        with urlopen(Request(url, headers=headers), timeout=timeout_seconds) as response:
+        with urlopen(
+            Request(url, headers=headers), timeout=timeout_seconds
+        ) as response:
             payload = response.read()
             return Sample(
                 status=response.status,
                 response_bytes=len(payload),
                 latency_ms=(time.perf_counter() - started) * 1000,
+                operation=operation,
             )
     except HTTPError as error:
         payload = error.read()
@@ -50,6 +66,7 @@ def request_once(url: str, timeout_seconds: float, headers: dict[str, str]) -> S
             response_bytes=len(payload),
             latency_ms=(time.perf_counter() - started) * 1000,
             error=f"http-{error.code}",
+            operation=operation,
         )
     except (TimeoutError, URLError, OSError) as error:
         return Sample(
@@ -57,7 +74,32 @@ def request_once(url: str, timeout_seconds: float, headers: dict[str, str]) -> S
             response_bytes=0,
             latency_ms=(time.perf_counter() - started) * 1000,
             error=type(error).__name__,
+            operation=operation,
         )
+
+
+def summarize_samples(
+    samples: list[Sample],
+    concurrency: int,
+    elapsed_seconds: float,
+) -> dict[str, float | int]:
+    latencies = [sample.latency_ms for sample in samples]
+    failures = sum(
+        sample.error is not None or not 200 <= sample.status < 400 for sample in samples
+    )
+    return {
+        "requests": len(samples),
+        "concurrency": concurrency,
+        "failures": failures,
+        "error_rate": failures / len(samples) if samples else 1.0,
+        "response_bytes": sum(sample.response_bytes for sample in samples),
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "requests_per_second": round(len(samples) / elapsed_seconds, 2),
+        "latency_mean_ms": round(statistics.fmean(latencies), 2),
+        "latency_p50_ms": round(percentile(latencies, 0.50), 2),
+        "latency_p95_ms": round(percentile(latencies, 0.95), 2),
+        "latency_max_ms": round(max(latencies), 2),
+    }
 
 
 def run_load(
@@ -77,22 +119,57 @@ def run_load(
             )
         )
     elapsed_seconds = time.perf_counter() - started
-    latencies = [sample.latency_ms for sample in samples]
-    failures = sum(
-        sample.error is not None or not 200 <= sample.status < 400 for sample in samples
+    summary = summarize_samples(samples, concurrency, elapsed_seconds)
+    return summary, samples
+
+
+def run_workload(
+    base_url: str,
+    request_specs: list[RequestSpec],
+    requests: int,
+    concurrency: int,
+    timeout_seconds: float,
+    headers: dict[str, str] | None = None,
+) -> tuple[dict[str, object], list[Sample]]:
+    if not request_specs:
+        raise ValueError("request_specs must not be empty")
+    if any(spec.weight < 1 for spec in request_specs):
+        raise ValueError("request weights must be positive")
+
+    headers = headers or {}
+    weighted_specs = [spec for spec in request_specs for _ in range(spec.weight)]
+    if requests < len(weighted_specs):
+        raise ValueError(
+            "requests must cover at least one complete weight cycle "
+            f"({len(weighted_specs)} requests)"
+        )
+    scheduled_specs = [
+        weighted_specs[index % len(weighted_specs)] for index in range(requests)
+    ]
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        samples = list(
+            executor.map(
+                lambda spec: request_once(
+                    urljoin(base_url.rstrip("/") + "/", spec.path.lstrip("/")),
+                    timeout_seconds,
+                    headers,
+                    spec.name,
+                ),
+                scheduled_specs,
+            )
+        )
+    elapsed_seconds = time.perf_counter() - started
+    summary: dict[str, object] = summarize_samples(
+        samples, concurrency, elapsed_seconds
     )
-    summary: dict[str, float | int] = {
-        "requests": len(samples),
-        "concurrency": concurrency,
-        "failures": failures,
-        "error_rate": failures / len(samples) if samples else 1.0,
-        "response_bytes": sum(sample.response_bytes for sample in samples),
-        "elapsed_seconds": round(elapsed_seconds, 3),
-        "requests_per_second": round(len(samples) / elapsed_seconds, 2),
-        "latency_mean_ms": round(statistics.fmean(latencies), 2),
-        "latency_p50_ms": round(percentile(latencies, 0.50), 2),
-        "latency_p95_ms": round(percentile(latencies, 0.95), 2),
-        "latency_max_ms": round(max(latencies), 2),
+    summary["operations"] = {
+        spec.name: summarize_samples(
+            [sample for sample in samples if sample.operation == spec.name],
+            concurrency,
+            elapsed_seconds,
+        )
+        for spec in request_specs
     }
     return summary, samples
 
@@ -107,6 +184,28 @@ def parse_headers(values: Iterable[str]) -> dict[str, str]:
     return headers
 
 
+def load_request_specs(path: str) -> list[RequestSpec]:
+    with open(path, encoding="utf-8") as scenario_file:
+        scenario = json.load(scenario_file)
+    raw_requests = scenario.get("requests")
+    if not isinstance(raw_requests, list) or not raw_requests:
+        raise ValueError("scenario must contain a non-empty 'requests' list")
+
+    request_specs = [
+        RequestSpec(
+            name=request["name"],
+            path=request["path"],
+            weight=request.get("weight", 1),
+        )
+        for request in raw_requests
+    ]
+    if len({spec.name for spec in request_specs}) != len(request_specs):
+        raise ValueError("scenario request names must be unique")
+    if any(not spec.name.strip() or not spec.path.strip() for spec in request_specs):
+        raise ValueError("scenario request names and paths must not be blank")
+    return request_specs
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run a bounded concurrent smoke load against UserService."
@@ -117,6 +216,10 @@ def parse_args() -> argparse.Namespace:
         required=os.environ.get("USERSERVICE_BASE_URL") is None,
     )
     parser.add_argument("--path", default="/actuator/health")
+    parser.add_argument(
+        "--scenario",
+        help="JSON file containing weighted request names and paths",
+    )
     parser.add_argument("--requests", type=int, default=200)
     parser.add_argument("--concurrency", type=int, default=10)
     parser.add_argument("--timeout-seconds", type=float, default=5.0)
@@ -130,25 +233,44 @@ def main() -> int:
     args = parse_args()
     if args.requests < 1 or args.concurrency < 1:
         raise ValueError("requests and concurrency must be positive")
-    url = urljoin(args.base_url.rstrip("/") + "/", args.path.lstrip("/"))
-    summary, samples = run_load(
-        url,
-        args.requests,
-        args.concurrency,
-        args.timeout_seconds,
-        parse_headers(args.header),
-    )
+    headers = parse_headers(args.header)
+    if args.scenario:
+        summary, samples = run_workload(
+            args.base_url,
+            load_request_specs(args.scenario),
+            args.requests,
+            args.concurrency,
+            args.timeout_seconds,
+            headers,
+        )
+        target = args.base_url
+    else:
+        target = urljoin(args.base_url.rstrip("/") + "/", args.path.lstrip("/"))
+        summary, samples = run_load(
+            target,
+            args.requests,
+            args.concurrency,
+            args.timeout_seconds,
+            headers,
+        )
     output = {
-        "target": url,
+        "target": target,
         "summary": summary,
-        "errors": [
-            asdict(sample) for sample in samples if sample.error is not None
-        ][:10],
+        "errors": [asdict(sample) for sample in samples if sample.error is not None][
+            :10
+        ],
     }
     print(json.dumps(output, indent=2, sort_keys=True))
+    summaries_to_check = [summary]
+    operations = summary.get("operations")
+    if isinstance(operations, dict):
+        summaries_to_check.extend(operations.values())
     return int(
-        summary["error_rate"] > args.max_error_rate
-        or summary["latency_p95_ms"] > args.max_p95_ms
+        any(
+            result["error_rate"] > args.max_error_rate
+            or result["latency_p95_ms"] > args.max_p95_ms
+            for result in summaries_to_check
+        )
     )
 
 

--- a/tests/load/user_service_load_smoke.py
+++ b/tests/load/user_service_load_smoke.py
@@ -145,8 +145,7 @@ def run_workload(
         raise ValueError("base_url must contain at least one target")
     if requests < len(base_urls):
         raise ValueError(
-            "requests must reach every target "
-            f"({len(base_urls)} requests)"
+            "requests must reach every target " f"({len(base_urls)} requests)"
         )
 
     headers = headers or {}


### PR DESCRIPTION
## Summary

- add a deterministic weighted public-read scenario over seeded consultant, agency/topic and language data
- run two real UserService JVMs against shared isolated MariaDB 11.0.6 and Redis 7 state
- distribute traffic deterministically across both replicas and enforce aggregate, per-operation and per-replica thresholds
- exercise the generated AgencyService client through a healthy local batch-read stub
- auto-select JDK 21 on macOS and fail before Docker when no supported runtime is available
- provide bounded startup, warm-up and verified cleanup in one command

## Why

PR #735 restored truthful required CI, but the checked-in load proof exercised only liveness. The first version of this PR added seeded application reads against one UserService JVM. The current head extends that proof across two real JVMs sharing database and Redis state, without claiming that write, scheduler, authentication or deployed routing paths are already replica-safe.

The final verification also reproduced a local JDK 25 failure at Spotless/google-java-format. The runner now establishes the repository's Java 21 requirement before any container starts.

## Current two-replica evidence

`bash scripts/load/run-seeded-public-read-replicas.sh`

- 1,400 requests at concurrency 32
- 700 requests per replica
- 0 failures across all six named operations
- 405,400 response bytes
- 765.46 requests/second
- 41.54 ms mean, 80.83 ms p95, 218.58 ms maximum
- replica p95: 88.95 ms and 62.11 ms
- slowest operation p95: 102.75 ms
- no temporary containers, JVMs or listeners remained after cleanup

## Verification

- 27 Python architecture/load/CI contracts
- Python Black and compilation checks
- shell syntax for both replica scripts
- JDK 21 Maven package and Spotless
- local CodeRabbit review of both newly published commits: no findings
- previous full Java 21 unit suite: 3,795 tests, 0 failures/errors, 7 skips
- previous required integration/contract/E2E suite: 940 tests, 0 failures/errors, 3 skips

## Scope and release boundary

This is bounded local mixed-read evidence, not a production capacity claim. It does not prove concurrent writes, scheduler idempotency, authentication/authorization, Kubernetes service routing, or deployed PreDev behavior. The supported UserService replica maximum therefore remains one.

The architecture target remains Matrix-only chat, the ORISO-owned frontend, and the ORISO-controlled Element Call/MatrixRTC fork with LiveKit. Rocket.Chat and Jitsi remain removal targets; this load-test slice does not reintroduce either dependency.

Closes OpenResilienceInitiative/ORISO-UserService#743
Refs OpenResilienceInitiative/ORISO-UserService#335
Refs OpenResilienceInitiative/ORISO-UserService#543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
