### PR TITLE
[Stability] Route username availability through identity input port

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -65,6 +65,11 @@ public class IdentityManager implements IdentityManaging {
   }
 
   @Override
+  public boolean isUsernameAvailable(String username) {
+    return identityClient.isUsernameAvailable(username);
+  }
+
+  @Override
   public boolean isEmailAvailableOrOwn(String username, String email) {
     var user = identityClient.findUserByEmail(email);
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -61,7 +61,6 @@ import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
@@ -132,7 +131,6 @@ public class UserController implements UsersApi {
   private final @NonNull AskerDataProvider askerDataProvider;
   private final @NonNull VideoChatConfig videoChatConfig;
   private final @NonNull KeycloakUserDataProvider keycloakUserDataProvider;
-  private final @NotNull IdentityClient identityClient;
   private final @NonNull MagicLinkLoginService magicLinkLoginService;
   private final @NonNull ConsultantAgencyService consultantAgencyService;
 
@@ -158,7 +156,7 @@ public class UserController implements UsersApi {
   public ResponseEntity<Void> usernameAvailability(@PathVariable String username) {
     boolean usernameAvailable;
     try {
-      usernameAvailable = identityClient.isUsernameAvailable(username);
+      usernameAvailable = identityManager.isUsernameAvailable(username);
     } catch (RuntimeException exception) {
       log.warn(
           "Could not check username availability for {}. Treating it as available so registration is not blocked. cause={}",

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -22,8 +22,8 @@ import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
 import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
@@ -55,7 +55,7 @@ class UserRegistrationControllerDelegate {
   private final @NonNull Messaging messenger;
   private final @NonNull ConsultantDtoMapper consultantDtoMapper;
   private final @NonNull UserHelper userHelper;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityManaging identityManager;
   private final @NonNull MagicLinkLoginService magicLinkLoginService;
   private final @NonNull PasswordResetService passwordResetService;
   private final @NonNull SessionDeleteService sessionDeleteService;
@@ -64,7 +64,7 @@ class UserRegistrationControllerDelegate {
   private boolean featureTopicsEnabled;
 
   ResponseEntity<Void> userExists(String username) {
-    val usernameAvailable = identityClient.isUsernameAvailable(username);
+    val usernameAvailable = identityManager.isUsernameAvailable(username);
     val userExists = !usernameAvailable;
     if (userExists) {
       return ResponseEntity.ok().build();
@@ -73,7 +73,7 @@ class UserRegistrationControllerDelegate {
   }
 
   ResponseEntity<Void> usernameAvailability(String username) {
-    val usernameAvailable = identityClient.isUsernameAvailable(username);
+    val usernameAvailable = identityManager.isUsernameAvailable(username);
     return usernameAvailable
         ? ResponseEntity.noContent().build()
         : ResponseEntity.status(HttpStatus.CONFLICT).build();

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
@@ -23,5 +23,7 @@ public interface IdentityManaging {
 
   OtpInfoDTO getOtpCredential(String username);
 
+  boolean isUsernameAvailable(String username);
+
   boolean isEmailAvailableOrOwn(String username, String email);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -100,4 +100,13 @@ class IdentityManagerTest {
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }
+
+  @Test
+  void isUsernameAvailableShouldDelegateToIdentityClient() {
+    when(identityClient.isUsernameAvailable(RAW_USERNAME)).thenReturn(true);
+
+    assertThat(identityManager.isUsernameAvailable(RAW_USERNAME)).isTrue();
+
+    verify(identityClient).isUsernameAvailable(RAW_USERNAME);
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -225,30 +225,30 @@ class UserControllerAuthorizationIT {
     mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isUnauthorized());
 
-    verifyNoInteractions(identityClient);
+    verifyNoInteractions(identityManager);
   }
 
   @Test
   @WithMockUser(authorities = {AuthorityValue.TECHNICAL_DEFAULT})
   void userExists_Should_ReturnNotFound_WhenTechnicalUserIsAuthorized() throws Exception {
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(true);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(true);
 
     mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
 
-    verify(identityClient).isUsernameAvailable(username);
+    verify(identityManager).isUsernameAvailable(username);
   }
 
   @Test
   void usernameAvailability_Should_StayPublic_WhenNoKeycloakAuthorization() throws Exception {
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(true);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(true);
 
     mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
 
-    verify(identityClient).isUsernameAvailable(username);
+    verify(identityManager).isUsernameAvailable(username);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -397,7 +397,7 @@ class UserControllerIT {
   void userExists_Should_Return404_When_UserDoesNotExist() throws Exception {
     /* given */
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
     /* when */
     mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
         /* then */
@@ -408,7 +408,7 @@ class UserControllerIT {
   void userExists_Should_Return200_When_UserDoesExist() throws Exception {
     /* given */
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
 
     /* when */
     mvc.perform(get("/users/{username}", username).accept(MediaType.APPLICATION_JSON))
@@ -420,7 +420,7 @@ class UserControllerIT {
   void usernameAvailability_Should_ReturnNoContent_When_UserDoesNotExist() throws Exception {
     /* given */
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(Boolean.TRUE);
 
     /* when */
     mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
@@ -462,7 +462,7 @@ class UserControllerIT {
   void usernameAvailability_Should_ReturnConflict_When_UserDoesExist() throws Exception {
     /* given */
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
+    when(identityManager.isUsernameAvailable(username)).thenReturn(Boolean.FALSE);
 
     /* when */
     mvc.perform(get("/users/availability/{username}", username).accept(MediaType.APPLICATION_JSON))
@@ -475,7 +475,7 @@ class UserControllerIT {
       throws Exception {
     /* given */
     var username = "john@doe.com";
-    when(identityClient.isUsernameAvailable(username))
+    when(identityManager.isUsernameAvailable(username))
         .thenThrow(new RuntimeException("Keycloak 401"));
 
     /* when */

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -36,8 +36,8 @@ import de.caritas.cob.userservice.api.model.EnquiryData;
 import de.caritas.cob.userservice.api.model.NewSessionValidationConstraint;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.service.archive.SessionDeleteService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService;
@@ -73,7 +73,7 @@ class UserRegistrationControllerDelegateTest {
   @Mock private Messaging messenger;
   @Mock private ConsultantDtoMapper consultantDtoMapper;
   @Mock private UserHelper userHelper;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityManaging identityManager;
   @Mock private MagicLinkLoginService magicLinkLoginService;
   @Mock private PasswordResetService passwordResetService;
   @Mock private SessionDeleteService sessionDeleteService;
@@ -82,7 +82,7 @@ class UserRegistrationControllerDelegateTest {
 
   @Test
   void userExistsShouldReturnOkWhenUsernameExists() {
-    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(false);
+    when(identityManager.isUsernameAvailable(USERNAME)).thenReturn(false);
 
     var response = delegate.userExists(USERNAME);
 
@@ -91,7 +91,7 @@ class UserRegistrationControllerDelegateTest {
 
   @Test
   void usernameAvailabilityShouldReturnConflictWhenUsernameIsTaken() {
-    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(false);
+    when(identityManager.isUsernameAvailable(USERNAME)).thenReturn(false);
 
     var response = delegate.usernameAvailability(USERNAME);
 
@@ -273,7 +273,7 @@ class UserRegistrationControllerDelegateTest {
   @Test
   void userExists_usernameAvailable_returnsNotFound() {
     // Available usernames indicate the account does not exist yet.
-    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(true);
+    when(identityManager.isUsernameAvailable(USERNAME)).thenReturn(true);
 
     var response = delegate.userExists(USERNAME);
 
@@ -283,7 +283,7 @@ class UserRegistrationControllerDelegateTest {
   @Test
   void usernameAvailability_available_returnsNoContent() {
     // Available usernames confirm the handle can be registered.
-    when(identityClient.isUsernameAvailable(USERNAME)).thenReturn(true);
+    when(identityManager.isUsernameAvailable(USERNAME)).thenReturn(true);
 
     var response = delegate.usernameAvailability(USERNAME);
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -162,6 +162,28 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_username_availability_web_boundaries_depend_on_identity_input_port(self):
+        sources = (
+            CONTROLLERS / "UserController.java",
+            CONTROLLERS / "UserRegistrationControllerDelegate.java",
+        )
+        forbidden_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityClient;"
+        )
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in sources
+            if forbidden_import in source.read_text()
+        ]
+
+        self.assertEqual(
+            [],
+            offenders,
+            "Username-availability web adapters must call IdentityManaging instead "
+            "of bypassing the application boundary through IdentityClient:\n"
+            + "\n".join(offenders),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- add username availability to the application-owned `IdentityManaging` input port
- route both user web entry points through `IdentityManager` instead of importing the outbound `IdentityClient`
- preserve the public availability endpoint fail-open behavior and registration conflict semantics
- ratchet the boundary with an executable CI contract

## Why

`UserController` and `UserRegistrationControllerDelegate` still bypassed the application boundary for one identity operation. This small stacked refactor makes the web dependency direction explicit before any broader service split.

## TDD evidence

- RED: the new module-boundary test reported both web sources as direct `IdentityClient` consumers
- RED: `IdentityManagerTest` failed compilation because `isUsernameAvailable` did not exist on the application service
- GREEN: 32 focused manager/delegate tests, 0 failures/errors/skips
- GREEN: 136 `UserControllerIT` tests, 0 failures/errors/skips
- GREEN: 31 Python CI contract tests
- GREEN: full JDK 21 unit suite, 3,822 tests, 0 failures/errors/skips

## Architecture boundary

This PR changes only the internal identity dependency direction. It introduces no provider transport and no Rocket.Chat or Jitsi dependency. The separate target architecture remains Matrix-only chat with the ORISO frontend and the ORISO-controlled MatrixRTC/Element Call fork using LiveKit.

## Stack and rollout state

- stacked on #771
- code and local verification only at publication time
- no merge, deployment, PreDev rollout, or runtime claim

Closes #775.