### PR TITLE
[Stability] Route user identity policy through input port

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -210,7 +210,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs, OTP values and provider configuration. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -228,7 +228,8 @@ identity port contract also rejects imports from the concrete Keycloak adapter
 and Keycloak SDK types, so its login and profile results cannot regress from
 `IdentityLogin` and `IdentityProfile` to provider transports. A dedicated
 Magic-Link boundary contract applies the same rule to the service and both web
-entry points.
+entry points. The user-web identity-policy contract rejects direct imports of
+outbound identity configuration from the controller and its user delegates.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current
@@ -236,8 +237,8 @@ runtime contract reports a maximum supported replica count of one; modular
 source layout must not be confused with proven multi-instance behavior.
 
 This is a ratcheted incremental modularization, not a claim that all three
-domains are already isolated. The next safe sequence is broad identity
-command/configuration decoupling, then the admin controller composition
+domains are already isolated. The next safe sequence is broad identity command
+decoupling, then the admin controller composition
 boundary, then session-list adapter removal. Each step must add a failing
 boundary contract before moving dependencies.
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AbsenceDTO;
@@ -31,8 +30,8 @@ import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.DecryptionService;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -57,7 +56,7 @@ class UserAccountControllerDelegate {
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull DecryptionService decryptionService;
   private final @NonNull ConsultantDataFacade consultantDataFacade;
-  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentityPolicy identityPolicy;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull Messaging messenger;
@@ -131,7 +130,7 @@ class UserAccountControllerDelegate {
             partialUserData,
             otpInfoDTO,
             videoChatConfig.getE2eEncryptionEnabled(),
-            identityClientConfig.getDisplayNameAllowedForConsultants());
+            identityPolicy.isConsultantDisplayNameAllowed());
 
     return new ResponseEntity<>(fullUserData, HttpStatus.OK);
   }
@@ -162,7 +161,7 @@ class UserAccountControllerDelegate {
   }
 
   private boolean isOtpAllowed() {
-    return identityClientConfig.isOtpAllowed(authenticatedUser.getRoles());
+    return identityPolicy.isTwoFactorAuthenticationAllowed(authenticatedUser.getRoles());
   }
 
   private OtpInfoDTO retrieveOtpCredentialIfAllowed() {
@@ -242,10 +241,7 @@ class UserAccountControllerDelegate {
       email = userAccountProvider.retrieveValidatedUser().getEmail();
     }
 
-    boolean hasRealEmail =
-        nonNull(email)
-            && !email.isBlank()
-            && !email.endsWith(identityClientConfig.getEmailDummySuffix());
+    boolean hasRealEmail = identityPolicy.isProfileEmailUsableForMagicLink(email);
     if (!hasRealEmail) {
       throw new BadRequestException(
           "Magic link login can only be enabled when a profile email is set.");

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -61,7 +61,6 @@ import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -118,7 +117,6 @@ public class UserController implements UsersApi {
   private final @NotNull ConsultantDataFacade consultantDataFacade;
   private final @NotNull SessionDataService sessionDataService;
   private final @NotNull SessionArchiveService sessionArchiveService;
-  private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull Messaging messenger;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
@@ -9,7 +9,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Locale;
 import lombok.NonNull;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 class UserTwoFactorAuthControllerDelegate {
 
   private final @NonNull AuthenticatedUser authenticatedUser;
-  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentityPolicy identityPolicy;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull AccountInviteService accountInviteService;
@@ -101,7 +101,7 @@ class UserTwoFactorAuthControllerDelegate {
    * disabled cannot sidestep the policy by choosing the email flow.
    */
   private void assertTwoFactorAuthAllowed() {
-    if (!identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())) {
+    if (!identityPolicy.isTwoFactorAuthenticationAllowed(authenticatedUser.getRoles())) {
       throw new ConflictException("2FA is disabled for user role");
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.config.auth;
 
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,7 +20,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Validated
 @Configuration
 @ConfigurationProperties(prefix = "identity")
-public class IdentityConfig implements IdentityClientConfig {
+public class IdentityConfig implements IdentityClientConfig, IdentityPolicy {
 
   private static final char PATH_SEPARATOR = '/';
 
@@ -87,5 +88,22 @@ public class IdentityConfig implements IdentityClientConfig {
             && otpAllowedForSingleTenantAdmins
         || roles.contains(UserRole.RESTRICTED_AGENCY_ADMIN.getValue())
             && otpAllowedForRestrictedAgencyAdmins;
+  }
+
+  @Override
+  public boolean isTwoFactorAuthenticationAllowed(Set<String> roles) {
+    return isOtpAllowed(roles);
+  }
+
+  @Override
+  public boolean isConsultantDisplayNameAllowed() {
+    return Boolean.TRUE.equals(displayNameAllowedForConsultants);
+  }
+
+  @Override
+  public boolean isProfileEmailUsableForMagicLink(String email) {
+    return StringUtils.hasText(email)
+        && emailDummySuffix != null
+        && !email.endsWith(emailDummySuffix);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityPolicy.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityPolicy.java
@@ -1,0 +1,13 @@
+package de.caritas.cob.userservice.api.port.in;
+
+import java.util.Set;
+
+/** Application-owned identity policy decisions needed by inbound adapters. */
+public interface IdentityPolicy {
+
+  boolean isTwoFactorAuthenticationAllowed(Set<String> roles);
+
+  boolean isConsultantDisplayNameAllowed();
+
+  boolean isProfileEmailUsableForMagicLink(String email);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -43,8 +43,8 @@ import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.DecryptionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
@@ -70,7 +70,7 @@ class UserAccountControllerDelegateTest {
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private DecryptionService decryptionService;
   @Mock private ConsultantDataFacade consultantDataFacade;
-  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityPolicy identityPolicy;
   @Mock private IdentityManaging identityManager;
   @Mock private AccountManaging accountManager;
   @Mock private Messaging messenger;
@@ -96,7 +96,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenThrow(new RuntimeException("OTP down"));
     when(userDtoMapper.userDataOf(
@@ -120,7 +120,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
@@ -139,7 +139,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
@@ -159,7 +159,7 @@ class UserAccountControllerDelegateTest {
     consultant.setEmail("dummy@example.invalid");
     when(authenticatedUser.isConsultant()).thenReturn(true);
     when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
-    when(identityClientConfig.getEmailDummySuffix()).thenReturn("@example.invalid");
+    when(identityPolicy.isProfileEmailUsableForMagicLink(anyString())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.patchUser(patchUserDTO))
         .isInstanceOf(BadRequestException.class);
@@ -358,9 +358,9 @@ class UserAccountControllerDelegateTest {
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.of(consultantMap));
     when(userDtoMapper.displayNameOf(consultantMap)).thenReturn("Display Name");
     when(messenger.getAvailability(USER_ID)).thenReturn(true);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(true);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(true);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(true);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(true), eq(true)))
         .thenReturn(fullUserData);
 
@@ -382,9 +382,9 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isAgencySuperAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -410,9 +410,9 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
     when(askerDataProvider.retrieveData(user)).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -439,11 +439,11 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(new User());
     when(askerDataProvider.retrieveData(any(User.class))).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenReturn(otpInfo);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), eq(otpInfo), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -466,9 +466,9 @@ class UserAccountControllerDelegateTest {
     when(consultantDataProvider.retrieveData(any(Consultant.class))).thenReturn(partialUserData);
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.empty());
     when(messenger.getAvailability(USER_ID)).thenReturn(false);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -493,9 +493,9 @@ class UserAccountControllerDelegateTest {
     when(accountManager.findConsultant(USER_ID))
         .thenThrow(new RuntimeException("display name down"));
     when(messenger.getAvailability(USER_ID)).thenReturn(true);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -518,9 +518,9 @@ class UserAccountControllerDelegateTest {
     when(consultantDataProvider.retrieveData(any(Consultant.class))).thenReturn(partialUserData);
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.empty());
     when(messenger.getAvailability(USER_ID)).thenThrow(new RuntimeException("availability down"));
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -623,7 +623,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(authenticatedUser.isAdviceSeeker()).thenReturn(true);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
-    when(identityClientConfig.getEmailDummySuffix()).thenReturn("@example.invalid");
+    when(identityPolicy.isProfileEmailUsableForMagicLink(anyString())).thenReturn(true);
     when(userDtoMapper.mapOf(patchUserDTO, authenticatedUser)).thenReturn(Optional.of(patchMap));
     when(accountManager.patchUser(patchMap)).thenReturn(Optional.of(patchMap));
     when(userDtoMapper.preferredLanguageOf(patchUserDTO)).thenReturn(Optional.empty());

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -50,10 +50,10 @@ import de.caritas.cob.userservice.api.model.*;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
@@ -324,7 +324,7 @@ class UserControllerIT {
 
   @MockitoBean
   @SuppressWarnings("unused")
-  private IdentityClientConfig identityClientConfig;
+  private IdentityPolicy identityPolicy;
 
   @MockitoBean
   @SuppressWarnings("unused")
@@ -565,7 +565,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_NotActivateIfSingleTenantAdminButNotConfiguredToUse2Fa()
       throws Exception {
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.SINGLE_TENANT_ADMIN.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -580,7 +580,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_NotActivateIfTenantSuperAdminButNotConfiguredToUse2Fa()
       throws Exception {
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.TENANT_ADMIN.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -595,7 +595,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_Activate() throws Exception {
     when(authenticatedUser.getUsername()).thenReturn("username");
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.CONSULTANT.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(true);
     when(identityManager.setUpOneTimePassword(anyString(), anyString(), anyString()))
         .thenReturn(true);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -17,7 +17,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +37,7 @@ class UserTwoFactorAuthControllerDelegateTest {
   private static final String SECRET = "12345678901234567890123456789012";
 
   @Mock private AuthenticatedUser authenticatedUser;
-  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityPolicy identityPolicy;
   @Mock private IdentityManaging identityManager;
   @Mock private AccountManaging accountManager;
   @Mock private AccountInviteService accountInviteService;
@@ -153,7 +153,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByAppShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -164,7 +164,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void startTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(
             () -> delegate.startTwoFactorAuthByEmailSetup(new EmailDTO("person@example.org")))
@@ -176,7 +176,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.finishTwoFactorAuthByEmailSetup(OTP))
         .isInstanceOf(ConflictException.class)
@@ -227,7 +227,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_consultantDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -238,7 +238,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_singleTenantAdminDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -249,7 +249,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_tenantSuperAdminDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -263,6 +263,6 @@ class UserTwoFactorAuthControllerDelegateTest {
   }
 
   private void allowOtpForCurrentRoles() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(true);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.config.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.validation.ConstraintViolation;
@@ -82,6 +83,34 @@ class IdentityConfigTest {
     violations = validator.validate(identityConfig);
 
     assertValidationError("technicalUser", "must not be null");
+  }
+
+  @Test
+  void identityPolicyShouldUseConfiguredOtpRolePermission() {
+    givenAValidIdentityConfig();
+    identityConfig.setOtpAllowedForUsers(true);
+
+    assertTrue(identityConfig.isTwoFactorAuthenticationAllowed(Set.of(UserRole.USER.getValue())));
+  }
+
+  @Test
+  void identityPolicyShouldUseConfiguredConsultantDisplayNamePermission() {
+    givenAValidIdentityConfig();
+    identityConfig.setDisplayNameAllowedForConsultants(true);
+
+    assertTrue(identityConfig.isConsultantDisplayNameAllowed());
+  }
+
+  @Test
+  void identityPolicyShouldAcceptOnlyNonDummyProfileEmailsForMagicLink() {
+    givenAValidIdentityConfig();
+    identityConfig.setEmailDummySuffix("@dummy.invalid");
+
+    assertTrue(identityConfig.isProfileEmailUsableForMagicLink("person@example.org"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink(null));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink(""));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("   "));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("person@dummy.invalid"));
   }
 
   private void givenAValidIdentityConfig() {

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -184,6 +184,28 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_user_web_boundaries_do_not_import_outbound_identity_configuration(self):
+        sources = [
+            CONTROLLERS / "UserController.java",
+            *CONTROLLERS.glob("User*ControllerDelegate.java"),
+        ]
+        forbidden_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;"
+        )
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in sources
+            if forbidden_import in source.read_text()
+        ]
+
+        self.assertEqual(
+            [],
+            offenders,
+            "User web adapters must ask an application-owned identity policy "
+            "instead of reading outbound identity configuration:\n"
+            + "\n".join(offenders),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- add an application-owned `IdentityPolicy` input port for user web policy decisions
- remove direct `IdentityClientConfig` dependencies from `UserController` and user web delegates
- keep OTP permission, consultant display-name, and Magic Link email classification behavior behind validated identity configuration
- add a permanent module-boundary ratchet and update the stability evidence

## Stack

- Parent issue: #335
- Closes #777
- Stacked on #776 (`refactor/identity-username-input-775`)
- Review and merge after #776

## Verification

- JDK 21 unit suite: 3,856 tests, 0 failures, 0 errors, 0 skipped
- Full integration suite: 969 tests, 0 failures, 0 errors, 14 environment-gated skips
- User web integration: 155 authorization + 136 controller tests, 0 failures/errors/skips
- Python CI contracts: 32 tests, all green
- Spotless and `git diff --check`: green

## Architecture guardrail

This is a modular-monolith boundary change, not a microservice split. It does not introduce or restore any chat transport. The target remains Matrix-only chat through the ORISO-owned frontend and the controlled Element Call/MatrixRTC fork with LiveKit; Rocket.Chat and Jitsi remain removal targets, not fallbacks.

## Runtime state

Code and local verification only. This draft is not merged or deployed, and it is not PreDev runtime proof.