### PR TITLE
[Stability] Bound AgencyService fallback after batch failure

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -163,11 +163,21 @@ closed.
 
 ## Chatty-call reductions
 
-- With the default `rocket-chat.enabled=false`, account and availability reads
-  no longer call Rocket.Chat. Matrix-only deployments also do not create the
-  Rocket.Chat MongoDB client or credential job.
+- Rocket.Chat is a complete removal target, never a fallback. Until its legacy
+  code is deleted, the default `rocket-chat.enabled=false` prevents account and
+  availability reads from calling it and prevents creation of its MongoDB
+  client or credential job. Matrix remains the sole intended chat transport;
+  Jitsi is likewise not part of the target call stack.
 - Anonymous live-chat queue visibility is topic-only and therefore avoids an
   AgencyService lookup merely to resolve consulting-type visibility.
+- When the consultant-agency batch read is empty or fails, the local fallback
+  performs no per-agency AgencyService retries and loads the lowest known
+  consulting type for all agency IDs in one grouped session query. For `N`
+  agencies, this changes the failure path from `1 + N` outbound calls plus `N`
+  local queries to one outbound batch call plus one local query while
+  preserving IDs, topic assignments and configured fallback values. This is
+  local code/test evidence until the branch is merged, deployed and measured
+  on PreDev.
 - Appointment deletion uses one conditional database `DELETE` and its affected
   row count. It preserves the 404 contract without a read-before-delete round
   trip.
@@ -188,6 +198,11 @@ model.
 
 ## Internal module boundaries
 
+The target is Matrix-only. Rocket.Chat references below describe legacy code
+that remains to be deleted; they are not an approved fallback or target
+adapter. Video calling belongs to the ORISO-controlled Element Call/MatrixRTC
+fork with LiveKit, without Jitsi.
+
 The intended dependency direction is:
 
 ```mermaid
@@ -196,7 +211,7 @@ flowchart LR
   IN[Input ports]
   APP[Managers, facades and workflows]
   OUT[Output ports]
-  ADAPTERS[Matrix, Keycloak, Rocket.Chat, repositories and generated clients]
+  ADAPTERS[Matrix, Keycloak, repositories, generated clients and legacy adapters]
 
   HTTP --> IN --> APP --> OUT --> ADAPTERS
 ```

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -19,6 +19,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface SessionRepository extends CrudRepository<Session, Long> {
 
+  interface AgencyConsultingTypeProjection {
+
+    Long getAgencyId();
+
+    Integer getConsultingTypeId();
+  }
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT session FROM Session session WHERE session.id = :sessionId")
   Optional<Session> findByIdForUpdate(@Param("sessionId") Long sessionId);
@@ -429,4 +436,10 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
       "SELECT DISTINCT s.consultingTypeId FROM Session s WHERE s.agencyId = :agencyId ORDER BY s.consultingTypeId")
   List<Integer> findDistinctConsultingTypeIdsByAgencyId(
       @Param("agencyId") Long agencyId, Pageable pageable);
+
+  @Query(
+      "SELECT s.agencyId AS agencyId, MIN(s.consultingTypeId) AS consultingTypeId "
+          + "FROM Session s WHERE s.agencyId IN :agencyIds GROUP BY s.agencyId")
+  List<AgencyConsultingTypeProjection> findLowestConsultingTypeIdsByAgencyIds(
+      @Param("agencyIds") Set<Long> agencyIds);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
@@ -19,14 +19,13 @@ import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -200,7 +199,7 @@ public class ConsultantAgencyService {
             "AgencyService returned no agencies for consultant {} and ids {}. Falling back to local topic assignments",
             consultantId,
             agencyIds);
-        return agenciesWithLocalTopicAssignments(consultantId, agencyIds);
+        return agenciesWithLocalTopicAssignments(agencyIds, consultantTopicIds);
       }
       return enrichAgenciesWithConsultantTopicIds(agencies, consultantTopicIds);
     } catch (RuntimeException exception) {
@@ -208,7 +207,7 @@ public class ConsultantAgencyService {
           "Could not load agencies for consultant {} from AgencyService, falling back to local topic assignments",
           consultantId,
           exception);
-      return agenciesWithLocalTopicAssignments(consultantId, agencyIds);
+      return agenciesWithLocalTopicAssignments(agencyIds, consultantTopicIds);
     }
   }
 
@@ -234,43 +233,24 @@ public class ConsultantAgencyService {
   }
 
   private List<AgencyDTO> agenciesWithLocalTopicAssignments(
-      String consultantId, List<Long> agencyIds) {
-    var topicIds = consultantTopicRepository.findTopicIdsByConsultantId(consultantId);
+      List<Long> agencyIds, List<Long> topicIds) {
+    Map<Long, Integer> consultingTypesByAgency =
+        sessionRepository.findLowestConsultingTypeIdsByAgencyIds(Set.copyOf(agencyIds)).stream()
+            .collect(
+                Collectors.toMap(
+                    SessionRepository.AgencyConsultingTypeProjection::getAgencyId,
+                    SessionRepository.AgencyConsultingTypeProjection::getConsultingTypeId));
+
     return agencyIds.stream()
-        .map(agencyId -> resolveAgencyWithLocalFallback(agencyId, topicIds))
+        .map(
+            agencyId ->
+                new AgencyDTO()
+                    .id(agencyId)
+                    .offline(false)
+                    .topicIds(topicIds)
+                    .consultingType(
+                        consultingTypesByAgency.getOrDefault(
+                            agencyId, registrationAgencyFallbackConsultingTypeId)))
         .collect(Collectors.toList());
-  }
-
-  private AgencyDTO resolveAgencyWithLocalFallback(Long agencyId, List<Long> topicIds) {
-    try {
-      AgencyDTO agency = agencyService.getAgencyWithoutCaching(agencyId);
-      if (agency != null) {
-        if (agency.getTopicIds() == null || agency.getTopicIds().isEmpty()) {
-          agency.setTopicIds(topicIds);
-        }
-        if (agency.getConsultingType() != null) {
-          return agency;
-        }
-      }
-    } catch (RuntimeException exception) {
-      log.debug(
-          "Could not load agency {} individually from AgencyService during consultant fallback",
-          agencyId,
-          exception);
-    }
-
-    AgencyDTO fallbackAgency = new AgencyDTO().id(agencyId).offline(false).topicIds(topicIds);
-    resolveConsultingTypeForFallback(agencyId).ifPresent(fallbackAgency::setConsultingType);
-    return fallbackAgency;
-  }
-
-  private Optional<Integer> resolveConsultingTypeForFallback(Long agencyId) {
-    var consultingTypesFromSessions =
-        sessionRepository.findDistinctConsultingTypeIdsByAgencyId(agencyId, PageRequest.of(0, 1));
-    if (!consultingTypesFromSessions.isEmpty()) {
-      return Optional.of(consultingTypesFromSessions.get(0));
-    }
-
-    return Optional.ofNullable(registrationAgencyFallbackConsultingTypeId);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/SessionRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/SessionRepositoryIT.java
@@ -14,6 +14,9 @@ import de.caritas.cob.userservice.api.model.SessionData.SessionDataType;
 import de.caritas.cob.userservice.api.model.User;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
@@ -43,7 +46,9 @@ class SessionRepositoryIT {
 
   @AfterEach
   public void reset() {
-    underTest.delete(session);
+    if (session != null) {
+      underTest.delete(session);
+    }
     session = null;
     user = null;
   }
@@ -85,32 +90,61 @@ class SessionRepositoryIT {
         underTest.findById(persistedSession.getId()).orElseThrow().getConversationType());
   }
 
+  @Test
+  void findLowestConsultingTypeIdsByAgencyIdsShouldGroupAndSelectMinimum() {
+    givenAUser();
+    var sessions =
+        List.of(
+            validSession(10L, 4), validSession(10L, 2), validSession(20L, 7), validSession(30L, 9));
+    underTest.saveAll(sessions);
+    entityManager.flush();
+
+    try {
+      var consultingTypesByAgency =
+          underTest.findLowestConsultingTypeIdsByAgencyIds(Set.of(10L, 20L)).stream()
+              .collect(
+                  Collectors.toMap(
+                      SessionRepository.AgencyConsultingTypeProjection::getAgencyId,
+                      SessionRepository.AgencyConsultingTypeProjection::getConsultingTypeId));
+
+      assertEquals(Map.of(10L, 2, 20L, 7), consultingTypesByAgency);
+    } finally {
+      underTest.deleteAll(sessions);
+    }
+  }
+
   private void givenValidSession() {
-    session = new Session();
-    session.setUser(user);
-    session.setConsultingTypeId(1);
-    session.setRegistrationType(easyRandom.nextObject(RegistrationType.class));
-    session.setPostcode(RandomStringUtils.randomNumeric(5));
-    session.setLanguageCode(easyRandom.nextObject(LanguageCode.class));
-    session.setStatus(easyRandom.nextObject(SessionStatus.class));
-    session.setIsConsultantDirectlySet(false);
-    session.setConversationType(ConversationType.AGENCY_COUNSELLING);
+    session = validSession(null, 1);
+  }
+
+  private Session validSession(Long agencyId, int consultingTypeId) {
+    var validSession = new Session();
+    validSession.setUser(user);
+    validSession.setAgencyId(agencyId);
+    validSession.setConsultingTypeId(consultingTypeId);
+    validSession.setRegistrationType(easyRandom.nextObject(RegistrationType.class));
+    validSession.setPostcode(RandomStringUtils.randomNumeric(5));
+    validSession.setLanguageCode(easyRandom.nextObject(LanguageCode.class));
+    validSession.setStatus(easyRandom.nextObject(SessionStatus.class));
+    validSession.setIsConsultantDirectlySet(false);
+    validSession.setConversationType(ConversationType.AGENCY_COUNSELLING);
 
     var sessionData1 =
         new SessionData(
-            session,
+            validSession,
             SessionDataType.REGISTRATION,
             RandomStringUtils.randomAlphanumeric(1, 255),
             RandomStringUtils.randomAlphanumeric(1, 255));
 
     var sessionData2 =
         new SessionData(
-            session,
+            validSession,
             SessionDataType.REGISTRATION,
             RandomStringUtils.randomAlphanumeric(1, 255),
             RandomStringUtils.randomAlphanumeric(1, 255));
 
-    session.setSessionData(List.of(sessionData1, sessionData2));
+    validSession.setSessionData(List.of(sessionData1, sessionData2));
+    return validSession;
   }
 
   private void givenAUser() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -200,11 +200,9 @@ public class ConsultantAgencyServiceTest {
     when(consultantAgencyRepository.findByConsultantId("valid"))
         .thenReturn(singletonList(activeConsultantAgency));
     when(agencyService.getAgenciesNotCached(singletonList(AGENCY_ID))).thenReturn(emptyList());
-    when(agencyService.getAgencyWithoutCaching(AGENCY_ID))
-        .thenThrow(new RuntimeException("Not found"));
     when(consultantTopicRepository.findTopicIdsByConsultantId("valid")).thenReturn(List.of(1L));
-    when(sessionRepository.findDistinctConsultingTypeIdsByAgencyId(AGENCY_ID, PageRequest.of(0, 1)))
-        .thenReturn(List.of());
+    when(sessionRepository.findLowestConsultingTypeIdsByAgencyIds(Set.of(AGENCY_ID)))
+        .thenReturn(emptyList());
     ReflectionTestUtils.setField(
         consultantAgencyService, "registrationAgencyFallbackConsultingTypeId", 1);
 
@@ -214,6 +212,7 @@ public class ConsultantAgencyServiceTest {
     assertEquals(AGENCY_ID, agencies.get(0).getId());
     assertEquals(List.of(1L), agencies.get(0).getTopicIds());
     assertEquals(Integer.valueOf(1), agencies.get(0).getConsultingType());
+    verify(agencyService, Mockito.never()).getAgencyWithoutCaching(any());
   }
 
   @Test
@@ -273,11 +272,10 @@ public class ConsultantAgencyServiceTest {
         .thenReturn(singletonList(activeConsultantAgency));
     when(agencyService.getAgenciesNotCached(singletonList(AGENCY_ID)))
         .thenThrow(new RuntimeException("Unauthorized"));
-    when(agencyService.getAgencyWithoutCaching(AGENCY_ID))
-        .thenThrow(new RuntimeException("Unauthorized"));
     when(consultantTopicRepository.findTopicIdsByConsultantId("valid")).thenReturn(List.of(1L, 2L));
-    when(sessionRepository.findDistinctConsultingTypeIdsByAgencyId(AGENCY_ID, PageRequest.of(0, 1)))
-        .thenReturn(List.of(3));
+    var agencyConsultingType = agencyConsultingType(AGENCY_ID, 3);
+    when(sessionRepository.findLowestConsultingTypeIdsByAgencyIds(Set.of(AGENCY_ID)))
+        .thenReturn(List.of(agencyConsultingType));
     ReflectionTestUtils.setField(
         consultantAgencyService, "registrationAgencyFallbackConsultingTypeId", null);
 
@@ -287,6 +285,7 @@ public class ConsultantAgencyServiceTest {
     assertEquals(AGENCY_ID, resultAgencies.get(0).getId());
     assertEquals(List.of(1L, 2L), resultAgencies.get(0).getTopicIds());
     assertEquals(Integer.valueOf(3), resultAgencies.get(0).getConsultingType());
+    verify(agencyService, Mockito.never()).getAgencyWithoutCaching(any());
   }
 
   @Test
@@ -299,17 +298,61 @@ public class ConsultantAgencyServiceTest {
         .thenReturn(singletonList(activeConsultantAgency));
     when(agencyService.getAgenciesNotCached(singletonList(AGENCY_ID)))
         .thenThrow(new RuntimeException("Unauthorized"));
-    when(agencyService.getAgencyWithoutCaching(AGENCY_ID))
-        .thenThrow(new RuntimeException("Unauthorized"));
     when(consultantTopicRepository.findTopicIdsByConsultantId("valid")).thenReturn(List.of(1L));
-    when(sessionRepository.findDistinctConsultingTypeIdsByAgencyId(AGENCY_ID, PageRequest.of(0, 1)))
-        .thenReturn(List.of());
+    when(sessionRepository.findLowestConsultingTypeIdsByAgencyIds(Set.of(AGENCY_ID)))
+        .thenReturn(emptyList());
     ReflectionTestUtils.setField(
         consultantAgencyService, "registrationAgencyFallbackConsultingTypeId", 1);
 
     var resultAgencies = consultantAgencyService.getOnlineAgenciesOfConsultant("valid");
 
     assertEquals(Integer.valueOf(1), resultAgencies.get(0).getConsultingType());
+    verify(agencyService, Mockito.never()).getAgencyWithoutCaching(any());
+  }
+
+  @Test
+  public void
+      getOnlineAgenciesOfConsultant_Should_boundFallbackCallsAndPreserveAgencyAssignments_When_batchFails() {
+    var agencyIds = List.of(1L, 2L, 3L);
+    var activeConsultantAgencies =
+        agencyIds.stream()
+            .map(
+                agencyId ->
+                    new ConsultantAgency(
+                        agencyId, CONSULTANT, agencyId, nowInUtc(), nowInUtc(), null, 1L, null))
+            .toList();
+    when(consultantAgencyRepository.findByConsultantId("valid"))
+        .thenReturn(activeConsultantAgencies);
+    when(agencyService.getAgenciesNotCached(agencyIds))
+        .thenThrow(new RuntimeException("Unavailable"));
+    when(consultantTopicRepository.findTopicIdsByConsultantId("valid")).thenReturn(List.of(7L, 8L));
+    var firstAgencyConsultingType = agencyConsultingType(1L, 4);
+    var secondAgencyConsultingType = agencyConsultingType(2L, 5);
+    when(sessionRepository.findLowestConsultingTypeIdsByAgencyIds(Set.copyOf(agencyIds)))
+        .thenReturn(List.of(firstAgencyConsultingType, secondAgencyConsultingType));
+    ReflectionTestUtils.setField(
+        consultantAgencyService, "registrationAgencyFallbackConsultingTypeId", 9);
+
+    var resultAgencies = consultantAgencyService.getOnlineAgenciesOfConsultant("valid");
+
+    assertEquals(agencyIds, resultAgencies.stream().map(AgencyDTO::getId).toList());
+    assertEquals(
+        List.of(4, 5, 9), resultAgencies.stream().map(AgencyDTO::getConsultingType).toList());
+    assertTrue(
+        resultAgencies.stream().allMatch(agency -> agency.getTopicIds().equals(List.of(7L, 8L))));
+    verify(agencyService, times(1)).getAgenciesNotCached(agencyIds);
+    verify(agencyService, Mockito.never()).getAgencyWithoutCaching(any());
+    verify(sessionRepository, times(1))
+        .findLowestConsultingTypeIdsByAgencyIds(Set.copyOf(agencyIds));
+    verify(consultantTopicRepository, times(1)).findTopicIdsByConsultantId("valid");
+  }
+
+  private SessionRepository.AgencyConsultingTypeProjection agencyConsultingType(
+      Long agencyId, Integer consultingTypeId) {
+    var projection = Mockito.mock(SessionRepository.AgencyConsultingTypeProjection.class);
+    when(projection.getAgencyId()).thenReturn(agencyId);
+    when(projection.getConsultingTypeId()).thenReturn(consultingTypeId);
+    return projection;
   }
 
   private static List<ConsultantAgency> givenConsultantAgenciesWithDeletionDateNull() {

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -181,6 +181,23 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_consultant_agency_fallback_does_not_retry_agency_service_per_id(self):
+        source = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java"
+        ).read_text()
+
+        self.assertNotIn(
+            "agencyService.getAgencyWithoutCaching(",
+            source,
+            "A failed agency batch must not trigger one outbound retry per agency",
+        )
+        self.assertNotIn(
+            "findDistinctConsultingTypeIdsByAgencyId(",
+            source,
+            "Fallback consulting types must be loaded in one local batch query",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #785
Parent: #335

This stacked change bounds the consultant-agency outage fallback after the initial AgencyService batch read fails or returns no agencies.

- removes every per-agency AgencyService retry from the fallback path
- replaces one session lookup per agency with one grouped `MIN(consultingTypeId)` query
- preserves every agency ID, consultant topic assignment, lowest known session consulting type, and the configured fallback value
- adds an executable source boundary so the `1 + N` outbound pattern cannot return
- records the Matrix-only target architecture: Rocket.Chat and Jitsi are removal targets, never fallbacks; video calling belongs to the ORISO-controlled Element Call/MatrixRTC fork with LiveKit

## Call-count contract

| Failure path for N agencies | Before | After |
| --- | ---: | ---: |
| AgencyService calls | `1 + N` | `1` |
| local session queries | `N` | `1` |

## Verification

- Red: the new boundary contract and three existing fallback tests failed against the old per-ID implementation.
- Focused service tests: 14 tests, 0 failures, 0 errors, 0 skipped.
- Focused repository integration: 3 tests, 0 failures, 0 errors, 0 skipped; executes the grouped minimum query.
- Full unit suite: 3,850 tests, 0 failures, 0 errors, 0 skipped.
- CI and architecture contracts: 30 tests, all green.
- Required integration suite: 969 tests, 0 failures, 0 errors, 14 environment-bound skips; all required E2E reports present.
- Packaging and zero-quarantine guard: green.

## Stack and evidence boundary

This PR is stacked on #769 and should be reviewed/merged after #769. The evidence above proves the branch code and local CI contract only. It is not evidence that this commit is merged, deployed, or active on PreDev; deployed routing and SigNoz measurements remain a separate post-deployment gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
