### PR TITLE
[Stability] Remove remaining email-supplier test quarantine

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,8 +30,8 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,843 | 0 | 0 | 7 | `./mvnw -B -Dskip.integration-tests=true clean test` |
-| Integration + contract + E2E | 964 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
+| Unit | 3,849 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Integration + contract + E2E | 968 | 0 | 0 | 14 | `./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
 
@@ -40,23 +40,32 @@ replica tests. Those focused tests pass, including the scheduler proof on fresh
 MariaDB 10.11 and the browser-login proof on Redis 7. Earlier overlapping broad
 attempts remain excluded from evidence; the totals above come only from the
 later serial Maven completions. The latest clean integration completion
-independently reports 964/0/0/5.
+independently reports 968/0/0/14; the 14 skips are the required
+environment-gated reports exercised below.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
 CSRF token, which contradicts the service's security contract. No failing test
-is skipped or quarantined.
+is skipped or quarantined. Seven email-supplier log regressions were also
+re-enabled after their appenders were given the production logger context and a
+complete lifecycle. The 30-test focused email-supplier suite now runs with zero
+failures, errors or skips.
+
+`scripts/ci/check-no-test-quarantine.py` is exercised by the blocking Python CI
+contract suite. It rejects JUnit `@Disabled*` and `@Ignore` annotations anywhere
+under `src/test`, so the zero-quarantine state cannot silently regress.
 
 `scripts/ci/run-required-integration-tests.sh` now owns the complete `*IT`
 suite, starts from a clean build, requires at least 900 executed tests and
 checks for critical E2E reports.
 The previous three-test required subset and the non-blocking legacy quarantine
-were removed. The nineteen environment-gated integration tests are not
-quarantined: all fourteen Redis tests pass in their required Redis 7
-service-container job. The five MariaDB tests skipped without an external
-database are covered by the required fresh-MariaDB 10.11 job; its seven selected
-schema and replica contract classes execute nine tests on branch, pull-request
-and publish workflows.
+were removed. The broad execution without external containers records fourteen
+environment-gated container-level skips: one for each of nine Redis contract
+classes and five MariaDB contract classes. They are not quarantine. The
+required Redis 7 service-container job executes fourteen test methods from the
+nine Redis classes. The required fresh-MariaDB 10.11 job executes nine test
+methods from the five MariaDB classes on branch, pull-request and publish
+workflows.
 
 The first clean Ubuntu run exposed three portability defects that a warmed local
 workspace had hidden. Each Spring test context now owns a unique H2 database so

--- a/documentation/user-service-historical-failure-classification.json
+++ b/documentation/user-service-historical-failure-classification.json
@@ -188,7 +188,8 @@
     "additionalRequiredContracts": [
       "fresh MariaDB schema and replica contracts",
       "Redis replica-state contracts",
-      "CI contract forbidding the removed quarantine workflow"
+      "CI contract forbidding the removed quarantine workflow",
+      "CI source guard rejecting JUnit disabled and ignored test annotations"
     ]
   }
 }

--- a/scripts/ci/check-no-test-quarantine.py
+++ b/scripts/ci/check-no-test-quarantine.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+JAVA_UNICODE_ESCAPE = re.compile(r"\\u+([0-9a-fA-F]{4})")
+QUARANTINE_ANNOTATION = re.compile(
+    r"@\s*(?P<annotation>"
+    r"(?:org\s*\.\s*junit\s*\.\s*"
+    r"(?:jupiter\s*\.\s*api\s*\.\s*(?:condition\s*\.\s*)?)?)?"
+    r"(?:Disabled[A-Za-z0-9_]*|Ignore))\b"
+)
+
+
+def translate_java_unicode_escapes(source: str) -> str:
+    return JAVA_UNICODE_ESCAPE.sub(
+        lambda match: chr(int(match.group(1), 16)),
+        source,
+    )
+
+
+def java_code_only(source: str) -> str:
+    output = []
+    index = 0
+    state = "code"
+
+    def mask(characters: str) -> None:
+        output.extend("\n" if character == "\n" else " " for character in characters)
+
+    while index < len(source):
+        if state == "code":
+            if source.startswith("//", index):
+                mask("//")
+                index += 2
+                state = "line-comment"
+            elif source.startswith("/*", index):
+                mask("/*")
+                index += 2
+                state = "block-comment"
+            elif source.startswith('"""', index):
+                mask('"""')
+                index += 3
+                state = "text-block"
+            elif source[index] == '"':
+                mask('"')
+                index += 1
+                state = "string"
+            elif source[index] == "'":
+                mask("'")
+                index += 1
+                state = "character"
+            else:
+                output.append(source[index])
+                index += 1
+        elif state == "line-comment":
+            if source[index] == "\n":
+                output.append("\n")
+                index += 1
+                state = "code"
+            else:
+                mask(source[index])
+                index += 1
+        elif state == "block-comment":
+            if source.startswith("*/", index):
+                mask("*/")
+                index += 2
+                state = "code"
+            else:
+                mask(source[index])
+                index += 1
+        elif state == "text-block":
+            if source.startswith('"""', index):
+                mask('"""')
+                index += 3
+                state = "code"
+            elif source[index] == "\\" and index + 1 < len(source):
+                mask(source[index : index + 2])
+                index += 2
+            else:
+                mask(source[index])
+                index += 1
+        else:
+            delimiter = '"' if state == "string" else "'"
+            if source[index] == "\\" and index + 1 < len(source):
+                mask(source[index : index + 2])
+                index += 2
+            elif source[index] == delimiter:
+                mask(source[index])
+                index += 1
+                state = "code"
+            else:
+                mask(source[index])
+                index += 1
+
+    return "".join(output)
+
+
+def find_quarantine_annotations(test_root: Path) -> list[str]:
+    offenders = []
+    for source in sorted(test_root.rglob("*.java")):
+        code = java_code_only(translate_java_unicode_escapes(source.read_text()))
+        for match in QUARANTINE_ANNOTATION.finditer(code):
+            line_number = code.count("\n", 0, match.start()) + 1
+            annotation = re.sub(r"\s+", "", match.group("annotation"))
+            offenders.append(
+                f"{source.relative_to(test_root)}:{line_number}: @{annotation}"
+            )
+    return offenders
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject disabled or ignored Java tests."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPOSITORY_ROOT / "src/test",
+        help="Test source root to inspect.",
+    )
+    args = parser.parse_args()
+
+    if not args.root.is_dir():
+        print(f"Test source root does not exist: {args.root}", file=sys.stderr)
+        return 2
+
+    offenders = find_quarantine_annotations(args.root)
+    if offenders:
+        print("Test quarantine annotations are forbidden:")
+        print("\n".join(offenders))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewEnquiryEmailSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewEnquiryEmailSupplierTest.java
@@ -27,8 +27,8 @@ import de.caritas.cob.userservice.mailservice.generated.web.model.MailDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,8 +48,8 @@ class NewEnquiryEmailSupplierTest {
 
   @Mock private ReleaseToggleService releaseToggleService;
 
-  @Mock private Logger log;
-
+  private Logger logger;
+  private Level originalLogLevel;
   private TestLogAppender testAppender;
 
   @BeforeEach
@@ -60,10 +60,24 @@ class NewEnquiryEmailSupplierTest {
     this.newEnquiryEmailSupplier.setCurrentSession(session);
 
     // Attach a custom appender to the logger
-    Logger logger = (Logger) LoggerFactory.getLogger(NewEnquiryEmailSupplier.class);
+    logger = (Logger) LoggerFactory.getLogger(NewEnquiryEmailSupplier.class);
+    originalLogLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
     testAppender = new TestLogAppender();
+    testAppender.setContext(logger.getLoggerContext());
     testAppender.start();
     logger.addAppender(testAppender);
+  }
+
+  @AfterEach
+  void tearDownTestAppender() {
+    if (testAppender != null) {
+      logger.detachAppender(testAppender);
+      testAppender.stop();
+    }
+    if (logger != null) {
+      logger.setLevel(originalLogLevel);
+    }
   }
 
   @Test
@@ -172,7 +186,6 @@ class NewEnquiryEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_ConsultantIsNull() {
     // given
     ConsultantAgency consultantAgency = new ConsultantAgency();
@@ -188,7 +201,6 @@ class NewEnquiryEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_ConsultantEmailIsBlank() {
     // given
     Consultant consultant = new Consultant();
@@ -209,7 +221,6 @@ class NewEnquiryEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_ConsultantIsAbsent() {
     // given
     Consultant consultant = new Consultant();
@@ -231,7 +242,6 @@ class NewEnquiryEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_NotificationsAreEnabledAndConsultantAbsent() {
     // given
     Consultant consultant = new Consultant();

--- a/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
@@ -49,7 +50,6 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -86,6 +86,8 @@ class NewMessageEmailSupplierTest {
   private de.caritas.cob.userservice.api.service.donotdisturb.DoNotDisturbService
       doNotDisturbService;
 
+  private Logger logger;
+  private Level originalLogLevel;
   private TestLogAppender testLogAppender;
 
   @BeforeEach
@@ -107,9 +109,11 @@ class NewMessageEmailSupplierTest {
             .build();
 
     // Attach a custom appender to the logger
-    ch.qos.logback.classic.Logger logger =
-        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(NewMessageEmailSupplier.class);
+    logger = (Logger) LoggerFactory.getLogger(NewMessageEmailSupplier.class);
+    originalLogLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
     testLogAppender = new TestLogAppender();
+    testLogAppender.setContext(logger.getLoggerContext());
     testLogAppender.start();
     logger.addAppender(testLogAppender);
   }
@@ -117,7 +121,11 @@ class NewMessageEmailSupplierTest {
   @AfterEach
   public void tearDownTestLogAppender() {
     if (testLogAppender != null) {
+      logger.detachAppender(testLogAppender);
       testLogAppender.stop();
+    }
+    if (logger != null) {
+      logger.setLevel(originalLogLevel);
     }
   }
 
@@ -420,7 +428,6 @@ class NewMessageEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void
       generateEmails_Should_LogDebugMessage_When_ConsultantIsOfflineAndNotificationsDisabledWithLogAppender() {
     when(roles.contains(UserRole.USER.getValue())).thenReturn(true);
@@ -439,7 +446,6 @@ class NewMessageEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_UserIsOnlineWithLogAppender() {
     when(roles.contains(UserRole.CONSULTANT.getValue())).thenReturn(true);
     when(session.getUser()).thenReturn(USER);
@@ -454,7 +460,6 @@ class NewMessageEmailSupplierTest {
   }
 
   @Test
-  @Disabled("TODO this is passing locally but failing in mvn. Fix in CARITAS-285")
   void generateEmails_Should_LogDebugMessage_When_ConsultantIsOnlineWithLogAppender() {
     when(roles.contains(UserRole.USER.getValue())).thenReturn(true);
     when(session.getConsultant()).thenReturn(CONSULTANT);

--- a/tests/ci/test_no_test_quarantine.py
+++ b/tests/ci/test_no_test_quarantine.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts/ci/check-no-test-quarantine.py"
+
+
+class NoTestQuarantineContractTest(unittest.TestCase):
+    def run_checker(self, sources: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_root = Path(temp_dir)
+            for relative_path, content in sources.items():
+                source = source_root / relative_path
+                source.parent.mkdir(parents=True, exist_ok=True)
+                source.write_text(content)
+
+            return subprocess.run(
+                [sys.executable, CHECKER, "--root", source_root],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_rejects_junit_quarantine_annotations(self):
+        result = self.run_checker(
+            {
+                "DisabledTest.java": """
+                    class DisabledTest {
+                      @Disabled("flaky")
+                      void quarantined() {}
+                    }
+                """,
+                "nested/IgnoredTest.java": """
+                    class IgnoredTest {
+                      @Ignore
+                      void quarantined() {}
+                    }
+                """,
+                "FullyQualifiedDisabledTest.java": """
+                    class FullyQualifiedDisabledTest {
+                      @org.junit.jupiter.api.Disabled("flaky")
+                      void quarantined() {}
+                    }
+                """,
+                "SameLineDisabledTest.java": """
+                    class SameLineDisabledTest {
+                      @Test @Disabled void quarantined() {}
+                    }
+                """,
+                "EscapedDisabledTest.java": r"""
+                    class EscapedDisabledTest {
+                      @\u0044isabled void quarantined() {}
+                    }
+                """,
+                "SeparatedDisabledTest.java": """
+                    class SeparatedDisabledTest {
+                      @org /* separator */ . junit . jupiter . api . Disabled
+                      void quarantined() {}
+                    }
+                """,
+            }
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("DisabledTest.java:3: @Disabled", result.stdout)
+        self.assertIn(
+            "FullyQualifiedDisabledTest.java:3: @org.junit.jupiter.api.Disabled",
+            result.stdout,
+        )
+        self.assertIn("SameLineDisabledTest.java:3: @Disabled", result.stdout)
+        self.assertIn("EscapedDisabledTest.java:3: @Disabled", result.stdout)
+        self.assertIn(
+            "SeparatedDisabledTest.java:3: @org.junit.jupiter.api.Disabled",
+            result.stdout,
+        )
+        self.assertIn("nested/IgnoredTest.java:3: @Ignore", result.stdout)
+
+    def test_accepts_active_tests_and_annotation_text_in_comments(self):
+        result = self.run_checker(
+            {
+                "ActiveTest.java": """
+                    class ActiveTest {
+                      // Explains why @Disabled is forbidden.
+                      /*
+                      @Ignore and @Disabled are documentation here.
+                       */
+                      String policy = "@Disabled is forbidden";
+                      @Test
+                      void active() {}
+                    }
+                """,
+                "EscapedDocumentation.java": r"""
+                    class EscapedDocumentation {
+                      // @\u0044isabled is documentation.
+                      String policy = "@\u0044isabled is forbidden";
+                      @Test void active() {}
+                    }
+                """,
+            }
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_repository_contains_no_quarantined_tests(self):
+        result = subprocess.run(
+            [sys.executable, CHECKER],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_rejects_a_missing_test_source_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_root = Path(temp_dir) / "missing"
+            result = subprocess.run(
+                [sys.executable, CHECKER, "--root", missing_root],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(2, result.returncode)
+        self.assertIn(f"Test source root does not exist: {missing_root}", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Seven email-supplier log-assertion tests were still disabled under the historical assumption that they failed only in Maven. Reproducing them without `@Disabled` showed that production behavior was correct: Maven's effective INFO logger level filtered the expected DEBUG events, and the test appender had no logger context or complete lifecycle.

## What

- re-enable all seven email-supplier tests
- configure each test appender with the production logger context
- temporarily enable DEBUG logging for the tested class
- detach and stop the appender after each test
- restore the original logger level, including partial-setup failure paths
- remove the stale mock logger and quarantine annotations

## Verification

- RED reproduction: 30 focused tests, 7 failures, 0 skips
- GREEN focused suite: 30 tests, 0 failures, 0 errors, 0 skips
- two additional randomized focused repetitions: green
- full unit suite: 3,849 tests, 0 failures, 0 errors, 0 skips
- integration suite: 968 tests, 0 failures, 0 errors, 14 environment-gated skips
- real Redis contract gate: 14 tests, 0 failures, 0 errors, 0 skips
- real MariaDB 10.11 contract gate: 9 tests, 0 failures, 0 errors, 0 skips
- CI contract tests: 29 tests, green
- Java 21 package build: success
- Spotless and `git diff --check`: green
- local CodeRabbit review: one valid cleanup finding fixed; immediate re-run rate-limited by the service

The 14 integration skips are not quarantine: nine Redis and five MariaDB contracts are deliberately environment-gated and run in their dedicated blocking GitHub workflows.

Depends on #767.

Closes OpenResilienceInitiative/ORISO-UserService#768.
## Zero-quarantine regression guard

- add a blocking source guard that rejects JUnit `@Disabled*` and `@Ignore` annotations under `src/test`
- lex Java comments, strings, text blocks, qualified names and Unicode escapes so the guard catches executable annotations without documentation false positives
- prove the guard red against the parent branch, where it reports the exact seven former email-supplier quarantines
- keep the focused 30-test email-supplier suite green with zero skips on JDK 21

Latest commit: `022646c3`. Branch and PR build, Docker, both complete integration lanes, both Redis and MariaDB contracts, API diff and Required PreDev CI are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



