### PR TITLE
perf(admin): batch tenant enrichment in searches

### DIFF
--- a/api/useradminservice.yaml
+++ b/api/useradminservice.yaml
@@ -593,6 +593,7 @@ paths:
             type: integer
             default: 10
             minimum: 1
+            maximum: 100
         - name: field
           in: query
           description: field to sort by
@@ -928,6 +929,7 @@ paths:
               type: integer
               default: 10
               minimum: 1
+              maximum: 100
           - name: field
             in: query
             description: field to sort by

--- a/services/tenantservice.yaml
+++ b/services/tenantservice.yaml
@@ -89,6 +89,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/RestrictedTenantDTO'
         400:

--- a/services/tenantservice.yaml
+++ b/services/tenantservice.yaml
@@ -63,6 +63,38 @@ paths:
           description: BAD REQUEST - invalid/incomplete request or body object
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenant/public/ids:
+    summary: 'Represents publicly allowed tenant data for a bounded set of ids'
+    description: Existing tenants are returned; unknown ids are omitted and duplicate ids are normalized.
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Gets public tenant information in one bounded batch [Authorization: no-auth]'
+      operationId: getRestrictedTenantDataByTenantIds
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              minItems: 1
+              maxItems: 100
+              items:
+                type: integer
+                format: int64
+      responses:
+        200:
+          description: Existing requested tenants; unknown ids are omitted
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RestrictedTenantDTO'
+        400:
+          description: BAD REQUEST - request must contain 1 to 100 tenant ids
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
     RestrictedTenantDTO:

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -17,7 +17,6 @@ import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.model.AdminAgency.AdminAgencyBase;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
-import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
@@ -153,27 +150,17 @@ public class AgencyAdminUserService {
   }
 
   private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {
-    return fullAdmins.stream()
-        .filter(admin -> admin.getTenantId() != null)
-        .map(admin -> new AbstractMap.SimpleEntry<>(admin.getTenantId(), tenantName(admin)))
-        .filter(entry -> entry.getValue() != null)
+    Set<Long> tenantIds =
+        fullAdmins.stream()
+            .map(Admin::getTenantId)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toSet());
+    return tenantService.getRestrictedTenantData(tenantIds).stream()
+        .filter(tenant -> tenant.getId() != null && tenant.getName() != null)
         .collect(
             Collectors.toMap(
-                Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing));
-  }
-
-  private String tenantName(Admin admin) {
-    try {
-      return tenantService.getRestrictedTenantData(admin.getTenantId()).getName();
-    } catch (HttpClientErrorException exception) {
-      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
-        log.warn(
-            "Tenant data not found for agency admin {} and tenantId {}",
-            admin.getId(),
-            admin.getTenantId());
-        return null;
-      }
-      throw exception;
-    }
+                tenant -> tenant.getId(),
+                tenant -> tenant.getName(),
+                (existing, replacement) -> existing));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -17,7 +17,6 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,17 +24,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class TenantAdminUserService {
 
   private final @NonNull RetrieveAdminService retrieveAdminService;
@@ -126,28 +121,18 @@ public class TenantAdminUserService {
   }
 
   private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {
-    return fullAdmins.stream()
-        .filter(admin -> admin.getTenantId() != null)
-        .map(admin -> new AbstractMap.SimpleEntry<>(admin.getTenantId(), tenantName(admin)))
-        .filter(entry -> entry.getValue() != null)
+    Set<Long> tenantIds =
+        fullAdmins.stream()
+            .map(Admin::getTenantId)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toSet());
+    return tenantService.getRestrictedTenantData(tenantIds).stream()
+        .filter(tenant -> tenant.getId() != null && tenant.getName() != null)
         .collect(
             Collectors.toMap(
-                Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing));
-  }
-
-  private String tenantName(Admin admin) {
-    try {
-      return tenantService.getRestrictedTenantData(admin.getTenantId()).getName();
-    } catch (HttpClientErrorException exception) {
-      if (HttpStatus.NOT_FOUND.equals(exception.getStatusCode())) {
-        log.warn(
-            "Tenant data not found for tenant admin {} and tenantId {}",
-            admin.getId(),
-            admin.getTenantId());
-        return null;
-      }
-      throw exception;
-    }
+                tenant -> tenant.getId(),
+                tenant -> tenant.getName(),
+                (existing, replacement) -> existing));
   }
 
   public List<AdminResponseDTO> findTenantAdmins(Long tenantId) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
@@ -4,6 +4,8 @@ import de.caritas.cob.userservice.api.config.apiclient.TenantServiceApiControlle
 import de.caritas.cob.userservice.api.service.cache.SharedReadCache;
 import de.caritas.cob.userservice.api.service.cache.SharedReadCache.CacheName;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.List;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +71,30 @@ public class TenantService {
       sharedReadCache.put(CacheName.TENANT, tenantIdKey(tenantId), tenant);
     }
     return tenant;
+  }
+
+  public List<RestrictedTenantDTO> getRestrictedTenantData(Set<Long> tenantIds) {
+    if (tenantIds.isEmpty()) {
+      return List.of();
+    }
+    log.info("Calling tenant service to get tenant data for {} tenant ids", tenantIds.size());
+    var tenants =
+        tenantServiceApiControllerFactory
+            .createControllerApi()
+            .getRestrictedTenantDataByTenantIds(List.copyOf(tenantIds));
+    if (tenants == null) {
+      return List.of();
+    }
+    tenants.forEach(
+        tenant -> {
+          if (tenant.getId() != null) {
+            sharedReadCache.put(CacheName.TENANT, tenantIdKey(tenant.getId()), tenant);
+          }
+          if (tenant.getSubdomain() != null) {
+            sharedReadCache.put(CacheName.TENANT, subdomainKey(tenant.getSubdomain()), tenant);
+          }
+        });
+    return tenants;
   }
 
   private String subdomainKey(String subdomain) {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -664,6 +664,16 @@ class UserAdminControllerE2EIT {
 
   @Test
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void searchTenantAdmin_Should_acceptPageSizeAtTenantBatchLimit() throws Exception {
+    this.mockMvc
+        .perform(
+            get(
+                "/useradmin/tenantadmins/search?query=*&page=1&perPage=100&order=ASC&field=FIRSTNAME"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void searchTenantAdmin_Should_returnOk_When_sortingByUpdateDate() throws Exception {
 
     when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
@@ -739,6 +749,16 @@ class UserAdminControllerE2EIT {
             get(
                 "/useradmin/agencyadmins/search?query=*&page=1&perPage=101&order=ASC&field=FIRSTNAME"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void searchAgencyAdmins_Should_acceptPageSizeAtTenantBatchLimit() throws Exception {
+    this.mockMvc
+        .perform(
+            get(
+                "/useradmin/agencyadmins/search?query=*&page=1&perPage=100&order=ASC&field=FIRSTNAME"))
+        .andExpect(status().isOk());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -654,6 +654,16 @@ class UserAdminControllerE2EIT {
 
   @Test
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void searchTenantAdmin_Should_rejectPageSizesAboveTenantBatchLimit() throws Exception {
+    this.mockMvc
+        .perform(
+            get(
+                "/useradmin/tenantadmins/search?query=*&page=1&perPage=101&order=ASC&field=FIRSTNAME"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void searchTenantAdmin_Should_returnOk_When_sortingByUpdateDate() throws Exception {
 
     when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
@@ -719,6 +729,16 @@ class UserAdminControllerE2EIT {
     JSONArray embedded = JsonPath.read(contentAsString, "_embedded");
 
     assertAllElementsAreOfAdminType(embedded, AdminType.AGENCY);
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void searchAgencyAdmins_Should_rejectPageSizesAboveTenantBatchLimit() throws Exception {
+    this.mockMvc
+        .perform(
+            get(
+                "/useradmin/agencyadmins/search?query=*&page=1&perPage=101&order=ASC&field=FIRSTNAME"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -32,8 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
 class AgencyAdminUserServiceTest {
@@ -164,16 +162,19 @@ class AgencyAdminUserServiceTest {
   }
 
   @Test
-  void findAgencyAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {
+  void findAgencyAdminsByInfix_Should_NotUsePerTenantLookups() {
     // given
     PageRequest pageRequest = PageRequest.of(0, 10);
     Admin.AdminBase firstAdminBase = adminBase("agency-admin-1", 1L);
-    Admin.AdminBase secondAdminBase = adminBase("agency-admin-2", 2L);
+    Admin.AdminBase secondAdminBase = adminBase("agency-admin-2", 1L);
+    Admin.AdminBase thirdAdminBase = adminBase("agency-admin-3", 2L);
     Page<Admin.AdminBase> adminsPage =
-        new PageImpl<>(Arrays.asList(firstAdminBase, secondAdminBase), pageRequest, 2);
+        new PageImpl<>(
+            Arrays.asList(firstAdminBase, secondAdminBase, thirdAdminBase), pageRequest, 3);
     Admin firstAgencyAdmin = agencyAdmin("agency-admin-1", 1L);
-    Admin secondAgencyAdmin = agencyAdmin("agency-admin-2", 2L);
-    List<Admin> fullAdmins = Arrays.asList(firstAgencyAdmin, secondAgencyAdmin);
+    Admin secondAgencyAdmin = agencyAdmin("agency-admin-2", 1L);
+    Admin thirdAgencyAdmin = agencyAdmin("agency-admin-3", 2L);
+    List<Admin> fullAdmins = Arrays.asList(firstAgencyAdmin, secondAgencyAdmin, thirdAgencyAdmin);
     when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.AGENCY, pageRequest))
         .thenReturn(adminsPage);
     when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
@@ -181,10 +182,8 @@ class AgencyAdminUserServiceTest {
         .thenReturn(Collections.emptyList());
     when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
         .thenReturn(Collections.emptyList());
-    when(tenantService.getRestrictedTenantData(1L))
-        .thenReturn(new RestrictedTenantDTO().name("Known tenant"));
-    when(tenantService.getRestrictedTenantData(2L))
-        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(tenantService.getRestrictedTenantData(Set.of(1L, 2L)))
+        .thenReturn(List.of(new RestrictedTenantDTO().id(1L).name("Known tenant")));
     when(userServiceMapper.mapOfAdmin(
             Mockito.any(),
             Mockito.anyList(),
@@ -209,6 +208,8 @@ class AgencyAdminUserServiceTest {
             Mockito.any());
     Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
+    Mockito.verify(tenantService).getRestrictedTenantData(Set.of(1L, 2L));
+    Mockito.verify(tenantService, Mockito.never()).getRestrictedTenantData(Mockito.anyLong());
   }
 
   private Admin agencyAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,8 +38,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -189,23 +188,24 @@ class TenantAdminUserServiceTest {
   }
 
   @Test
-  void findTenantAdminsByInfix_Should_NotFail_WhenTenantServiceReturnsNotFound() {
+  void findTenantAdminsByInfix_Should_NotUsePerTenantLookups() {
     // given
     PageRequest pageRequest = PageRequest.of(0, 10);
     Admin.AdminBase firstAdminBase = adminBase("tenant-admin-1", 1L);
-    Admin.AdminBase secondAdminBase = adminBase("tenant-admin-2", 2L);
+    Admin.AdminBase secondAdminBase = adminBase("tenant-admin-2", 1L);
+    Admin.AdminBase thirdAdminBase = adminBase("tenant-admin-3", 2L);
     Page<Admin.AdminBase> adminsPage =
-        new PageImpl<>(Arrays.asList(firstAdminBase, secondAdminBase), pageRequest, 2);
+        new PageImpl<>(
+            Arrays.asList(firstAdminBase, secondAdminBase, thirdAdminBase), pageRequest, 3);
     Admin firstTenantAdmin = tenantAdmin("tenant-admin-1", 1L);
-    Admin secondTenantAdmin = tenantAdmin("tenant-admin-2", 2L);
-    List<Admin> fullAdmins = Arrays.asList(firstTenantAdmin, secondTenantAdmin);
+    Admin secondTenantAdmin = tenantAdmin("tenant-admin-2", 1L);
+    Admin thirdTenantAdmin = tenantAdmin("tenant-admin-3", 2L);
+    List<Admin> fullAdmins = Arrays.asList(firstTenantAdmin, secondTenantAdmin, thirdTenantAdmin);
     when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
         .thenReturn(adminsPage);
     when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
-    when(tenantService.getRestrictedTenantData(1L))
-        .thenReturn(new RestrictedTenantDTO().name("Known tenant"));
-    when(tenantService.getRestrictedTenantData(2L))
-        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(tenantService.getRestrictedTenantData(Set.of(1L, 2L)))
+        .thenReturn(List.of(new RestrictedTenantDTO().id(1L).name("Known tenant")));
     when(userServiceMapper.mapOfAdmin(
             Mockito.any(),
             Mockito.anyList(),
@@ -230,6 +230,8 @@ class TenantAdminUserServiceTest {
             Mockito.any());
     Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
+    Mockito.verify(tenantService).getRestrictedTenantData(Set.of(1L, 2L));
+    Mockito.verify(tenantService, Mockito.never()).getRestrictedTenantData(Mockito.anyLong());
   }
 
   private Admin tenantAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
@@ -81,6 +81,7 @@ class TenantServiceTest {
 
     assertThat(result).containsExactly(knownTenant);
     assertThat(tenantControllerApi.tenantIdsCalls.get()).isEqualTo(1);
+    assertThat(tenantControllerApi.lastTenantIds).containsExactlyInAnyOrder(TENANT_ID, 99L);
     assertThat(tenantControllerApi.tenantIdCalls.get()).isZero();
   }
 
@@ -88,6 +89,7 @@ class TenantServiceTest {
   void getRestrictedTenantData_emptyTenantIds_doesNotCallApi() {
     assertThat(tenantService.getRestrictedTenantData(Set.of())).isEmpty();
     assertThat(tenantControllerApi.tenantIdsCalls.get()).isZero();
+    assertThat(tenantControllerApi.tenantIdCalls.get()).isZero();
   }
 
   // Callers such as HttpTenantFilter rely on upstream errors surfacing unchanged.
@@ -178,6 +180,20 @@ class TenantServiceTest {
       cachedTenantService.getRestrictedTenantData(TENANT_ID);
 
       assertThat(tenantControllerApi.tenantIdCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void getRestrictedTenantData_batchPopulatesIdAndSubdomainCache() {
+      var expected = new RestrictedTenantDTO().id(TENANT_ID).subdomain(SUBDOMAIN);
+      tenantControllerApi.tenantIdsResult = List.of(expected);
+
+      cachedTenantService.getRestrictedTenantData(Set.of(TENANT_ID));
+
+      assertThat(cachedTenantService.getRestrictedTenantData(TENANT_ID)).isSameAs(expected);
+      assertThat(cachedTenantService.getRestrictedTenantData(SUBDOMAIN)).isSameAs(expected);
+      assertThat(tenantControllerApi.tenantIdsCalls.get()).isEqualTo(1);
+      assertThat(tenantControllerApi.tenantIdCalls.get()).isZero();
+      assertThat(tenantControllerApi.subdomainCalls.get()).isZero();
     }
 
     @Test
@@ -299,6 +315,7 @@ class TenantServiceTest {
     RestrictedTenantDTO subdomainResult;
     RestrictedTenantDTO tenantIdResult;
     List<RestrictedTenantDTO> tenantIdsResult;
+    List<Long> lastTenantIds;
     RuntimeException subdomainException;
     RuntimeException tenantIdException;
     final AtomicInteger subdomainCalls = new AtomicInteger();
@@ -310,6 +327,7 @@ class TenantServiceTest {
       subdomainResult = null;
       tenantIdResult = null;
       tenantIdsResult = null;
+      lastTenantIds = null;
       subdomainException = null;
       tenantIdException = null;
       subdomainCalls.set(0);
@@ -342,6 +360,7 @@ class TenantServiceTest {
     @Override
     public List<RestrictedTenantDTO> getRestrictedTenantDataByTenantIds(List<Long> tenantIds) {
       tenantIdsCalls.incrementAndGet();
+      lastTenantIds = List.copyOf(tenantIds);
       return tenantIdsResult != null ? tenantIdsResult : List.of();
     }
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
@@ -12,7 +12,9 @@ import de.caritas.cob.userservice.api.config.apiclient.TenantServiceApiControlle
 import de.caritas.cob.userservice.api.service.cache.SharedReadCache;
 import de.caritas.cob.userservice.tenantservice.generated.web.TenantControllerApi;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -68,6 +70,24 @@ class TenantServiceTest {
 
     assertThat(result).isSameAs(expected);
     assertThat(tenantControllerApi.tenantIdCalls.get()).isEqualTo(1);
+  }
+
+  @Test
+  void getRestrictedTenantData_validTenantIds_returnsDtosFromOneBatchCall() {
+    var knownTenant = new RestrictedTenantDTO().id(TENANT_ID).name("Berlin");
+    tenantControllerApi.tenantIdsResult = List.of(knownTenant);
+
+    var result = tenantService.getRestrictedTenantData(Set.of(TENANT_ID, 99L));
+
+    assertThat(result).containsExactly(knownTenant);
+    assertThat(tenantControllerApi.tenantIdsCalls.get()).isEqualTo(1);
+    assertThat(tenantControllerApi.tenantIdCalls.get()).isZero();
+  }
+
+  @Test
+  void getRestrictedTenantData_emptyTenantIds_doesNotCallApi() {
+    assertThat(tenantService.getRestrictedTenantData(Set.of())).isEmpty();
+    assertThat(tenantControllerApi.tenantIdsCalls.get()).isZero();
   }
 
   // Callers such as HttpTenantFilter rely on upstream errors surfacing unchanged.
@@ -278,19 +298,23 @@ class TenantServiceTest {
 
     RestrictedTenantDTO subdomainResult;
     RestrictedTenantDTO tenantIdResult;
+    List<RestrictedTenantDTO> tenantIdsResult;
     RuntimeException subdomainException;
     RuntimeException tenantIdException;
     final AtomicInteger subdomainCalls = new AtomicInteger();
     final AtomicInteger tenantIdCalls = new AtomicInteger();
+    final AtomicInteger tenantIdsCalls = new AtomicInteger();
     CountDownLatch[] subdomainLatch;
 
     void reset() {
       subdomainResult = null;
       tenantIdResult = null;
+      tenantIdsResult = null;
       subdomainException = null;
       tenantIdException = null;
       subdomainCalls.set(0);
       tenantIdCalls.set(0);
+      tenantIdsCalls.set(0);
       subdomainLatch = null;
     }
 
@@ -313,6 +337,12 @@ class TenantServiceTest {
         throw tenantIdException;
       }
       return tenantIdResult != null ? tenantIdResult : new RestrictedTenantDTO().id(tenantId);
+    }
+
+    @Override
+    public List<RestrictedTenantDTO> getRestrictedTenantDataByTenantIds(List<Long> tenantIds) {
+      tenantIdsCalls.incrementAndGet();
+      return tenantIdsResult != null ? tenantIdsResult : List.of();
     }
 
     private void awaitLatch() {


### PR DESCRIPTION
## Summary

- replace per-result TenantService lookups in tenant-admin and agency-admin searches with one deduplicated batch request per page
- leave tenant names empty for missing historical references without per-ID fallback calls or expected 404 warning noise
- cap both search page sizes at 100 so one page always fits the provider contract
- keep the returned tenant data in the existing shared read cache

## Why

Fresh SigNoz evidence showed 62 TenantService 404 error spans across 14 tenant-admin searches and 12 more across 3 agency-admin searches, while every parent search still succeeded. The previous enrichment path made one dependency call per result; this change makes exactly one bounded call per page.

## Verification

- 3,845 unit tests: 0 failures, 0 errors, 7 skipped
- required integration contract: 966 tests, 0 failures, 0 errors, 14 skipped
- CI contract tests: 25/25
- real MariaDB contracts: 9/9
- real Redis contracts: 14/14
- focused search tests prove duplicate IDs are sent once, missing IDs are omitted, and individual lookup fallback is never used
- controller E2E tests reject `perPage=101` for both search routes
- provider and consumer OpenAPI definitions for the new endpoint are identical

## Dependency and rollout order

Depends on OpenResilienceInitiative/ORISO-TenantService#139. TenantService must be merged and deployed first. This PR intentionally has no legacy per-ID fallback, so UserService must not deploy before the provider endpoint is live. After both deployments, SigNoz must confirm one TenantService client span per search and zero expected 404 error spans.

Closes #762
Parent: #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)