### PR TITLE
fix(replica): make authenticated tutorial writes atomic (#773)

### DIFF
--- a/.github/workflows/mariadb-contract.yml
+++ b/.github/workflows/mariadb-contract.yml
@@ -38,5 +38,11 @@ jobs:
     - name: Verify real MariaDB schema contracts
       run: >-
         ./mvnw -B -Dskip.unit-tests=true
-        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,OrganizerMariaDbReplicaIT,DeactivateGroupChatSchedulerMariaDbReplicaIT,ConsultantMessageStatServiceMariaDbReplicaIT,InactiveAccountNotificationServiceReplicaIT,DeleteInactiveSessionsAndUserSchedulerReplicaIT
+        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,OrganizerMariaDbReplicaIT,DeactivateGroupChatSchedulerMariaDbReplicaIT,ConsultantMessageStatServiceMariaDbReplicaIT,InactiveAccountNotificationServiceReplicaIT,DeleteInactiveSessionsAndUserSchedulerReplicaIT,TutorialProgressServiceMariaDbReplicaIT
         integration-test
+
+    - name: Prove authenticated writes across two replicas
+      env:
+        USERSERVICE_LOAD_REQUESTS: 80
+        USERSERVICE_LOAD_CONCURRENCY: 12
+      run: ./scripts/load/run-authenticated-write-replicas.sh

--- a/documentation/USER_SERVICE_REPLICA_SAFETY.md
+++ b/documentation/USER_SERVICE_REPLICA_SAFETY.md
@@ -236,6 +236,29 @@ database reads, provider cleanup or error-mail work.
 one context setup and one invocation of each mode under two concurrent
 scheduler instances. Its 12-hour claim has the same daily duration constraint.
 
+Authenticated tutorial-progress writes no longer implement read-then-insert in
+the service layer. `TutorialProgressStore` owns the transaction and uses
+MariaDB's native `ON DUPLICATE KEY UPDATE` against the unique
+user/surface/tour/version scope. Its small transaction uses `READ_COMMITTED`:
+when two replicas send an identical update within the same `DATETIME` second,
+the database may perform a no-op update, and a `REPEATABLE_READ` snapshot would
+otherwise remain unable to see the winning row. The real-MariaDB
+`TutorialProgressServiceMariaDbReplicaIT` forces both instances to read the
+missing scope before either writes and proves both calls return the one
+canonical row without a duplicate-key warning. It also preserves the per-user
+row cap for new scopes while allowing existing scopes to update.
+
+`scripts/load/run-authenticated-write-replicas.sh` extends that database proof
+through the running HTTP/security stack. It starts two real UserService JVMs
+against one disposable MariaDB and Redis, verifies a locally signed consultant
+JWT through a disposable JWK endpoint, alternates concurrent CSRF-protected
+PUTs over both replicas, reads through both, restarts one JVM and repeats the
+cross-replica verification. The contract fails on any non-200 response,
+per-operation or per-replica p95 above the bound, more than one canonical row,
+or a duplicate-key warning. The reusable MariaDB workflow runs this proof.
+This establishes the authenticated tutorial-progress slice only; it does not
+raise the global supported replica count.
+
 ## Current dependency sequence
 
 1. Land the Redis-backed single-use token PR #740 in `pre-dev` before merging

--- a/documentation/USER_SERVICE_REPLICA_SAFETY.md
+++ b/documentation/USER_SERVICE_REPLICA_SAFETY.md
@@ -253,11 +253,13 @@ through the running HTTP/security stack. It starts two real UserService JVMs
 against one disposable MariaDB and Redis, verifies a locally signed consultant
 JWT through a disposable JWK endpoint, alternates concurrent CSRF-protected
 PUTs over both replicas, reads through both, restarts one JVM and repeats the
-cross-replica verification. The contract fails on any non-200 response,
-per-operation or per-replica p95 above the bound, more than one canonical row,
-or a duplicate-key warning. The reusable MariaDB workflow runs this proof.
-This establishes the authenticated tutorial-progress slice only; it does not
-raise the global supported replica count.
+cross-replica verification. A separate versioned scope warms the fresh JVM and
+is excluded from the report; the measured scope remains absent until the main
+phase, so its first-write race is still exercised. The contract fails on any
+non-200 response, per-operation or per-replica p95 above the bound, more than
+one canonical row, or a duplicate-key warning. The reusable MariaDB workflow
+runs this proof. This establishes the authenticated tutorial-progress slice
+only; it does not raise the global supported replica count.
 
 ## Current dependency sequence
 

--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -294,3 +294,14 @@ capacity claim or deployed SigNoz proof. The runtime gauge still reports one
 supported replica and six remaining local-state components. The exact image
 must still be deployed under normal authenticated traffic and queried through
 SigNoz before changing either claim.
+
+Local authenticated-write proof on 2026-07-27 used two real UserService JVMs,
+one disposable MariaDB 11.0.6 database, shared Redis and a locally signed
+consultant JWT verified through a disposable JWK endpoint. Eighty concurrent
+tutorial-progress PUTs alternated over both replicas, followed by a read from
+each replica: 0 failures, 439 ms aggregate p95 and exactly one canonical
+database row. After restarting one replica, 12 further writes and both
+cross-replica reads completed with 0 failures and 384 ms p95. The runner applies
+the same zero-error and 1,000 ms p95 bound per operation and per replica. This
+is a bounded authenticated state-transition and restart proof for one slice,
+not deployed PreDev or whole-service multi-replica evidence.

--- a/scripts/load/ensure-java-21.sh
+++ b/scripts/load/ensure-java-21.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+java_major_version() {
+  local java_command="$1"
+  local version_output
+  version_output="$("${java_command}" -version 2>&1 | head -n 1)" || return 1
+  if [[ "${version_output}" =~ \"([0-9]+)(\.([0-9]+))? ]]; then
+    if [[ "${BASH_REMATCH[1]}" == "1" ]]; then
+      printf '%s\n' "${BASH_REMATCH[3]}"
+    else
+      printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
+    return 0
+  fi
+  return 1
+}
+
+ensure_java_21() {
+  local current_java
+  local current_major=""
+  local current_version="unavailable"
+  current_java="$(command -v java 2>/dev/null || true)"
+  if [[ -n "${current_java}" ]]; then
+    current_major="$(java_major_version "${current_java}" || true)"
+    current_version="$("${current_java}" -version 2>&1 | head -n 1)"
+  fi
+  if [[ "${current_major}" == "21" ]]; then
+    return 0
+  fi
+
+  local resolver="${JAVA_21_HOME_RESOLVER:-}"
+  if [[ -z "${resolver}" && -x /usr/libexec/java_home ]]; then
+    resolver="/usr/libexec/java_home"
+  fi
+  if [[ -n "${resolver}" && -x "${resolver}" ]]; then
+    local java_21_home
+    java_21_home="$("${resolver}" -v 21 2>/dev/null || true)"
+    if [[ -x "${java_21_home}/bin/java" ]] &&
+      [[ "$(java_major_version "${java_21_home}/bin/java" || true)" == "21" ]]; then
+      export JAVA_HOME="${java_21_home}"
+      export PATH="${JAVA_HOME}/bin:${PATH}"
+      return 0
+    fi
+  fi
+
+  echo "UserService requires Java 21; current runtime: ${current_version}" >&2
+  return 1
+}

--- a/scripts/load/run-authenticated-write-replicas.sh
+++ b/scripts/load/run-authenticated-write-replicas.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${repo_root}/scripts/load/ensure-java-21.sh"
+ensure_java_21
+
+request_count="${USERSERVICE_LOAD_REQUESTS:-200}"
+restart_request_count="${USERSERVICE_RESTART_REQUESTS:-12}"
+concurrency="${USERSERVICE_LOAD_CONCURRENCY:-16}"
+max_p95_ms="${USERSERVICE_LOAD_MAX_P95_MS:-1000}"
+keep_run_dir="${USERSERVICE_KEEP_RUN_DIR:-false}"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/userservice-authenticated-replicas.XXXXXX")"
+run_id="userservice-authenticated-replicas-$$"
+mariadb_container="${run_id}-mariadb"
+redis_container="${run_id}-redis"
+replica_one_pid=""
+replica_two_pid=""
+jwk_stub_pid=""
+started_replica_pid=""
+
+allocate_port() {
+  python3 -c \
+    'import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()'
+}
+
+stop_process() {
+  local process_id="$1"
+  if [[ -n "${process_id}" ]] && kill -0 "${process_id}" 2>/dev/null; then
+    kill "${process_id}" 2>/dev/null || true
+    wait "${process_id}" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  local exit_status="$?"
+  stop_process "${replica_one_pid}"
+  stop_process "${replica_two_pid}"
+  stop_process "${jwk_stub_pid}"
+  docker rm -f "${mariadb_container}" >/dev/null 2>&1 || true
+  docker rm -f "${redis_container}" >/dev/null 2>&1 || true
+  if [[ "${keep_run_dir}" == "true" && "${exit_status}" != "0" ]]; then
+    echo "Preserved failed replica proof artifacts: ${run_dir}" >&2
+  else
+    rm -r "${run_dir}"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command in docker curl grep openssl python3 java; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  fi
+done
+
+replica_one_port="$(allocate_port)"
+replica_two_port="$(allocate_port)"
+jwk_stub_port="$(allocate_port)"
+
+docker run --detach \
+  --name "${mariadb_container}" \
+  --env MARIADB_ROOT_PASSWORD=root \
+  --env MARIADB_DATABASE=userservice \
+  --publish 127.0.0.1::3306 \
+  --health-cmd "healthcheck.sh --connect --innodb_initialized" \
+  --health-interval 2s \
+  --health-timeout 5s \
+  --health-retries 30 \
+  mariadb:11.0.6 \
+  >"${run_dir}/mariadb.container"
+
+docker run --detach \
+  --name "${redis_container}" \
+  --publish 127.0.0.1::6379 \
+  --health-cmd "redis-cli ping" \
+  --health-interval 2s \
+  --health-timeout 3s \
+  --health-retries 30 \
+  redis:7-alpine \
+  >"${run_dir}/redis.container"
+
+for container in "${mariadb_container}" "${redis_container}"; do
+  healthy=false
+  for ((attempt = 1; attempt <= 90; attempt += 1)); do
+    if [[ "$(docker inspect --format '{{.State.Health.Status}}' "${container}")" == "healthy" ]]; then
+      healthy=true
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${healthy}" != true ]]; then
+    echo "Container did not become healthy: ${container}" >&2
+    docker logs --tail 120 "${container}" >&2
+    exit 1
+  fi
+done
+
+mariadb_binding="$(docker port "${mariadb_container}" 3306/tcp | head -n 1)"
+redis_binding="$(docker port "${redis_container}" 6379/tcp | head -n 1)"
+mariadb_port="${mariadb_binding##*:}"
+redis_port="${redis_binding##*:}"
+jdbc_url="jdbc:mariadb://127.0.0.1:${mariadb_port}/userservice"
+identity_url="http://127.0.0.1:${jwk_stub_port}/auth/realms/testing/.well-known/openid-configuration"
+
+python3 "${repo_root}/tests/load/jwt_jwk_stub.py" \
+  --port "${jwk_stub_port}" \
+  --private-key "${run_dir}/jwt-private-key.pem" \
+  --token-file "${run_dir}/consultant.jwt" \
+  >"${run_dir}/jwk-stub.log" 2>&1 &
+jwk_stub_pid="$!"
+
+jwk_ready=false
+for ((attempt = 1; attempt <= 30; attempt += 1)); do
+  if curl --fail --silent "http://127.0.0.1:${jwk_stub_port}/health" >/dev/null; then
+    jwk_ready=true
+    break
+  fi
+  if ! kill -0 "${jwk_stub_pid}" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+if [[ "${jwk_ready}" != true ]]; then
+  echo "Disposable JWK endpoint did not become ready" >&2
+  cat "${run_dir}/jwk-stub.log" >&2
+  exit 1
+fi
+
+"${repo_root}/mvnw" -B -DskipTests -Dskip.unit-tests=true -Dskip.integration-tests=true package \
+  >"${run_dir}/package.log" 2>&1
+jar_path="${repo_root}/target/UserService.jar"
+if [[ ! -f "${jar_path}" ]]; then
+  echo "Packaged UserService jar is missing: ${jar_path}" >&2
+  tail -120 "${run_dir}/package.log" >&2
+  exit 1
+fi
+
+start_replica() {
+  local port="$1"
+  local log_file="$2"
+  env \
+    SPRING_PROFILES_ACTIVE=testing \
+    SERVER_PORT="${port}" \
+    SPRING_DATASOURCE_URL="${jdbc_url}" \
+    SPRING_DATASOURCE_USERNAME=root \
+    SPRING_DATASOURCE_PASSWORD=root \
+    SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver \
+    SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT=org.hibernate.dialect.MariaDBDialect \
+    SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
+    SPRING_LIQUIBASE_ENABLED=true \
+    SPRING_SQL_INIT_MODE=never \
+    SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION=false \
+    SPRING_DATA_REDIS_HOST=127.0.0.1 \
+    SPRING_DATA_REDIS_PORT="${redis_port}" \
+    IDENTITY_OPENID_CONNECT_URL="${identity_url}" \
+    KEYCLOAK_AUTH_SERVER_URL="http://127.0.0.1:${jwk_stub_port}/auth" \
+    MATRIX_EVENT_LISTENER_ENABLED=false \
+    ROCKET_CHAT_ENABLED=false \
+    SPRING_TASK_SCHEDULING_ENABLED=false \
+    LOGGING_LEVEL_ROOT=WARN \
+    java -jar "${jar_path}" >"${log_file}" 2>&1 &
+  started_replica_pid="$!"
+}
+
+wait_for_replica() {
+  local port="$1"
+  local process_id="$2"
+  local log_file="$3"
+  local ready=false
+  for ((attempt = 1; attempt <= 180; attempt += 1)); do
+    if curl --fail --silent \
+      "http://127.0.0.1:${port}/actuator/health/liveness" \
+      >/dev/null; then
+      ready=true
+      break
+    fi
+    if ! kill -0 "${process_id}" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${ready}" != true ]]; then
+    echo "UserService replica on port ${port} did not become live:" >&2
+    tail -160 "${log_file}" >&2
+    exit 1
+  fi
+}
+
+start_replica "${replica_one_port}" "${run_dir}/replica-one.log"
+replica_one_pid="${started_replica_pid}"
+wait_for_replica "${replica_one_port}" "${replica_one_pid}" "${run_dir}/replica-one.log"
+
+start_replica "${replica_two_port}" "${run_dir}/replica-two.log"
+replica_two_pid="${started_replica_pid}"
+wait_for_replica "${replica_two_port}" "${replica_two_pid}" "${run_dir}/replica-two.log"
+
+python3 "${repo_root}/tests/load/authenticated_tutorial_replica_load.py" \
+  --replica-url "http://127.0.0.1:${replica_one_port}" \
+  --replica-url "http://127.0.0.1:${replica_two_port}" \
+  --token-file "${run_dir}/consultant.jwt" \
+  --requests "${request_count}" \
+  --concurrency "${concurrency}" \
+  --max-p95-ms "${max_p95_ms}" \
+  | tee "${run_dir}/initial-report.json"
+
+stop_process "${replica_one_pid}"
+replica_one_pid=""
+start_replica "${replica_one_port}" "${run_dir}/replica-one-restarted.log"
+replica_one_pid="${started_replica_pid}"
+wait_for_replica \
+  "${replica_one_port}" \
+  "${replica_one_pid}" \
+  "${run_dir}/replica-one-restarted.log"
+
+python3 "${repo_root}/tests/load/authenticated_tutorial_replica_load.py" \
+  --replica-url "http://127.0.0.1:${replica_one_port}" \
+  --replica-url "http://127.0.0.1:${replica_two_port}" \
+  --token-file "${run_dir}/consultant.jwt" \
+  --requests "${restart_request_count}" \
+  --concurrency 2 \
+  --max-p95-ms "${max_p95_ms}" \
+  | tee "${run_dir}/restart-report.json"
+
+canonical_rows="$(
+  docker exec "${mariadb_container}" \
+    mariadb --batch --skip-column-names --user=root --password=root userservice \
+    --execute \
+    "SELECT COUNT(*) FROM tutorial_progress WHERE user_id='tutorial-replica-jwt-user' AND surface='frontend' AND tour_id='consultant-walkthrough' AND tour_version=1;"
+)"
+if [[ "${canonical_rows}" != "1" ]]; then
+  echo "Expected one canonical tutorial progress row, found ${canonical_rows}" >&2
+  exit 1
+fi
+
+if grep -En "Duplicate entry.*uq_tutorial_progress_scope" \
+  "${run_dir}/replica-one.log" \
+  "${run_dir}/replica-two.log" \
+  "${run_dir}/replica-one-restarted.log"; then
+  echo "Concurrent authenticated writes emitted a duplicate-key warning" >&2
+  exit 1
+fi
+
+echo "Authenticated two-replica write proof passed with one canonical row after restart."

--- a/scripts/load/run-authenticated-write-replicas.sh
+++ b/scripts/load/run-authenticated-write-replicas.sh
@@ -197,6 +197,18 @@ start_replica "${replica_two_port}" "${run_dir}/replica-two.log"
 replica_two_pid="${started_replica_pid}"
 wait_for_replica "${replica_two_port}" "${replica_two_pid}" "${run_dir}/replica-two.log"
 
+# Warm the JWT/JWK, security, controller, transaction and SQL paths on a separate scope. The
+# measured version-1 scope remains absent, so the main phase still exercises its first-write race.
+python3 "${repo_root}/tests/load/authenticated_tutorial_replica_load.py" \
+  --replica-url "http://127.0.0.1:${replica_one_port}" \
+  --replica-url "http://127.0.0.1:${replica_two_port}" \
+  --token-file "${run_dir}/consultant.jwt" \
+  --tour-version 999 \
+  --requests 12 \
+  --concurrency 2 \
+  --max-p95-ms 5000 \
+  >/dev/null
+
 python3 "${repo_root}/tests/load/authenticated_tutorial_replica_load.py" \
   --replica-url "http://127.0.0.1:${replica_one_port}" \
   --replica-url "http://127.0.0.1:${replica_two_port}" \

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TutorialProgressRepository.java
@@ -1,9 +1,13 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.TutorialProgress;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface TutorialProgressRepository extends CrudRepository<TutorialProgress, Long> {
 
@@ -14,4 +18,42 @@ public interface TutorialProgressRepository extends CrudRepository<TutorialProgr
 
   /** Number of progress rows a user owns — used to cap per-user row growth. */
   long countByUserId(String userId);
+
+  /**
+   * Atomically creates or updates one versioned progress scope.
+   *
+   * <p>The unique scope constraint is shared by every replica. Using MariaDB's native upsert keeps
+   * concurrent first writes on the normal SQL path instead of emitting duplicate-key warnings and
+   * recovering from an exception.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      value =
+          """
+          INSERT INTO tutorial_progress (
+            user_id, surface, tour_id, tour_version, status, current_step_id,
+            started_at, completed_at, create_date, update_date, tenant_id
+          ) VALUES (
+            :userId, :surface, :tourId, :tourVersion, :status, :currentStepId,
+            :startedAt, :completedAt, :createDate, :updateDate, :tenantId
+          )
+          ON DUPLICATE KEY UPDATE
+            status = VALUES(status),
+            current_step_id = VALUES(current_step_id),
+            completed_at = VALUES(completed_at),
+            update_date = VALUES(update_date)
+          """,
+      nativeQuery = true)
+  int upsertScopedProgress(
+      @Param("userId") String userId,
+      @Param("surface") String surface,
+      @Param("tourId") String tourId,
+      @Param("tourVersion") Integer tourVersion,
+      @Param("status") String status,
+      @Param("currentStepId") String currentStepId,
+      @Param("startedAt") LocalDateTime startedAt,
+      @Param("completedAt") LocalDateTime completedAt,
+      @Param("createDate") LocalDateTime createDate,
+      @Param("updateDate") LocalDateTime updateDate,
+      @Param("tenantId") Long tenantId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressService.java
@@ -56,41 +56,31 @@ public class TutorialProgressService {
   @Value("${tutorial.max-rows-per-user:50}")
   private int maxRowsPerUser = 50;
 
-  @Transactional
+  private final @NonNull TutorialProgressStore tutorialProgressStore;
+
   public TutorialProgressItem upsertOwnProgress(
       String userId, Long tenantId, UpsertTutorialProgressRequest request) {
     validate(request);
 
     var now = LocalDateTime.now();
-    var existing =
-        tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            userId, request.getSurface(), request.getTourId(), request.getTourVersion());
-    if (existing.isEmpty() && tutorialProgressRepository.countByUserId(userId) >= maxRowsPerUser) {
-      throw new BadRequestException("tutorial progress row limit reached for this user");
-    }
-    var progress =
-        existing.orElseGet(
-            () ->
-                TutorialProgress.builder()
-                    .userId(userId)
-                    .surface(request.getSurface())
-                    .tourId(request.getTourId())
-                    .tourVersion(request.getTourVersion())
-                    .createDate(now)
-                    .startedAt(now)
-                    .tenantId(tenantId)
-                    .build());
-
-    progress.setStatus(request.getStatus());
-    progress.setCurrentStepId(request.getCurrentStepId());
-    progress.setUpdateDate(now);
+    var desired =
+        TutorialProgress.builder()
+            .userId(userId)
+            .surface(request.getSurface())
+            .tourId(request.getTourId())
+            .tourVersion(request.getTourVersion())
+            .status(request.getStatus())
+            .currentStepId(request.getCurrentStepId())
+            .createDate(now)
+            .updateDate(now)
+            .startedAt(now)
+            .tenantId(tenantId)
+            .build();
     if (isTerminal(request.getStatus())) {
-      progress.setCompletedAt(now);
-    } else {
-      progress.setCompletedAt(null);
+      desired.setCompletedAt(now);
     }
 
-    return toItem(tutorialProgressRepository.save(progress));
+    return toItem(tutorialProgressStore.upsert(desired, maxRowsPerUser));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressStore.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressStore.java
@@ -1,0 +1,80 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import java.util.Objects;
+import java.util.function.Supplier;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Owns the transactional upsert invariant for one versioned tutorial-progress scope.
+ *
+ * <p>Two replicas may both observe a missing row. MariaDB's native upsert and the database unique
+ * constraint serialize both writes without leaking or logging a duplicate-key failure through the
+ * HTTP interface.
+ */
+@Component
+@RequiredArgsConstructor
+public class TutorialProgressStore {
+
+  private final @NonNull TutorialProgressRepository tutorialProgressRepository;
+  private final @NonNull PlatformTransactionManager transactionManager;
+
+  public TutorialProgress upsert(TutorialProgress desired, int maxRowsPerUser) {
+    return inNewTransaction(() -> writeOnce(desired, maxRowsPerUser));
+  }
+
+  private TutorialProgress writeOnce(TutorialProgress desired, int maxRowsPerUser) {
+    var existing = findScope(desired);
+    if (existing == null
+        && tutorialProgressRepository.countByUserId(desired.getUserId()) >= maxRowsPerUser) {
+      throw new BadRequestException("tutorial progress row limit reached for this user");
+    }
+    tutorialProgressRepository.upsertScopedProgress(
+        desired.getUserId(),
+        desired.getSurface(),
+        desired.getTourId(),
+        desired.getTourVersion(),
+        desired.getStatus(),
+        desired.getCurrentStepId(),
+        desired.getStartedAt(),
+        desired.getCompletedAt(),
+        desired.getCreateDate(),
+        desired.getUpdateDate(),
+        desired.getTenantId());
+    return tutorialProgressRepository
+        .findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            desired.getUserId(),
+            desired.getSurface(),
+            desired.getTourId(),
+            desired.getTourVersion())
+        .orElseThrow(
+            () -> new IllegalStateException("atomic tutorial progress upsert lost its row"));
+  }
+
+  private TutorialProgress findScope(TutorialProgress desired) {
+    return tutorialProgressRepository
+        .findByUserIdAndSurfaceAndTourIdAndTourVersion(
+            desired.getUserId(),
+            desired.getSurface(),
+            desired.getTourId(),
+            desired.getTourVersion())
+        .orElse(null);
+  }
+
+  private <T> T inNewTransaction(Supplier<T> action) {
+    TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+    transaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    // A no-op ON DUPLICATE KEY UPDATE does not make the winner's row part of this transaction's
+    // REPEATABLE_READ snapshot. READ_COMMITTED guarantees the canonical read immediately after
+    // the atomic statement can see the row committed by another replica.
+    transaction.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+    return Objects.requireNonNull(transaction.execute(ignored -> action.get()));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceMariaDbReplicaIT.java
@@ -1,0 +1,204 @@
+package de.caritas.cob.userservice.api.service.tutorial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.model.TutorialProgress;
+import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.UpsertTutorialProgressRequest;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.AdditionalAnswers;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class TutorialProgressServiceMariaDbReplicaIT {
+
+  private static final String USER_ID = "tutorial-replica-proof";
+  private static final String SURFACE = "frontend";
+  private static final String TOUR_ID = "consultant-walkthrough";
+  private static final int TOUR_VERSION = 1;
+
+  @Autowired private TutorialProgressRepository tutorialProgressRepository;
+  @Autowired private PlatformTransactionManager transactionManager;
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.mariadb.jdbc.Driver");
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MariaDBDialect");
+  }
+
+  @AfterEach
+  void deleteReplicaProofRows() {
+    tutorialProgressRepository.findByUserIdAndSurface(USER_ID, SURFACE).stream()
+        .forEach(tutorialProgressRepository::delete);
+  }
+
+  @Test
+  void concurrentFirstWritesFromTwoReplicasUpsertOneCanonicalProgressRow() throws Exception {
+    Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    var logs = new ListAppender<ILoggingEvent>();
+    logs.start();
+    rootLogger.addAppender(logs);
+    var bothReadsCompleted = new CountDownLatch(2);
+    var releaseWrites = new CountDownLatch(1);
+    var firstRepository = repositoryPausedAfterRead(bothReadsCompleted, releaseWrites);
+    var secondRepository = repositoryPausedAfterRead(bothReadsCompleted, releaseWrites);
+    var firstInstance =
+        new TutorialProgressService(
+            firstRepository, new TutorialProgressStore(firstRepository, transactionManager));
+    var secondInstance =
+        new TutorialProgressService(
+            secondRepository, new TutorialProgressStore(secondRepository, transactionManager));
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> first =
+          executor.submit(() -> firstInstance.upsertOwnProgress(USER_ID, null, request("profile")));
+      Future<?> second =
+          executor.submit(
+              () -> secondInstance.upsertOwnProgress(USER_ID, null, request("profile")));
+
+      assertThat(bothReadsCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+      releaseWrites.countDown();
+      first.get(10, TimeUnit.SECONDS);
+      second.get(10, TimeUnit.SECONDS);
+    } finally {
+      releaseWrites.countDown();
+      executor.shutdownNow();
+      rootLogger.detachAppender(logs);
+    }
+
+    assertThat(logs.list)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .noneMatch(message -> message.contains("Duplicate entry"));
+    assertThat(tutorialProgressRepository.findByUserIdAndSurface(USER_ID, SURFACE))
+        .singleElement()
+        .satisfies(
+            progress -> {
+              assertThat(progress.getTourId()).isEqualTo(TOUR_ID);
+              assertThat(progress.getTourVersion()).isEqualTo(TOUR_VERSION);
+              assertThat(progress.getStatus()).isEqualTo("in_progress");
+              assertThat(progress.getCurrentStepId()).isEqualTo("profile");
+            });
+  }
+
+  @Test
+  void existingScopeRemainsWritableWhenTheRowCapIsReached() {
+    var store = new TutorialProgressStore(tutorialProgressRepository, transactionManager);
+    store.upsert(progress(1, "in_progress"), 1);
+
+    var updated = store.upsert(progress(1, "completed"), 0);
+
+    assertThat(updated.getStatus()).isEqualTo("completed");
+    assertThat(updated.getCompletedAt()).isNotNull();
+    assertThat(tutorialProgressRepository.findByUserIdAndSurface(USER_ID, SURFACE)).hasSize(1);
+  }
+
+  @Test
+  void newScopeIsRejectedWhenTheRowCapIsReached() {
+    var store = new TutorialProgressStore(tutorialProgressRepository, transactionManager);
+    store.upsert(progress(1, "in_progress"), 1);
+
+    assertThatThrownBy(() -> store.upsert(progress(2, "in_progress"), 1))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("row limit");
+    assertThat(tutorialProgressRepository.findByUserIdAndSurface(USER_ID, SURFACE)).hasSize(1);
+  }
+
+  private TutorialProgressRepository repositoryPausedAfterRead(
+      CountDownLatch bothReadsCompleted, CountDownLatch releaseWrites) {
+    TutorialProgressRepository adapter =
+        mock(
+            TutorialProgressRepository.class,
+            withSettings()
+                .defaultAnswer(AdditionalAnswers.delegatesTo(tutorialProgressRepository)));
+    doAnswer(
+            invocation -> {
+              var existing =
+                  tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
+                      invocation.getArgument(0),
+                      invocation.getArgument(1),
+                      invocation.getArgument(2),
+                      invocation.getArgument(3));
+              bothReadsCompleted.countDown();
+              await(releaseWrites);
+              return existing;
+            })
+        .when(adapter)
+        .findByUserIdAndSurfaceAndTourIdAndTourVersion(USER_ID, SURFACE, TOUR_ID, TOUR_VERSION);
+    return adapter;
+  }
+
+  private UpsertTutorialProgressRequest request(String currentStepId) {
+    var request = new UpsertTutorialProgressRequest();
+    request.setSurface(SURFACE);
+    request.setTourId(TOUR_ID);
+    request.setTourVersion(TOUR_VERSION);
+    request.setStatus("in_progress");
+    request.setCurrentStepId(currentStepId);
+    return request;
+  }
+
+  private TutorialProgress progress(int version, String status) {
+    var now = LocalDateTime.now();
+    return TutorialProgress.builder()
+        .userId(USER_ID)
+        .surface(SURFACE)
+        .tourId(TOUR_ID)
+        .tourVersion(version)
+        .status(status)
+        .currentStepId("profile")
+        .startedAt(now)
+        .completedAt("completed".equals(status) ? now : null)
+        .createDate(now)
+        .updateDate(now)
+        .build();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent tutorial progress proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/tutorial/TutorialProgressServiceTest.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.service.tutorial;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,9 +12,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestExceptio
 import de.caritas.cob.userservice.api.model.TutorialProgress;
 import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
 import de.caritas.cob.userservice.api.service.tutorial.TutorialProgressService.UpsertTutorialProgressRequest;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -25,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TutorialProgressServiceTest {
 
   @Mock private TutorialProgressRepository tutorialProgressRepository;
+  @Mock private TutorialProgressStore tutorialProgressStore;
 
   @InjectMocks private TutorialProgressService service;
 
@@ -49,7 +49,7 @@ class TutorialProgressServiceTest {
 
     assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
         .isInstanceOf(BadRequestException.class);
-    verify(tutorialProgressRepository, never()).save(any());
+    verify(tutorialProgressStore, never()).upsert(any(), anyInt());
   }
 
   @Test
@@ -59,57 +59,19 @@ class TutorialProgressServiceTest {
 
     assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
         .isInstanceOf(BadRequestException.class);
-    verify(tutorialProgressRepository, never()).save(any());
-  }
-
-  @Test
-  void upsertOwnProgress_rejectsNewRowsBeyondThePerUserCap() {
-    var req = request("in_progress");
-    req.setTourVersion(7);
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            "user-1", "frontend", "consultant-walkthrough", 7))
-        .thenReturn(Optional.empty());
-    when(tutorialProgressRepository.countByUserId("user-1")).thenReturn(50L);
-
-    assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, req))
-        .isInstanceOf(BadRequestException.class);
-    verify(tutorialProgressRepository, never()).save(any());
-  }
-
-  @Test
-  void upsertOwnProgress_stillUpdatesAnExistingRowWhenTheCapIsReached() {
-    var req = request("completed");
-    var existing =
-        TutorialProgress.builder()
-            .userId("user-1")
-            .surface("frontend")
-            .tourId("consultant-walkthrough")
-            .tourVersion(1)
-            .status("in_progress")
-            .build();
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            "user-1", "frontend", "consultant-walkthrough", 1))
-        .thenReturn(Optional.of(existing));
-    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-
-    var item = service.upsertOwnProgress("user-1", 1L, req);
-
-    assertThat(item.getStatus()).isEqualTo("completed");
+    verify(tutorialProgressStore, never()).upsert(any(), anyInt());
   }
 
   @Test
   void upsertOwnProgress_createsScopedRecordForTheAuthenticatedUser() {
     // Business reason: progress is keyed by user, surface, tour and version so
     // multiple tutorials and audiences can track state independently.
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            "user-1", "frontend", "consultant-walkthrough", 1))
-        .thenReturn(Optional.empty());
-    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(tutorialProgressStore.upsert(any(), anyInt())).thenAnswer(inv -> inv.getArgument(0));
 
     var item = service.upsertOwnProgress("user-1", 1L, request("in_progress"));
 
     var captor = ArgumentCaptor.forClass(TutorialProgress.class);
-    verify(tutorialProgressRepository).save(captor.capture());
+    verify(tutorialProgressStore).upsert(captor.capture(), anyInt());
     assertThat(captor.getValue().getUserId()).isEqualTo("user-1");
     assertThat(captor.getValue().getSurface()).isEqualTo("frontend");
     assertThat(captor.getValue().getTourId()).isEqualTo("consultant-walkthrough");
@@ -119,40 +81,10 @@ class TutorialProgressServiceTest {
   }
 
   @Test
-  void upsertOwnProgress_overwritesExistingScopeIdempotently() {
-    // Business reason: restarting or re-running a tour updates the same
-    // versioned scope instead of piling up rows.
-    var existing =
-        TutorialProgress.builder()
-            .id(7L)
-            .userId("user-1")
-            .surface("frontend")
-            .tourId("consultant-walkthrough")
-            .tourVersion(1)
-            .status("completed")
-            .createDate(LocalDateTime.now())
-            .build();
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            "user-1", "frontend", "consultant-walkthrough", 1))
-        .thenReturn(Optional.of(existing));
-    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-
-    service.upsertOwnProgress("user-1", 1L, request("in_progress"));
-
-    var captor = ArgumentCaptor.forClass(TutorialProgress.class);
-    verify(tutorialProgressRepository).save(captor.capture());
-    assertThat(captor.getValue().getId()).isEqualTo(7L);
-    assertThat(captor.getValue().getStatus()).isEqualTo("in_progress");
-  }
-
-  @Test
   void upsertOwnProgress_completedSetsCompletionTimestamp() {
     // Business reason: completion requires an explicit final-step write and is
     // observable through the completedAt timestamp.
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            any(), any(), any(), any()))
-        .thenReturn(Optional.empty());
-    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(tutorialProgressStore.upsert(any(), anyInt())).thenAnswer(inv -> inv.getArgument(0));
 
     var item = service.upsertOwnProgress("user-1", 1L, request("completed"));
 
@@ -161,10 +93,7 @@ class TutorialProgressServiceTest {
 
   @Test
   void upsertOwnProgress_skippedIsStoredAsSkippedNotCompleted() {
-    when(tutorialProgressRepository.findByUserIdAndSurfaceAndTourIdAndTourVersion(
-            any(), any(), any(), any()))
-        .thenReturn(Optional.empty());
-    when(tutorialProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(tutorialProgressStore.upsert(any(), anyInt())).thenAnswer(inv -> inv.getArgument(0));
 
     var item = service.upsertOwnProgress("user-1", 1L, request("skipped"));
 
@@ -176,7 +105,7 @@ class TutorialProgressServiceTest {
   void upsertOwnProgress_rejectsUnknownStatus() {
     assertThatThrownBy(() -> service.upsertOwnProgress("user-1", 1L, request("finished")))
         .isInstanceOf(BadRequestException.class);
-    verify(tutorialProgressRepository, never()).save(any());
+    verify(tutorialProgressStore, never()).upsert(any(), anyInt());
   }
 
   @Test

--- a/tests/load/authenticated_tutorial_replica_load.py
+++ b/tests/load/authenticated_tutorial_replica_load.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Exercise authenticated tutorial writes and reads across UserService replicas."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+import json
+import math
+from pathlib import Path
+import statistics
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+USER_ID = "tutorial-replica-jwt-user"
+SCOPE = {
+    "surface": "frontend",
+    "tourId": "consultant-walkthrough",
+    "tourVersion": 1,
+}
+
+
+@dataclass(frozen=True)
+class Sample:
+    operation: str
+    target: str
+    status: int
+    latency_ms: float
+    response_bytes: int
+    error: str | None = None
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    return ordered[max(0, math.ceil(quantile * len(ordered)) - 1)]
+
+
+def summarize(samples: list[Sample], elapsed_seconds: float) -> dict[str, float | int]:
+    latencies = [sample.latency_ms for sample in samples]
+    failures = sum(sample.error is not None or sample.status != 200 for sample in samples)
+    return {
+        "requests": len(samples),
+        "failures": failures,
+        "error_rate": failures / len(samples) if samples else 1.0,
+        "response_bytes": sum(sample.response_bytes for sample in samples),
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "requests_per_second": round(len(samples) / elapsed_seconds, 2),
+        "latency_mean_ms": round(statistics.fmean(latencies), 2),
+        "latency_p50_ms": round(percentile(latencies, 0.50), 2),
+        "latency_p95_ms": round(percentile(latencies, 0.95), 2),
+        "latency_max_ms": round(max(latencies), 2),
+    }
+
+
+def request(
+    target: str,
+    token: str,
+    operation: str,
+    payload: dict[str, object] | None,
+    timeout_seconds: float,
+) -> Sample:
+    started = time.perf_counter()
+    url = f"{target.rstrip('/')}/users/tutorials/progress"
+    headers = {"Authorization": f"Bearer {token}"}
+    data = None
+    method = "GET"
+    if payload is None:
+        url = f"{url}?{urlencode({'surface': 'frontend'})}"
+    else:
+        data = json.dumps(payload, separators=(",", ":")).encode()
+        method = "PUT"
+        headers.update(
+            {
+                "Content-Type": "application/json",
+                "Cookie": "CSRF-TOKEN=replica-proof",
+                "X-CSRF-Token": "replica-proof",
+            }
+        )
+    try:
+        with urlopen(
+            Request(url, data=data, headers=headers, method=method),
+            timeout=timeout_seconds,
+        ) as response:
+            body = response.read()
+            error = validate_read(body) if payload is None else None
+            return Sample(
+                operation,
+                target,
+                response.status,
+                (time.perf_counter() - started) * 1000,
+                len(body),
+                error,
+            )
+    except HTTPError as error:
+        body = error.read()
+        return Sample(
+            operation,
+            target,
+            error.code,
+            (time.perf_counter() - started) * 1000,
+            len(body),
+            f"http-{error.code}",
+        )
+    except (TimeoutError, URLError, OSError, ValueError, json.JSONDecodeError) as error:
+        return Sample(
+            operation,
+            target,
+            0,
+            (time.perf_counter() - started) * 1000,
+            0,
+            type(error).__name__,
+        )
+
+
+def validate_read(body: bytes) -> str | None:
+    progress = json.loads(body)
+    if not isinstance(progress, list):
+        return "read-body-is-not-a-list"
+    matching = [
+        row
+        for row in progress
+        if all(row.get(key) == value for key, value in SCOPE.items())
+    ]
+    if len(matching) != 1:
+        return f"canonical-scope-count-{len(matching)}"
+    if matching[0].get("status") != "in_progress":
+        return "unexpected-status"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--replica-url", action="append", required=True)
+    parser.add_argument("--token-file", type=Path, required=True)
+    parser.add_argument("--requests", type=int, default=200)
+    parser.add_argument("--concurrency", type=int, default=16)
+    parser.add_argument("--timeout-seconds", type=float, default=5.0)
+    parser.add_argument("--max-p95-ms", type=float, default=1000.0)
+    args = parser.parse_args()
+    if len(args.replica_url) != 2:
+        raise ValueError("exactly two --replica-url values are required")
+    if args.requests < 2 or args.concurrency < 1:
+        raise ValueError("requests must be at least two and concurrency must be positive")
+
+    token = args.token_file.read_text(encoding="utf-8").strip()
+    writes = [
+        (
+            args.replica_url[index % len(args.replica_url)],
+            {
+                **SCOPE,
+                "status": "in_progress",
+                "currentStepId": "profile" if index % 2 == 0 else "messages",
+            },
+        )
+        for index in range(args.requests)
+    ]
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        write_samples = list(
+            executor.map(
+                lambda item: request(
+                    item[0], token, "upsert", item[1], args.timeout_seconds
+                ),
+                writes,
+            )
+        )
+    read_samples = [
+        request(target, token, "read", None, args.timeout_seconds)
+        for target in args.replica_url
+    ]
+    samples = [*write_samples, *read_samples]
+    elapsed_seconds = time.perf_counter() - started
+    summary: dict[str, object] = summarize(samples, elapsed_seconds)
+    summary["operations"] = {
+        operation: summarize(
+            [sample for sample in samples if sample.operation == operation],
+            elapsed_seconds,
+        )
+        for operation in ("upsert", "read")
+    }
+    summary["replicas"] = {
+        target: summarize(
+            [sample for sample in samples if sample.target == target],
+            elapsed_seconds,
+        )
+        for target in args.replica_url
+    }
+    output = {
+        "authenticated_user": USER_ID,
+        "scope": SCOPE,
+        "summary": summary,
+        "errors": [asdict(sample) for sample in samples if sample.error is not None][
+            :10
+        ],
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    checked = [
+        summary,
+        *summary["operations"].values(),
+        *summary["replicas"].values(),
+    ]
+    return int(
+        any(
+            result["error_rate"] > 0
+            or result["latency_p95_ms"] > args.max_p95_ms
+            for result in checked
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/load/authenticated_tutorial_replica_load.py
+++ b/tests/load/authenticated_tutorial_replica_load.py
@@ -17,10 +17,9 @@ from urllib.request import Request, urlopen
 
 
 USER_ID = "tutorial-replica-jwt-user"
-SCOPE = {
+BASE_SCOPE = {
     "surface": "frontend",
     "tourId": "consultant-walkthrough",
-    "tourVersion": 1,
 }
 
 
@@ -63,6 +62,7 @@ def request(
     token: str,
     operation: str,
     payload: dict[str, object] | None,
+    scope: dict[str, object],
     timeout_seconds: float,
 ) -> Sample:
     started = time.perf_counter()
@@ -88,7 +88,7 @@ def request(
             timeout=timeout_seconds,
         ) as response:
             body = response.read()
-            error = validate_read(body) if payload is None else None
+            error = validate_read(body, scope) if payload is None else None
             return Sample(
                 operation,
                 target,
@@ -118,14 +118,14 @@ def request(
         )
 
 
-def validate_read(body: bytes) -> str | None:
+def validate_read(body: bytes, scope: dict[str, object]) -> str | None:
     progress = json.loads(body)
     if not isinstance(progress, list):
         return "read-body-is-not-a-list"
     matching = [
         row
         for row in progress
-        if all(row.get(key) == value for key, value in SCOPE.items())
+        if all(row.get(key) == value for key, value in scope.items())
     ]
     if len(matching) != 1:
         return f"canonical-scope-count-{len(matching)}"
@@ -140,6 +140,7 @@ def main() -> int:
     parser.add_argument("--token-file", type=Path, required=True)
     parser.add_argument("--requests", type=int, default=200)
     parser.add_argument("--concurrency", type=int, default=16)
+    parser.add_argument("--tour-version", type=int, default=1)
     parser.add_argument("--timeout-seconds", type=float, default=5.0)
     parser.add_argument("--max-p95-ms", type=float, default=1000.0)
     args = parser.parse_args()
@@ -149,11 +150,12 @@ def main() -> int:
         raise ValueError("requests must be at least two and concurrency must be positive")
 
     token = args.token_file.read_text(encoding="utf-8").strip()
+    scope = {**BASE_SCOPE, "tourVersion": args.tour_version}
     writes = [
         (
             args.replica_url[index % len(args.replica_url)],
             {
-                **SCOPE,
+                **scope,
                 "status": "in_progress",
                 "currentStepId": "profile" if index % 2 == 0 else "messages",
             },
@@ -165,13 +167,13 @@ def main() -> int:
         write_samples = list(
             executor.map(
                 lambda item: request(
-                    item[0], token, "upsert", item[1], args.timeout_seconds
+                    item[0], token, "upsert", item[1], scope, args.timeout_seconds
                 ),
                 writes,
             )
         )
     read_samples = [
-        request(target, token, "read", None, args.timeout_seconds)
+        request(target, token, "read", None, scope, args.timeout_seconds)
         for target in args.replica_url
     ]
     samples = [*write_samples, *read_samples]
@@ -193,7 +195,7 @@ def main() -> int:
     }
     output = {
         "authenticated_user": USER_ID,
-        "scope": SCOPE,
+        "scope": scope,
         "summary": summary,
         "errors": [asdict(sample) for sample in samples if sample.error is not None][
             :10

--- a/tests/load/jwt_jwk_stub.py
+++ b/tests/load/jwt_jwk_stub.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Serve a disposable JWK and write one matching consultant JWT for replica tests."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+
+KEY_ID = "userservice-replica-proof"
+
+
+def base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def generate_key(private_key: Path) -> None:
+    subprocess.run(
+        [
+            "openssl",
+            "genpkey",
+            "-algorithm",
+            "RSA",
+            "-pkeyopt",
+            "rsa_keygen_bits:2048",
+            "-out",
+            str(private_key),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    private_key.chmod(0o600)
+
+
+def modulus(private_key: Path) -> str:
+    output = subprocess.check_output(
+        ["openssl", "rsa", "-in", str(private_key), "-noout", "-modulus"],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+    prefix = "Modulus="
+    if not output.startswith(prefix):
+        raise RuntimeError("OpenSSL did not return an RSA modulus")
+    return base64url(bytes.fromhex(output.removeprefix(prefix)))
+
+
+def sign_jwt(private_key: Path) -> str:
+    now = int(time.time())
+    header = {"alg": "RS256", "kid": KEY_ID, "typ": "JWT"}
+    claims = {
+        "sub": "tutorial-replica-jwt-user",
+        "preferred_username": "tutorial-replica-consultant",
+        "username": "tutorial-replica-consultant",
+        "tenantId": 1,
+        "realm_access": {"roles": ["consultant"]},
+        "iat": now - 30,
+        "exp": now + 3600,
+    }
+    encoded_header = base64url(
+        json.dumps(header, separators=(",", ":"), sort_keys=True).encode()
+    )
+    encoded_claims = base64url(
+        json.dumps(claims, separators=(",", ":"), sort_keys=True).encode()
+    )
+    signing_input = f"{encoded_header}.{encoded_claims}".encode("ascii")
+    signature = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", str(private_key)],
+        input=signing_input,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ).stdout
+    return f"{signing_input.decode('ascii')}.{base64url(signature)}"
+
+
+def create_server(host: str, port: int, jwk_set: dict[str, object]) -> ThreadingHTTPServer:
+    payload = json.dumps(jwk_set, separators=(",", ":")).encode()
+
+    class JwkHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/health":
+                response = b'{"status":"UP"}'
+            elif self.path.endswith("/certs"):
+                response = payload
+            else:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            pass
+
+    return ThreadingHTTPServer((host, port), JwkHandler)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--private-key", type=Path, required=True)
+    parser.add_argument("--token-file", type=Path, required=True)
+    args = parser.parse_args()
+
+    generate_key(args.private_key)
+    args.token_file.write_text(sign_jwt(args.private_key), encoding="utf-8")
+    args.token_file.chmod(0o600)
+    jwk_set = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": KEY_ID,
+                "n": modulus(args.private_key),
+                "e": "AQAB",
+            }
+        ]
+    }
+    server = create_server(args.host, args.port, jwk_set)
+    print(f"Disposable JWK endpoint listening on {args.host}:{server.server_port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+        if args.token_file.exists():
+            os.chmod(args.token_file, 0o600)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- move tutorial-progress persistence behind a dedicated transactional store
- replace read-then-insert with MariaDB `ON DUPLICATE KEY UPDATE`
- use `READ_COMMITTED` for the bounded upsert transaction so identical concurrent no-op updates can immediately read the canonical winner
- add a real MariaDB race contract that proves two instances return one row without duplicate-key warnings
- add a reusable two-JVM authenticated load/restart proof with a disposable JWK/JWT endpoint, shared MariaDB and Redis
- run that proof from the required MariaDB workflow and document the bounded slice

## Root cause

Two replicas could both read a missing tutorial-progress scope and then race to insert the same unique key. Catching the duplicate avoided one 500 but still emitted warning stacks. A native upsert removed that exception path, but real HTTP load exposed a second detail: MariaDB stores these timestamps at one-second precision, so an identical `ON DUPLICATE KEY UPDATE` can be a no-op. Under the default `REPEATABLE_READ` snapshot, the transaction could then fail to see the row committed by the winning replica. The small store-owned transaction now uses `READ_COMMITTED` and reads the canonical row after the atomic statement.

## Runtime proof

The local proof packaged the real application and started two UserService JVMs against one disposable MariaDB 11.0.6 database and shared Redis 7. A locally signed consultant JWT was verified through the real resource-server JWK path; every PUT also passed the real CSRF filter. A separate version-999 scope warms the fresh JWT/security/controller/SQL paths and is excluded from the report. The measured version-1 scope remains absent until the main phase, so its first-write race is still exercised.

- initial phase: 80 concurrent PUTs alternating across both replicas plus one GET per replica; 82 requests, 0 failures, 39 ms aggregate p95
- restart phase: restart replica one, then 12 further PUTs plus one GET per replica; 14 requests, 0 failures, 372 ms aggregate p95
- per-operation and per-replica zero-error and 1,000 ms p95 gates passed
- exactly one canonical measured-scope database row remained
- both replicas read the state and no duplicate-key warning was emitted
- all temporary JVMs, listeners and containers were removed

## Validation

- Java 21 unit suite: 3,812 tests, 0 failures, 0 errors, 7 skipped
- required integration/E2E suite with Redis contracts: 967 tests, 0 failures, 0 errors, 8 skipped
- real MariaDB schema/replica selection: 12 tests, 0 failures, 0 errors, 0 skipped
- Python CI contracts: 25 tests passed
- shell/Python syntax, Spotless and `git diff --check` passed
- GitHub Feature Branch and Pull Request workflows: all terminal checks passed on `85eeff1d`

## Dependencies and scope

- stacked on #757 (`feat/replica-safety-metrics-543`)
- complements the public-read load evidence in #744
- proves only the authenticated tutorial-progress state transition; it does not raise the whole-service replica limit and is not deployed-runtime or SigNoz evidence
- preserves the Matrix-only target architecture: no Rocket.Chat or Jitsi fallback is introduced; the proof explicitly disables Rocket.Chat and the Matrix listener

Closes #773
