### PR TITLE
[Stability] Isolate magic-link identity sessions

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -1,6 +1,6 @@
 # UserService stability, dependency measurements and module decision
 
-Date: 2026-07-25
+Date: 2026-07-27
 Target branch: `pre-dev`
 
 ## Reproducible stability result
@@ -30,8 +30,8 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,843 | 0 | 0 | 7 | `./mvnw -B -Dskip.integration-tests=true clean test` |
-| Integration + contract + E2E | 964 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
+| Unit | 3,852 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
 
@@ -40,7 +40,7 @@ replica tests. Those focused tests pass, including the scheduler proof on fresh
 MariaDB 10.11 and the browser-login proof on Redis 7. Earlier overlapping broad
 attempts remain excluded from evidence; the totals above come only from the
 later serial Maven completions. The latest clean integration completion
-independently reports 964/0/0/5.
+independently reports 969/0/0/5.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
@@ -187,17 +187,22 @@ flowchart LR
   IN[Input ports]
   APP[Managers, facades and workflows]
   OUT[Output ports]
-  ADAPTERS[Matrix, Keycloak, Rocket.Chat, repositories and generated clients]
+  ADAPTERS[Matrix, Keycloak, repositories and generated clients]
 
   HTTP --> IN --> APP --> OUT --> ADAPTERS
 ```
+
+Rocket.Chat references below describe legacy code that still has to be removed;
+they are not part of the target architecture. The target chat transport is
+Matrix only, with the ORISO frontend and the controlled MatrixRTC/Element Call
+fork using LiveKit.
 
 The current state is deliberately tracked per domain instead of describing the
 whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs, OTP values and provider configuration. `MagicLinkLoginService` and its HTTP response still expose the Keycloak token transport separately from this port. |
+| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs, OTP values and provider configuration. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -213,7 +218,9 @@ contract rejects any reintroduction of the deleted
 `KeycloakCreateUserResponseDTO` outside the Keycloak adapter boundary. The
 identity port contract also rejects imports from the concrete Keycloak adapter
 and Keycloak SDK types, so its login and profile results cannot regress from
-`IdentityLogin` and `IdentityProfile` to provider transports.
+`IdentityLogin` and `IdentityProfile` to provider transports. A dedicated
+Magic-Link boundary contract applies the same rule to the service and both web
+entry points.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current
@@ -221,11 +228,10 @@ runtime contract reports a maximum supported replica count of one; modular
 source layout must not be confused with proven multi-instance behavior.
 
 This is a ratcheted incremental modularization, not a claim that all three
-domains are already isolated. The next safe sequence is the remaining
-Magic-Link token transport and broad identity command/configuration decoupling,
-then the admin controller composition boundary, then session-list adapter
-removal. Each step must add a failing boundary contract before moving
-dependencies.
+domains are already isolated. The next safe sequence is broad identity
+command/configuration decoupling, then the admin controller composition
+boundary, then session-list adapter removal. Each step must add a failing
+boundary contract before moving dependencies.
 
 ## Microservice decision
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakIdentitySessionExchange.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakIdentitySessionExchange.java
@@ -1,0 +1,105 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
+import de.caritas.cob.userservice.api.port.out.IdentitySessionExchange;
+import java.util.Map;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/** Keycloak token-exchange adapter for trusted identity subjects. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KeycloakIdentitySessionExchange implements IdentitySessionExchange {
+
+  private static final String TOKEN_ENDPOINT_PATH = "/token";
+  private static final String TOKEN_GRANT_PASSWORD = "password";
+  private static final String TOKEN_GRANT_EXCHANGE =
+      "urn:ietf:params:oauth:grant-type:token-exchange";
+
+  private final @NonNull RestTemplate restTemplate;
+  private final @NonNull IdentityClientConfig identityClientConfig;
+
+  @Value("${keycloak.config.admin-username}")
+  private String keycloakAdminUsername;
+
+  @Value("${keycloak.config.admin-password}")
+  private String keycloakAdminPassword;
+
+  @Value("${keycloak.config.app-client-id:app}")
+  private String keycloakAppClientId;
+
+  @Override
+  public Optional<IdentitySession> exchangeForUser(String identityUserId) {
+    String adminToken = loginAdminForToken();
+    if (isBlank(adminToken)) {
+      return Optional.empty();
+    }
+
+    try {
+      MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+      form.add("grant_type", TOKEN_GRANT_EXCHANGE);
+      form.add("client_id", keycloakAppClientId);
+      form.add("subject_token", adminToken);
+      form.add("requested_subject", identityUserId);
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
+      String tokenUrl = identityClientConfig.getOpenIdConnectUrl(TOKEN_ENDPOINT_PATH);
+      var response =
+          restTemplate.postForEntity(tokenUrl, entity, KeycloakLoginResponseDTO.class).getBody();
+      return Optional.ofNullable(response).map(KeycloakIdentitySessionExchange::toIdentitySession);
+    } catch (Exception exchangeFailure) {
+      log.warn("Identity session exchange failed ({})", exchangeFailure.getClass().getSimpleName());
+      return Optional.empty();
+    }
+  }
+
+  private String loginAdminForToken() {
+    try {
+      MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+      form.add("grant_type", TOKEN_GRANT_PASSWORD);
+      form.add("client_id", keycloakAppClientId);
+      form.add("username", keycloakAdminUsername);
+      form.add("password", keycloakAdminPassword);
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
+      String tokenUrl = identityClientConfig.getOpenIdConnectUrl(TOKEN_ENDPOINT_PATH);
+      var response = restTemplate.postForEntity(tokenUrl, entity, Map.class);
+      if (response.getBody() == null) {
+        return null;
+      }
+      Object token = response.getBody().get("access_token");
+      return token == null ? null : String.valueOf(token);
+    } catch (Exception loginFailure) {
+      log.warn("Identity admin-session login failed ({})", loginFailure.getClass().getSimpleName());
+      return null;
+    }
+  }
+
+  private static IdentitySession toIdentitySession(KeycloakLoginResponseDTO response) {
+    return new IdentitySession(
+        response.getAccessToken(),
+        response.getExpiresIn(),
+        response.getRefreshExpiresIn(),
+        response.getRefreshToken(),
+        response.getTokenType(),
+        response.getSessionState(),
+        response.getScope());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AbsenceDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatInfoResponseDTO;
@@ -21,6 +20,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionListResponseD
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MasterKeyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MobileTokenDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewMessageNotificationDTO;
@@ -177,7 +177,7 @@ public class UserController implements UsersApi {
   }
 
   @org.springframework.web.bind.annotation.PostMapping("/users/magic-link/consume")
-  public ResponseEntity<KeycloakLoginResponseDTO> consumeMagicLink(
+  public ResponseEntity<MagicLinkSessionResponseDTO> consumeMagicLink(
       @Valid @RequestBody MagicLinkConsumeDTO consumeDTO) {
     return userRegistrationControllerDelegate.consumeMagicLink(consumeDTO);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -3,12 +3,12 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 import static de.caritas.cob.userservice.api.model.NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE;
 
 import com.google.common.collect.Lists;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateEnquiryMessageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EnquiryMessageDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetConfirmDTO;
@@ -87,9 +87,10 @@ class UserRegistrationControllerDelegate {
     return ResponseEntity.noContent().build();
   }
 
-  ResponseEntity<KeycloakLoginResponseDTO> consumeMagicLink(MagicLinkConsumeDTO consumeDTO) {
+  ResponseEntity<MagicLinkSessionResponseDTO> consumeMagicLink(MagicLinkConsumeDTO consumeDTO) {
     return magicLinkLoginService
         .consumeMagicLink(consumeDTO.getToken())
+        .map(MagicLinkSessionResponseDTO::from)
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.badRequest().build());
   }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/MagicLinkSessionResponseDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/dto/MagicLinkSessionResponseDTO.java
@@ -1,0 +1,26 @@
+package de.caritas.cob.userservice.api.adapters.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
+
+/** Public magic-link consume response preserving the existing token JSON contract. */
+public record MagicLinkSessionResponseDTO(
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("expires_in") int expiresIn,
+    @JsonProperty("refresh_expires_in") int refreshExpiresIn,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("token_type") String tokenType,
+    @JsonProperty("session_state") String sessionState,
+    String scope) {
+
+  public static MagicLinkSessionResponseDTO from(IdentitySession session) {
+    return new MagicLinkSessionResponseDTO(
+        session.accessToken(),
+        session.expiresIn(),
+        session.refreshExpiresIn(),
+        session.refreshToken(),
+        session.tokenType(),
+        session.sessionState(),
+        session.scope());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySession.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySession.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral authenticated session returned by an identity-provider exchange. */
+public record IdentitySession(
+    String accessToken,
+    int expiresIn,
+    int refreshExpiresIn,
+    String refreshToken,
+    String tokenType,
+    String sessionState,
+    String scope) {}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySessionExchange.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySessionExchange.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import java.util.Optional;
+
+/** Exchanges a trusted identity subject for an authenticated provider-neutral session. */
+public interface IdentitySessionExchange {
+
+  Optional<IdentitySession> exchangeForUser(String identityUserId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
@@ -4,11 +4,11 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
+import de.caritas.cob.userservice.api.port.out.IdentitySessionExchange;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import jakarta.mail.Authenticator;
@@ -31,12 +31,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -44,17 +39,13 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class MagicLinkLoginService {
 
-  private static final String TOKEN_ENDPOINT_PATH = "/token";
-  private static final String TOKEN_GRANT_PASSWORD = "password";
-  private static final String TOKEN_GRANT_EXCHANGE =
-      "urn:ietf:params:oauth:grant-type:token-exchange";
   private static final Duration MAGIC_LINK_TOKEN_TTL = Duration.ofMinutes(15);
   private static final String TOKEN_SCOPE = "magic-login";
 
   private final @NonNull UserService userService;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull RestTemplate restTemplate;
-  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentitySessionExchange identitySessionExchange;
   private final @NonNull OneTimeTokenStore oneTimeTokenStore;
 
   @Value("${identity.email-dummy-suffix:@beratungcaritas.de}")
@@ -62,15 +53,6 @@ public class MagicLinkLoginService {
 
   @Value("${magic.link.frontend.base-url:https://app.oriso.org}")
   private String magicLinkFrontendBaseUrl;
-
-  @Value("${keycloak.config.admin-username}")
-  private String keycloakAdminUsername;
-
-  @Value("${keycloak.config.admin-password}")
-  private String keycloakAdminPassword;
-
-  @Value("${keycloak.config.app-client-id:app}")
-  private String keycloakAppClientId;
 
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
@@ -98,7 +80,7 @@ public class MagicLinkLoginService {
     return MagicLinkRequestResult.ACCEPTED;
   }
 
-  public Optional<KeycloakLoginResponseDTO> consumeMagicLink(String token) {
+  public Optional<IdentitySession> consumeMagicLink(String token) {
     if (isBlank(token)) {
       return Optional.empty();
     }
@@ -115,19 +97,32 @@ public class MagicLinkLoginService {
       return Optional.empty();
     }
 
-    KeycloakLoginResponseDTO exchanged = exchangeTokenForUser(claim.get().subjectId());
-    if (exchanged == null) {
-      // Restore token for short-lived retry if exchange failed due transient infra issue.
-      try {
-        oneTimeTokenStore.restore(TOKEN_SCOPE, token, claim.get(), false);
-      } catch (RuntimeException redisFailure) {
-        log.warn(
-            "Magic-link token retry restoration unavailable ({})",
-            redisFailure.getClass().getSimpleName());
-      }
+    Optional<IdentitySession> exchanged;
+    try {
+      exchanged = identitySessionExchange.exchangeForUser(claim.get().subjectId());
+    } catch (RuntimeException exchangeFailure) {
+      log.warn(
+          "Magic-link identity session exchange unavailable ({})",
+          exchangeFailure.getClass().getSimpleName());
+      restoreTokenForRetry(token, claim.get());
       return Optional.empty();
     }
-    return Optional.of(exchanged);
+    if (exchanged.isEmpty()) {
+      // Restore token for short-lived retry if exchange failed due transient infra issue.
+      restoreTokenForRetry(token, claim.get());
+      return Optional.empty();
+    }
+    return exchanged;
+  }
+
+  private void restoreTokenForRetry(String token, OneTimeTokenStore.TokenClaim claim) {
+    try {
+      oneTimeTokenStore.restore(TOKEN_SCOPE, token, claim, false);
+    } catch (RuntimeException redisFailure) {
+      log.warn(
+          "Magic-link token retry restoration unavailable ({})",
+          redisFailure.getClass().getSimpleName());
+    }
   }
 
   private Optional<AccountLoginTarget> resolveAccount(String username) {
@@ -261,54 +256,6 @@ public class MagicLinkLoginService {
     return normalizeBaseUrl(magicLinkFrontendBaseUrl)
         + "/login?magicToken="
         + URLEncoder.encode(oneTimeToken, StandardCharsets.UTF_8);
-  }
-
-  private KeycloakLoginResponseDTO exchangeTokenForUser(String keycloakUserId) {
-    String adminToken = loginAdminForToken();
-    if (isBlank(adminToken)) {
-      return null;
-    }
-    try {
-      MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-      form.add("grant_type", TOKEN_GRANT_EXCHANGE);
-      form.add("client_id", keycloakAppClientId);
-      form.add("subject_token", adminToken);
-      form.add("requested_subject", keycloakUserId);
-      HttpHeaders headers = new HttpHeaders();
-      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
-      String tokenUrl = identityClientConfig.getOpenIdConnectUrl(TOKEN_ENDPOINT_PATH);
-      return restTemplate.postForEntity(tokenUrl, entity, KeycloakLoginResponseDTO.class).getBody();
-    } catch (Exception ex) {
-      log.warn(
-          "Magic link token exchange failed for user {}, reason: {}",
-          keycloakUserId,
-          ex.getMessage());
-      return null;
-    }
-  }
-
-  private String loginAdminForToken() {
-    try {
-      MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-      form.add("grant_type", TOKEN_GRANT_PASSWORD);
-      form.add("client_id", keycloakAppClientId);
-      form.add("username", keycloakAdminUsername);
-      form.add("password", keycloakAdminPassword);
-      HttpHeaders headers = new HttpHeaders();
-      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
-      String tokenUrl = identityClientConfig.getOpenIdConnectUrl(TOKEN_ENDPOINT_PATH);
-      var response = restTemplate.postForEntity(tokenUrl, entity, Map.class);
-      if (response.getBody() == null) {
-        return null;
-      }
-      Object token = response.getBody().get("access_token");
-      return token == null ? null : String.valueOf(token);
-    } catch (Exception ex) {
-      log.warn("Magic link admin token fetch failed, reason: {}", ex.getMessage());
-      return null;
-    }
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakIdentitySessionExchangeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakIdentitySessionExchangeTest.java
@@ -1,0 +1,116 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakIdentitySessionExchangeTest {
+
+  private static final String TOKEN_URL = "https://identity.example/token";
+
+  @Mock private RestTemplate restTemplate;
+  @Mock private IdentityClientConfig identityClientConfig;
+
+  private KeycloakIdentitySessionExchange exchange;
+
+  @BeforeEach
+  void setUp() {
+    exchange = new KeycloakIdentitySessionExchange(restTemplate, identityClientConfig);
+    ReflectionTestUtils.setField(exchange, "keycloakAdminUsername", "admin");
+    ReflectionTestUtils.setField(exchange, "keycloakAdminPassword", "secret");
+    ReflectionTestUtils.setField(exchange, "keycloakAppClientId", "app");
+    when(identityClientConfig.getOpenIdConnectUrl("/token")).thenReturn(TOKEN_URL);
+  }
+
+  @Test
+  void exchangeForUserShouldMapProviderResponseAndKeepGrantFieldsInsideAdapter() {
+    var providerResponse =
+        new KeycloakLoginResponseDTO(
+            "access-token", 300, 600, "refresh-token", "Bearer", "session-state", "openid profile");
+    when(restTemplate.postForEntity(eq(TOKEN_URL), any(), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "admin-token")));
+    when(restTemplate.postForEntity(eq(TOKEN_URL), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenReturn(ResponseEntity.ok(providerResponse));
+
+    var result = exchange.exchangeForUser("identity-user-id");
+
+    assertThat(result)
+        .hasValueSatisfying(
+            session -> {
+              assertThat(session.accessToken()).isEqualTo("access-token");
+              assertThat(session.expiresIn()).isEqualTo(300);
+              assertThat(session.refreshExpiresIn()).isEqualTo(600);
+              assertThat(session.refreshToken()).isEqualTo("refresh-token");
+              assertThat(session.tokenType()).isEqualTo("Bearer");
+              assertThat(session.sessionState()).isEqualTo("session-state");
+              assertThat(session.scope()).isEqualTo("openid profile");
+            });
+
+    var adminRequest = requestCaptor();
+    verify(restTemplate).postForEntity(eq(TOKEN_URL), adminRequest.capture(), eq(Map.class));
+    assertThat(form(adminRequest).getFirst("grant_type")).isEqualTo("password");
+    assertThat(form(adminRequest).getFirst("client_id")).isEqualTo("app");
+    assertThat(form(adminRequest).getFirst("username")).isEqualTo("admin");
+    assertThat(form(adminRequest).getFirst("password")).isEqualTo("secret");
+
+    var exchangeRequest = requestCaptor();
+    verify(restTemplate)
+        .postForEntity(
+            eq(TOKEN_URL), exchangeRequest.capture(), eq(KeycloakLoginResponseDTO.class));
+    assertThat(form(exchangeRequest).getFirst("grant_type"))
+        .isEqualTo("urn:ietf:params:oauth:grant-type:token-exchange");
+    assertThat(form(exchangeRequest).getFirst("client_id")).isEqualTo("app");
+    assertThat(form(exchangeRequest).getFirst("subject_token")).isEqualTo("admin-token");
+    assertThat(form(exchangeRequest).getFirst("requested_subject")).isEqualTo("identity-user-id");
+  }
+
+  @Test
+  void exchangeForUserShouldReturnEmptyWhenAdminLoginHasNoToken() {
+    when(restTemplate.postForEntity(eq(TOKEN_URL), any(), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()));
+
+    assertThat(exchange.exchangeForUser("identity-user-id")).isEmpty();
+
+    verify(restTemplate, never())
+        .postForEntity(eq(TOKEN_URL), any(), eq(KeycloakLoginResponseDTO.class));
+  }
+
+  @Test
+  void exchangeForUserShouldReturnEmptyWhenProviderExchangeFails() {
+    when(restTemplate.postForEntity(eq(TOKEN_URL), any(), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("access_token", "admin-token")));
+    when(restTemplate.postForEntity(eq(TOKEN_URL), any(), eq(KeycloakLoginResponseDTO.class)))
+        .thenThrow(new IllegalStateException("identity provider unavailable"));
+
+    assertThat(exchange.exchangeForUser("identity-user-id")).isEmpty();
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static ArgumentCaptor<HttpEntity> requestCaptor() {
+    return ArgumentCaptor.forClass(HttpEntity.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static MultiValueMap<String, String> form(ArgumentCaptor<HttpEntity> captor) {
+    return (MultiValueMap<String, String>) captor.getValue().getBody();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -54,6 +54,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
@@ -425,6 +426,36 @@ class UserControllerIT {
     mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
         /* then */
         .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void consumeMagicLinkShouldPreservePublicSnakeCaseSessionContract() throws Exception {
+    when(magicLinkLoginService.consumeMagicLink("one-time-token"))
+        .thenReturn(
+            Optional.of(
+                new IdentitySession(
+                    "access-token",
+                    300,
+                    600,
+                    "refresh-token",
+                    "Bearer",
+                    "session-state",
+                    "openid profile")));
+
+    mvc.perform(
+            post("/users/magic-link/consume")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"token\":\"one-time-token\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.access_token").value("access-token"))
+        .andExpect(jsonPath("$.expires_in").value(300))
+        .andExpect(jsonPath("$.refresh_expires_in").value(600))
+        .andExpect(jsonPath("$.refresh_token").value("refresh-token"))
+        .andExpect(jsonPath("$.token_type").value("Bearer"))
+        .andExpect(jsonPath("$.session_state").value("session-state"))
+        .andExpect(jsonPath("$.scope").value("openid profile"))
+        .andExpect(jsonPath("$.accessToken").doesNotExist())
+        .andExpect(jsonPath("$.refreshToken").doesNotExist());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -11,13 +11,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatCredentials;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateEnquiryMessageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EnquiryMessageDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkConsumeDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkRequestDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.MagicLinkSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.NewRegistrationResponseDto;
 import de.caritas.cob.userservice.api.adapters.web.dto.PasswordResetApplication;
@@ -38,6 +38,7 @@ import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
 import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
@@ -113,13 +114,15 @@ class UserRegistrationControllerDelegateTest {
   void consumeMagicLinkShouldReturnOkWhenTokenIsValid() {
     var consume = new MagicLinkConsumeDTO();
     consume.setToken("token");
-    var loginResponse = new KeycloakLoginResponseDTO();
-    when(magicLinkLoginService.consumeMagicLink("token")).thenReturn(Optional.of(loginResponse));
+    var identitySession =
+        new IdentitySession(
+            "access-token", 300, 600, "refresh-token", "Bearer", "session-state", "openid profile");
+    when(magicLinkLoginService.consumeMagicLink("token")).thenReturn(Optional.of(identitySession));
 
     var response = delegate.consumeMagicLink(consume);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isSameAs(loginResponse);
+    assertThat(response.getBody()).isEqualTo(MagicLinkSessionResponseDTO.from(identitySession));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginServiceTest.java
@@ -4,14 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentitySession;
+import de.caritas.cob.userservice.api.port.out.IdentitySessionExchange;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService.MagicLinkRequestResult;
 import de.caritas.cob.userservice.api.service.user.UserService;
@@ -27,7 +26,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -38,7 +36,7 @@ class MagicLinkLoginServiceTest {
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
   @Mock private RestTemplate restTemplate;
-  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentitySessionExchange identitySessionExchange;
   @Mock private OneTimeTokenStore oneTimeTokenStore;
 
   @InjectMocks private MagicLinkLoginService magicLinkLoginService;
@@ -49,9 +47,6 @@ class MagicLinkLoginServiceTest {
     ReflectionTestUtils.setField(magicLinkLoginService, "consultingTypeServiceApiUrl", "");
     ReflectionTestUtils.setField(
         magicLinkLoginService, "magicLinkFrontendBaseUrl", "https://app.oriso.org");
-    ReflectionTestUtils.setField(magicLinkLoginService, "keycloakAdminUsername", "admin");
-    ReflectionTestUtils.setField(magicLinkLoginService, "keycloakAdminPassword", "secret");
-    ReflectionTestUtils.setField(magicLinkLoginService, "keycloakAppClientId", "app");
     when(oneTimeTokenStore.claim(anyString(), anyString())).thenReturn(Optional.empty());
   }
 
@@ -130,30 +125,28 @@ class MagicLinkLoginServiceTest {
 
   @Test
   void consumeMagicLink_Should_ReturnEmpty_When_TokenIsBlank() {
-    Optional<KeycloakLoginResponseDTO> result = magicLinkLoginService.consumeMagicLink("  ");
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink("  ");
 
     assertThat(result).isEmpty();
   }
 
   @Test
   void consumeMagicLink_Should_ReturnEmpty_When_TokenIsNull() {
-    Optional<KeycloakLoginResponseDTO> result = magicLinkLoginService.consumeMagicLink(null);
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink(null);
 
     assertThat(result).isEmpty();
   }
 
   @Test
   void consumeMagicLink_Should_ReturnEmpty_When_TokenNotFound() {
-    Optional<KeycloakLoginResponseDTO> result =
-        magicLinkLoginService.consumeMagicLink("non-existent-token");
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink("non-existent-token");
 
     assertThat(result).isEmpty();
   }
 
   @Test
   void consumeMagicLink_Should_ReturnEmpty_When_TokenExchangeFails() {
-    Optional<KeycloakLoginResponseDTO> result =
-        magicLinkLoginService.consumeMagicLink("some-random-token");
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink("some-random-token");
 
     assertThat(result).isEmpty();
   }
@@ -255,14 +248,12 @@ class MagicLinkLoginServiceTest {
 
   @Test
   void consumeMagicLink_Should_ReturnEmpty_When_AdminLoginFails() {
-    // Store a valid token via reflection trick — skip SMTP, inject token directly
-    // by calling loginAdminForToken indirectly: restTemplate.postForEntity returns null body
-    when(identityClientConfig.getOpenIdConnectUrl(anyString())).thenReturn("http://kc/token");
-    when(restTemplate.postForEntity(contains("/token"), any(), any()))
-        .thenReturn(ResponseEntity.ok(null));
+    OneTimeTokenStore.TokenClaim claim = validClaim("user-keycloak-id");
+    when(oneTimeTokenStore.claim("magic-login", "valid-token")).thenReturn(Optional.of(claim));
+    when(identitySessionExchange.exchangeForUser("user-keycloak-id")).thenReturn(Optional.empty());
 
-    // Consume non-existent token → empty (token not in map)
-    assertThat(magicLinkLoginService.consumeMagicLink("no-such-token")).isEmpty();
+    assertThat(magicLinkLoginService.consumeMagicLink("valid-token")).isEmpty();
+    verify(oneTimeTokenStore).restore("magic-login", "valid-token", claim, false);
   }
 
   // ── NPE guard: emailDummySuffix = null ───────────────────────────────────
@@ -293,13 +284,10 @@ class MagicLinkLoginServiceTest {
     OneTimeTokenStore.TokenClaim claim = validClaim("user-keycloak-id");
     when(oneTimeTokenStore.claim("magic-login", "valid-token")).thenReturn(Optional.of(claim));
 
-    // First call: token is in map, but exchange will fail (no admin credentials) → returns empty
-    // The important thing is the token is REMOVED from the map after first consume attempt
-    when(identityClientConfig.getOpenIdConnectUrl(anyString())).thenReturn("http://kc/token");
-    when(restTemplate.postForEntity(contains("/token"), any(), any()))
+    when(identitySessionExchange.exchangeForUser("user-keycloak-id"))
         .thenThrow(new RuntimeException("connection refused"));
 
-    magicLinkLoginService.consumeMagicLink("valid-token");
+    assertThat(magicLinkLoginService.consumeMagicLink("valid-token")).isEmpty();
 
     verify(oneTimeTokenStore).restore("magic-login", "valid-token", claim, false);
   }
@@ -311,14 +299,9 @@ class MagicLinkLoginServiceTest {
     OneTimeTokenStore.TokenClaim claim = validClaim("user-keycloak-id");
     when(oneTimeTokenStore.claim("magic-login", "retry-token")).thenReturn(Optional.of(claim));
 
-    // Admin login returns null body → loginAdminForToken returns null → exchangeTokenForUser
-    // returns null → token is restored
-    when(identityClientConfig.getOpenIdConnectUrl(anyString())).thenReturn("http://kc/token");
-    when(restTemplate.postForEntity(contains("/token"), any(), any()))
-        .thenReturn(ResponseEntity.ok(null));
+    when(identitySessionExchange.exchangeForUser("user-keycloak-id")).thenReturn(Optional.empty());
 
-    Optional<KeycloakLoginResponseDTO> result =
-        magicLinkLoginService.consumeMagicLink("retry-token");
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink("retry-token");
 
     assertThat(result).isEmpty();
     verify(oneTimeTokenStore).restore("magic-login", "retry-token", claim, false);
@@ -543,28 +526,19 @@ class MagicLinkLoginServiceTest {
         .doesNotThrowAnyException();
   }
 
-  // ── consumeMagicLink — happy path returns KeycloakLoginResponseDTO ────────
+  // ── consumeMagicLink — happy path returns provider-neutral session ────────
 
   @Test
   void consumeMagicLink_Should_ReturnDto_When_TokenValidAndExchangeSucceeds() {
     when(oneTimeTokenStore.claim("magic-login", "happy-token"))
         .thenReturn(Optional.of(validClaim("user-kc-id")));
 
-    Map<String, Object> adminBody = new HashMap<>();
-    adminBody.put("access_token", "admin-access-token");
-    KeycloakLoginResponseDTO responseDTO = new KeycloakLoginResponseDTO();
+    IdentitySession session = identitySession();
+    when(identitySessionExchange.exchangeForUser("user-kc-id")).thenReturn(Optional.of(session));
 
-    when(identityClientConfig.getOpenIdConnectUrl(anyString())).thenReturn("http://kc/token");
-    when(restTemplate.postForEntity(anyString(), any(), org.mockito.ArgumentMatchers.eq(Map.class)))
-        .thenReturn(ResponseEntity.ok(adminBody));
-    when(restTemplate.postForEntity(
-            anyString(), any(), org.mockito.ArgumentMatchers.eq(KeycloakLoginResponseDTO.class)))
-        .thenReturn(ResponseEntity.ok(responseDTO));
+    Optional<IdentitySession> result = magicLinkLoginService.consumeMagicLink("happy-token");
 
-    Optional<KeycloakLoginResponseDTO> result =
-        magicLinkLoginService.consumeMagicLink("happy-token");
-
-    assertThat(result).isPresent();
+    assertThat(result).contains(session);
   }
 
   // ── exchangeTokenForUser catch block — admin succeeds, exchange throws ────
@@ -575,19 +549,12 @@ class MagicLinkLoginServiceTest {
     when(oneTimeTokenStore.claim("magic-login", "exchange-fail-token"))
         .thenReturn(Optional.of(claim));
 
-    Map<String, Object> adminBody = new HashMap<>();
-    adminBody.put("access_token", "admin-token");
-    when(identityClientConfig.getOpenIdConnectUrl(anyString())).thenReturn("http://kc/token");
-    when(restTemplate.postForEntity(anyString(), any(), org.mockito.ArgumentMatchers.eq(Map.class)))
-        .thenReturn(ResponseEntity.ok(adminBody));
-    when(restTemplate.postForEntity(
-            anyString(), any(), org.mockito.ArgumentMatchers.eq(KeycloakLoginResponseDTO.class)))
+    when(identitySessionExchange.exchangeForUser("user-id"))
         .thenThrow(new RuntimeException("exchange failed"));
 
-    Optional<KeycloakLoginResponseDTO> result =
+    Optional<IdentitySession> result =
         magicLinkLoginService.consumeMagicLink("exchange-fail-token");
 
-    // exchangeTokenForUser catch → returns null → token restored
     assertThat(result).isEmpty();
     verify(oneTimeTokenStore).restore("magic-login", "exchange-fail-token", claim, false);
   }
@@ -690,6 +657,11 @@ class MagicLinkLoginServiceTest {
 
   private OneTimeTokenStore.TokenClaim validClaim(String subjectId) {
     return new OneTimeTokenStore.TokenClaim(subjectId, Instant.now().plusSeconds(900));
+  }
+
+  private IdentitySession identitySession() {
+    return new IdentitySession(
+        "access-token", 300, 600, "refresh-token", "Bearer", "session-state", "openid profile");
   }
 
   private User validUserWithMagicLinkEnabled() {

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -136,6 +136,32 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "Keycloak SDK types",
         )
 
+    def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
+        sources = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/auth/"
+            "MagicLinkLoginService.java",
+            CONTROLLERS / "UserController.java",
+            CONTROLLERS / "UserRegistrationControllerDelegate.java",
+        )
+        forbidden_prefix = (
+            "import de.caritas.cob.userservice.api.adapters.keycloak."
+        )
+        offenders = [
+            f"{source.relative_to(ROOT)} imports {line}"
+            for source in sources
+            for line in source.read_text().splitlines()
+            if line.startswith(forbidden_prefix)
+        ]
+
+        self.assertEqual(
+            [],
+            offenders,
+            "Magic-link application and web boundaries must expose "
+            "application-owned sessions instead of Keycloak transport DTOs:\n"
+            + "\n".join(offenders),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- introduce the provider-neutral `IdentitySession` and `IdentitySessionExchange` output contract
- move Keycloak password-grant, token-exchange and transport mapping into `KeycloakIdentitySessionExchange`
- keep the public seven-field magic-link response unchanged through a web-owned snake-case DTO
- preserve one-time-token restoration on empty or exceptional identity exchange failures
- ratchet the module boundary so application and web code cannot re-import Keycloak transport types

## Architecture context

The target chat architecture remains Matrix-only with the ORISO-owned frontend and the controlled MatrixRTC/Element Call fork using LiveKit. Rocket.Chat references in the current codebase are legacy removal debt, not part of the target architecture. This focused slice changes the identity-session boundary and does not claim that legacy chat removal is complete.

## Verification

- Red/Green: the new module-boundary test initially reported the three Keycloak imports in `MagicLinkLoginService`, `UserController` and `UserRegistrationControllerDelegate`
- Red/Green: exceptional identity exchange initially escaped and failed two token-restoration tests; the service now fails closed and restores the claim
- focused service, adapter and delegate tests: 64 passed
- focused HTTP JSON contract: passed with all seven snake-case fields and no camel-case aliases
- unit suite: 3,852 passed, 0 failed, 0 errored, 0 skipped
- integration, contract and E2E suite with Redis 7: 969 passed, 0 failed, 0 errored, 5 MariaDB-gated skips
- fresh MariaDB 10.11 contracts: 9 passed, 0 skipped
- dedicated Redis 7 contracts: 14 passed, 0 skipped
- Python CI contracts: 26 passed
- local CodeRabbit review: 0 findings

## Stack and reconciliation

- Depends on #769
- Refs #770
- #753 independently introduces broader provider-neutral identity results from `pre-dev`; this stacked slice intentionally preserves the later stability and zero-quarantine work and will require semantic reconciliation when the stacks converge

No merge or deployment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
