### PR TITLE
fix(livechat): open the conversation after a cross-tenant live chat is accepted (#774)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserSessionControllerDelegate.java
@@ -311,6 +311,26 @@ class UserSessionControllerDelegate {
       }
     }
 
+    // Step 1c (#774 follow-up): once a cross-tenant live chat is accepted it becomes IN_PROGRESS
+    // and
+    // keeps the asker's tenant, so Step 1 (tenant-filtered) and the anonymous-NEW fallback above no
+    // longer match it. Without this, routing to the just-accepted conversation 204s and the chat
+    // never opens. Resolve it across tenants, but only when this consultant is its directly
+    // assigned
+    // advisor — no agency/topic widening, and tenant ownership is unchanged.
+    if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
+      log.info("Step 1c: Trying cross-tenant directly-assigned session for ID: {}", sessionId);
+      var assignedCrossTenant =
+          sessionListFacade.retrieveDirectlyAssignedSessionsForConsultantBySessionIds(
+              consultant, singletonList(sessionId));
+      if (assignedCrossTenant != null
+          && assignedCrossTenant.getSessions() != null
+          && !assignedCrossTenant.getSessions().isEmpty()) {
+        log.info("Step 1c result: cross-tenant assigned session {} resolved", sessionId);
+        return assignedCrossTenant;
+      }
+    }
+
     if (groupSessionList.getSessions() == null || groupSessionList.getSessions().isEmpty()) {
       log.info("Step 2: No session found, trying to find as CHAT with ID: {}", sessionId);
       var token = rcToken != null ? rcToken : "dummy-rc-token";

--- a/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
@@ -215,6 +215,26 @@ public class SessionListFacade {
     return new GroupSessionListResponseDTO().sessions(sessions);
   }
 
+  /**
+   * Resolves a cross-tenant session the consultant is directly assigned to (#774 follow-up). Used
+   * as the open-path fallback after a cross-tenant live chat is accepted, so routing to the
+   * accepted conversation resolves it instead of 204-ing.
+   */
+  public GroupSessionListResponseDTO retrieveDirectlyAssignedSessionsForConsultantBySessionIds(
+      Consultant consultant, List<Long> sessionIds) {
+    List<ConsultantSessionResponseDTO> consultantSessions =
+        consultantSessionListService.retrieveDirectlyAssignedSessionsForConsultantBySessionIds(
+            consultant, sessionIds);
+
+    SessionMapper sessionMapper = new SessionMapper();
+    var sessions =
+        consultantSessions.stream()
+            .map(sessionMapper::toGroupSessionResponse)
+            .collect(Collectors.toList());
+
+    return new GroupSessionListResponseDTO().sessions(sessions);
+  }
+
   public GroupSessionListResponseDTO retrieveChatsForConsultantByChatIds(
       Consultant consultant, List<Long> chatIds, RocketChatCredentials rocketChatCredentials) {
     List<ConsultantSessionResponseDTO> consultantChatSessions =

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -678,6 +678,33 @@ public class SessionService {
   }
 
   /**
+   * Loads sessions the consultant is <b>directly assigned to</b> by id, bypassing the tenant
+   * filter.
+   *
+   * <p>#774 follow-up: once a consultant accepts a cross-tenant anonymous Live Chat, the session
+   * becomes IN_PROGRESS and keeps the asker's tenant. The frontend then re-reads it by id to route
+   * to the accepted conversation, but {@link #getSessionsByIds} is tenant-filtered and no longer
+   * matches the anonymous-NEW fallback above, so the post-accept read returns 204 and the accepted
+   * chat never opens. This scoped fallback resolves such a session across tenants, but only when
+   * the consultant is its directly assigned advisor ({@link Session#isAdvisedBy(Consultant)}) — it
+   * never widens access by agency or topic, and it does not change the session's tenant ownership
+   * (the asker keeps seeing their own chat).
+   */
+  public List<ConsultantSessionResponseDTO> getDirectlyAssignedSessionsByIdsCrossTenant(
+      Consultant consultant, Set<Long> sessionIds) {
+    if (!isNotEmpty(sessionIds)) {
+      return emptyList();
+    }
+    var sessions =
+        runCrossTenant(
+            () ->
+                StreamSupport.stream(sessionRepository.findAllById(sessionIds).spliterator(), false)
+                    .filter(session -> session.isAdvisedBy(consultant))
+                    .collect(Collectors.toList()));
+    return mapSessionsToConsultantSessionDto(sessions);
+  }
+
+  /**
    * Runs a read in technical-tenant context so the anonymous Live Chat visibility query bypasses
    * the Hibernate tenant filter (the queue is deliberately cross-tenant), restoring the caller's
    * tenant afterwards so no other query in the request leaks. Mirrors the queue provider's own

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
@@ -82,6 +82,18 @@ public class ConsultantSessionListService {
     return sessionService.getVisibleAnonymousLiveChatEnquiriesByIds(consultant, uniqueSessionIds);
   }
 
+  /**
+   * Loads a cross-tenant session the consultant is directly assigned to (#774 follow-up). Used as
+   * the open-path fallback after a cross-tenant live chat is accepted, so routing to the accepted
+   * conversation resolves it instead of 204-ing.
+   */
+  public List<ConsultantSessionResponseDTO>
+      retrieveDirectlyAssignedSessionsForConsultantBySessionIds(
+          Consultant consultant, List<Long> sessionIds) {
+    var uniqueSessionIds = new HashSet<>(sessionIds);
+    return sessionService.getDirectlyAssignedSessionsByIdsCrossTenant(consultant, uniqueSessionIds);
+  }
+
   public List<ConsultantSessionResponseDTO> retrieveChatsForConsultantAndChatIds(
       Consultant consultant, List<Long> chatIds, String rcAuthToken) {
     log.info(

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -1212,6 +1212,36 @@ class SessionServiceTest {
 
   @Test
   void
+      getDirectlyAssignedSessionsByIdsCrossTenant_Should_ReturnSession_When_ConsultantIsAssignedAdvisor() {
+    Consultant consultant = mock(Consultant.class);
+
+    // Only the directly-assigned advisor may resolve a cross-tenant session this way.
+    Session spied = org.mockito.Mockito.spy(easyRandom.nextObject(Session.class));
+    when(sessionRepository.findAllById(Set.of(103510L))).thenReturn(List.of(spied));
+    org.mockito.Mockito.doReturn(true).when(spied).isAdvisedBy(consultant);
+
+    List<ConsultantSessionResponseDTO> result =
+        sessionService.getDirectlyAssignedSessionsByIdsCrossTenant(consultant, Set.of(103510L));
+
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void
+      getDirectlyAssignedSessionsByIdsCrossTenant_Should_ReturnEmpty_When_ConsultantIsNotAssigned() {
+    Consultant consultant = mock(Consultant.class);
+    Session spied = org.mockito.Mockito.spy(easyRandom.nextObject(Session.class));
+    when(sessionRepository.findAllById(Set.of(103510L))).thenReturn(List.of(spied));
+    org.mockito.Mockito.doReturn(false).when(spied).isAdvisedBy(consultant);
+
+    List<ConsultantSessionResponseDTO> result =
+        sessionService.getDirectlyAssignedSessionsByIdsCrossTenant(consultant, Set.of(103510L));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void
       getVisibleAnonymousLiveChatEnquiriesByIds_Should_ReturnEmptyAndNotQuery_When_ConsultantHasNoTopics() {
     Consultant consultant = mock(Consultant.class);
     when(consultant.getId()).thenReturn(CONSULTANT_ID);


### PR DESCRIPTION
Follow-up to #741. Accepting a live chat request appeared to do nothing — the button ran, but the conversation never opened. Confirmed live: the **open** works (consultant reaches the request preview) but the **accept** does not complete.

## Cause
After acceptance the anonymous session becomes `IN_PROGRESS` and keeps the asker's tenant. The frontend then re-reads it by id (`fetchSessionRoutingAfterAccept` → `GET /users/sessions/room/{id}`) to route to the accepted conversation. That read (`getSessionsByIds`) is tenant-filtered, and the anonymous-**NEW** fallback added in #741 no longer matches an accepted session — so it returned **204**. The frontend accept chain then rejected, and `AcceptAssign`'s catch only surfaces `CONFLICT`, so the failure was swallowed: "nothing opens".

This is the post-accept cross-tenant read gap flagged on #741.

## Fix
Add **Step 1c** to the by-id open path (`getSessionOrChatForConsultant`): resolve a session across tenants **only when the consultant is its directly assigned advisor** (`Session.isAdvisedBy`). No agency/topic widening, and tenant ownership is unchanged — the asker keeps seeing their own chat, avoiding the two-sided risk of moving the session to the consultant's tenant.

## Tests
New service tests (assigned → resolved; not-assigned → empty). Full unit suite: **3802 passing, 0 failures**.

## Notes
- Needs deploying to dev to verify live (I could not reproduce end-to-end: this consultant account isn't topic-eligible for the specific session, and direct API probes are unauthenticated).
- Known remaining follow-on: an accepted cross-tenant session still won't appear in the consultant's **Chats/My-Sessions list** (that list query is tenant-filtered). Opening via the post-accept redirect / direct link now works; surfacing it in the list is a separate decision (make the list cross-tenant-aware, or adopt the session into the consultant's tenant on accept — the latter is cleaner but affects the asker's view, so it needs product input).
- Frontend UX aside: `AcceptAssign` swallows non-`CONFLICT` accept errors silently; worth surfacing an error so a future failure isn't an invisible "nothing happens".

🤖 Generated with [Claude Code](https://claude.com/claude-code)