### PR TITLE
feat(observability): trace Matrix sync cycles (#760)

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -152,6 +152,38 @@ their runtime registration, tags and finite buckets; the exact image still has
 to be deployed and queried through SigNoz before the observability gate is
 closed.
 
+### Matrix background-sync trace attribution
+
+A second read-only seven-day SigNoz audit on 2026-07-26 found 2,870
+`/_matrix/client/r0/sync` calls emitted as standalone one-span traces. Their
+approximately 30-second p50 and p95 match the configured long poll and are not
+a latency defect. Of the sampled calls, 2,744 returned HTTP 200. A burst of 123
+HTTP 404 responses was confined to the two minutes from 06:00 through 06:02 on
+2026-07-22; successful responses resumed afterwards. Three other sampled calls
+ended as transport-level client errors.
+
+The listener intentionally runs on a background executor, so it has no incoming
+web-request parent. It now opens one `userservice.matrix.sync` observation for
+each leader-owned cycle and keeps that scope active across the long poll, lease
+re-check, event processing and durable cursor commit. The only custom
+low-cardinality attribute is `result`, bounded to `success`, `soft_failure`,
+`leadership_lost` or `exception`. Matrix tokens, cursors, room/user identifiers
+and URL values are not added.
+
+Lease loss detected before processing is a normal ownership transition and
+continues without an error. A rejected cursor commit occurs after processing
+may already have produced durable side effects; it is tagged
+`leadership_lost` but remains an error and preserves the existing outer-loop
+backoff to avoid a hot duplicate replay.
+
+The audited PreDev pod predates this observation. After the branch image is
+deployed, the required readback is:
+
+- sampled Matrix `/sync` client spans have a `userservice.matrix.sync` parent;
+- downstream work from the processed batch remains in the same trace;
+- expected successful 30-second polls are not marked as errors;
+- exported custom attributes contain only the bounded `result` key.
+
 ## Chatty-call reductions
 
 - With the default `rocket-chat.enabled=false`, account and availability reads

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -11,6 +11,8 @@ import de.caritas.cob.userservice.api.service.notification.EventNotificationServ
 import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.statistics.ConsultantMessageStatService;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.util.*;
@@ -43,6 +45,7 @@ public class MatrixEventListenerService {
   private final @NonNull MatrixSyncCoordinationRegistry matrixSyncCoordinationRegistry;
 
   private OutboundHttpMetrics outboundHttpMetrics;
+  private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
   // Batch scratch refreshed from the canonical session repository before processing each room.
   private final Map<String, Long> roomToSessionMap = new ConcurrentHashMap<>();
@@ -71,6 +74,11 @@ public class MatrixEventListenerService {
   @Autowired(required = false)
   void setOutboundHttpMetrics(OutboundHttpMetrics outboundHttpMetrics) {
     this.outboundHttpMetrics = outboundHttpMetrics;
+  }
+
+  @Autowired(required = false)
+  void setObservationRegistry(ObservationRegistry observationRegistry) {
+    this.observationRegistry = observationRegistry;
   }
 
   // Backoff bounds (milliseconds) for both the token bootstrap and the sync error path.
@@ -150,16 +158,13 @@ public class MatrixEventListenerService {
           continue;
         }
 
-        // Perform Matrix sync (long-polling with 30-second timeout)
-        Map<String, Object> syncResult = performMatrixSync();
+        MatrixSyncCycleResult cycleResult = executeObservedMatrixSyncCycle();
 
-        if (syncResult != null) {
-          // Re-check ownership after the long poll. A stale owner must never process or commit.
-          if (!matrixSyncCoordinationRegistry.renewLease()) {
-            stepDownAfterLostLease();
-            continue;
-          }
-          processAndCommitSyncResult(syncResult);
+        if (cycleResult == MatrixSyncCycleResult.LEADERSHIP_LOST) {
+          continue;
+        }
+
+        if (cycleResult == MatrixSyncCycleResult.SUCCESS) {
           // Successful sync: reset the error backoff and failure counter.
           errorBackoffMs = INITIAL_BACKOFF_MS;
           consecutiveSyncFailures = 0;
@@ -208,6 +213,62 @@ public class MatrixEventListenerService {
 
     releaseLeadership();
     log.info("🔷 Matrix sync loop stopped");
+  }
+
+  /**
+   * Observes one leader-owned Matrix long poll, its event processing and cursor commit as one
+   * background operation. The result attribute is deliberately bounded; Matrix tokens, cursors,
+   * room identifiers and URL values must never become observation attributes.
+   */
+  private MatrixSyncCycleResult executeObservedMatrixSyncCycle() {
+    Observation observation =
+        Observation.createNotStarted("userservice.matrix.sync", observationRegistry).start();
+    String result = "exception";
+
+    try (Observation.Scope ignored = observation.openScope()) {
+      Map<String, Object> syncResult = performMatrixSync();
+      if (syncResult == null) {
+        result = "soft_failure";
+        return MatrixSyncCycleResult.SOFT_FAILURE;
+      }
+
+      // Re-check ownership after the long poll. A stale owner must never process or commit.
+      if (!matrixSyncCoordinationRegistry.renewLease()) {
+        stepDownAfterLostLease();
+        result = "leadership_lost";
+        return MatrixSyncCycleResult.LEADERSHIP_LOST;
+      }
+
+      processAndCommitSyncResult(syncResult);
+      result = "success";
+      return MatrixSyncCycleResult.SUCCESS;
+    } catch (MatrixSyncLeadershipLostException exception) {
+      result = "leadership_lost";
+      // Unlike the pre-processing lease check, a rejected commit happens after event processing
+      // may already have produced durable side effects. Preserve the existing outer-loop error
+      // backoff instead of immediately replaying the same shared cursor in a hot retry.
+      observation.error(exception);
+      throw exception;
+    } catch (RuntimeException | Error exception) {
+      observation.error(exception);
+      throw exception;
+    } finally {
+      observation.lowCardinalityKeyValue("result", result);
+      observation.stop();
+    }
+  }
+
+  private enum MatrixSyncCycleResult {
+    SUCCESS,
+    SOFT_FAILURE,
+    LEADERSHIP_LOST
+  }
+
+  private static final class MatrixSyncLeadershipLostException extends IllegalStateException {
+
+    private MatrixSyncLeadershipLostException(String message) {
+      super(message);
+    }
   }
 
   private boolean tryAcquireLeadership() {
@@ -356,7 +417,8 @@ public class MatrixEventListenerService {
     String nextCursor = (String) nextBatch;
     if (!matrixSyncCoordinationRegistry.commitCursor(nextCursor)) {
       stepDownAfterLostLease();
-      throw new IllegalStateException("Matrix sync cursor commit rejected after lease loss");
+      throw new MatrixSyncLeadershipLostException(
+          "Matrix sync cursor commit rejected after lease loss");
     }
     syncToken = nextCursor;
     log.debug("🔷 Matrix sync cursor committed");

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
@@ -35,6 +36,10 @@ import de.caritas.cob.userservice.api.service.notification.EventNotificationServ
 import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.statistics.ConsultantMessageStatService;
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -790,6 +796,154 @@ class MatrixEventListenerServiceTest {
                     && e.getFormattedMessage().contains("Matrix sync failed"));
   }
 
+  @Test
+  void executeObservedSyncCycle_shouldKeepObservationActiveThroughSyncAndCursorCommit() {
+    var registry = ObservationRegistry.create();
+    var handler = new CapturingObservationHandler();
+    registry.observationConfig().observationHandler(handler);
+    var service = newServiceWithSyncExecutor();
+    ReflectionTestUtils.setField(service, "observationRegistry", registry);
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    stubRoomContext(10L, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultantWithId(CONSULTANT_DOMAIN_ID)));
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    var syncObservation = new AtomicReference<Observation>();
+    var processingObservation = new AtomicReference<Observation>();
+    var commitObservation = new AtomicReference<Observation>();
+    when(matrixSynapseService.makeMatrixRequest(
+            eq("https://matrix.example/_matrix/client/r0/sync?timeout=30000"),
+            eq("GET"),
+            eq("admin-token"),
+            eq(null)))
+        .thenAnswer(
+            ignored -> {
+              syncObservation.set(registry.getCurrentObservation());
+              var syncResult =
+                  new HashMap<String, Object>(
+                      syncResultWithEvents(
+                          MATRIX_ROOM_ID,
+                          List.of(
+                              messageEvent(
+                                  CONSULTANT_MATRIX_ID, "m.text", "observed", "$event-observed"))));
+              syncResult.put("next_batch", "batch-observed");
+              return syncResult;
+            });
+    doAnswer(
+            ignored -> {
+              processingObservation.set(registry.getCurrentObservation());
+              return null;
+            })
+        .when(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            eq(MATRIX_ROOM_ID), eq(CONSULTANT_DOMAIN_ID), eq(true), any(PrivacyEnvelope.class));
+    when(matrixSyncCoordinationRegistry.renewLease()).thenReturn(true);
+    when(matrixSyncCoordinationRegistry.commitCursor("batch-observed"))
+        .thenAnswer(
+            ignored -> {
+              commitObservation.set(registry.getCurrentObservation());
+              return true;
+            });
+
+    Object result = ReflectionTestUtils.invokeMethod(service, "executeObservedMatrixSyncCycle");
+
+    assertThat(result).hasToString("SUCCESS");
+    verify(matrixSyncCoordinationRegistry).commitCursor("batch-observed");
+    assertThat(registry.getCurrentObservation()).isNull();
+    assertThat(syncObservation.get()).isNotNull();
+    assertThat(processingObservation.get()).isSameAs(syncObservation.get());
+    assertThat(commitObservation.get()).isSameAs(syncObservation.get());
+    assertThat(handler.stopCount).isEqualTo(1);
+    assertThat(handler.stoppedContext).isNotNull();
+    assertThat(handler.stoppedContext.getName()).isEqualTo("userservice.matrix.sync");
+    assertThat(lowCardinalityValue(handler.stoppedContext, "result")).isEqualTo("success");
+    assertThat(handler.stoppedContext.getError()).isNull();
+  }
+
+  @Test
+  void executeObservedSyncCycle_shouldRecordSoftFailureWithoutSensitiveAttributes() {
+    var registry = ObservationRegistry.create();
+    var handler = new CapturingObservationHandler();
+    registry.observationConfig().observationHandler(handler);
+    var service = newService();
+    ReflectionTestUtils.setField(service, "observationRegistry", registry);
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(
+            anyString(), eq("GET"), eq("admin-token"), eq(null)))
+        .thenReturn(null);
+
+    Object result = ReflectionTestUtils.invokeMethod(service, "executeObservedMatrixSyncCycle");
+
+    assertThat(result).hasToString("SOFT_FAILURE");
+    assertThat(registry.getCurrentObservation()).isNull();
+    assertThat(lowCardinalityValue(handler.stoppedContext, "result")).isEqualTo("soft_failure");
+    assertThat(handler.stoppedContext.getLowCardinalityKeyValues())
+        .extracting(KeyValue::getKey)
+        .containsExactly("result");
+    assertThat(handler.stoppedContext.getHighCardinalityKeyValues()).isEmpty();
+    assertThat(handler.stoppedContext.getError()).isNull();
+  }
+
+  @Test
+  void executeObservedSyncCycle_shouldRecordAndRethrowUnexpectedFailure() {
+    var registry = ObservationRegistry.create();
+    var handler = new CapturingObservationHandler();
+    registry.observationConfig().observationHandler(handler);
+    var service = newService();
+    ReflectionTestUtils.setField(service, "observationRegistry", registry);
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(
+            anyString(), eq("GET"), eq("admin-token"), eq(null)))
+        .thenReturn(Map.of("next_batch", "batch-failing"));
+    when(matrixSyncCoordinationRegistry.renewLease())
+        .thenThrow(new IllegalStateException("coordination unavailable"));
+
+    assertThatThrownBy(
+            () -> ReflectionTestUtils.invokeMethod(service, "executeObservedMatrixSyncCycle"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("coordination unavailable");
+
+    assertThat(registry.getCurrentObservation()).isNull();
+    assertThat(lowCardinalityValue(handler.stoppedContext, "result")).isEqualTo("exception");
+    assertThat(handler.stoppedContext.getError())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("coordination unavailable");
+  }
+
+  @Test
+  void executeObservedSyncCycle_shouldRecordLeadershipLostAndRethrowRejectedCommitForBackoff() {
+    var registry = ObservationRegistry.create();
+    var handler = new CapturingObservationHandler();
+    registry.observationConfig().observationHandler(handler);
+    var service = newService();
+    ReflectionTestUtils.setField(service, "observationRegistry", registry);
+    ReflectionTestUtils.setField(service, "adminAccessToken", "admin-token");
+    ReflectionTestUtils.setField(service, "hasLeadership", true);
+    when(matrixSynapseService.getMatrixApiUrl()).thenReturn("https://matrix.example");
+    when(matrixSynapseService.makeMatrixRequest(
+            anyString(), eq("GET"), eq("admin-token"), eq(null)))
+        .thenReturn(Map.of("next_batch", "batch-rejected"));
+    when(matrixSyncCoordinationRegistry.renewLease()).thenReturn(true);
+    when(matrixSyncCoordinationRegistry.commitCursor("batch-rejected")).thenReturn(false);
+
+    assertThatThrownBy(
+            () -> ReflectionTestUtils.invokeMethod(service, "executeObservedMatrixSyncCycle"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Matrix sync cursor commit rejected after lease loss");
+
+    verify(matrixSyncCoordinationRegistry).commitCursor("batch-rejected");
+    assertThat(ReflectionTestUtils.getField(service, "hasLeadership")).isEqualTo(false);
+    assertThat(registry.getCurrentObservation()).isNull();
+    assertThat(lowCardinalityValue(handler.stoppedContext, "result")).isEqualTo("leadership_lost");
+    assertThat(handler.stoppedContext.getError())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Matrix sync cursor commit rejected after lease loss");
+  }
+
   // ── processMatrixSyncEvents ────────────────────────────────────────────────
 
   @Test
@@ -1423,6 +1577,32 @@ class MatrixEventListenerServiceTest {
 
   private static String invokeClassifyContent(MatrixEventListenerService service, String msgtype) {
     return (String) ReflectionTestUtils.invokeMethod(service, "classifyContent", msgtype);
+  }
+
+  private static String lowCardinalityValue(Observation.Context context, String expectedKey) {
+    return context.getLowCardinalityKeyValues().stream()
+        .filter(keyValue -> keyValue.getKey().equals(expectedKey))
+        .map(KeyValue::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static final class CapturingObservationHandler
+      implements ObservationHandler<Observation.Context> {
+
+    private Observation.Context stoppedContext;
+    private int stopCount;
+
+    @Override
+    public void onStop(Observation.Context context) {
+      stoppedContext = context;
+      stopCount++;
+    }
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+      return true;
+    }
   }
 
   private static String invokeExtractThreadRootId(


### PR DESCRIPTION
## Summary

- wrap each leader-owned Matrix sync cycle in a `userservice.matrix.sync` observation
- keep the same observation active across the long poll, lease re-check, event processing and durable cursor commit
- expose only the bounded `result` values `success`, `soft_failure`, `leadership_lost` and `exception`
- document the live PreDev baseline and the required post-deploy SigNoz readback

## Why

A read-only seven-day PreDev SigNoz audit found 2,870 Matrix
`/_matrix/client/r0/sync` calls as standalone one-span traces. Their roughly
30-second p50 and p95 match the configured long poll and are expected. The
background listener had no parent observation, so the client spans could not be
attributed to one listener cycle or its downstream work.

The 123 observed HTTP 404 spans were confined to a two-minute burst on
2026-07-22; successful HTTP 200 responses resumed and dominate the current
runtime. This change addresses trace attribution, not Matrix request latency or
retry behavior.

## Privacy and cardinality

The observation adds exactly one custom low-cardinality key: `result`. It does
not attach access tokens, cursors, room IDs, user IDs or URL/query values. Tests
assert that no high-cardinality attributes are emitted.

## Verification

- Matrix listener tests: 85 passed
- complete Java 21 unit suite: 3,847 passed, 0 failed, 7 skipped
- complete Java 21 integration suite: 964 passed, 0 failed, 5 skipped
- dedicated MariaDB 10.11 suite: 9 passed
- CI contract tests: 25 passed
- local CodeRabbit review findings addressed

GitHub branch and PR builds, Docker validation, both complete integration jobs,
both Redis and MariaDB contracts, the API diff and Required PreDev CI are
terminal green. The GitHub CodeRabbit status is an explicit draft-PR skip.

## Dependency and rollout

- stacked on #757 because the observed cycle includes its replica-safe lease and cursor ownership
- requires a post-deploy SigNoz readback before the observability acceptance criteria can be closed
- no deployment is included in this PR

Depends on #757.
Refs #760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
