### PR TITLE
[Stability] Type identity email-owner lookup

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -183,6 +183,11 @@ closed.
   and performs the requested-set intersection in-process. The code-level bound
   is therefore zero identity calls for an empty role set and exactly one for a
   non-empty set, instead of up to one `userHasRole` request per candidate role.
+- Email-ownership validation now consumes the focused
+  `IdentityEmailOwnerLookup` port and the typed `IdentityEmailOwner` result.
+  Application code no longer interprets Keycloak adapter map keys. This is a
+  module-boundary improvement, not a call-count reduction: an ownership check
+  still performs exactly one external identity lookup.
 
 The runtime metrics above are the gate for further optimization: prioritize a
 dependency only when PreDev shows high calls per request, payload volume or p95
@@ -207,14 +212,15 @@ flowchart LR
 Rocket.Chat references below describe legacy code that still has to be removed;
 they are not part of the target architecture. The target chat transport is
 Matrix only, with the ORISO frontend and the controlled MatrixRTC/Element Call
-fork using LiveKit.
+fork using LiveKit. Rocket.Chat and Jitsi are removal targets, not fallbacks or
+parallel production transports.
 
 The current state is deliberately tracked per domain instead of describing the
 whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -238,7 +244,9 @@ The web-mapper contract rejects direct imports of the outbound identity client.
 The user-data facade contract keeps profile reads off that broad command port.
 The role-read contract keeps full realm-role reads behind the focused
 `IdentityRoleLookup` port and prevents per-candidate role checks from returning
-to consultant-agency validation.
+to consultant-agency validation. The email-owner contract likewise keeps the
+read off the broad command port and rejects application-level dependence on
+Keycloak adapter map keys.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class IdentityManager implements IdentityManaging {
 
   private final IdentityClient identityClient;
+  private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
   private final UsernameTranscoder usernameTranscoder;
 
   @Override
@@ -72,11 +74,17 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean isEmailAvailableOrOwn(String username, String email) {
-    var user = identityClient.findUserByEmail(email);
+    var owner = identityEmailOwnerLookup.findByEmail(email);
+    if (owner.isEmpty()) {
+      return true;
+    }
 
-    return user.isEmpty()
-        || username.equals(user.get("encodedUsername"))
-        || usernameTranscoder.decodeUsername(username).equals(user.get("decodedUsername"));
+    var ownerUsername = owner.orElseThrow().username();
+    return ownerUsername != null
+        && (username.equals(ownerUsername)
+            || usernameTranscoder
+                .decodeUsername(username)
+                .equals(usernameTranscoder.decodeUsername(ownerUsername)));
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.keycloak;
 
-import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpSetupDTO;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
 import java.util.Map;
@@ -13,8 +12,6 @@ import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 public class KeycloakMapper {
-
-  private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   public OtpSetupDTO otpSetupDtoOf(String initialCode, String secret, String email) {
     var otpSetupDTO = new OtpSetupDTO();
@@ -51,14 +48,5 @@ public class KeycloakMapper {
         "createdBefore", "false",
         "attemptsLeft", String.valueOf(!status.equals(HttpStatus.TOO_MANY_REQUESTS)),
         "email", "null");
-  }
-
-  public Map<String, String> mapOf(UserRepresentation userRepresentation) {
-    var username = userRepresentation.getUsername();
-
-    return Map.of(
-        "encodedUsername", username,
-        "decodedUsername", usernameTranscoder.decodeUsername(username),
-        "email", userRepresentation.getEmail());
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -24,6 +24,8 @@ import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -65,7 +67,8 @@ import org.springframework.web.client.RestClientResponseException;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KeycloakService implements IdentityClient, IdentityProfileLookup, IdentityRoleLookup {
+public class KeycloakService
+    implements IdentityClient, IdentityEmailOwnerLookup, IdentityProfileLookup, IdentityRoleLookup {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -199,12 +202,11 @@ public class KeycloakService implements IdentityClient, IdentityProfileLookup, I
   }
 
   @Override
-  public Map<String, String> findUserByEmail(String email) {
+  public Optional<IdentityEmailOwner> findByEmail(String email) {
     return keycloakClient.getUsersResource().search(email, 0, Integer.MAX_VALUE).stream()
-        .filter(userRepresentation -> userRepresentation.getEmail().equals(email))
+        .filter(userRepresentation -> email.equals(userRepresentation.getEmail()))
         .findFirst()
-        .map(keycloakMapper::mapOf)
-        .orElseGet(Map::of);
+        .map(userRepresentation -> new IdentityEmailOwner(userRepresentation.getUsername()));
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -32,8 +32,6 @@ public interface IdentityClient {
 
   Map<String, String> finishEmailVerification(final String username, final String initialCode);
 
-  Map<String, String> findUserByEmail(String email);
-
   String createKeycloakUser(final UserDTO user);
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwner.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwner.java
@@ -1,0 +1,4 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral identity owner of an email address. */
+public record IdentityEmailOwner(String username) {}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwnerLookup.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwnerLookup.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import java.util.Optional;
+
+/** Focused outbound identity email-owner lookup contract. */
+public interface IdentityEmailOwnerLookup {
+
+  Optional<IdentityEmailOwner> findByEmail(String email);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -7,7 +7,10 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +26,7 @@ class IdentityManagerTest {
   private static final String EMAIL = "consultant@example.org";
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
@@ -54,50 +58,39 @@ class IdentityManagerTest {
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptRawKeycloakUsernameForEncodedConsultant() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", RAW_USERNAME,
-                "decodedUsername", RAW_USERNAME,
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(RAW_USERNAME)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptEncodedKeycloakUsernameForEncodedConsultant() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", ENCODED_USERNAME,
-                "decodedUsername", RAW_USERNAME,
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(ENCODED_USERNAME)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldRejectEmailOwnedByDifferentUser() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", "other-user",
-                "decodedUsername", "other-user",
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner("other-user")));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptUnusedEmail() {
-    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of());
+    when(identityEmailOwnerLookup.findByEmail(EMAIL)).thenReturn(Optional.empty());
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldRejectIncompleteOwnerDataWithoutThrowing() {
-    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of("email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(null)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -40,6 +40,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -1481,31 +1482,29 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void findUserByEmail_Should_ReturnMappedUser_When_MatchFound() {
+  public void findByEmail_Should_ReturnTypedOwner_When_ExactMatchFound() {
     var email = "mail@example.com";
     UserRepresentation userRepresentation = mock(UserRepresentation.class);
     when(userRepresentation.getEmail()).thenReturn(email);
+    when(userRepresentation.getUsername()).thenReturn(USERNAME);
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.search(email, 0, Integer.MAX_VALUE))
         .thenReturn(singletonList(userRepresentation));
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-    var expected = new HashMap<String, String>();
-    expected.put("email", email);
-    when(keycloakMapper.mapOf(userRepresentation)).thenReturn(expected);
 
-    var result = keycloakService.findUserByEmail(email);
+    var result = keycloakService.findByEmail(email);
 
-    assertThat(result, is(expected));
+    assertThat(result, is(Optional.of(new IdentityEmailOwner(USERNAME))));
   }
 
   @Test
-  public void findUserByEmail_Should_ReturnEmptyMap_When_NoMatchFound() {
+  public void findByEmail_Should_ReturnEmpty_When_NoMatchFound() {
     var email = "mail@example.com";
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.search(email, 0, Integer.MAX_VALUE)).thenReturn(List.of());
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    var result = keycloakService.findUserByEmail(email);
+    var result = keycloakService.findByEmail(email);
 
     assertThat(result.isEmpty(), is(true));
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -37,6 +37,7 @@ import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
@@ -126,7 +127,12 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean private Keycloak keycloak;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
@@ -62,7 +63,12 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -80,6 +80,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -172,7 +173,12 @@ class UserControllerAuthorizationIT {
   @MockitoBean private AskerImportService askerImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private IdentityManager identityManager;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -54,6 +54,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
@@ -292,7 +293,12 @@ class UserControllerIT {
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -51,7 +52,12 @@ class CreateAdminServiceIT {
 
   @Autowired private CreateAdminService createAdminService;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminSe
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,12 @@ public class UpdateAdminServiceIT {
 
   @Autowired private UpdateAdminService updateAdminService;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   private IdentityClient identityClient;
 
   @Autowired private RetrieveAdminService retrieveAdminService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -29,6 +29,7 @@ import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -80,7 +81,12 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private RocketChatFacade rocketChatFacade;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -30,7 +31,12 @@ public class ConsultantUpdateServiceBase {
 
   @Autowired protected ConsultantUpdateService consultantUpdateService;
 
-  @MockitoBean(extraInterfaces = {IdentityProfileLookup.class, IdentityRoleLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityEmailOwnerLookup.class,
+        IdentityProfileLookup.class,
+        IdentityRoleLookup.class
+      })
   protected IdentityClient identityClient;
 
   @MockitoBean protected RocketChatService rocketChatService;

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -144,6 +144,36 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "Keycloak SDK types",
         )
 
+    def test_identity_email_owner_lookup_uses_a_focused_typed_port(self):
+        identity_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        identity_manager = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java"
+        ).read_text()
+
+        self.assertNotIn(
+            "findUserByEmail(",
+            identity_port,
+            "The broad identity command port must not expose email-owner reads",
+        )
+        self.assertIn(
+            "IdentityEmailOwnerLookup",
+            identity_manager,
+            "IdentityManager must use the focused typed email-owner lookup",
+        )
+        self.assertNotIn(
+            '"encodedUsername"',
+            identity_manager,
+            "Application code must not interpret Keycloak adapter map keys",
+        )
+        self.assertNotIn(
+            '"decodedUsername"',
+            identity_manager,
+            "Application code must not interpret Keycloak adapter map keys",
+        )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- split email-owner lookup out of the broad `IdentityClient` command port
- return the provider-neutral `IdentityEmailOwner` value through `IdentityEmailOwnerLookup`
- stop `IdentityManager` from interpreting Keycloak adapter map keys
- preserve exact ownership behavior for raw and encoded usernames, absent owners, different owners, and incomplete provider data
- document the boundary and the unchanged one-call behavior

## Call-count and architecture impact

This is a modular-monolith boundary improvement, not a call-count reduction. One email-ownership check still performs exactly one external identity lookup.

The target chat architecture remains Matrix only: the ORISO frontend plus the controlled MatrixRTC/Element Call fork using LiveKit. Rocket.Chat and Jitsi are removal targets, not fallbacks or parallel production transports.

## Stack

- Parent stability issue: #335
- Closes #787
- Stacked after #784
- Base: `perf/batch-identity-role-read-783`

Review this PR as the delta on top of #784. It is intentionally a draft until the stack is reviewed in order.

## Verification

- Red: the new boundary contract failed while `IdentityClient.findUserByEmail` still existed
- Red: focused Java test compilation failed before `IdentityEmailOwner` and `IdentityEmailOwnerLookup` existed
- Focused Java: 108 tests, 0 failures, 0 errors, 0 skipped
- Affected Spring contexts: 336 tests, 0 failures, 0 errors, 0 skipped
- Clean full unit suite: 3,826 tests, 0 failures, 0 errors, 0 skipped
- Required integration/contract/E2E suite: 969 tests, 0 failures, 0 errors, 14 environment-gated container skips
- Python CI contracts: 36 tests, all passed
- No-test-quarantine gate: passed
- Spotless and `git diff --check`: passed

## Release truth

This PR contains code, tests, and documentation only. It is not merged and is not deployed to PreDev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
