### PR TITLE
[Stability] Split username availability port

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -179,6 +179,12 @@ closed.
   identity outage, but logs only the bounded exception class. The outbound
   metrics retain attempt/outcome/latency evidence without one full stack trace
   per public request.
+- Username-availability reads now consume the focused, provider-neutral
+  `IdentityUsernameAvailability` port, and the unused broad identity dependency
+  was removed from `UserVerifier`. This is a module-boundary improvement, not a
+  call-count reduction: one availability operation still performs exactly two
+  adapter-internal identity lookups, one for the decoded and one for the encoded
+  username.
 - Consultant role-set validation reads the user's complete realm-role list once
   and performs the requested-set intersection in-process. The code-level bound
   is therefore zero identity calls for an empty role set and exactly one for a
@@ -225,7 +231,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -253,7 +259,10 @@ to consultant-agency validation. The email-owner contract likewise keeps the
 read off the broad command port and rejects application-level dependence on
 Keycloak adapter map keys. The authentication contract keeps login, logout and
 password verification off the broad command client and requires every
-production consumer to depend on the focused provider-neutral port.
+production consumer to depend on the focused provider-neutral port. The
+username-availability contract likewise protects its focused port, names all
+four active direct consumers and rejects the unused broad dependency in
+`UserVerifier`.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class IdentityManager implements IdentityManaging {
   private final IdentityAuthentication identityAuthentication;
   private final IdentityClient identityClient;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final IdentityUsernameAvailability identityUsernameAvailability;
   private final UsernameTranscoder usernameTranscoder;
 
   @Override
@@ -71,7 +73,7 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean isUsernameAvailable(String username) {
-    return identityClient.isUsernameAvailable(username);
+    return identityUsernameAvailability.isUsernameAvailable(username);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -31,6 +31,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
@@ -73,7 +74,8 @@ public class KeycloakService
         IdentityClient,
         IdentityEmailOwnerLookup,
         IdentityProfileLookup,
-        IdentityRoleLookup {
+        IdentityRoleLookup,
+        IdentityUsernameAvailability {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -411,6 +413,7 @@ public class KeycloakService
    * @param username (decoded or encoded)
    * @return true if does not exist, else false
    */
+  @Override
   public boolean isUsernameAvailable(String username) {
     List<UserRepresentation> keycloakDecodedUserList =
         findByUsername(usernameTranscoder.decodeUsername(username));

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUsernameRegistry.java
@@ -6,7 +6,7 @@ import static org.apache.commons.lang3.StringUtils.substringAfter;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -23,7 +23,7 @@ public class AnonymousUsernameRegistry {
 
   private final @NonNull UserService userService;
   private final @NonNull ConsultantService consultantService;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityUsernameAvailability identityUsernameAvailability;
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
@@ -88,7 +88,7 @@ public class AnonymousUsernameRegistry {
             () ->
                 userService.findUserByUsername(username).isPresent()
                     || consultantService.getConsultantByUsername(username).isPresent())
-        || !identityClient.isUsernameAvailable(username)
+        || !identityUsernameAvailability.isUsernameAvailable(username)
         || existsInMatrix(username);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/helper/UserVerifier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/UserVerifier.java
@@ -3,9 +3,6 @@ package de.caritas.cob.userservice.api.helper;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,12 +11,10 @@ import org.springframework.stereotype.Component;
 
 /** Verifier class for user verifications. */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class UserVerifier {
 
   public static final int MAX_AGE_VALUE = 100;
-  private final @NonNull IdentityClient identityClient;
 
   @Value("${feature.demographics.enabled}")
   private boolean demographicsFeatureEnabled;
@@ -35,12 +30,6 @@ public class UserVerifier {
     // TODO: Fix Keycloak permissions for technical user
     log.info("Skipping username availability check for user: {}", userDTO.getUsername());
     return;
-
-    // Original code (commented out):
-    // if (!identityClient.isUsernameAvailable(userDTO.getUsername())) {
-    //   throw new CustomValidationHttpStatusException(
-    //       HttpStatusExceptionReason.USERNAME_NOT_AVAILABLE, HttpStatus.CONFLICT);
-    // }
   }
 
   public void checkIfAllRequiredAttributesAreCorrectlyFilled(UserDTO userDTO) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -32,8 +32,6 @@ public interface IdentityClient {
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);
 
-  boolean isUsernameAvailable(String username);
-
   void updateUserRole(final String userId);
 
   void ensureRole(final String userId, final String roleName);

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityUsernameAvailability.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityUsernameAvailability.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral username availability contract. */
+public interface IdentityUsernameAvailability {
+
+  boolean isUsernameAvailable(String username);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -82,6 +83,7 @@ public class AskerImportService {
   private final String IMPORT_LOG_CHARSET = "UTF-8";
   private final String DUMMY_POSTCODE = "00000";
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityUsernameAvailability identityUsernameAvailability;
   private final @NonNull UserService userService;
   private final @NonNull SessionService sessionService;
   private final @NonNull RocketChatService rocketChatService;
@@ -143,7 +145,7 @@ public class AskerImportService {
         }
 
         // Check if decoded username is already taken
-        if (!identityClient.isUsernameAvailable(record.getUsername())) {
+        if (!identityUsernameAvailability.isUsernameAvailable(record.getUsername())) {
           writeToImportLog(
               String.format(
                   "Could not create Keycloak user %s - username or e-mail address is already taken.",
@@ -336,7 +338,7 @@ public class AskerImportService {
         UserDTO userDTO = convertAskerToUserDTO(record, agencyDTO.getConsultingType());
 
         // Check if decoded username is already taken
-        if (!identityClient.isUsernameAvailable(record.getUsername())) {
+        if (!identityUsernameAvailability.isUsernameAvailable(record.getUsername())) {
           writeToImportLog(
               String.format(
                   "Could not create Keycloak user %s - username or e-mail address is already taken.",

--- a/src/main/java/de/caritas/cob/userservice/api/service/ConsultantImportService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ConsultantImportService.java
@@ -11,7 +11,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import java.io.FileReader;
@@ -50,7 +50,7 @@ public class ConsultantImportService {
   @Value("${multitenancy.enabled}")
   private Boolean multiTenancyEnabled;
 
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityUsernameAvailability identityUsernameAvailability;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull ConsultingTypeManager consultingTypeManager;
   private final @NonNull AgencyService agencyService;
@@ -187,7 +187,7 @@ public class ConsultantImportService {
           }
 
           // Check if decoded username is already taken
-          if (!identityClient.isUsernameAvailable(importRecord.getUsername())) {
+          if (!identityUsernameAvailability.isUsernameAvailable(importRecord.getUsername())) {
             writeToImportLog(
                 String.format(
                     "Could not create Keycloak user for old id %s - username or e-mail address is already taken.",

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ class IdentityManagerTest {
   @Mock private IdentityClient identityClient;
   @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
@@ -108,12 +110,12 @@ class IdentityManagerTest {
   }
 
   @Test
-  void isUsernameAvailableShouldDelegateToIdentityClient() {
-    when(identityClient.isUsernameAvailable(RAW_USERNAME)).thenReturn(true);
+  void isUsernameAvailableShouldDelegateToFocusedAvailabilityPort() {
+    when(identityUsernameAvailability.isUsernameAvailable(RAW_USERNAME)).thenReturn(true);
 
     assertThat(identityManager.isUsernameAvailable(RAW_USERNAME)).isTrue();
 
-    verify(identityClient).isUsernameAvailable(RAW_USERNAME);
+    verify(identityUsernameAvailability).isUsernameAvailable(RAW_USERNAME);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -788,6 +788,7 @@ public class KeycloakServiceTest {
     boolean isAvailable = this.keycloakService.isUsernameAvailable("username");
 
     assertThat(isAvailable, is(true));
+    verify(usersResource, times(2)).search(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -41,6 +41,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.ConsultingTypeControllerApi;
@@ -133,7 +134,8 @@ class UserAdminControllerE2EIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -69,7 +70,8 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -84,6 +84,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.AskerImportService;
@@ -179,7 +180,8 @@ class UserControllerAuthorizationIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -59,6 +59,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
@@ -299,7 +300,8 @@ class UserControllerIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -58,7 +59,8 @@ class CreateAdminServiceIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -38,7 +39,8 @@ public class UpdateAdminServiceIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -33,6 +33,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -87,7 +88,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,7 +38,8 @@ public class ConsultantUpdateServiceBase {
         IdentityAuthentication.class,
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
-        IdentityRoleLookup.class
+        IdentityRoleLookup.class,
+        IdentityUsernameAvailability.class
       })
   protected IdentityClient identityClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/user/anonymous/AnonymousUsernameRegistryTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.conversation.service.user.anonymous.AnonymousUsernameRegistry;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -36,7 +36,7 @@ class AnonymousUsernameRegistryTest {
   @InjectMocks private AnonymousUsernameRegistry anonymousUsernameRegistry;
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private UsernameTranscoder usernameTranscoder;
 
@@ -45,7 +45,7 @@ class AnonymousUsernameRegistryTest {
     setField(anonymousUsernameRegistry, "usernameTranscoder", usernameTranscoder);
     setField(anonymousUsernameRegistry, "usernamePrefix", "Ratsuchende_r ");
     // By default every candidate username is free in Keycloak; individual tests override this.
-    when(identityClient.isUsernameAvailable(anyString())).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable(anyString())).thenReturn(true);
   }
 
   @AfterEach
@@ -162,9 +162,9 @@ class AnonymousUsernameRegistryTest {
     when(userService.findUserByUsername(any())).thenReturn(Optional.empty());
     when(consultantService.getConsultantByUsername(any())).thenReturn(Optional.empty());
     // 3 and 5 are gone from the local DB but still exist in Keycloak -> must be skipped.
-    when(identityClient.isUsernameAvailable("Ratsuchende_r 3")).thenReturn(false);
-    when(identityClient.isUsernameAvailable("Ratsuchende_r 5")).thenReturn(false);
-    when(identityClient.isUsernameAvailable("Ratsuchende_r 7")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("Ratsuchende_r 3")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("Ratsuchende_r 5")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("Ratsuchende_r 7")).thenReturn(true);
 
     anonymousUsernameRegistry.generateUniqueUsername();
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -63,6 +64,7 @@ class AskerImportServiceTest {
   @InjectMocks private AskerImportService askerImportService;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Mock private UserService userService;
   @Mock private SessionService sessionService;
   @Mock private RocketChatService rocketChatService;
@@ -156,7 +158,7 @@ class AskerImportServiceTest {
 
     askerImportService.startImportForAskersWithoutSession();
 
-    verify(identityClient, never()).isUsernameAvailable(anyString());
+    verify(identityUsernameAvailability, never()).isUsernameAvailable(anyString());
   }
 
   // ---------------------------------------------------------------------------
@@ -169,7 +171,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,takenuser,,42,password123\r\n");
     when(userHelper.isUsernameValid("takenuser")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("takenuser")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("takenuser")).thenReturn(false);
 
     askerImportService.startImportForAskersWithoutSession();
 
@@ -185,7 +187,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
 
     String keycloakResponse = "kc-user-id";
     when(identityClient.createKeycloakUser(any(UserDTO.class), anyString(), anyString()))
@@ -220,7 +222,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
 
     String keycloakResponse = "kc-user-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
@@ -252,7 +254,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String keycloakResponse = "kc-user-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenReturn(keycloakResponse);
@@ -339,7 +341,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -362,7 +364,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -390,7 +392,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -415,7 +417,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenThrow(
             new CustomValidationHttpStatusException(
@@ -437,7 +439,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,validuser,valid@example.com,42,\r\n");
     when(userHelper.isUsernameValid("validuser")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(false);
     when(userHelper.getRandomPassword()).thenReturn("generated-pw");
 
     askerImportService.startImportForAskersWithoutSession();
@@ -487,7 +489,7 @@ class AskerImportServiceTest {
 
     askerImportService.startImport();
 
-    verify(identityClient, never()).isUsernameAvailable(anyString());
+    verify(identityUsernameAvailability, never()).isUsernameAvailable(anyString());
   }
 
   // --- startImport — consultant not in agency ---
@@ -506,7 +508,7 @@ class AskerImportServiceTest {
 
     askerImportService.startImport();
 
-    verify(identityClient, never()).isUsernameAvailable(anyString());
+    verify(identityUsernameAvailability, never()).isUsernameAvailable(anyString());
   }
 
   // --- startImport — username already taken ---
@@ -520,7 +522,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(false);
 
     askerImportService.startImport();
 
@@ -538,7 +540,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -563,7 +565,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -592,7 +594,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -626,7 +628,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -670,7 +672,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -717,7 +719,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -788,7 +790,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -809,7 +811,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenThrow(new RuntimeException("unexpected"));
 
@@ -830,7 +832,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(userHelper.getDummyEmail("kc-id")).thenReturn("dummy@example.com");
@@ -862,7 +864,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(false);
 
     askerImportService.startImport();
 
@@ -880,7 +882,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -911,7 +913,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -944,7 +946,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -979,7 +981,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1020,7 +1022,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1066,7 +1068,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1099,7 +1101,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1148,7 +1150,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenThrow(new RuntimeException("unexpected loop error"));
 
@@ -1190,7 +1192,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1213,7 +1215,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1238,7 +1240,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1263,7 +1265,7 @@ class AskerImportServiceTest {
     writeAskerWithoutSessionCsv("1,newasker,valid@example.com,42,password123\r\n");
     when(userHelper.isUsernameValid("newasker")).thenReturn(true);
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
-    when(identityClient.isUsernameAvailable("newasker")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("newasker")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1323,7 +1325,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1349,7 +1351,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1380,7 +1382,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1411,7 +1413,7 @@ class AskerImportServiceTest {
     when(agencyService.getAgencyWithoutCaching(42L)).thenReturn(agencyDTO(42L, 1, false));
     Consultant consultant = consultantInAgency("cons-id", 42L);
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1445,7 +1447,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))
@@ -1482,7 +1484,7 @@ class AskerImportServiceTest {
     Consultant consultant = consultantInAgency("cons-id", 42L);
     consultant.setRocketChatId("rc-cons-id");
     when(consultantService.getConsultant("cons-id")).thenReturn(Optional.of(consultant));
-    when(identityClient.isUsernameAvailable("validuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
     when(consultingTypeManager.getConsultingTypeSettings(1))

--- a/src/test/java/de/caritas/cob/userservice/api/service/ConsultantImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ConsultantImportServiceTest.java
@@ -15,7 +15,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.RolesDTO;
@@ -42,7 +42,7 @@ class ConsultantImportServiceTest {
 
   @InjectMocks private ConsultantImportService consultantImportService;
 
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Mock private ConsultantService consultantService;
   @Mock private ConsultingTypeManager consultingTypeManager;
   @Mock private AgencyService agencyService;
@@ -152,7 +152,7 @@ class ConsultantImportServiceTest {
 
     consultantImportService.startImport();
 
-    verify(identityClient, never()).isUsernameAvailable(anyString());
+    verify(identityUsernameAvailability, never()).isUsernameAvailable(anyString());
   }
 
   @Test
@@ -165,7 +165,7 @@ class ConsultantImportServiceTest {
         .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_A"))));
     when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
         .thenReturn(Optional.empty());
-    when(identityClient.isUsernameAvailable("newuser")).thenReturn(false);
+    when(identityUsernameAvailability.isUsernameAvailable("newuser")).thenReturn(false);
 
     consultantImportService.startImport();
 
@@ -204,7 +204,7 @@ class ConsultantImportServiceTest {
         .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_CONSULTANT"))));
     when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
         .thenReturn(Optional.empty());
-    when(identityClient.isUsernameAvailable("brandnewuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("brandnewuser")).thenReturn(true);
     Consultant newConsultant = new Consultant();
     newConsultant.setId("new-id-456");
     when(createConsultantSaga.createNewConsultant(any(), any())).thenReturn(newConsultant);
@@ -246,7 +246,7 @@ class ConsultantImportServiceTest {
         .thenReturn(typeWithRoles(Map.of("roleA", List.of("ROLE_CONSULTANT"))));
     when(consultantService.findConsultantByUsernameOrEmail(anyString(), anyString()))
         .thenReturn(Optional.empty());
-    when(identityClient.isUsernameAvailable("tenantuser")).thenReturn(true);
+    when(identityUsernameAvailability.isUsernameAvailable("tenantuser")).thenReturn(true);
     Consultant newConsultant = new Consultant();
     newConsultant.setId("tenant-cons-id");
     when(createConsultantSaga.createNewConsultant(any(), any())).thenReturn(newConsultant);

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -226,6 +226,58 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_username_availability_uses_a_focused_provider_neutral_port(self):
+        identity_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        availability_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityUsernameAvailability.java"
+        )
+        consumers = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/conversation/service/user/"
+            "anonymous/AnonymousUsernameRegistry.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/"
+            "ConsultantImportService.java",
+        )
+        user_verifier = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/helper/UserVerifier.java"
+        ).read_text()
+
+        self.assertTrue(
+            availability_port.exists(),
+            "A focused IdentityUsernameAvailability port must own availability reads",
+        )
+        self.assertNotIn(
+            "isUsernameAvailable(",
+            identity_port,
+            "The broad identity command port must not expose username availability",
+        )
+
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in consumers
+            if "IdentityUsernameAvailability" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "All active availability consumers must use the focused port:\n"
+            + "\n".join(offenders),
+        )
+        self.assertNotIn(
+            "IdentityClient",
+            user_verifier,
+            "UserVerifier must not retain an unused broad identity dependency",
+        )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- add the focused, provider-neutral `IdentityUsernameAvailability` output port
- remove username availability from the broad `IdentityClient`
- migrate all four active direct consumers and remove the unused broad identity dependency from `UserVerifier`
- preserve raw and encoded username behavior plus the public fail-open path
- protect the new seam with an executable module-boundary contract

## Call-count evidence

This PR does not claim a chatty-call reduction. One availability operation still performs exactly two adapter-internal Keycloak lookups: one decoded username and one encoded username. The adapter contract now verifies this exact two-lookup behavior.

## Architecture context

The target chat architecture remains Matrix only: the ORISO frontend plus the controlled MatrixRTC/Element Call fork backed by LiveKit. Rocket.Chat and Jitsi are complete removal targets, not fallbacks or parallel production transports.

## Verification

- `python3 -m pytest tests/ci -q`: 38 passed
- focused availability and adapter suite: 195 tests, 0 failures, 0 errors, 0 skipped
- affected Spring contexts: passed
- clean unit suite: 3,827 tests, 0 failures, 0 errors, 0 skipped
- required integration suite: 969 tests, 0 failures, 0 errors, 14 environment-gated container skips
- no-test-quarantine, formatting and diff checks: passed

## Stack and release state

- stacked after #790
- base branch: `refactor/identity-authentication-789`
- parent stability issue: #335
- code and local CI evidence only; not merged and not deployed to PreDev

Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)