### PR TITLE
fix(deletion): prevent external side-effect replay

### DIFF
--- a/documentation/USER_SERVICE_REPLICA_SAFETY.md
+++ b/documentation/USER_SERVICE_REPLICA_SAFETY.md
@@ -220,6 +220,14 @@ losing replica performs no database deletion, provider cleanup or error-mail
 work. All four existing domain integration cases remain green with isolated
 claim state. Its 30-minute bound has the same hourly duration constraint.
 
+The claim prevents concurrent duplicate execution, while transaction ordering
+prevents sequential replay. `AnonymousUserDeletionBatch` owns the database
+transaction and returns before `DeleteUserAnonymousService` sends workflow
+error mail. `DeleteUserAnonymousSchedulerIT` forces a Matrix deletion error and
+a subsequent notification failure, then proves the user and session deletion
+already committed. Keycloak deletion also treats `NotFound` after its one
+unauthorized-session refresh as the idempotent already-deleted outcome.
+
 The daily account-deletion scheduler acquires a separate durable claim before
 technical tenant context and before any database or external-provider cleanup.
 `DeleteUserAccountSchedulerReplicaIT` releases two scheduler instances

--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,8 +30,8 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,843 | 0 | 0 | 7 | `./mvnw -B -Dskip.integration-tests=true clean test` |
-| Integration + contract + E2E | 964 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
+| Unit | 3,849 | 0 | 0 | 7 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Integration + contract + E2E | 965 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
 
@@ -40,7 +40,7 @@ replica tests. Those focused tests pass, including the scheduler proof on fresh
 MariaDB 10.11 and the browser-login proof on Redis 7. Earlier overlapping broad
 attempts remain excluded from evidence; the totals above come only from the
 later serial Maven completions. The latest clean integration completion
-independently reports 964/0/0/5.
+independently reports 965/0/0/5.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
@@ -152,11 +152,55 @@ their runtime registration, tags and finite buckets; the exact image still has
 to be deployed and queried through SigNoz before the observability gate is
 closed.
 
+### Live PreDev measurement after the observability subset
+
+A second read-only SigNoz audit on 2026-07-26 found the bounded custom metrics
+in the running pod. The pod still predates the final PR head, so this proves
+that an observability subset is live, not that the full candidate was deployed.
+The metric attributes were limited to dependency, method, outcome, direction
+and histogram bucket. No path, query, user, room or message identifier appeared
+in custom metric attributes.
+
+Across the pod lifetime from 10:30 UTC, the custom call counter recorded 937
+successful Matrix GETs, 737 successful Matrix POSTs, 350 successful Matrix
+DELETEs and nine successful Matrix PUTs. It also recorded bounded
+AgencyService, ConsultingTypeService, Keycloak and TenantService outcomes.
+`Content-Length` supplied 19,543 Matrix request bytes and 7,844 Keycloak
+response bytes. Chunked Matrix responses and upstream responses without
+`Content-Length` remain deliberately uncounted rather than estimated. No
+`userservice.outbound.retries` series existed, which means no instrumented
+retry had emitted an event during that process lifetime.
+
+The last-24-hour traces exposed one high-fan-out workflow. A 13:00 UTC
+`deleteUserAnonymousScheduler.performDeletionWorkflow` execution made:
+
+| Matrix/Tenant operation | Calls | Errors | p95 |
+| --- | ---: | ---: | ---: |
+| Matrix admin login | 1 | 0 | 270.18 ms |
+| Matrix user deactivation | 141 | 0 | 42.83 ms |
+| Matrix room purge | 70 | 0 | 14.18 ms |
+| Tenant lookup | 1 | 1 | 15.12 ms |
+
+The same 141 Matrix user deactivations appeared in every measured scheduler
+execution; room purges alternated between 70 and 130. The single admin login per
+execution proves the 50-minute token cache works and is not the fan-out cause.
+PreDev logs instead show a Keycloak `NotFound` after an unauthorized-session
+refresh, followed by a workflow-error mail lookup for technical tenant `0`
+that returns 404. Notification was inside the deletion transaction, so the
+database work rolled back after the irreversible Matrix and Keycloak calls had
+already run.
+
 ## Chatty-call reductions
 
 - With the default `rocket-chat.enabled=false`, account and availability reads
   no longer call Rocket.Chat. Matrix-only deployments also do not create the
   Rocket.Chat MongoDB client or credential job.
+- Anonymous deletion now treats Keycloak `NotFound` as idempotent even after
+  its one unauthorized-session refresh. The database deletion batch commits
+  before workflow-error notification begins, so tenant or mail failures cannot
+  replay already completed Matrix and Keycloak side effects. A Spring/H2
+  integration test forces both the Matrix workflow error and notification
+  failure and proves that the user and session remain deleted.
 - Anonymous live-chat queue visibility is topic-only and therefore avoids an
   AgencyService lookup merely to resolve consulting-type visibility.
 - Appointment deletion uses one conditional database `DELETE` and its affected

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -813,16 +813,22 @@ public class KeycloakService implements IdentityClient {
    */
   public void deleteUser(String userId) {
     try {
-      keycloakClient.getUsersResource().get(userId).remove();
-    } catch (NotFoundException e) {
-      log.warn("User {} not found in Keycloak, skipping deletion.", userId);
+      removeUserIfPresent(userId);
     } catch (NotAuthorizedException e) {
       log.warn(
           "Keycloak admin session was unauthorized for deleting user {}, forcing token refresh"
               + " and retrying once",
           userId);
       keycloakClient.refreshAdminSession();
+      removeUserIfPresent(userId);
+    }
+  }
+
+  private void removeUserIfPresent(String userId) {
+    try {
       keycloakClient.getUsersResource().get(userId).remove();
+    } catch (NotFoundException e) {
+      log.warn("User {} not found in Keycloak, skipping deletion.", userId);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/AnonymousUserDeletionBatch.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/AnonymousUserDeletionBatch.java
@@ -1,0 +1,76 @@
+package de.caritas.cob.userservice.api.workflow.delete.service;
+
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Performs one anonymous-user deletion batch within a database transaction. */
+@Service
+@RequiredArgsConstructor
+public class AnonymousUserDeletionBatch {
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull DeleteUserAccountService deleteUserAccountService;
+
+  @Value("${user.anonymous.deleteworkflow.periodMinutes}")
+  private int deletionPeriodMinutes;
+
+  /**
+   * Deletes anonymous users whose sessions are done and overdue.
+   *
+   * <p>The transaction ends when this method returns. Notification must happen in the caller so a
+   * mail or tenant lookup failure cannot roll back database deletions after external side effects
+   * have already completed.
+   */
+  @Transactional
+  public List<DeletionWorkflowError> deleteOverdueUsers() {
+    List<Session> doneSessions = sessionRepository.findByStatus(SessionStatus.DONE);
+    LocalDateTime deletionTime = LocalDateTime.now().minusMinutes(deletionPeriodMinutes);
+
+    Set<User> usersWithoutOpenSessions =
+        doneSessions.stream()
+            .filter(sessionUsersHavingAllSessionsDoneAndOverdue(deletionTime))
+            .map(Session::getUser)
+            .collect(Collectors.toSet());
+
+    return usersWithoutOpenSessions.stream()
+        .map(deleteUserAccountService::performUserDeletion)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  private Predicate<Session> sessionUsersHavingAllSessionsDoneAndOverdue(
+      LocalDateTime deletionTime) {
+    return session -> {
+      Set<Session> userSessions = session.getUser().getSessions();
+      return CollectionUtils.isEmpty(userSessions)
+          || (allSessionsAreDone(userSessions)
+              && allSessionsAreBeforeDeletionTime(deletionTime, userSessions));
+    };
+  }
+
+  private boolean allSessionsAreDone(Set<Session> sessions) {
+    return sessions.stream().map(Session::getStatus).allMatch(SessionStatus.DONE::equals);
+  }
+
+  private boolean allSessionsAreBeforeDeletionTime(
+      LocalDateTime deletionTime, Set<Session> sessions) {
+    return sessions.stream()
+        .map(Session::getUpdateDate)
+        .allMatch(updateDate -> updateDate.isBefore(deletionTime));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousService.java
@@ -2,22 +2,10 @@ package de.caritas.cob.userservice.api.workflow.delete.service;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
-import de.caritas.cob.userservice.api.model.Session;
-import de.caritas.cob.userservice.api.model.Session.SessionStatus;
-import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
-import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /** Service to trigger deletion of anonymous users. */
@@ -25,57 +13,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DeleteUserAnonymousService {
 
-  private final @NonNull SessionRepository sessionRepository;
-  private final @NonNull DeleteUserAccountService deleteUserAccountService;
+  private final @NonNull AnonymousUserDeletionBatch deletionBatch;
   private final @NonNull WorkflowErrorMailService workflowErrorMailService;
 
-  @Value("${user.anonymous.deleteworkflow.periodMinutes}")
-  private int deletionPeriodMinutes;
-
   /** Deletes all anonymous users with special constraints. */
-  @Transactional
   public void deleteInactiveAnonymousUsers() {
-    List<DeletionWorkflowError> workflowErrors = deleteAnonymousUsersWithOverdueSessions();
+    List<DeletionWorkflowError> workflowErrors = deletionBatch.deleteOverdueUsers();
 
     if (isNotEmpty(workflowErrors)) {
       this.workflowErrorMailService.buildAndSendErrorMail(workflowErrors);
     }
-  }
-
-  private List<DeletionWorkflowError> deleteAnonymousUsersWithOverdueSessions() {
-    List<Session> doneSessions = this.sessionRepository.findByStatus(SessionStatus.DONE);
-    LocalDateTime deletionTime = LocalDateTime.now().minusMinutes(deletionPeriodMinutes);
-
-    Set<User> usersWithoutOpenSessions =
-        doneSessions.stream()
-            .filter(sessionUsersHavingAllSessionsDoneAndOverdue(deletionTime))
-            .map(Session::getUser)
-            .collect(Collectors.toSet());
-
-    return usersWithoutOpenSessions.stream()
-        .map(deleteUserAccountService::performUserDeletion)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
-
-  private Predicate<Session> sessionUsersHavingAllSessionsDoneAndOverdue(
-      LocalDateTime deletionTime) {
-    return session -> {
-      Set<Session> userSessions = session.getUser().getSessions();
-      return CollectionUtils.isEmpty(userSessions)
-          || (allSessionsAreDone(userSessions)
-              && allSessionsAreBeforeDeletionTime(deletionTime, userSessions));
-    };
-  }
-
-  private boolean allSessionsAreDone(Set<Session> sessions) {
-    return sessions.stream().map(Session::getStatus).allMatch(SessionStatus.DONE::equals);
-  }
-
-  private boolean allSessionsAreBeforeDeletionTime(
-      LocalDateTime deletionTime, Set<Session> sessions) {
-    return sessions.stream()
-        .map(Session::getUpdateDate)
-        .allMatch(updateDate -> updateDate.isBefore(deletionTime));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1635,6 +1635,25 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void deleteUser_Should_TreatNotFoundAfterUnauthorizedRetryAsAlreadyDeleted() {
+    UsersResource usersResource = mock(UsersResource.class);
+    UserResource userResource = mock(UserResource.class);
+    org.mockito.Mockito.doThrow(new jakarta.ws.rs.NotAuthorizedException("unauthorized"))
+        .doThrow(new jakarta.ws.rs.NotFoundException("already deleted"))
+        .when(userResource)
+        .remove();
+    when(usersResource.get(any())).thenReturn(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    keycloakService.deleteUser(USER_ID);
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(userResource, times(2)).remove();
+    assertThat(
+        logCaptor.contains(Level.WARN, "not found in Keycloak, skipping deletion"), is(true));
+  }
+
+  @Test
   public void ensureRole_Should_SkipUpdate_When_UserAlreadyHasRole() {
     UserResource userResource = givenUserResourceWithRealmRoles("consultant");
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAnonymousSchedulerIT.java
@@ -2,8 +2,11 @@ package de.caritas.cob.userservice.api.workflow.delete.scheduler;
 
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTING_TYPE_ID_AIDS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
@@ -23,6 +26,7 @@ import de.caritas.cob.userservice.api.testConfig.ConsultingTypeManagerTestConfig
 import de.caritas.cob.userservice.api.testConfig.KeycloakTestConfig;
 import de.caritas.cob.userservice.api.testConfig.RocketChatTestConfig;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
+import de.caritas.cob.userservice.api.workflow.delete.service.WorkflowErrorMailService;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +75,8 @@ class DeleteUserAnonymousSchedulerIT {
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
   @MockitoBean MatrixSynapseService matrixSynapseService;
+
+  @MockitoBean WorkflowErrorMailService workflowErrorMailService;
 
   private Session currentSession;
 
@@ -139,6 +145,21 @@ class DeleteUserAnonymousSchedulerIT {
     prepareCurrentSessionForDeletion();
 
     deleteUserAnonymousScheduler.performDeletionWorkflow();
+
+    assertSessionAndUserDoNotExistInDatabase(
+        currentSession.getId(), currentSession.getUser().getUserId());
+  }
+
+  @Test
+  void performDeletionWorkflow_Should_commitDeletionBeforeErrorNotificationFails() {
+    prepareCurrentSessionForDeletion();
+    when(matrixSynapseService.deactivateUser(anyString())).thenReturn(false);
+    doThrow(new IllegalStateException("tenant unavailable"))
+        .when(workflowErrorMailService)
+        .buildAndSendErrorMail(anyList());
+
+    assertThrows(
+        IllegalStateException.class, deleteUserAnonymousScheduler::performDeletionWorkflow);
 
     assertSessionAndUserDoNotExistInDatabase(
         currentSession.getId(), currentSession.getUser().getUserId());

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/AnonymousUserDeletionBatchTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/AnonymousUserDeletionBatchTest.java
@@ -1,0 +1,186 @@
+package de.caritas.cob.userservice.api.workflow.delete.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AnonymousUserDeletionBatchTest {
+
+  private static final int DELETION_PERIOD_MINUTES = 1200;
+
+  @InjectMocks private AnonymousUserDeletionBatch deletionBatch;
+
+  @Mock private SessionRepository sessionRepository;
+
+  @Mock private DeleteUserAccountService deleteUserAccountService;
+
+  @BeforeEach
+  public void setUp() {
+    ReflectionTestUtils.setField(deletionBatch, "deletionPeriodMinutes", DELETION_PERIOD_MINUTES);
+  }
+
+  @Test
+  void deleteOverdueUsers_Should_runInsideTheDeletionTransaction() throws Exception {
+    var entrypoint = AnonymousUserDeletionBatch.class.getMethod("deleteOverdueUsers");
+
+    assertThat(entrypoint.getAnnotation(Transactional.class)).isNotNull();
+  }
+
+  @Test
+  void deleteOverdueUsers_Should_notPerformAnyDeletion_When_noSessionIsAvailable() {
+    this.deletionBatch.deleteOverdueUsers();
+
+    verifyNoMoreInteractions(this.deleteUserAccountService);
+  }
+
+  @Test
+  void deleteOverdueUsers_Should_notPerformAnyDeletion_When_noSessionIsDone() {
+    whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
+        getAnyStatusWhichIsNotDone());
+
+    this.deletionBatch.deleteOverdueUsers();
+
+    verifyNoMoreInteractions(this.deleteUserAccountService);
+  }
+
+  private SessionStatus[] getAnyStatusWhichIsNotDone() {
+    List<SessionStatus> anyStatusNotDone = new ArrayList<>(List.of(SessionStatus.values()));
+    anyStatusNotDone.remove(SessionStatus.DONE);
+    return anyStatusNotDone.toArray(SessionStatus[]::new);
+  }
+
+  private void whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
+      SessionStatus... sessionStatus) {
+    User user = new User();
+    Set<Session> userSessions =
+        Stream.of(sessionStatus)
+            .map(createSessionForUserWithUpdateDateNow(user))
+            .collect(Collectors.toSet());
+    user.setSessions(userSessions);
+
+    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
+  }
+
+  private Function<SessionStatus, Session> createSessionForUserWithUpdateDateNow(User user) {
+    return createSessionForUserWithUpdateDate(user, LocalDateTime.now());
+  }
+
+  private Function<SessionStatus, Session> createSessionForUserWithUpdateDate(
+      User user, LocalDateTime sessionUpdateDate) {
+    return (sessionStatus) -> createSessionForUser(user, sessionUpdateDate, sessionStatus);
+  }
+
+  private Session createSessionForUser(
+      User user, LocalDateTime updateDate, SessionStatus sessionStatus) {
+    Session session = new Session();
+    session.setId((long) sessionStatus.getValue());
+    session.setUpdateDate(updateDate);
+    session.setStatus(sessionStatus);
+    session.setUser(user);
+    return session;
+  }
+
+  @Test
+  void deleteOverdueUsers_Should_notPerformAnyDeletion_When_notAllSessionsAreDone() {
+    whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
+        SessionStatus.IN_PROGRESS, SessionStatus.DONE);
+
+    this.deletionBatch.deleteOverdueUsers();
+
+    verifyNoMoreInteractions(this.deleteUserAccountService);
+  }
+
+  @ParameterizedTest
+  @MethodSource("createUpdateDatesWithinDeletionPeriod")
+  void deleteOverdueUsers_Should_notPerformAnyDeletion_When_sessionsAreDoneWithinDeletionPeriod(
+      LocalDateTime updateDate) {
+    User user = new User();
+    Set<Session> userSessions = Set.of(createSessionForUser(user, updateDate, SessionStatus.DONE));
+    user.setSessions(userSessions);
+
+    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
+
+    this.deletionBatch.deleteOverdueUsers();
+
+    verifyNoMoreInteractions(this.deleteUserAccountService);
+  }
+
+  private static List<LocalDateTime> createUpdateDatesWithinDeletionPeriod() {
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime oneSecondWithinDeletionPeriod =
+        now.minusMinutes(DELETION_PERIOD_MINUTES).plusSeconds(1);
+    LocalDateTime timeInTheFuture = now.plusSeconds(20);
+
+    return List.of(now, oneSecondWithinDeletionPeriod, timeInTheFuture);
+  }
+
+  @ParameterizedTest
+  @MethodSource("createOverdueUpdateDates")
+  void deleteOverdueUsers_Should_performAskerDeletion_When_userSessionsAreDoneAndOverdue(
+      LocalDateTime overdueUpdateDate) {
+    User user = new User();
+    Set<Session> userSessions =
+        Set.of(createSessionForUser(user, overdueUpdateDate, SessionStatus.DONE));
+    user.setSessions(userSessions);
+
+    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
+
+    this.deletionBatch.deleteOverdueUsers();
+
+    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
+  }
+
+  private static List<LocalDateTime> createOverdueUpdateDates() {
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime oneDeletionPeriodAgo = now.minusMinutes(DELETION_PERIOD_MINUTES).minusSeconds(1);
+    LocalDateTime timeLongInThePast = oneDeletionPeriodAgo.minusMinutes(10);
+
+    return List.of(oneDeletionPeriodAgo, timeLongInThePast);
+  }
+
+  @Test
+  void deleteOverdueUsers_Should_returnWorkflowErrors_When_someActionsFail() {
+    User user = new User();
+    Set<Session> userSessions =
+        Set.of(createSessionForUser(user, createOverdueUpdateDates().get(0), SessionStatus.DONE));
+    user.setSessions(userSessions);
+
+    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
+
+    DeletionWorkflowError error = mock(DeletionWorkflowError.class);
+    when(this.deleteUserAccountService.performUserDeletion(any())).thenReturn(List.of(error));
+
+    var result = this.deletionBatch.deleteOverdueUsers();
+
+    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
+    assertThat(result).containsExactly(error);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAnonymousServiceTest.java
@@ -1,187 +1,70 @@
 package de.caritas.cob.userservice.api.workflow.delete.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.model.Session;
-import de.caritas.cob.userservice.api.model.Session.SessionStatus;
-import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteUserAnonymousServiceTest {
 
-  private static final int DELETION_PERIOD_MINUTES = 1200;
+  @InjectMocks private DeleteUserAnonymousService deletionService;
 
-  @InjectMocks private DeleteUserAnonymousService deleteUserAnonymousService;
-
-  @Mock private SessionRepository sessionRepository;
-
-  @Mock private DeleteUserAccountService deleteUserAccountService;
-
+  @Mock private AnonymousUserDeletionBatch deletionBatch;
   @Mock private WorkflowErrorMailService workflowErrorMailService;
 
-  @BeforeEach
-  public void setUp() {
-    ReflectionTestUtils.setField(
-        deleteUserAnonymousService, "deletionPeriodMinutes", DELETION_PERIOD_MINUTES);
+  @Test
+  void deleteInactiveAnonymousUsers_Should_notifyOutsideTheDeletionTransaction() throws Exception {
+    var entrypoint = DeleteUserAnonymousService.class.getMethod("deleteInactiveAnonymousUsers");
+
+    assertThat(entrypoint.getAnnotation(Transactional.class)).isNull();
   }
 
   @Test
-  void deleteInactiveAnonymousUsers_Should_notPerformAnyDeletion_When_noSessionIsAvailable() {
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
+  void deleteInactiveAnonymousUsers_Should_notNotify_When_batchHasNoErrors() {
+    when(deletionBatch.deleteOverdueUsers()).thenReturn(List.of());
 
-    verifyNoMoreInteractions(this.workflowErrorMailService);
-    verifyNoMoreInteractions(this.deleteUserAccountService);
+    deletionService.deleteInactiveAnonymousUsers();
+
+    verify(workflowErrorMailService, never())
+        .buildAndSendErrorMail(org.mockito.ArgumentMatchers.any());
   }
 
   @Test
-  void deleteInactiveAnonymousUsers_Should_notPerformAnyDeletion_When_noSessionIsDone() {
-    whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
-        getAnyStatusWhichIsNotDone());
+  void deleteInactiveAnonymousUsers_Should_notifyAfterTransactionalBatchReturns() {
+    var error = org.mockito.Mockito.mock(DeletionWorkflowError.class);
+    when(deletionBatch.deleteOverdueUsers()).thenReturn(List.of(error));
 
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
+    deletionService.deleteInactiveAnonymousUsers();
 
-    verifyNoMoreInteractions(this.workflowErrorMailService);
-    verifyNoMoreInteractions(this.deleteUserAccountService);
-  }
-
-  private SessionStatus[] getAnyStatusWhichIsNotDone() {
-    List<SessionStatus> anyStatusNotDone = new ArrayList<>(List.of(SessionStatus.values()));
-    anyStatusNotDone.remove(SessionStatus.DONE);
-    return anyStatusNotDone.toArray(SessionStatus[]::new);
-  }
-
-  private void whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
-      SessionStatus... sessionStatus) {
-    User user = new User();
-    Set<Session> userSessions =
-        Stream.of(sessionStatus)
-            .map(createSessionForUserWithUpdateDateNow(user))
-            .collect(Collectors.toSet());
-    user.setSessions(userSessions);
-
-    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
-  }
-
-  private Function<SessionStatus, Session> createSessionForUserWithUpdateDateNow(User user) {
-    return createSessionForUserWithUpdateDate(user, LocalDateTime.now());
-  }
-
-  private Function<SessionStatus, Session> createSessionForUserWithUpdateDate(
-      User user, LocalDateTime sessionUpdateDate) {
-    return (sessionStatus) -> createSessionForUser(user, sessionUpdateDate, sessionStatus);
-  }
-
-  private Session createSessionForUser(
-      User user, LocalDateTime updateDate, SessionStatus sessionStatus) {
-    Session session = new Session();
-    session.setId((long) sessionStatus.getValue());
-    session.setUpdateDate(updateDate);
-    session.setStatus(sessionStatus);
-    session.setUser(user);
-    return session;
+    var order = inOrder(deletionBatch, workflowErrorMailService);
+    order.verify(deletionBatch).deleteOverdueUsers();
+    order.verify(workflowErrorMailService).buildAndSendErrorMail(List.of(error));
   }
 
   @Test
-  void deleteInactiveAnonymousUsers_Should_notPerformAnyDeletion_When_notAllSessionsAreDone() {
-    whenSessionRepositoryFindByStatus_ThenReturnUserSessionsWithStatus(
-        SessionStatus.IN_PROGRESS, SessionStatus.DONE);
+  void deleteInactiveAnonymousUsers_Should_notReplayBatch_When_notificationFails() {
+    var error = org.mockito.Mockito.mock(DeletionWorkflowError.class);
+    when(deletionBatch.deleteOverdueUsers()).thenReturn(List.of(error));
+    org.mockito.Mockito.doThrow(new IllegalStateException("tenant unavailable"))
+        .when(workflowErrorMailService)
+        .buildAndSendErrorMail(List.of(error));
 
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
+    assertThatThrownBy(deletionService::deleteInactiveAnonymousUsers)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("tenant unavailable");
 
-    verifyNoMoreInteractions(this.workflowErrorMailService);
-    verifyNoMoreInteractions(this.deleteUserAccountService);
-  }
-
-  @ParameterizedTest
-  @MethodSource("createUpdateDatesWithinDeletionPeriod")
-  void
-      deleteInactiveAnonymousUsers_Should_notPerformAnyDeletion_When_sessionsAreDoneWithinDeletionPeriod(
-          LocalDateTime updateDate) {
-    User user = new User();
-    Set<Session> userSessions = Set.of(createSessionForUser(user, updateDate, SessionStatus.DONE));
-    user.setSessions(userSessions);
-
-    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
-
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
-
-    verifyNoMoreInteractions(this.workflowErrorMailService);
-    verifyNoMoreInteractions(this.deleteUserAccountService);
-  }
-
-  private static List<LocalDateTime> createUpdateDatesWithinDeletionPeriod() {
-    LocalDateTime now = LocalDateTime.now();
-    LocalDateTime oneSecondWithinDeletionPeriod =
-        now.minusMinutes(DELETION_PERIOD_MINUTES).plusSeconds(1);
-    LocalDateTime timeInTheFuture = now.plusSeconds(20);
-
-    return List.of(now, oneSecondWithinDeletionPeriod, timeInTheFuture);
-  }
-
-  @ParameterizedTest
-  @MethodSource("createOverdueUpdateDates")
-  void deleteInactiveAnonymousUsers_Should_performAskerDeletion_When_userSessionsAreDoneAndOverdue(
-      LocalDateTime overdueUpdateDate) {
-    User user = new User();
-    Set<Session> userSessions =
-        Set.of(createSessionForUser(user, overdueUpdateDate, SessionStatus.DONE));
-    user.setSessions(userSessions);
-
-    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
-
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
-
-    verifyNoMoreInteractions(this.workflowErrorMailService);
-    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
-  }
-
-  private static List<LocalDateTime> createOverdueUpdateDates() {
-    LocalDateTime now = LocalDateTime.now();
-    LocalDateTime oneDeletionPeriodAgo = now.minusMinutes(DELETION_PERIOD_MINUTES).minusSeconds(1);
-    LocalDateTime timeLongInThePast = oneDeletionPeriodAgo.minusMinutes(10);
-
-    return List.of(oneDeletionPeriodAgo, timeLongInThePast);
-  }
-
-  @Test
-  void deleteInactiveAnonymousUsers_Should_sendErrorMails_When_someActionsFail() {
-    User user = new User();
-    Set<Session> userSessions =
-        Set.of(createSessionForUser(user, createOverdueUpdateDates().get(0), SessionStatus.DONE));
-    user.setSessions(userSessions);
-
-    when(this.sessionRepository.findByStatus(any())).thenReturn(new ArrayList<>(userSessions));
-
-    DeletionWorkflowError error = mock(DeletionWorkflowError.class);
-    when(this.deleteUserAccountService.performUserDeletion(any())).thenReturn(List.of(error));
-
-    this.deleteUserAnonymousService.deleteInactiveAnonymousUsers();
-
-    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
-    verify(this.workflowErrorMailService, times(1)).buildAndSendErrorMail(List.of(error));
-    verify(this.deleteUserAccountService, times(1)).performUserDeletion(user);
+    verify(deletionBatch).deleteOverdueUsers();
   }
 }


### PR DESCRIPTION
## Summary

- commit the anonymous-user deletion batch before workflow-error notification starts
- treat Keycloak `NotFound` after the single unauthorized-session refresh as an idempotent already-deleted outcome
- add unit and Spring/H2 regression coverage for notification failure after external cleanup
- document the live SigNoz evidence and the transaction-ordering guarantee

## Runtime evidence

Read-only PreDev traces showed the same 141 Matrix user deactivations in every measured anonymous-deletion run. The failure chain was:

1. Keycloak returned unauthorized and then `NotFound` after the one allowed refresh.
2. Matrix cleanup and database deletion continued.
3. Workflow-error notification failed during a technical-tenant lookup.
4. Because notification still ran inside the deletion transaction, database state rolled back after the external side effects and the same users were selected again.

## Relationship to #746

PR #746 is the smaller immediate repair for the exact observed RuntimeException and technical/global tenant-template lookup. This draft is the structural follow-up:

- #746 catches the observed notification RuntimeException and removes the invalid tenant lookup.
- #759 ends the deletion transaction before notification begins, so later notification failures cannot roll back deletion even if their failure shape changes.
- #759 retains notification failure visibility instead of treating the scheduler execution as fully successful.
- #759 additionally makes Keycloak `Unauthorized → NotFound` an idempotent already-deleted outcome.

These PRs must not be merged in parallel. Merge/review #746 first, then #757, then rebase and retarget this draft to the resulting `pre-dev`.

## Regression proof

The Spring/H2 regression test forces a Matrix workflow error and a subsequent notification exception, then proves the user and session deletion remain committed.

## Architecture boundary

This repair supports the complete migration target: remove Rocket.Chat and Jitsi, use Matrix as the sole chat transport, retain the ORISO-owned frontend, and use an ORISO-controlled Element Call/MatrixRTC fork with LiveKit for calls. It does not claim that the coordinated migration package is already merged or deployed.

## Verification

- 3,849 unit tests: 0 failures, 0 errors, 7 skipped
- 965 integration/contract/E2E tests: 0 failures, 0 errors, 5 skipped
- 25 Python architecture/CI contracts passed
- Spotless check passed across 1,276 Java files
- `git diff --check` passed
- all branch, PR, Redis, MariaDB, API and aggregate PreDev GitHub gates passed

## Dependencies

- Depends on #746 for the immediate technical-context repair
- Depends on #757 for the current replica-safety and observability baseline
- Closes #758 after rebase, review and merge
- Current stacked base: `feat/replica-safety-metrics-543`
- Required delivery order: #746 → #757 → rebase/retarget #759 → human review → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
