### PR TITLE
[Stability] Measure OTP admin-session retries

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -296,6 +296,7 @@ public class KeycloakService implements IdentityClient {
       log.warn(
           "Keycloak admin session was unauthorized for an OTP provider request, forcing token"
               + " refresh and retrying once");
+      recordRetry("admin-session-refresh");
       keycloakClient.refreshAdminSession();
       return request.get();
     }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -305,11 +306,15 @@ public class KeycloakServiceTest {
   @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void getOtpCredential_Should_Return_Response_When_RequestWasSuccessful() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
     var entity = new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK);
     when(this.keycloakClient.get(anyString(), any(), any())).thenReturn(entity);
 
     assertEquals(OTP_INFO_DTO, keycloakService.getOtpCredential(USERNAME));
+
+    verifyNoInteractions(outboundHttpMetrics);
   }
 
   @Test
@@ -328,6 +333,8 @@ public class KeycloakServiceTest {
   @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void getOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     var unauthorized =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
     var entity = new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK);
@@ -339,10 +346,13 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).getBearerToken();
+    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
   }
 
   @Test
   public void getOtpCredential_Should_RetryOnlyOnce_When_BothRequestsAreUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     var unauthorized =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
     when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
@@ -354,10 +364,13 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).get(any(), any(), any());
+    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
   }
 
   @Test
   public void getOtpCredential_Should_NotRefreshAdminSession_When_RequestFailsWithNon401() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     var badRequest =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.BAD_REQUEST);
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
@@ -369,6 +382,7 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient, never()).refreshAdminSession();
     verify(keycloakClient).get(any(), any(), any());
+    verifyNoInteractions(outboundHttpMetrics);
   }
 
   @Test


### PR DESCRIPTION
## Why

PreDev trace `6730099a9db89d70090fa54e026228ee` showed one failed Keycloak OTP provider request followed by the existing bounded admin-session refresh retry. The retry was absent from `userservice.outbound.retries`.

## What changed

- record the existing OTP-provider 401 retry under `dependency=keycloak`, `operation=admin-session-refresh`
- keep one-retry and non-401 behavior unchanged
- cover success, first-401 recovery, repeated-401 propagation, and non-401 failure paths

## Verification

- TDD red: the focused test failed because the retry metric was not emitted
- 99 Keycloak tests
- 3,849 unit tests (0 failures/errors, 7 skipped)
- 968 integration tests across 97 reports (0 failures/errors, 14 skipped)
- 14 Redis contracts
- 9 MariaDB contracts
- 25 CI contracts
- package build
- CodeRabbit local review: 0 findings after test hardening

Depends on #765.
Refs #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)