### PR TITLE
[Stability] Split identity authentication port

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,8 +30,8 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,852 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
-| Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
+| Unit | 3,827 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Integration + contract + E2E | 969 | 0 | 0 | 14 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
 
@@ -40,7 +40,7 @@ replica tests. Those focused tests pass, including the scheduler proof on fresh
 MariaDB 10.11 and the browser-login proof on Redis 7. Earlier overlapping broad
 attempts remain excluded from evidence; the totals above come only from the
 later serial Maven completions. The latest clean integration completion
-independently reports 969/0/0/5.
+independently reports 969/0/0/14.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
@@ -188,6 +188,11 @@ closed.
   Application code no longer interprets Keycloak adapter map keys. This is a
   module-boundary improvement, not a call-count reduction: an ownership check
   still performs exactly one external identity lookup.
+- Login, refresh-token logout and password verification now consume the focused,
+  provider-neutral `IdentityAuthentication` port. The broad `IdentityClient`
+  no longer exposes authentication operations. This is also a boundary
+  improvement rather than a call-count reduction: each authentication operation
+  still performs exactly one external identity call.
 
 The runtime metrics above are the gate for further optimization: prioritize a
 dependency only when PreDev shows high calls per request, payload volume or p95
@@ -220,7 +225,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Password and technical-user login return the provider-neutral `IdentityLogin` value. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -246,7 +251,9 @@ The role-read contract keeps full realm-role reads behind the focused
 `IdentityRoleLookup` port and prevents per-candidate role checks from returning
 to consultant-agency validation. The email-owner contract likewise keeps the
 read off the broad command port and rejects application-level dependence on
-Keycloak adapter map keys.
+Keycloak adapter map keys. The authentication contract keeps login, logout and
+password verification off the broad command client and requires every
+production consumer to depend on the focused provider-neutral port.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import java.util.Map;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IdentityManager implements IdentityManaging {
 
+  private final IdentityAuthentication identityAuthentication;
   private final IdentityClient identityClient;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
   private final UsernameTranscoder usernameTranscoder;
@@ -44,7 +46,7 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean validatePasswordIgnoring2fa(String username, String password) {
-    return identityClient.verifyIgnoringOtp(username, password);
+    return identityAuthentication.verifyPasswordIgnoringSecondFactor(username, password);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/actions/session/PostConversationFinishedAliasMessageActionCommand.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/session/PostConversationFinishedAliasMessageActionCommand.java
@@ -9,7 +9,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.config.apiclient.MessageServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.model.Session;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
@@ -30,7 +30,7 @@ public class PostConversationFinishedAliasMessageActionCommand implements Action
   private final @NonNull MessageServiceApiControllerFactory messageServiceApiControllerFactory;
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull MatrixSessionSystemMessageService matrixSessionSystemMessageService;
 
@@ -77,7 +77,8 @@ public class PostConversationFinishedAliasMessageActionCommand implements Action
   @SuppressWarnings("Duplicates")
   private void addDefaultHeaders(ApiClient apiClient) {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var keycloakLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
     var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.accessToken());
     tenantHeaderSupplier.addTenantHeader(headers);
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
@@ -68,7 +69,11 @@ import org.springframework.web.client.RestClientResponseException;
 @Slf4j
 @RequiredArgsConstructor
 public class KeycloakService
-    implements IdentityClient, IdentityEmailOwnerLookup, IdentityProfileLookup, IdentityRoleLookup {
+    implements IdentityAuthentication,
+        IdentityClient,
+        IdentityEmailOwnerLookup,
+        IdentityProfileLookup,
+        IdentityRoleLookup {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -151,7 +156,8 @@ public class KeycloakService
    * @param password the password
    * @return provider-neutral identity credentials
    */
-  public IdentityLogin loginUser(final String userName, final String password) {
+  @Override
+  public IdentityLogin login(final String userName, final String password) {
     var response = keycloakAuthClient.loginUser(userName, password);
     return new IdentityLogin(
         response.getAccessToken(),
@@ -161,7 +167,7 @@ public class KeycloakService
   }
 
   @Override
-  public boolean verifyIgnoringOtp(String username, String password) {
+  public boolean verifyPasswordIgnoringSecondFactor(String username, String password) {
     return keycloakAuthClient.verifyIgnoringOtp(username, password);
   }
 
@@ -172,7 +178,8 @@ public class KeycloakService
    * @param refreshToken the refreshToken
    * @return true if logout was successful
    */
-  public boolean logoutUser(final String refreshToken) {
+  @Override
+  public boolean logout(final String refreshToken) {
     return keycloakAuthClient.logoutUser(refreshToken);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackUserAccountInformation;
 import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -35,6 +36,7 @@ public class AnonymousUserCreatorService {
   private boolean rocketChatEnabled;
 
   private final @NonNull CreateUserFacade createUserFacade;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClient identityClient;
   private final @NonNull RocketChatService rocketChatService;
   private final @NonNull RollbackFacade rollbackFacade;
@@ -63,7 +65,7 @@ public class AnonymousUserCreatorService {
       if (!rocketChatEnabled) {
         createUserFacade.provisionMatrixUser(user, userDto.getUsername());
       }
-      identityLogin = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
+      identityLogin = identityAuthentication.login(userDto.getUsername(), userDto.getPassword());
       if (rocketChatEnabled) {
         ensureRocketChatUserExists(userDto, identityId);
         rcLoginResponseDto = loginRocketChatUser(userDto.getUsername(), userDto.getPassword());

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAuthentication.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAuthentication.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral identity authentication contract. */
+public interface IdentityAuthentication {
+
+  IdentityLogin login(String username, String password);
+
+  boolean logout(String refreshToken);
+
+  boolean verifyPasswordIgnoringSecondFactor(String username, String password);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -12,10 +12,6 @@ public interface IdentityClient {
 
   void changeLanguage(final String userId, final String language);
 
-  IdentityLogin loginUser(final String userName, final String password);
-
-  boolean logoutUser(final String refreshToken);
-
   void changeEmailAddress(final String emailAddress);
 
   void changeEmailAddress(final String username, final String emailAddress);
@@ -69,6 +65,4 @@ public interface IdentityClient {
   void closeSession(String sessionId);
 
   void deactivateUser(String userId);
-
-  boolean verifyIgnoringOtp(String username, String password);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
@@ -1,6 +1,6 @@
 package de.caritas.cob.userservice.api.service.agency;
 
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -26,7 +26,7 @@ public class AgencyMatrixCredentialClient {
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   @Value("${agency.service.api.url}")
@@ -66,7 +66,8 @@ public class AgencyMatrixCredentialClient {
 
   private HttpHeaders technicalUserHeaders() {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var keycloakLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
     var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.accessToken());
     tenantHeaderSupplier.addTenantHeader(headers);
     return headers;

--- a/src/main/java/de/caritas/cob/userservice/api/service/appointment/AppointmentService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/appointment/AppointmentService.java
@@ -10,7 +10,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AppointmentAgencyServiceA
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentAskerServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentConsultantServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
@@ -48,7 +48,7 @@ public class AppointmentService {
 
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   @Value("${feature.appointment.enabled}")
@@ -164,7 +164,8 @@ public class AppointmentService {
   @SuppressWarnings("Duplicates")
   private void addTechnicalUserHeaders(ApiClient apiClient) {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var keycloakLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
     var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.accessToken());
     tenantHeaderSupplier.addTenantHeader(headers);
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidator.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.service.user.validation;
 
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,17 +11,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserAccountValidator {
 
-  private final @NotNull IdentityClient identityClient;
+  private final @NotNull IdentityAuthentication identityAuthentication;
 
   /**
    * Checks if user can be logged in via the provided credentials. If password is wrong a {@link
-   * BadRequestException} is thrown by {@link IdentityClient}.
+   * BadRequestException} is thrown by {@link IdentityAuthentication}.
    *
    * @param username username
    * @param password password
    */
   public void checkPasswordValidity(String username, String password) {
-    var loginResponse = identityClient.loginUser(username, password);
-    identityClient.logoutUser(loginResponse.refreshToken());
+    var loginResponse = identityAuthentication.login(username, password);
+    identityAuthentication.logout(loginResponse.refreshToken());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
@@ -26,10 +27,21 @@ class IdentityManagerTest {
   private static final String EMAIL = "consultant@example.org";
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
+
+  @Test
+  void validatePasswordIgnoring2faShouldPreserveEncodedUsernameForIdentityAuthentication() {
+    when(identityAuthentication.verifyPasswordIgnoringSecondFactor(ENCODED_USERNAME, "password"))
+        .thenReturn(true);
+
+    assertThat(identityManager.validatePasswordIgnoring2fa(ENCODED_USERNAME, "password")).isTrue();
+
+    verify(identityAuthentication).verifyPasswordIgnoringSecondFactor(ENCODED_USERNAME, "password");
+  }
 
   @Test
   void validateOneTimePasswordShouldUseRawUsernameForKeycloakEmailUpdate() {

--- a/src/test/java/de/caritas/cob/userservice/api/actions/session/PostConversationFinishedAliasMessageActionCommandTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/session/PostConversationFinishedAliasMessageActionCommandTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.config.apiclient.MessageServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
 import de.caritas.cob.userservice.api.model.Session;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -43,7 +43,7 @@ class PostConversationFinishedAliasMessageActionCommandTest {
 
   @Mock private TenantHeaderSupplier tenantHeaderSupplier;
 
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
 
   @Mock private IdentityClientConfig identityClientConfig;
 
@@ -54,7 +54,7 @@ class PostConversationFinishedAliasMessageActionCommandTest {
   void execute_Should_doNothing_When_sessionIsNullOrWithoutRcRooms(Session session) {
     this.actionCommand.execute(session);
 
-    verifyNoMoreInteractions(this.identityClient);
+    verifyNoMoreInteractions(this.identityAuthentication);
     verifyNoMoreInteractions(this.securityHeaderSupplier);
     verifyNoMoreInteractions(this.messageControllerApi);
   }
@@ -68,7 +68,7 @@ class PostConversationFinishedAliasMessageActionCommandTest {
   @Test
   void execute_Should_postFinishedConversationMessage_When_sessionHasGroupId() {
     var identityLogin = new IdentityLogin("token", 0, 0, "refresh-token");
-    when(this.identityClient.loginUser(any(), any())).thenReturn(identityLogin);
+    when(this.identityAuthentication.login(any(), any())).thenReturn(identityLogin);
     when(identityClientConfig.getTechnicalUser()).thenReturn(new TechnicalUserConfig());
     when(this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(any()))
         .thenReturn(new HttpHeaders());
@@ -78,7 +78,7 @@ class PostConversationFinishedAliasMessageActionCommandTest {
 
     this.actionCommand.execute(session);
 
-    verify(this.identityClient, times(1)).loginUser(null, null);
+    verify(this.identityAuthentication, times(1)).login(null, null);
     verify(this.securityHeaderSupplier, times(1)).getKeycloakAndCsrfHttpHeaders("token");
     var expectedMessageType = new AliasOnlyMessageDTO().messageType(FINISHED_CONVERSATION);
     verify(this.messageControllerApi, times(1))

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
@@ -84,14 +84,14 @@ class KeycloakServiceLoggingTest {
   }
 
   @Test
-  void loginUser_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging() {
+  void login_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging() {
     var loginResponse =
         new KeycloakLoginResponseDTO(
             "access-token", 300, 600, "refresh-token", "Bearer", "session", "scope");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
 
-    var identityLogin = keycloakService.loginUser(USERNAME, PASSWORD);
+    var identityLogin = keycloakService.login(USERNAME, PASSWORD);
     assertThat(identityLogin.accessToken()).isEqualTo("access-token");
     assertThat(identityLogin.refreshToken()).isEqualTo("refresh-token");
 
@@ -107,31 +107,31 @@ class KeycloakServiceLoggingTest {
   }
 
   @Test
-  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutThrowsException() {
+  void logout_ShouldNotLogRefreshToken_WhenKeycloakLogoutThrowsException() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenThrow(new RestClientException("keycloak unavailable"));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isFalse();
 
     assertRefreshTokenWasNotLogged();
   }
 
   @Test
-  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutReturnsUnexpectedStatus() {
+  void logout_ShouldNotLogRefreshToken_WhenKeycloakLogoutReturnsUnexpectedStatus() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isFalse();
 
     assertRefreshTokenWasNotLogged();
   }
 
   @Test
-  void logoutUser_ShouldRedactRefreshToken_WhenRequestBodyIsRenderedForDebugLogging() {
+  void logout_ShouldRedactRefreshToken_WhenRequestBodyIsRenderedForDebugLogging() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isTrue();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isTrue();
 
     var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     verify(restTemplate).postForEntity(anyString(), requestCaptor.capture(), eq(Void.class));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -159,7 +159,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void loginUser_Should_MapKeycloakResponseToProviderNeutralCredentials() {
+  public void login_Should_MapKeycloakResponseToProviderNeutralCredentials() {
     KeycloakLoginResponseDTO loginResponseDTO =
         new EasyRandom().nextObject(KeycloakLoginResponseDTO.class);
     when(restTemplate.postForEntity(
@@ -168,7 +168,7 @@ public class KeycloakServiceTest {
             ArgumentMatchers.<Class<KeycloakLoginResponseDTO>>any()))
         .thenReturn(new ResponseEntity<>(loginResponseDTO, HttpStatus.OK));
 
-    IdentityLogin response = keycloakService.loginUser(USER_ID, OLD_PW);
+    IdentityLogin response = keycloakService.login(USER_ID, OLD_PW);
 
     assertThat(response.accessToken(), is(loginResponseDTO.getAccessToken()));
     assertThat(response.expiresIn(), is(loginResponseDTO.getExpiresIn()));
@@ -177,7 +177,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void loginUser_Should_ReturnBadRequest_When_KeycloakLoginFails() {
+  public void login_Should_ReturnBadRequest_When_KeycloakLoginFails() {
     var exception =
         new RestClientResponseException("some exception", 500, "text", null, null, null);
     when(restTemplate.postForEntity(
@@ -187,7 +187,7 @@ public class KeycloakServiceTest {
         .thenThrow(exception);
 
     try {
-      keycloakService.loginUser(USER_ID, OLD_PW);
+      keycloakService.login(USER_ID, OLD_PW);
       fail("Expected exception: BadRequestException");
     } catch (BadRequestException badRequestException) {
       assertTrue(true, "Excepted BadRequestException thrown");
@@ -195,33 +195,33 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void logoutUser_Should_ReturnTrue_When_KeycloakLoginWasSuccessful() {
+  public void logout_Should_ReturnTrue_When_KeycloakLoginWasSuccessful() {
     when(restTemplate.postForEntity(
             ArgumentMatchers.anyString(), any(), ArgumentMatchers.<Class<Void>>any()))
         .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
-    assertTrue(keycloakService.logoutUser(REFRESH_TOKEN));
+    assertTrue(keycloakService.logout(REFRESH_TOKEN));
   }
 
   @Test
-  public void logoutUser_Should_ReturnFalseAndLogError_WhenKeycloakLogoutFailsWithException() {
+  public void logout_Should_ReturnFalseAndLogError_WhenKeycloakLogoutFailsWithException() {
     RestClientException exception = new RestClientException("error");
     when(restTemplate.postForEntity(ArgumentMatchers.anyString(), any(), any()))
         .thenThrow(exception);
 
-    boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
+    boolean response = keycloakService.logout(REFRESH_TOKEN);
 
     assertFalse(response);
     assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
   }
 
   @Test
-  public void logoutUser_Should_ReturnFalseAndLogError_When_KeycloakLogoutFails() {
+  public void logout_Should_ReturnFalseAndLogError_When_KeycloakLogoutFails() {
     when(restTemplate.postForEntity(
             ArgumentMatchers.anyString(), any(), ArgumentMatchers.<Class<Void>>any()))
         .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
 
-    boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
+    boolean response = keycloakService.logout(REFRESH_TOKEN);
 
     assertFalse(response);
     assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
@@ -1365,33 +1365,35 @@ public class KeycloakServiceTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
     var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
     when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
     when(exception.getResponseBodyAsString()).thenReturn("Missing totp");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenThrow(exception);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnFalse_When_OtherBadRequest() {
+  public void verifyPasswordIgnoringSecondFactor_Should_ReturnFalse_When_OtherBadRequest() {
     var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
     when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
     when(exception.getResponseBodyAsString()).thenReturn("Invalid credentials");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenThrow(exception);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(false));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
     var loginResponse = mock(KeycloakLoginResponseDTO.class);
     when(loginResponse.getRefreshToken()).thenReturn(REFRESH_TOKEN);
     ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
@@ -1402,14 +1404,15 @@ public class KeycloakServiceTest {
     ResponseEntity<Void> logoutResponse = new ResponseEntity<>(HttpStatus.NO_CONTENT);
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class))).thenReturn(logoutResponse);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
     verify(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrueWithoutLogout_When_NoRefreshToken() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrueWithoutLogout_When_NoRefreshToken() {
     var loginResponse = mock(KeycloakLoginResponseDTO.class);
     when(loginResponse.getRefreshToken()).thenReturn(null);
     ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
@@ -1417,7 +1420,7 @@ public class KeycloakServiceTest {
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenReturn(responseEntity);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
     verify(restTemplate, org.mockito.Mockito.never())

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -129,6 +130,7 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControlle
 import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -65,6 +66,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -79,6 +79,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -175,6 +176,7 @@ class UserControllerAuthorizationIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -53,6 +53,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -295,6 +296,7 @@ class UserControllerIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -54,6 +55,7 @@ class CreateAdminServiceIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAgencyAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -34,6 +35,7 @@ public class UpdateAdminServiceIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -83,6 +84,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
@@ -33,6 +34,7 @@ public class ConsultantUpdateServiceBase {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -74,7 +74,7 @@ class AnonymousUserCreatorServiceTest {
     String responseDTO = "identity-id";
     IdentityLogin identityLogin = identityLogin();
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
-    when(keycloakService.loginUser(anyString(), anyString())).thenReturn(identityLogin);
+    when(keycloakService.login(anyString(), anyString())).thenReturn(identityLogin);
     when(createUserFacade.updateIdentityAndCreateAccount(anyString(), any(), any()))
         .thenReturn(user);
 
@@ -97,7 +97,7 @@ class AnonymousUserCreatorServiceTest {
         () -> {
           String responseDTO = "identity-id";
           when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
-          when(keycloakService.loginUser(anyString(), anyString()))
+          when(keycloakService.login(anyString(), anyString()))
               .thenThrow(new BadRequestException(ERROR));
 
           anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
@@ -136,7 +136,7 @@ class AnonymousUserCreatorServiceTest {
         () -> {
           String responseDTO = "identity-id";
           when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
-          when(keycloakService.loginUser(anyString(), anyString())).thenReturn(identityLogin());
+          when(keycloakService.login(anyString(), anyString())).thenReturn(identityLogin());
           when(userHelper.getDummyEmail(anyString())).thenReturn("user-id@beratungcaritas.de");
           when(rocketChatService.createUser(anyString(), anyString(), anyString()))
               .thenReturn(ResponseEntity.ok(new StandardResponseDTO(true, null)));
@@ -159,7 +159,7 @@ class AnonymousUserCreatorServiceTest {
     String responseDTO = "identity-id";
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
     IdentityLogin identityLogin = identityLogin();
-    when(keycloakService.loginUser(anyString(), anyString())).thenReturn(identityLogin);
+    when(keycloakService.login(anyString(), anyString())).thenReturn(identityLogin);
     LoginResponseDTO loginResponseDTO = easyRandom.nextObject(LoginResponseDTO.class);
     ResponseEntity<LoginResponseDTO> responseEntity =
         new ResponseEntity<>(loginResponseDTO, HttpStatus.OK);
@@ -191,7 +191,7 @@ class AnonymousUserCreatorServiceTest {
     String responseDTO = "identity-id";
     when(keycloakService.createKeycloakUser(any())).thenReturn(responseDTO);
     IdentityLogin identityLogin = identityLogin();
-    when(keycloakService.loginUser(anyString(), anyString())).thenReturn(identityLogin);
+    when(keycloakService.login(anyString(), anyString())).thenReturn(identityLogin);
     LoginResponseDTO loginResponseDTO = easyRandom.nextObject(LoginResponseDTO.class);
     ResponseEntity<LoginResponseDTO> responseEntity =
         new ResponseEntity<>(loginResponseDTO, HttpStatus.OK);

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
@@ -37,7 +37,7 @@ class AgencyMatrixCredentialClientTest {
 
   private RestTemplate restTemplate;
   private MockRestServiceServer mockServer;
-  private IdentityClient identityClient;
+  private IdentityAuthentication identityAuthentication;
   private IdentityClientConfig identityClientConfig;
   private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
 
@@ -45,7 +45,7 @@ class AgencyMatrixCredentialClientTest {
   void setUp() {
     restTemplate = new RestTemplate();
     mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-    identityClient = mock(IdentityClient.class);
+    identityAuthentication = mock(IdentityAuthentication.class);
     identityClientConfig = mock(IdentityClientConfig.class);
 
     var securityHeaderSupplier = new SecurityHeaderSupplier(new AuthenticatedUser());
@@ -60,7 +60,7 @@ class AgencyMatrixCredentialClientTest {
             restTemplate,
             securityHeaderSupplier,
             tenantHeaderSupplier,
-            identityClient,
+            identityAuthentication,
             identityClientConfig);
     ReflectionTestUtils.setField(
         agencyMatrixCredentialClient, "agencyServiceBaseUrl", AGENCY_SERVICE_URL);
@@ -101,7 +101,7 @@ class AgencyMatrixCredentialClientTest {
     technicalUser.setPassword("secret");
 
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    when(identityClient.loginUser("technical", "secret"))
+    when(identityAuthentication.login("technical", "secret"))
         .thenThrow(new BadRequestException("Keycloak unavailable"));
 
     assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).isEmpty();
@@ -142,6 +142,6 @@ class AgencyMatrixCredentialClientTest {
     var loginResponse = new IdentityLogin(accessToken, 0, 0, "refresh-token");
 
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    when(identityClient.loginUser("technical", "secret")).thenReturn(loginResponse);
+    when(identityAuthentication.login("technical", "secret")).thenReturn(loginResponse);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
@@ -17,7 +17,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AppointmentAskerServiceAp
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentConsultantServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -63,7 +63,7 @@ class AppointmentServiceTest {
   @Mock SecurityHeaderSupplier securityHeaderSupplier;
 
   @Mock TenantHeaderSupplier tenantHeaderSupplier;
-  @Mock IdentityClient identityClient;
+  @Mock IdentityAuthentication identityAuthentication;
 
   @SuppressWarnings("unused")
   @Mock
@@ -91,7 +91,7 @@ class AppointmentServiceTest {
     appointmentService = spy(createAppointmentService());
     nonSpiedAppointmentService = createAppointmentService();
 
-    when(identityClient.loginUser(any(), any())).thenReturn(identityLogin);
+    when(identityAuthentication.login(any(), any())).thenReturn(identityLogin);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(any())).thenReturn(httpHeaders);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(httpHeaders);
     when(consultantDTO.getId()).thenReturn("testId");
@@ -108,7 +108,7 @@ class AppointmentServiceTest {
         new StubAppointmentAskerServiceApiControllerFactory(appointmentAskerApi),
         securityHeaderSupplier,
         tenantHeaderSupplier,
-        identityClient,
+        identityAuthentication,
         identityClientConfig);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidatorTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,14 +22,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class UserAccountValidatorTest {
 
   @InjectMocks private UserAccountValidator userAccountValidator;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
 
   @Test
   public void checkPasswordValidity_Should_ThrowBadRequestException_When_KeycloakLoginFails() {
     assertThrows(
         BadRequestException.class,
         () -> {
-          when(identityClient.loginUser(anyString(), anyString()))
+          when(identityAuthentication.login(anyString(), anyString()))
               .thenThrow(new BadRequestException(ERROR));
 
           this.userAccountValidator.checkPasswordValidity(USERNAME, PASSWORD);
@@ -39,10 +39,11 @@ public class UserAccountValidatorTest {
   @Test
   public void checkPasswordValidity_Should_LogOutUser_When_LoginWasSuccessful() {
     IdentityLogin identityLogin = new IdentityLogin("access-token", 300, 600, "refresh-token");
-    when(identityClient.loginUser(anyString(), anyString())).thenReturn(identityLogin);
+    when(identityAuthentication.login(USERNAME, PASSWORD)).thenReturn(identityLogin);
 
     this.userAccountValidator.checkPasswordValidity(USERNAME, PASSWORD);
 
-    verify(identityClient, times(1)).logoutUser(anyString());
+    verify(identityAuthentication, times(1)).login(USERNAME, PASSWORD);
+    verify(identityAuthentication, times(1)).logout("refresh-token");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -69,12 +69,12 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public IdentityLogin loginUser(String userName, String password) {
+      public IdentityLogin login(String userName, String password) {
         return new IdentityLogin("", 0, 0, "");
       }
 
       @Override
-      public boolean logoutUser(String refreshToken) {
+      public boolean logout(String refreshToken) {
         return true;
       }
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -174,6 +174,58 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "Application code must not interpret Keycloak adapter map keys",
         )
 
+    def test_identity_authentication_uses_a_focused_provider_neutral_port(self):
+        identity_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        authentication_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityAuthentication.java"
+        )
+        consumers = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/actions/session/"
+            "PostConversationFinishedAliasMessageActionCommand.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/conversation/service/user/"
+            "anonymous/AnonymousUserCreatorService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/agency/"
+            "AgencyMatrixCredentialClient.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/appointment/"
+            "AppointmentService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/user/validation/"
+            "UserAccountValidator.java",
+        )
+
+        self.assertTrue(
+            authentication_port.exists(),
+            "A focused IdentityAuthentication port must own authentication",
+        )
+        for method in ("loginUser(", "logoutUser(", "verifyIgnoringOtp("):
+            self.assertNotIn(
+                method,
+                identity_port,
+                "The broad identity command port must not expose authentication",
+            )
+
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in consumers
+            if "IdentityAuthentication" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "All production authentication consumers must use the focused port:\n"
+            + "\n".join(offenders),
+        )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- add a focused, provider-neutral `IdentityAuthentication` output port for login, refresh-token logout, and password verification
- remove those authentication operations from the broad `IdentityClient`
- migrate all six production consumers and their Spring test doubles to the focused port
- preserve encoded usernames, OTP-ignoring password verification, provider-neutral `IdentityLogin`, and refresh-token logout behavior
- document this as a module-boundary improvement with unchanged outbound call count

## Architecture context

The target chat architecture is Matrix only: the ORISO frontend plus the controlled MatrixRTC/Element Call fork backed by LiveKit. Rocket.Chat and Jitsi are full removal targets, not fallbacks or parallel production transports. This identity slice does not add or retain either dependency as a target-state choice.

## Call-count evidence

This PR does not claim a chatty-call reduction. Each login, logout, or password-verification operation still performs exactly one external identity call. The improvement is that application consumers no longer depend on the broad identity command client for authentication.

## Verification

- `python3 -m pytest tests/ci -q`: 37 passed
- focused authentication and adapter suite: 155 tests, 0 failures, 0 errors, 0 skipped
- clean unit suite: 3,827 tests, 0 failures, 0 errors, 0 skipped
- required integration suite: 969 tests, 0 failures, 0 errors, 14 environment-gated container skips
- no-test-quarantine contract: passed
- formatting and diff checks: passed

## Stack and release state

- stacked after #788
- base branch: `refactor/identity-email-owner-787`
- parent stability issue: #335
- code and local CI evidence only; not merged and not deployed to PreDev

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)