### PR TITLE
[Stability] Collapse consultant agency assignment reads

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -191,8 +191,7 @@ public class ConsultantAdminFacade {
   public void setConsultantAgencies(
       String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
     var persistedAgencyIds =
-        consultantAgencyAdminService.findConsultantAgencies(consultantId).getEmbedded().stream()
-            .map(agencyAdminResponse -> agencyAdminResponse.getEmbedded().getId())
+        consultantAgencyAdminService.findConsultantAgencyIds(consultantId).stream()
             .collect(Collectors.toSet());
     var desiredAgencyIds =
         agencyList.stream().map(CreateConsultantAgencyDTO::getAgencyId).collect(Collectors.toSet());

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -180,7 +180,7 @@ public class ConsultantAgencyRelationCreatorService {
   }
 
   private AgencyDTO retrieveAgency(Long agencyId) {
-    var agencyDto = this.agencyService.getAgencyWithoutCaching(agencyId);
+    var agencyDto = this.agencyService.getAgency(agencyId);
     return Optional.ofNullable(agencyDto)
         .orElseThrow(
             () ->

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
@@ -125,7 +125,7 @@ public class ConsultantTopicAgencyCompatibilityValidator {
   }
 
   private List<AgencyDTO> agenciesFor(List<Long> selectedAgencyIds) {
-    var agencies = agencyService.getAgenciesWithoutCaching(selectedAgencyIds);
+    var agencies = agencyService.getAgencies(selectedAgencyIds);
     if (agencies == null) {
       return Collections.emptyList();
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -82,11 +83,26 @@ public class AgencyService {
     if (!isNotEmpty(agencyIds)) {
       return emptyList();
     }
-    return sharedReadCache.getOrLoadTyped(
-        CacheName.AGENCY,
-        tenantKey("ids:" + agencyIds),
-        AGENCY_LIST_TYPE,
-        () -> getAgenciesFromAgencyService(agencyIds));
+    var agencies =
+        sharedReadCache.getOrLoadTyped(
+            CacheName.AGENCY,
+            tenantKey("ids:" + agencyIds),
+            AGENCY_LIST_TYPE,
+            () -> getAgenciesFromAgencyService(agencyIds));
+    cacheAgenciesById(agencies);
+    return agencies;
+  }
+
+  private void cacheAgenciesById(List<AgencyDTO> agencies) {
+    if (agencies == null) {
+      return;
+    }
+    agencies.stream()
+        .filter(Objects::nonNull)
+        .filter(agency -> agency.getId() != null)
+        .forEach(
+            agency ->
+                sharedReadCache.put(CacheName.AGENCY, tenantKey("id:" + agency.getId()), agency));
   }
 
   public List<AgencyDTO> getAgenciesNotCached(List<Long> agencyIds) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -428,10 +428,8 @@ class ConsultantAdminFacadeTest {
 
   @Test
   void setConsultantAgencies_Should_createMissingAndDeleteRemovedAndSkipExisting() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(
-        Lists.newArrayList(agencyAdminFullResponse(1L), agencyAdminFullResponse(2L)));
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList(1L, 2L));
     // desired set: keep 1, drop 2, add 3
     List<CreateConsultantAgencyDTO> desired =
         Lists.newArrayList(
@@ -446,13 +444,13 @@ class ConsultantAdminFacadeTest {
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(3L));
     verify(relationCreatorService, never())
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(1L));
+    verify(consultantAgencyAdminService, never()).findConsultantAgencies(any());
   }
 
   @Test
   void setConsultantAgencies_Should_notDelete_When_NothingRemoved() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(Lists.newArrayList(agencyAdminFullResponse(1L)));
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList(1L));
 
     consultantAdminFacade.setConsultantAgencies(
         "consultantId",
@@ -464,13 +462,13 @@ class ConsultantAdminFacadeTest {
         .markConsultantAgenciesForDeletion(any(), anyList());
     verify(relationCreatorService)
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(2L));
+    verify(consultantAgencyAdminService, never()).findConsultantAgencies(any());
   }
 
   @Test
   void setConsultantAgencies_Should_propagateValidationError() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(Lists.newArrayList());
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList());
     doThrow(new BadRequestException("topic not covered"))
         .when(relationCreatorService)
         .createNewConsultantAgency(eq("consultantId"), any());

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -97,8 +97,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(0);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     Session enquirySessionWithoutConsultant =
         createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
@@ -140,8 +140,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(true);
     agencyDTO.setConsultingType(0);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(extendedConsultingTypeResponseDTO);
 
@@ -180,8 +180,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(consultingType);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     var consultant = createConsultantWithoutAgencyAndSession();
     when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
@@ -301,7 +301,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
-          when(this.agencyService.getAgencyWithoutCaching(any())).thenReturn(null);
+          when(this.agencyService.getAgency(any())).thenReturn(null);
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
@@ -319,8 +319,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
-          when(agencyService.getAgencyWithoutCaching(any()))
-              .thenThrow(new InternalServerErrorException(""));
+          when(agencyService.getAgency(any())).thenThrow(new InternalServerErrorException(""));
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
@@ -337,8 +336,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           AgencyDTO agencyDTO = new AgencyDTO().consultingType(1).id(2L);
 
-          when(agencyService.getAgencyWithoutCaching(1731L)).thenReturn(emigrationAgency);
-          when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+          when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
+          when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(1)).thenReturn(true);
 
@@ -361,8 +360,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           AgencyDTO agencyDTO = new AgencyDTO().consultingType(15).id(2L);
 
-          when(agencyService.getAgencyWithoutCaching(1731L)).thenReturn(emigrationAgency);
-          when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+          when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
+          when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(15)).thenReturn(true);
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -113,8 +113,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(0);
     agencyDTO.setTenantId(1L);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     Session enquirySessionWithoutConsultant =
         createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
@@ -157,8 +157,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("valid-role-set");
     when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0).tenantId(83L);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(new ExtendedConsultingTypeResponseDTO());
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -77,7 +77,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(this.consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(new Consultant()));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO =
         new CreateConsultantAgencyDTO().roleSetKey("valid role set").agencyId(2L);
@@ -103,7 +103,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(this.consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
     doThrow(new BadRequestException("topic not covered"))
         .when(consultantTopicAgencyCompatibilityValidator)
         .validateCurrentTopicsAgainstAssignedAndAdditionalAgencies(anyString(), any(), any());
@@ -132,7 +132,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
 
     var input =
         new CreateConsultantAgencyDTOInputAdapter(
@@ -160,7 +160,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(280L)).thenReturn(agency);
+    when(agencyService.getAgency(280L)).thenReturn(agency);
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(new ExtendedConsultingTypeResponseDTO());
     when(consultantAgencyService.saveConsultantAgency(any(ConsultantAgency.class)))
@@ -192,7 +192,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
   public void createNewConsultantAgency_Should_throwBadRequest_When_agencyDoesNotExist() {
     when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(new Consultant()));
-    when(agencyService.getAgencyWithoutCaching(99L)).thenReturn(null);
+    when(agencyService.getAgency(99L)).thenReturn(null);
 
     assertThrows(
         BadRequestException.class,
@@ -214,8 +214,8 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(newAgency);
-    when(agencyService.getAgencyWithoutCaching(3L)).thenReturn(existingAgency);
+    when(agencyService.getAgency(2L)).thenReturn(newAgency);
+    when(agencyService.getAgency(3L)).thenReturn(existingAgency);
     when(consultingTypeManager.isConsultantBoundedToAgency(2)).thenReturn(true);
 
     assertThrows(
@@ -248,7 +248,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(true);
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(1L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(1L)).thenReturn(agencyDTO);
     when(consultingTypeManager.getConsultingTypeSettings(1))
         .thenReturn(easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class));
 
@@ -270,7 +270,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
 
     var input =
         new CreateConsultantAgencyDTOInputAdapter(
@@ -301,7 +301,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
 
     var input =
         new CreateConsultantAgencyDTOInputAdapter(
@@ -323,7 +323,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(givenConsultingTypeWithRoles("main", List.of("consultant-role")));
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -36,7 +36,7 @@ public class ConsultantUpdateServiceBase {
 
   @BeforeEach
   void stubAssignedAgencies() {
-    when(agencyService.getAgenciesWithoutCaching(anyList()))
+    when(agencyService.getAgencies(anyList()))
         .thenAnswer(
             invocation ->
                 invocation.<List<Long>>getArgument(0).stream()

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.admin.service.consultant.validation;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
@@ -32,7 +33,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredAcrossActiveAgencies() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -44,7 +45,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredByOfflineAgency() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, true, List.of(7L))));
 
@@ -56,7 +57,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsAgencyFromDifferentTenant() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+    when(agencyService.getAgencies(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of(3L))));
 
     var exception =
@@ -71,7 +72,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsForeignAgencyWithoutTopics() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+    when(agencyService.getAgencies(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of())));
 
     var exception =
@@ -89,7 +90,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(Optional.of(consultant("consultant-id", 1L)));
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -106,7 +107,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(List.of());
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -114,6 +115,20 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         () ->
             validator.validateCurrentTopicsAgainstAssignedAndAdditionalAgencies(
                 "consultant-id", List.of(10L, 20L), 1L));
+  }
+
+  @Test
+  void validateGrantTopicsAgainstSelectedAgencies_UsesTenantScopedCachedBatchLookup() {
+    when(agencyService.getAgencies(List.of(10L, 20L)))
+        .thenReturn(
+            List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
+
+    assertDoesNotThrow(
+        () ->
+            validator.validateGrantTopicsAgainstSelectedAgencies(
+                List.of(3L, 7L), List.of(10L, 20L), 1L));
+
+    verify(agencyService).getAgencies(List.of(10L, 20L));
   }
 
   private AgencyDTO agency(Long agencyId, Long tenantId, boolean offline, List<Long> topicIds) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +30,8 @@ import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
@@ -168,6 +172,64 @@ class AgencyServiceTest {
             eq("tenant:7:ids:[42, 43]"),
             any(TypeReference.class),
             any());
+  }
+
+  @Test
+  void getAgencies_ShouldWarmTenantScopedIdCacheForSubsequentSingleReads() {
+    TenantContext.setCurrentTenant(7L);
+    List<Long> agencyIds = List.of(42L);
+    AgencyDTO agency = new AgencyDTO().id(42L).name("Agency 42");
+    Map<String, Object> cacheValues = new ConcurrentHashMap<>();
+    when(sharedReadCache.getOrLoadTyped(any(), any(), any(TypeReference.class), any()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(1);
+              if (cacheValues.containsKey(key)) {
+                return cacheValues.get(key);
+              }
+              Object loaded = invocation.<Supplier<?>>getArgument(3).get();
+              cacheValues.put(key, loaded);
+              return loaded;
+            });
+    when(sharedReadCache.getOrLoad(any(), any(), any(Class.class), any()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(1);
+              if (cacheValues.containsKey(key)) {
+                return cacheValues.get(key);
+              }
+              Object loaded = invocation.<Supplier<?>>getArgument(3).get();
+              cacheValues.put(key, loaded);
+              return loaded;
+            });
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              cacheValues.put(invocation.getArgument(1), invocation.getArgument(2));
+              return null;
+            })
+        .when(sharedReadCache)
+        .put(eq(SharedReadCache.CacheName.AGENCY), any(), any());
+    stubAgencyLookup(List.of(toAgencyResponseDTO(agency)));
+
+    agencyService.getAgencies(agencyIds);
+    AgencyDTO cachedAgency = agencyService.getAgency(42L);
+
+    assertThat(cachedAgency.getId()).isEqualTo(42L);
+    verify(sharedReadCache).put(SharedReadCache.CacheName.AGENCY, "tenant:7:id:42", agency);
+    verify(agencyControllerApi, times(1)).getAgenciesByIds(agencyIds);
+  }
+
+  @Test
+  void getAgencies_ShouldNotNegativeCacheMissingIds() {
+    TenantContext.setCurrentTenant(7L);
+    AgencyDTO resolvedAgency = new AgencyDTO().id(42L).name("Agency 42");
+    stubAgencyLookup(List.of(toAgencyResponseDTO(resolvedAgency)));
+
+    agencyService.getAgencies(List.of(42L, 43L));
+
+    verify(sharedReadCache).put(SharedReadCache.CacheName.AGENCY, "tenant:7:id:42", resolvedAgency);
+    verify(sharedReadCache, never())
+        .put(eq(SharedReadCache.CacheName.AGENCY), eq("tenant:7:id:43"), any(AgencyDTO.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- diff consultant agency assignments from local relation IDs instead of loading the complete remote agency list
- warm tenant-scoped per-ID cache entries from the bounded AgencyService batch result
- reuse the cached batch/single reads across topic validation and relation preparation/finalization
- preserve missing-agency, tenant, topic, role, and team-agency behavior without negative caching

## Live evidence

PreDev trace fbc89fbe66163fd4006ecd458b3fbfda showed PUT /useradmin/consultants/{consultantId}/agencies at 437 ms with one 326 ms full agency-admin list read plus three repeated AgencyService reads. The trace succeeded, so these calls were redundant coordination, not retries.

Matrix long-poll traffic and tenant public-ID fan-out are outside this slice and are already covered by #761 and #763.

## Stack and migration boundary

- stacked on #763 to reuse its tenant-safe shared-read-cache foundation
- compatible with the Matrix-only Rocket.Chat removal in #756
- introduces no Rocket.Chat or Jitsi dependency and does not alter the ORISO Matrix/Element Call/LiveKit target architecture
- no merge or deployment performed

## Verification

- targeted unit tests: 77 passed, 0 failed
- complete unit suite: 3,849 passed, 0 failed, 7 skipped
- targeted integration regression: 18 passed, 0 failed
- required integration contract: 97 reports, 968 passed, 0 failed, 14 skipped
- Redis replica/cache contract: 14 passed, 0 failed
- JDK 21 and Spotless clean

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)