### PR TITLE
Make the RCToken header optional everywhere

### DIFF
--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -116,7 +116,7 @@ paths:
             type: integer
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
       responses:
@@ -160,7 +160,7 @@ paths:
             type: integer
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
       responses:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -747,7 +747,7 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: status
@@ -855,7 +855,7 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: offset
@@ -1661,7 +1661,7 @@ paths:
       parameters:
         - name: RCToken
           in: header
-          required: true
+          required: false
           schema:
             type: string
         - name: chatId

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationController.java
@@ -90,7 +90,7 @@ public class ConversationController implements ConversationsApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionListResponseDTO> getArchivedSessions(
-      Integer offset, Integer count, @RequestHeader String rcToken) {
+      Integer offset, Integer count, @RequestHeader(required = false) String rcToken) {
 
     ConsultantSessionListResponseDTO archivedSessions =
         this.conversationListResolver.resolveConversations(
@@ -108,7 +108,7 @@ public class ConversationController implements ConversationsApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionListResponseDTO> getArchivedTeamSessions(
-      Integer offset, Integer count, @RequestHeader String rcToken) {
+      Integer offset, Integer count, @RequestHeader(required = false) String rcToken) {
 
     ConsultantSessionListResponseDTO archivedTeamSessions =
         this.conversationListResolver.resolveConversations(

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -314,7 +314,7 @@ public class UserController implements UsersApi {
   }
 
   @Override
-  public ResponseEntity<GroupSessionListResponseDTO> getChatById(String rcToken, Long chatId) {
+  public ResponseEntity<GroupSessionListResponseDTO> getChatById(Long chatId, String rcToken) {
     return userSessionControllerDelegate.getChatById(rcToken, chatId);
   }
 
@@ -378,10 +378,10 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionListResponseDTO> getSessionsForAuthenticatedConsultant(
-      @RequestHeader String rcToken,
       Integer offset,
       Integer count,
       @RequestParam String filter,
+      @RequestHeader(required = false) String rcToken,
       @RequestParam Integer status) {
     return userSessionControllerDelegate.getSessionsForAuthenticatedConsultant(
         rcToken, offset, count, filter, status);
@@ -398,7 +398,10 @@ public class UserController implements UsersApi {
    */
   @Override
   public ResponseEntity<ConsultantSessionListResponseDTO> getTeamSessionsForAuthenticatedConsultant(
-      @RequestHeader String rcToken, Integer offset, Integer count, @RequestParam String filter) {
+      Integer offset,
+      Integer count,
+      @RequestParam String filter,
+      @RequestHeader(required = false) String rcToken) {
     return userSessionControllerDelegate.getTeamSessionsForAuthenticatedConsultant(
         rcToken, offset, count, filter);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -1119,15 +1119,16 @@ class UserControllerIT {
   }
 
   @Test
-  void getSessionsForAuthenticatedConsultant_Should_ReturnBadRequest_WhenHeaderParamIsMissing()
+  void getSessionsForAuthenticatedConsultant_Should_Succeed_WhenRcTokenHeaderIsMissing()
       throws Exception {
+    // The RCToken header is a Rocket.Chat leftover: it is threaded through the
+    // session-list code and then dropped, because the room lookup runs against
+    // Matrix. Callers must not be forced to send a dummy value for it.
     mvc.perform(
             get(PATH_GET_SESSIONS_FOR_AUTHENTICATED_CONSULTANT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest());
-
-    verifyNoMoreInteractions(authenticatedUser, sessionService);
+        .andExpect(status().isNoContent());
   }
 
   @Test
@@ -1354,14 +1355,14 @@ class UserControllerIT {
 
   /** Method: getTeamSessionsForAuthenticatedConsultant (role: consultant) */
   @Test
-  void getTeamSessionsForAuthenticatedConsultant_Should_ReturnBadRequest_WhenHeaderParamIsMissing()
+  void getTeamSessionsForAuthenticatedConsultant_Should_Succeed_WhenRcTokenHeaderIsMissing()
       throws Exception {
-
+    // See above: RCToken is optional, a missing one is not a client error.
     mvc.perform(
             get(PATH_GET_TEAM_SESSIONS_FOR_AUTHENTICATED_CONSULTANT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isNoContent());
   }
 
   @Test


### PR DESCRIPTION
## The finding

`RCToken` is a Rocket.Chat leftover that carries no meaning any more — but four endpoints still returned **400** without it.

Traced end to end:

1. `UserSessionControllerDelegate` builds `RocketChatCredentials` from the header and, when it is absent, substitutes the literal **`"dummy-rc-token"`** (line 295). A token that may be replaced by a placeholder validates nothing.
2. Those credentials reach `RocketChatRoomInformationProvider.retrieveRocketChatInformation`, which opens with `if (!rocketChatEnabled || isMatrixMigrationCredential(...))`.
3. `rocket-chat.enabled` is `false` by default (ADR-004), so that branch **always** wins — and it reads only `getRocketChatUserId()`. **The token is never read.**

Meanwhile the frontend sends `MATRIX_MIGRATION_DUMMY_RC_TOKEN`. Both sides were feeding each other a placeholder to satisfy a check that no longer exists.

## The change

`required: true` → `required: false` for `RCToken` in `api/userservice.yaml` (3) and `api/conversationservice.yaml` (2), plus `required = false` on the four `@RequestHeader` declarations.

Relaxing the flag moves the parameter **behind** the required ones in the generated interfaces, so three controller signatures had to be reordered to keep overriding — `getChatById`, `getSessionsForAuthenticatedConsultant`, `getTeamSessionsForAuthenticatedConsultant`.

This is a pure relaxation: a client that still sends the header is unaffected.

## Not touched: `RCUserId`

That one is **still live**. It becomes `RocketChatCredentials.rocketChatUserId` and is read for the Matrix room lookup. Only the token is dead. Renaming it belongs to #748.

## Testing

| Suite | Result |
|---|---|
| `UserControllerIT` | 135/135 |
| `ConversationController*` + `*SessionList*` | 104/104 |

Two IT cases asserted the old contract (`..._Should_ReturnBadRequest_WhenHeaderParamIsMissing`) and now assert the new one, renamed accordingly.

## Build note worth recording

The test suite **only runs on JDK 21**. On JDK 25 all 557 selected tests error out with `MockitoException: Mockito cannot mock this class` before a single assertion runs. I nearly misread that as a regression — it is the local toolchain. Worth pinning in CI docs.

Related: #747, #748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)