### PR TITLE
fix(ci): remove the CI health metric that never reached SigNoz

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -81,10 +81,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Report aggregate required conclusion to SigNoz
+    - name: Report the aggregate required conclusion
       env:
-        REPO: ${{ github.event.repository.name }}
-        WORKFLOW: ${{ github.workflow }}
         VALIDATE_RESULT: ${{ needs.validate.result }}
         REDIS_RESULT: ${{ needs.redis-contract.result }}
         MARIADB_RESULT: ${{ needs.mariadb-contract.result }}
@@ -94,13 +92,6 @@ jobs:
         if [[ "${VALIDATE_RESULT}" != success || "${REDIS_RESULT}" != success || "${MARIADB_RESULT}" != success || "${INTEGRATION_RESULT}" != success ]]; then
           conclusion=failure
         fi
-        now_ns="$(date +%s)000000000"
-        payload="{\"resourceMetrics\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"ci-cd\"}}]},\"scopeMetrics\":[{\"scope\":{\"name\":\"ci-health\"},\"metrics\":[{\"name\":\"ci_run_result\",\"sum\":{\"dataPoints\":[{\"attributes\":[{\"key\":\"repo\",\"value\":{\"stringValue\":\"${REPO}\"}},{\"key\":\"workflow\",\"value\":{\"stringValue\":\"${WORKFLOW}\"}},{\"key\":\"conclusion\",\"value\":{\"stringValue\":\"${conclusion}\"}}],\"startTimeUnixNano\":\"${now_ns}\",\"timeUnixNano\":\"${now_ns}\",\"asInt\":\"1\"}],\"aggregationTemporality\":2,\"isMonotonic\":true}}]}]}]}"
-        curl --fail-with-body --silent --show-error \
-          -X POST "https://signoz.oriso-dev.site/v1/metrics" \
-          -H "Content-Type: application/json" \
-          -d "${payload}" \
-          || echo "::warning::Failed to POST aggregate CI health metric to SigNoz"
         if [[ "${conclusion}" != success ]]; then
           echo "::error::Required CI failed: validate=${VALIDATE_RESULT}, redis=${REDIS_RESULT}, mariadb=${MARIADB_RESULT}, integration=${INTEGRATION_RESULT}"
           exit 1


### PR DESCRIPTION
## What

Removes the `ci_run_result` OTLP POST from the aggregate `required-ci` job. The gate logic itself is unchanged.

## Why

**It has never worked.** The same block merged in #735 is also present in AgencyService, ConsultingTypeService and TenantService; a run today produced:

```
curl: (7) Failed to connect to signoz.oriso-dev.site port 443
##[warning]Failed to POST aggregate CI health metric to SigNoz
```

Two independent breaks:

| | Finding |
|---|---|
| DNS | Public DNS resolves `signoz.oriso-dev.site` to **91.99.183.160**. The ingress is on **46.224.170.69**. GitHub-hosted runners never reach it. |
| TLS | Against the real host the handshake fails with `ssl_verify_result=20` — the certificate is not publicly trusted. |

The trailing `|| echo "::warning::…"` swallowed both, so the workflow reported success while emitting nothing. Nobody noticed, because the failure was designed to be invisible.

The endpoint path itself was correct — `signoz-webvitals-ingress` does route `/v1/metrics` to `oriso-platform-otel-collector:4318`. The problem is reachability from GitHub, not routing.

**The payload was unusable anyway.** A cumulative `Sum` with `isMonotonic: true` emitting a constant `1` per run never increases, so no aggregation over it means anything. The endpoint was unauthenticated, and no SigNoz ingest secret exists in the org or in any repository.

## Why removed rather than fixed

The metric answers no question anyone asks. It cannot say which test broke, when, why, or how long anything took. Hardening the transport would deliver a counter nobody would look at.

Useful CI and test observability is tracked separately — see the analysis in OpenResilienceInitiative/ORISO-Helm#148. Two prerequisites were found while verifying this, both on the application side:

- Trace sampling is configured nowhere, so Spring Boot's default of **0.1** applies: 90% of traces are discarded.
- An incoming W3C `traceparent` is not adopted. 35 probe requests carrying a sampled parent produced zero spans under the supplied trace ID. ClickHouse ingestion lag was measured at 7 seconds, so this is not a timing artefact.

## Risk

None to the gate. The conclusion logic, its `needs`, and its exit code are untouched.
