### PR TITLE
[Stability] Batch consultant role validation into one identity read

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -179,6 +179,10 @@ closed.
   identity outage, but logs only the bounded exception class. The outbound
   metrics retain attempt/outcome/latency evidence without one full stack trace
   per public request.
+- Consultant role-set validation reads the user's complete realm-role list once
+  and performs the requested-set intersection in-process. The code-level bound
+  is therefore zero identity calls for an empty role set and exactly one for a
+  non-empty set, instead of up to one `userHasRole` request per candidate role.
 
 The runtime metrics above are the gate for further optimization: prioritize a
 dependency only when PreDev shows high calls per request, payload volume or p95
@@ -210,7 +214,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -232,6 +236,9 @@ entry points. The user-web identity-policy contract rejects direct imports of
 outbound identity configuration from the controller and its user delegates.
 The web-mapper contract rejects direct imports of the outbound identity client.
 The user-data facade contract keeps profile reads off that broad command port.
+The role-read contract keeps full realm-role reads behind the focused
+`IdentityRoleLookup` port and prevents per-candidate role checks from returning
+to consultant-agency validation.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -27,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
@@ -64,7 +65,7 @@ import org.springframework.web.client.RestClientResponseException;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KeycloakService implements IdentityClient, IdentityProfileLookup {
+public class KeycloakService implements IdentityClient, IdentityProfileLookup, IdentityRoleLookup {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -879,7 +880,7 @@ public class KeycloakService implements IdentityClient, IdentityProfileLookup {
    * @return the realm role names assigned to the user
    */
   @Override
-  public List<String> getRealmRoles(String userId) {
+  public List<String> findAllByUserId(String userId) {
     try {
       return getUserRoles(userId).stream()
           .map(RoleRepresentation::getName)

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.model.ConsultantAgencyStatus;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -38,6 +39,7 @@ public class ConsultantAgencyRelationCreatorService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull AgencyService agencyService;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleLookup identityRoleLookup;
   private final @NonNull ConsultingTypeManager consultingTypeManager;
   private final @NonNull RocketChatAsyncHelper rocketChatAsyncHelper;
   private final @NonNull ConsultantTopicAgencyCompatibilityValidator
@@ -168,15 +170,14 @@ public class ConsultantAgencyRelationCreatorService {
   }
 
   private void checkConsultantHasRoleSet(Set<String> roles, String consultantId) {
-    roles.stream()
-        .filter(role -> identityClient.userHasRole(consultantId, role))
-        .findAny()
-        .orElseThrow(
-            () ->
-                new BadRequestException(
-                    String.format(
-                        "Consultant with id %s does not have the role set %s",
-                        consultantId, roles)));
+    var hasRequestedRole =
+        !roles.isEmpty()
+            && identityRoleLookup.findAllByUserId(consultantId).stream().anyMatch(roles::contains);
+    if (!hasRequestedRole) {
+      throw new BadRequestException(
+          String.format(
+              "Consultant with id %s does not have the role set %s", consultantId, roles));
+    }
   }
 
   private AgencyDTO retrieveAgency(Long agencyId) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -3,7 +3,6 @@ package de.caritas.cob.userservice.api.port.out;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -68,8 +67,6 @@ public interface IdentityClient {
   boolean userHasAuthority(String userId, String authority);
 
   boolean userHasRole(String userId, String userRole);
-
-  List<String> getRealmRoles(String userId);
 
   void closeSession(String sessionId);
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleLookup.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleLookup.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import java.util.List;
+
+/** Focused outbound identity realm-role read contract. */
+public interface IdentityRoleLookup {
+
+  List<String> findAllByUserId(String userId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/identity/UserIdentitiesService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/identity/UserIdentitiesService.java
@@ -3,7 +3,7 @@ package de.caritas.cob.userservice.api.service.identity;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserIdentitiesDTO;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,7 @@ public class UserIdentitiesService {
 
   private final @NonNull AdminRepository adminRepository;
   private final @NonNull ConsultantRepository consultantRepository;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleLookup identityRoleLookup;
 
   /**
    * Looks up the identities held by the given user.
@@ -35,7 +35,7 @@ public class UserIdentitiesService {
     dto.setHasAdminIdentity(adminRepository.existsById(userId));
     dto.setHasConsultantIdentity(
         consultantRepository.findByIdAndDeleteDateIsNull(userId).isPresent());
-    dto.setKeycloakRoles(identityClient.getRealmRoles(userId));
+    dto.setKeycloakRoles(identityRoleLookup.findAllByUserId(userId));
     return dto;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1557,23 +1557,23 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void getRealmRoles_Should_ReturnRoleNames_When_LookupSucceeds() {
+  public void findAllByUserId_Should_ReturnRoleNames_When_LookupSucceeds() {
     UserResource userResource = givenUserResourceWithRealmRoles("user", "consultant");
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    List<String> roles = keycloakService.getRealmRoles(USER_ID);
+    List<String> roles = keycloakService.findAllByUserId(USER_ID);
 
     assertThat(roles, is(Lists.newArrayList("user", "consultant")));
   }
 
   @Test
-  public void getRealmRoles_Should_ThrowKeycloakException_When_LookupFails() {
+  public void findAllByUserId_Should_ThrowKeycloakException_When_LookupFails() {
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.get(any())).thenThrow(new RuntimeException("boom"));
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    assertThrows(KeycloakException.class, () -> keycloakService.getRealmRoles(USER_ID));
+    assertThrows(KeycloakException.class, () -> keycloakService.findAllByUserId(USER_ID));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -38,6 +38,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.ConsultingTypeControllerApi;
@@ -125,7 +126,7 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean private Keycloak keycloak;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -61,7 +62,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -81,6 +81,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.AskerImportService;
@@ -171,7 +172,7 @@ class UserControllerAuthorizationIT {
   @MockitoBean private AskerImportService askerImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   private IdentityClient identityClient;
 
   @MockitoBean private IdentityManager identityManager;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -55,6 +55,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
@@ -291,7 +292,7 @@ class UserControllerIT {
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   private IdentityClient identityClient;
 
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -50,7 +51,7 @@ class CreateAdminServiceIT {
 
   @Autowired private CreateAdminService createAdminService;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   private IdentityClient identityClient;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -30,7 +31,7 @@ public class UpdateAdminServiceIT {
 
   @Autowired private UpdateAdminService updateAdminService;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   private IdentityClient identityClient;
 
   @Autowired private RetrieveAdminService retrieveAdminService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -79,7 +80,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   private IdentityClient identityClient;
 
   @MockitoBean private RocketChatFacade rocketChatFacade;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -57,6 +58,8 @@ public class ConsultantAgencyRelationCreatorServiceTest {
   @Mock private AgencyService agencyService;
 
   @Mock private IdentityClient identityClient;
+
+  @Mock private IdentityRoleLookup identityRoleLookup;
 
   @Mock private RocketChatAsyncHelper rocketChatAsyncHelper;
 
@@ -227,14 +230,19 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Test
   public void createConsultantAgencyRelations_Should_throwBadRequest_When_consultantHasNoRole() {
-    when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(false);
+    when(identityRoleLookup.findAllByUserId("consultant Id")).thenReturn(List.of("other-role"));
 
     assertThrows(
         BadRequestException.class,
         () ->
             consultantAgencyRelationCreatorService.createConsultantAgencyRelations(
-                "consultant Id", Set.of(1L), asSet("consultant"), LogService::logInfo));
+                "consultant Id",
+                Set.of(1L),
+                asSet("consultant", "tenant-admin", "user-admin"),
+                LogService::logInfo));
 
+    verify(identityRoleLookup).findAllByUserId("consultant Id");
+    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService, never()).saveConsultantAgency(any());
   }
 
@@ -245,7 +253,8 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     consultant.setId("consultant Id");
     consultant.setTenantId(1L);
 
-    when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(true);
+    when(identityRoleLookup.findAllByUserId("consultant Id"))
+        .thenReturn(List.of("other-role", "tenant-admin"));
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
     when(agencyService.getAgency(1L)).thenReturn(agencyDTO);
@@ -253,8 +262,13 @@ public class ConsultantAgencyRelationCreatorServiceTest {
         .thenReturn(easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class));
 
     consultantAgencyRelationCreatorService.createConsultantAgencyRelations(
-        "consultant Id", Set.of(1L), asSet("consultant"), LogService::logInfo);
+        "consultant Id",
+        Set.of(1L),
+        asSet("consultant", "tenant-admin", "user-admin"),
+        LogService::logInfo);
 
+    verify(identityRoleLookup).findAllByUserId("consultant Id");
+    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,7 +30,7 @@ public class ConsultantUpdateServiceBase {
 
   @Autowired protected ConsultantUpdateService consultantUpdateService;
 
-  @MockitoBean(extraInterfaces = IdentityProfileLookup.class)
+  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
   protected IdentityClient identityClient;
 
   @MockitoBean protected RocketChatService rocketChatService;

--- a/src/test/java/de/caritas/cob/userservice/api/service/identity/UserIdentitiesServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/identity/UserIdentitiesServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ class UserIdentitiesServiceTest {
 
   @Mock private ConsultantRepository consultantRepository;
 
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleLookup identityRoleLookup;
 
   @InjectMocks private UserIdentitiesService userIdentitiesService;
 
@@ -35,7 +35,7 @@ class UserIdentitiesServiceTest {
     lenient()
         .when(consultantRepository.findByIdAndDeleteDateIsNull(USER_ID))
         .thenReturn(Optional.empty());
-    lenient().when(identityClient.getRealmRoles(USER_ID)).thenReturn(List.of());
+    lenient().when(identityRoleLookup.findAllByUserId(USER_ID)).thenReturn(List.of());
 
     var result = userIdentitiesService.getUserIdentities(USER_ID);
 
@@ -47,7 +47,7 @@ class UserIdentitiesServiceTest {
     lenient().when(adminRepository.existsById(USER_ID)).thenReturn(false);
     when(consultantRepository.findByIdAndDeleteDateIsNull(USER_ID))
         .thenReturn(Optional.of(new Consultant()));
-    lenient().when(identityClient.getRealmRoles(USER_ID)).thenReturn(List.of());
+    lenient().when(identityRoleLookup.findAllByUserId(USER_ID)).thenReturn(List.of());
 
     var result = userIdentitiesService.getUserIdentities(USER_ID);
 
@@ -58,7 +58,7 @@ class UserIdentitiesServiceTest {
   void getUserIdentities_Should_ReturnBothFalseWithRoles_When_NeitherIdentityExists() {
     when(adminRepository.existsById(USER_ID)).thenReturn(false);
     when(consultantRepository.findByIdAndDeleteDateIsNull(USER_ID)).thenReturn(Optional.empty());
-    when(identityClient.getRealmRoles(USER_ID)).thenReturn(List.of("user-admin"));
+    when(identityRoleLookup.findAllByUserId(USER_ID)).thenReturn(List.of("user-admin"));
 
     var result = userIdentitiesService.getUserIdentities(USER_ID);
 
@@ -74,7 +74,7 @@ class UserIdentitiesServiceTest {
     lenient()
         .when(consultantRepository.findByIdAndDeleteDateIsNull(USER_ID))
         .thenReturn(Optional.of(new Consultant()));
-    when(identityClient.getRealmRoles(USER_ID)).thenReturn(roles);
+    when(identityRoleLookup.findAllByUserId(USER_ID)).thenReturn(roles);
 
     var result = userIdentitiesService.getUserIdentities(USER_ID);
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -257,6 +257,55 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "The broad identity command client must not own profile reads",
         )
 
+    def test_role_read_consumers_use_a_focused_identity_role_port(self):
+        broad_client_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityClient;"
+        )
+        focused_lookup_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;"
+        )
+        consumers = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "create/agencyrelation/ConsultantAgencyRelationCreatorService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/identity"
+            / "UserIdentitiesService.java",
+        )
+        missing_focused_port = [
+            str(source.relative_to(ROOT))
+            for source in consumers
+            if focused_lookup_import not in source.read_text()
+        ]
+        user_identities_service = consumers[1].read_text()
+        agency_relation_service = consumers[0].read_text()
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+
+        self.assertEqual(
+            [],
+            missing_focused_port,
+            "Realm-role readers must depend on a focused role-read port:\n"
+            + "\n".join(missing_focused_port),
+        )
+        self.assertNotIn(
+            broad_client_import,
+            user_identities_service,
+            "UserIdentitiesService must not depend on the broad command client",
+        )
+        self.assertNotIn(
+            "identityClient.userHasRole(",
+            agency_relation_service,
+            "Agency role-set validation must use one focused realm-role read",
+        )
+        self.assertNotIn(
+            "getRealmRoles(",
+            identity_client,
+            "The broad identity command client must not own realm-role reads",
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- introduce the focused `IdentityRoleLookup` outbound port and remove complete realm-role reads from the broad `IdentityClient`
- make consultant role-set validation fetch the assigned realm roles once and perform the requested-set intersection in-process
- move `UserIdentitiesService` to the same focused role-read port
- enforce the dependency and call-shape boundary with blocking CI and interaction contracts

## Call bound

- before: zero calls for an empty requested set, otherwise up to one `userHasRole` provider request per candidate role
- after: zero calls for an empty requested set, exactly one complete realm-role read for every non-empty requested set
- the three-candidate regression proves both matching and denied behavior with exactly one role-list invocation and zero per-candidate checks

## Stack

- Parent: OpenResilienceInitiative/ORISO-UserService#335
- Child: OpenResilienceInitiative/ORISO-UserService#783
- Stacked on #782 (`refactor/identity-profile-read-781`)
- Review and merge after #782

## Verification

- 3,857 JDK 21 unit tests: 0 failures, 0 errors, 0 skipped
- 969 integration/contract/E2E tests: 0 failures, 0 errors, 14 environment-dependent skips
- 167 focused Spring integration tests: 0 failures, 0 errors
- 115 focused role/identity unit tests: 0 failures, 0 errors
- 35 Python CI boundary/contract tests: green
- Spotless and `git diff --check`: green

## Architecture boundary

This is a bounded modular-monolith improvement, not a new deployable service. The target chat architecture remains Matrix-only with the ORISO-owned frontend and an ORISO-controlled Element Call/MatrixRTC fork plus LiveKit. Rocket.Chat and Jitsi remain complete removal targets, never fallbacks.

## Evidence boundary

This PR contains code and local/CI evidence only. It is not merged, deployed, or proven on PreDev. The code-level one-call bound still requires the normal post-deployment trace comparison before it can be claimed as live runtime evidence.

Closes OpenResilienceInitiative/ORISO-UserService#783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
