### PR TITLE
[Stability] Type identity second-factor boundary

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,8 +30,8 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,827 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
-| Integration + contract + E2E | 969 | 0 | 0 | 14 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
+| Unit | 3,870 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
 
@@ -39,8 +39,9 @@ The candidate includes focused scheduler and Matrix browser-login unit and
 replica tests. Those focused tests pass, including the scheduler proof on fresh
 MariaDB 10.11 and the browser-login proof on Redis 7. Earlier overlapping broad
 attempts remain excluded from evidence; the totals above come only from the
-later serial Maven completions. The latest clean integration completion
-independently reports 969/0/0/14.
+later serial Maven completions. The latest clean integration completion with
+the local Redis 7 contract container independently reports 969/0/0/5; the five
+skips are the separately required MariaDB 10.11 container contracts.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
@@ -125,7 +126,10 @@ Keycloak's JSON provider. A transport wrapper measures every admin-client
 attempt, latency, exact serialized request size, known response size and
 coarse HTTP or transport outcome in the same bounded
 `userservice.outbound.http.*` series. Its higher-level retry paths remain
-covered by the explicit retry counter.
+covered by the explicit retry counter. Second-factor operations use the fixed,
+low-cardinality operation tags `otp-fetch`, `otp-setup`, `otp-delete`,
+`email-verification-start` and `email-verification-finish`; no username, email
+address, token or OTP material is emitted as a metric tag.
 
 ### Live PreDev baseline before this change
 
@@ -199,6 +203,13 @@ closed.
   no longer exposes authentication operations. This is also a boundary
   improvement rather than a call-count reduction: each authentication operation
   still performs exactly one external identity call.
+- OTP retrieval, setup and deletion plus email-verification start and finish now
+  consume the focused, provider-neutral `IdentitySecondFactor` port and typed
+  application values. Each operation performs exactly one provider request in
+  the normal path. Only an initial unauthorized response may refresh the admin
+  token and retry exactly once, so the maximum is two provider attempts. The
+  fixed retry tags make those retries measurable per operation without leaking
+  user data.
 
 The runtime metrics above are the gate for further optimization: prioritize a
 dependency only when PreDev shows high calls per request, payload volume or p95
@@ -231,7 +242,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. | The broad `IdentityClient` still exposes web-layer user command DTOs and OTP values; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and session commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -262,7 +273,10 @@ password verification off the broad command client and requires every
 production consumer to depend on the focused provider-neutral port. The
 username-availability contract likewise protects its focused port, names all
 four active direct consumers and rejects the unused broad dependency in
-`UserVerifier`.
+`UserVerifier`. The second-factor contract keeps all five OTP and email
+verification operations off the broad command client, rejects generated
+provider DTOs and string-key maps at application boundaries, and requires the
+five fixed retry-operation tags.
 
 Replica-local caches, maps and scheduled side effects are tracked separately in
 [`USER_SERVICE_REPLICA_SAFETY.md`](USER_SERVICE_REPLICA_SAFETY.md). The current

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -2,14 +2,15 @@ package de.caritas.cob.userservice.api;
 
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
-import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,24 +23,25 @@ public class IdentityManager implements IdentityManaging {
   private final IdentityAuthentication identityAuthentication;
   private final IdentityClient identityClient;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final IdentitySecondFactor identitySecondFactor;
   private final IdentityUsernameAvailability identityUsernameAvailability;
   private final UsernameTranscoder usernameTranscoder;
 
   @Override
-  public Optional<String> setUpOneTimePassword(String username, String email) {
-    return identityClient.initiateEmailVerification(username, email);
+  public IdentityEmailVerificationStart setUpOneTimePassword(String username, String email) {
+    return identitySecondFactor.initiateEmailVerification(username, email);
   }
 
   @Override
   public boolean setUpOneTimePassword(String username, String initialCode, String secret) {
-    return identityClient.setUpOtpCredential(username, initialCode, secret);
+    return identitySecondFactor.setUpOtpCredential(username, initialCode, secret);
   }
 
   @Override
-  public Map<String, String> validateOneTimePassword(String username, String code) {
-    var validationResult = identityClient.finishEmailVerification(username, code);
-    if (validationResult.get("created").equals("true")) {
-      var email = validationResult.get("email");
+  public IdentityEmailVerification validateOneTimePassword(String username, String code) {
+    var validationResult = identitySecondFactor.finishEmailVerification(username, code);
+    if (validationResult.created()) {
+      var email = validationResult.email();
       identityClient.changeEmailAddress(usernameTranscoder.decodeUsername(username), email);
     }
 
@@ -63,12 +65,12 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public void deleteOneTimePassword(String username) {
-    identityClient.deleteOtpCredential(username);
+    identitySecondFactor.deleteOtpCredential(username);
   }
 
   @Override
-  public OtpInfoDTO getOtpCredential(String username) {
-    return identityClient.getOtpCredential(username);
+  public IdentityOtpCredential getOtpCredential(String username) {
+    return identitySecondFactor.getOtpCredential(username);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
@@ -1,8 +1,11 @@
 package de.caritas.cob.userservice.api.adapters.keycloak;
 
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.identity.IdentityOtpType;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.OtpSetupDTO;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
-import java.util.Map;
 import java.util.Objects;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.http.HttpStatus;
@@ -26,27 +29,33 @@ public class KeycloakMapper {
     return new UserRepresentation().singleAttribute("locale", locale);
   }
 
-  public Map<String, String> mapOf(ResponseEntity<SuccessWithEmail> responseEntity) {
+  public IdentityOtpCredential identityOtpCredentialOf(OtpInfoDTO otpInfo) {
+    var type =
+        otpInfo.getOtpType() == null
+            ? null
+            : IdentityOtpType.valueOf(otpInfo.getOtpType().getValue());
+    return new IdentityOtpCredential(
+        otpInfo.getOtpSetup(), otpInfo.getOtpSecret(), otpInfo.getOtpSecretQrCode(), type);
+  }
+
+  public IdentityEmailVerification identityEmailVerificationOf(
+      ResponseEntity<SuccessWithEmail> responseEntity) {
     var status = responseEntity.getStatusCode();
     var isCreated = status.equals(HttpStatus.CREATED);
     var hasBeenCreatedBefore = status.equals(HttpStatus.OK);
     var hasBeenTriedTooOften = status.equals(HttpStatus.TOO_MANY_REQUESTS);
 
-    return Map.of(
-        "created", String.valueOf(isCreated),
-        "createdBefore", String.valueOf(hasBeenCreatedBefore),
-        "attemptsLeft",
-            String.valueOf(!hasBeenTriedTooOften && !isCreated && !hasBeenCreatedBefore),
-        "email", Objects.requireNonNull(responseEntity.getBody()).getEmail());
+    return new IdentityEmailVerification(
+        isCreated,
+        hasBeenCreatedBefore,
+        !hasBeenTriedTooOften && !isCreated && !hasBeenCreatedBefore,
+        Objects.requireNonNull(responseEntity.getBody()).getEmail());
   }
 
-  public Map<String, String> mapOf(HttpClientErrorException exception) {
+  public IdentityEmailVerification identityEmailVerificationOf(HttpClientErrorException exception) {
     var status = exception.getStatusCode();
 
-    return Map.of(
-        "created", "false",
-        "createdBefore", "false",
-        "attemptsLeft", String.valueOf(!status.equals(HttpStatus.TOO_MANY_REQUESTS)),
-        "email", "null");
+    return new IdentityEmailVerification(
+        false, false, !status.equals(HttpStatus.TOO_MANY_REQUESTS), null);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -19,6 +19,9 @@ import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
@@ -31,6 +34,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
@@ -75,6 +79,7 @@ public class KeycloakService
         IdentityEmailOwnerLookup,
         IdentityProfileLookup,
         IdentityRoleLookup,
+        IdentitySecondFactor,
         IdentityUsernameAvailability {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
@@ -219,14 +224,18 @@ public class KeycloakService
   }
 
   @Override
-  public OtpInfoDTO getOtpCredential(String userName) {
+  public IdentityOtpCredential getOtpCredential(String userName) {
     var requestUrl = getOtpUrl(ENDPOINT_OTP_INFO, userName);
     var response =
         withFreshAdminTokenOnUnauthorized(
+            "otp-fetch",
             () ->
                 keycloakClient.get(keycloakClient.getBearerToken(), requestUrl, OtpInfoDTO.class));
 
-    return response.getBody();
+    var body = response.getBody();
+    return body == null
+        ? IdentityOtpCredential.empty()
+        : keycloakMapper.identityOtpCredentialOf(body);
   }
 
   @Override
@@ -236,6 +245,7 @@ public class KeycloakService
 
     try {
       withFreshAdminTokenOnUnauthorized(
+          "otp-setup",
           () ->
               keycloakClient.putForEntity(
                   keycloakClient.getBearerToken(), requestUrl, otpSetupDTO, OtpInfoDTO.class));
@@ -253,42 +263,46 @@ public class KeycloakService
   public void deleteOtpCredential(String userName) {
     var requestUrl = getOtpUrl(ENDPOINT_OTP_TEARDOWN, userName);
     withFreshAdminTokenOnUnauthorized(
+        "otp-delete",
         () -> keycloakClient.delete(keycloakClient.getBearerToken(), requestUrl, Void.class));
   }
 
   @Override
-  public Optional<String> initiateEmailVerification(String username, String email) {
+  public IdentityEmailVerificationStart initiateEmailVerification(String username, String email) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(null, null, email);
     var requestUrl = getOtpUrl(ENDPOINT_OTP_VERIFY_EMAIL, username);
 
     try {
       withFreshAdminTokenOnUnauthorized(
+          "email-verification-start",
           () ->
               keycloakClient.putForEntity(
                   keycloakClient.getBearerToken(), requestUrl, otpSetupDTO, Success.class));
-      return Optional.empty();
+      return IdentityEmailVerificationStart.success();
     } catch (RestClientException exception) {
-      return Optional.of("Keycloak answered: " + exception.getMessage());
+      return IdentityEmailVerificationStart.failure(
+          "Identity provider answered: " + exception.getMessage());
     }
   }
 
   @Override
-  public Map<String, String> finishEmailVerification(String username, String initialCode) {
+  public IdentityEmailVerification finishEmailVerification(String username, String initialCode) {
     var otpSetupDTO = keycloakMapper.otpSetupDtoOf(initialCode, null, null);
     var requestUrl = getOtpUrl(ENDPOINT_OTP_FINISH_EMAIL, username);
 
     try {
       var response =
           withFreshAdminTokenOnUnauthorized(
+              "email-verification-finish",
               () ->
                   keycloakClient.postForEntity(
                       keycloakClient.getBearerToken(),
                       requestUrl,
                       otpSetupDTO,
                       SuccessWithEmail.class));
-      return keycloakMapper.mapOf(response);
+      return keycloakMapper.identityEmailVerificationOf(response);
     } catch (HttpClientErrorException exception) {
-      return keycloakMapper.mapOf(exception);
+      return keycloakMapper.identityEmailVerificationOf(exception);
     }
   }
 
@@ -298,7 +312,7 @@ public class KeycloakService
         endpoint, java.util.regex.Matcher.quoteReplacement(decodedUsername));
   }
 
-  private <T> T withFreshAdminTokenOnUnauthorized(Supplier<T> request) {
+  private <T> T withFreshAdminTokenOnUnauthorized(String operation, Supplier<T> request) {
     try {
       return request.get();
     } catch (HttpClientErrorException exception) {
@@ -307,9 +321,10 @@ public class KeycloakService
       }
 
       log.warn(
-          "Keycloak admin session was unauthorized for an OTP provider request, forcing token"
-              + " refresh and retrying once");
-      recordRetry("admin-session-refresh");
+          "Keycloak admin session was unauthorized for {} request, forcing token refresh and"
+              + " retrying once",
+          operation);
+      recordRetry(operation);
       keycloakClient.refreshAdminSession();
       return request.get();
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -25,8 +25,8 @@ import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
@@ -164,7 +164,7 @@ class UserAccountControllerDelegate {
     return identityPolicy.isTwoFactorAuthenticationAllowed(authenticatedUser.getRoles());
   }
 
-  private OtpInfoDTO retrieveOtpCredentialIfAllowed() {
+  private IdentityOtpCredential retrieveOtpCredentialIfAllowed() {
     if (!isOtpAllowed()) {
       return null;
     }
@@ -179,7 +179,7 @@ class UserAccountControllerDelegate {
       // A failed Keycloak lookup must not look like role-policy denial. An empty
       // DTO keeps 2FA enabled in the response while safely reporting no active
       // credential, so users can still open setup/reset controls.
-      return new OtpInfoDTO();
+      return IdentityOtpCredential.empty();
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
@@ -40,12 +40,10 @@ class UserTwoFactorAuthControllerDelegate {
       return new ResponseEntity<>(HttpStatus.PRECONDITION_FAILED);
     }
 
-    identityManager
-        .setUpOneTimePassword(username, email)
-        .ifPresent(
-            message -> {
-              throw new InternalServerErrorException(message);
-            });
+    var verificationStart = identityManager.setUpOneTimePassword(username, email);
+    if (!verificationStart.started()) {
+      throw new InternalServerErrorException(verificationStart.failureMessage());
+    }
 
     return ResponseEntity.noContent().build();
   }
@@ -56,16 +54,16 @@ class UserTwoFactorAuthControllerDelegate {
     var username = usernameTranscoder.encodeUsername(authenticatedUser.getUsername());
     var validationResult = identityManager.validateOneTimePassword(username, tan);
 
-    if (Boolean.parseBoolean(validationResult.get("created"))) {
-      var patchMap = userDtoMapper.mapOf(validationResult.get("email"), authenticatedUser);
+    if (validationResult.created()) {
+      var patchMap = userDtoMapper.mapOf(validationResult.email(), authenticatedUser);
       accountManager.patchUser(patchMap);
       accountInviteService.markTwoFactorActive(authenticatedUser.getUserId());
       return ResponseEntity.noContent().build();
     }
-    if (Boolean.parseBoolean(validationResult.get("attemptsLeft"))) {
+    if (validationResult.attemptsLeft()) {
       return ResponseEntity.badRequest().build();
     }
-    if (Boolean.parseBoolean(validationResult.get("createdBefore"))) {
+    if (validationResult.createdBefore()) {
       return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).build();
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/UserDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/UserDtoMapper.java
@@ -12,7 +12,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.TwoFactorAuthDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.identity.IdentityOtpType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,24 +32,23 @@ public class UserDtoMapper {
 
   public UserDataResponseDTO userDataOf(
       UserDataResponseDTO userData,
-      OtpInfoDTO otpInfoDTO,
+      IdentityOtpCredential otpCredential,
       boolean isE2eEncEnabled,
       boolean isDisplayNameAllowed) {
     var twoFactorAuthDTO = new TwoFactorAuthDTO();
 
-    if (nonNull(otpInfoDTO)) {
+    if (nonNull(otpCredential)) {
       twoFactorAuthDTO.setIsEnabled(true);
-      if (Boolean.TRUE.equals(otpInfoDTO.getOtpSetup())) {
+      if (Boolean.TRUE.equals(otpCredential.setup())) {
         twoFactorAuthDTO.isActive(true);
-        var foreignType = otpInfoDTO.getOtpType();
-        if (nonNull(foreignType)) {
-          var type = foreignType.getValue().equals("APP") ? OtpType.APP : OtpType.EMAIL;
+        if (nonNull(otpCredential.type())) {
+          var type = otpCredential.type() == IdentityOtpType.APP ? OtpType.APP : OtpType.EMAIL;
           twoFactorAuthDTO.setType(type);
         }
       }
 
-      twoFactorAuthDTO.setQrCode(otpInfoDTO.getOtpSecretQrCode());
-      twoFactorAuthDTO.setSecret(otpInfoDTO.getOtpSecret());
+      twoFactorAuthDTO.setQrCode(otpCredential.secretQrCode());
+      twoFactorAuthDTO.setSecret(otpCredential.secret());
     }
 
     twoFactorAuthDTO.setIsToEncourage(userData.getEncourage2fa());

--- a/src/main/java/de/caritas/cob/userservice/api/identity/IdentityEmailVerification.java
+++ b/src/main/java/de/caritas/cob/userservice/api/identity/IdentityEmailVerification.java
@@ -1,0 +1,4 @@
+package de.caritas.cob.userservice.api.identity;
+
+public record IdentityEmailVerification(
+    boolean created, boolean createdBefore, boolean attemptsLeft, String email) {}

--- a/src/main/java/de/caritas/cob/userservice/api/identity/IdentityEmailVerificationStart.java
+++ b/src/main/java/de/caritas/cob/userservice/api/identity/IdentityEmailVerificationStart.java
@@ -1,0 +1,12 @@
+package de.caritas.cob.userservice.api.identity;
+
+public record IdentityEmailVerificationStart(boolean started, String failureMessage) {
+
+  public static IdentityEmailVerificationStart success() {
+    return new IdentityEmailVerificationStart(true, null);
+  }
+
+  public static IdentityEmailVerificationStart failure(String failureMessage) {
+    return new IdentityEmailVerificationStart(false, failureMessage);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/identity/IdentityOtpCredential.java
+++ b/src/main/java/de/caritas/cob/userservice/api/identity/IdentityOtpCredential.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.identity;
+
+public record IdentityOtpCredential(
+    Boolean setup, String secret, String secretQrCode, IdentityOtpType type) {
+
+  public static IdentityOtpCredential empty() {
+    return new IdentityOtpCredential(null, null, null, null);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/identity/IdentityOtpType.java
+++ b/src/main/java/de/caritas/cob/userservice/api/identity/IdentityOtpType.java
@@ -1,0 +1,6 @@
+package de.caritas.cob.userservice.api.identity;
+
+public enum IdentityOtpType {
+  EMAIL,
+  APP
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
@@ -1,17 +1,17 @@
 package de.caritas.cob.userservice.api.port.in;
 
 import de.caritas.cob.userservice.api.config.auth.UserRole;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
-import java.util.Map;
-import java.util.Optional;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 
 public interface IdentityManaging {
 
-  Optional<String> setUpOneTimePassword(String username, String email);
+  IdentityEmailVerificationStart setUpOneTimePassword(String username, String email);
 
   boolean setUpOneTimePassword(String username, String initialCode, String secret);
 
-  Map<String, String> validateOneTimePassword(String username, String code);
+  IdentityEmailVerification validateOneTimePassword(String username, String code);
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   boolean validatePasswordIgnoring2fa(String username, String password);
@@ -22,7 +22,7 @@ public interface IdentityManaging {
 
   void deleteOneTimePassword(String username);
 
-  OtpInfoDTO getOtpCredential(String username);
+  IdentityOtpCredential getOtpCredential(String username);
 
   boolean isUsernameAvailable(String username);
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -2,9 +2,6 @@ package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
-import java.util.Map;
-import java.util.Optional;
 
 public interface IdentityClient {
 
@@ -17,16 +14,6 @@ public interface IdentityClient {
   void changeEmailAddress(final String username, final String emailAddress);
 
   void deleteEmailAddress();
-
-  OtpInfoDTO getOtpCredential(final String userName);
-
-  boolean setUpOtpCredential(final String userName, final String initialCode, final String secret);
-
-  void deleteOtpCredential(final String userName);
-
-  Optional<String> initiateEmailVerification(final String username, final String email);
-
-  Map<String, String> finishEmailVerification(final String username, final String initialCode);
 
   String createKeycloakUser(final UserDTO user);
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySecondFactor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentitySecondFactor.java
@@ -1,0 +1,18 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+
+public interface IdentitySecondFactor {
+
+  IdentityOtpCredential getOtpCredential(String username);
+
+  boolean setUpOtpCredential(String username, String initialCode, String secret);
+
+  void deleteOtpCredential(String username);
+
+  IdentityEmailVerificationStart initiateEmailVerification(String username, String email);
+
+  IdentityEmailVerification finishEmailVerification(String username, String initialCode);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -6,12 +6,15 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +33,7 @@ class IdentityManagerTest {
   @Mock private IdentityClient identityClient;
   @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private IdentitySecondFactor identitySecondFactor;
   @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
@@ -48,26 +52,63 @@ class IdentityManagerTest {
   @Test
   void validateOneTimePasswordShouldUseRawUsernameForKeycloakEmailUpdate() {
     var encodedUsername = usernameTranscoder.encodeUsername(RAW_USERNAME);
-    var validationResult = Map.of("created", "true", "email", EMAIL);
-    when(identityClient.finishEmailVerification(encodedUsername, "123456"))
+    var validationResult = new IdentityEmailVerification(true, false, false, EMAIL);
+    when(identitySecondFactor.finishEmailVerification(encodedUsername, "123456"))
         .thenReturn(validationResult);
 
     assertThat(identityManager.validateOneTimePassword(encodedUsername, "123456"))
         .isEqualTo(validationResult);
 
-    verify(identityClient).finishEmailVerification(encodedUsername, "123456");
+    verify(identitySecondFactor).finishEmailVerification(encodedUsername, "123456");
     verify(identityClient).changeEmailAddress(RAW_USERNAME, EMAIL);
   }
 
   @Test
   void validateOneTimePasswordShouldKeepAlreadyRawUsernameForKeycloakEmailUpdate() {
-    var validationResult = Map.of("created", "true", "email", EMAIL);
-    when(identityClient.finishEmailVerification(RAW_USERNAME, "123456"))
+    var validationResult = new IdentityEmailVerification(true, false, false, EMAIL);
+    when(identitySecondFactor.finishEmailVerification(RAW_USERNAME, "123456"))
         .thenReturn(validationResult);
 
     identityManager.validateOneTimePassword(RAW_USERNAME, "123456");
 
     verify(identityClient).changeEmailAddress(RAW_USERNAME, EMAIL);
+  }
+
+  @Test
+  void initiateEmailVerificationShouldPreserveEncodedUsernameForFocusedPort() {
+    var start = IdentityEmailVerificationStart.success();
+    when(identitySecondFactor.initiateEmailVerification(ENCODED_USERNAME, EMAIL)).thenReturn(start);
+
+    assertThat(identityManager.setUpOneTimePassword(ENCODED_USERNAME, EMAIL)).isSameAs(start);
+
+    verify(identitySecondFactor).initiateEmailVerification(ENCODED_USERNAME, EMAIL);
+  }
+
+  @Test
+  void setupOtpShouldPreserveEncodedUsernameForFocusedPort() {
+    when(identitySecondFactor.setUpOtpCredential(ENCODED_USERNAME, "123456", "secret"))
+        .thenReturn(true);
+
+    assertThat(identityManager.setUpOneTimePassword(ENCODED_USERNAME, "123456", "secret")).isTrue();
+
+    verify(identitySecondFactor).setUpOtpCredential(ENCODED_USERNAME, "123456", "secret");
+  }
+
+  @Test
+  void getOtpCredentialShouldPreserveEncodedUsernameForFocusedPort() {
+    var credential = IdentityOtpCredential.empty();
+    when(identitySecondFactor.getOtpCredential(ENCODED_USERNAME)).thenReturn(credential);
+
+    assertThat(identityManager.getOtpCredential(ENCODED_USERNAME)).isSameAs(credential);
+
+    verify(identitySecondFactor).getOtpCredential(ENCODED_USERNAME);
+  }
+
+  @Test
+  void deleteOtpCredentialShouldPreserveEncodedUsernameForFocusedPort() {
+    identityManager.deleteOneTimePassword(ENCODED_USERNAME);
+
+    verify(identitySecondFactor).deleteOtpCredential(ENCODED_USERNAME);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapperTest.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.userservice.api.adapters.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.identity.IdentityOtpType;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.model.OtpType;
+import de.caritas.cob.userservice.api.model.SuccessWithEmail;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+
+class KeycloakMapperTest {
+
+  private final KeycloakMapper mapper = new KeycloakMapper();
+
+  @Test
+  void identityOtpCredentialOfMapsGeneratedTransportToProviderNeutralValue() {
+    var transport =
+        new OtpInfoDTO()
+            .otpSetup(true)
+            .otpSecret("secret")
+            .otpSecretQrCode("qr")
+            .otpType(OtpType.APP);
+
+    assertThat(mapper.identityOtpCredentialOf(transport))
+        .isEqualTo(new IdentityOtpCredential(true, "secret", "qr", IdentityOtpType.APP));
+  }
+
+  @Test
+  void identityOtpCredentialOfPreservesAbsentOptionalFields() {
+    assertThat(mapper.identityOtpCredentialOf(new OtpInfoDTO()))
+        .isEqualTo(IdentityOtpCredential.empty());
+  }
+
+  @Test
+  void identityEmailVerificationOfMapsCreatedResponse() {
+    var response =
+        new ResponseEntity<>(
+            new SuccessWithEmail().email("person@example.org"), HttpStatus.CREATED);
+
+    assertThat(mapper.identityEmailVerificationOf(response))
+        .isEqualTo(new IdentityEmailVerification(true, false, false, "person@example.org"));
+  }
+
+  @Test
+  void identityEmailVerificationOfMapsRemainingAttemptsWithoutTransportMapKeys() {
+    var exception = new HttpClientErrorException(HttpStatus.BAD_REQUEST);
+
+    assertThat(mapper.identityEmailVerificationOf(exception))
+        .isEqualTo(new IdentityEmailVerification(false, false, true, null));
+  }
+
+  @Test
+  void identityEmailVerificationOfMapsExhaustedAttempts() {
+    var exception = new HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS);
+
+    assertThat(mapper.identityEmailVerificationOf(exception))
+        .isEqualTo(new IdentityEmailVerification(false, false, false, null));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -38,6 +38,9 @@ import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.identity.IdentityOtpType;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
@@ -309,12 +312,15 @@ public class KeycloakServiceTest {
   public void getOtpCredential_Should_Return_Response_When_RequestWasSuccessful() {
     var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
     keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    var credential = new IdentityOtpCredential(true, "secret", "QrCode", IdentityOtpType.APP);
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
     var entity = new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK);
     when(this.keycloakClient.get(anyString(), any(), any())).thenReturn(entity);
+    when(keycloakMapper.identityOtpCredentialOf(OTP_INFO_DTO)).thenReturn(credential);
 
-    assertEquals(OTP_INFO_DTO, keycloakService.getOtpCredential(USERNAME));
+    assertEquals(credential, keycloakService.getOtpCredential(USERNAME));
 
+    verify(keycloakClient).get(anyString(), any(), eq(OtpInfoDTO.class));
     verifyNoInteractions(outboundHttpMetrics);
   }
 
@@ -332,22 +338,35 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void getOtpCredential_Should_ReturnEmptyCredential_When_ResponseBodyIsMissing() {
+    when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
+    when(keycloakClient.get(anyString(), any(), eq(OtpInfoDTO.class)))
+        .thenReturn(ResponseEntity.<OtpInfoDTO>ok().build());
+
+    assertEquals(IdentityOtpCredential.empty(), keycloakService.getOtpCredential(USERNAME));
+
+    verifyNoInteractions(keycloakMapper);
+  }
+
+  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void getOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
     var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
     keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    var credential = new IdentityOtpCredential(true, "secret", "QrCode", IdentityOtpType.APP);
     var unauthorized =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
     var entity = new ResponseEntity(OTP_INFO_DTO, HttpStatus.OK);
     when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
     when(keycloakClient.get(eq("stale-token"), any(), any())).thenThrow(unauthorized);
     when(keycloakClient.get(eq("fresh-token"), any(), any())).thenReturn(entity);
+    when(keycloakMapper.identityOtpCredentialOf(OTP_INFO_DTO)).thenReturn(credential);
 
-    assertEquals(OTP_INFO_DTO, keycloakService.getOtpCredential(USERNAME));
+    assertEquals(credential, keycloakService.getOtpCredential(USERNAME));
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).getBearerToken();
-    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
+    verify(outboundHttpMetrics).recordRetry("keycloak", "otp-fetch");
   }
 
   @Test
@@ -365,7 +384,7 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).get(any(), any(), any());
-    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
+    verify(outboundHttpMetrics).recordRetry("keycloak", "otp-fetch");
   }
 
   @Test
@@ -394,10 +413,13 @@ public class KeycloakServiceTest {
     assertDoesNotThrow(
         () ->
             keycloakService.setUpOtpCredential(USERNAME, randomAlphabetic(8), randomAlphabetic(8)));
+    verify(keycloakClient).putForEntity(any(), any(), any(), eq(OtpInfoDTO.class));
   }
 
   @Test
   public void setUpOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     var unauthorized =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
     when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
@@ -410,6 +432,7 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).getBearerToken();
+    verify(outboundHttpMetrics).recordRetry("keycloak", "otp-setup");
   }
 
   @Test
@@ -418,10 +441,13 @@ public class KeycloakServiceTest {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
 
     assertDoesNotThrow(() -> keycloakService.deleteOtpCredential(USERNAME));
+    verify(keycloakClient).delete(any(), any(), eq(Void.class));
   }
 
   @Test
   public void deleteOtpCredential_Should_RefreshAdminSessionOnce_When_FirstRequestIsUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     var unauthorized =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
     when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
@@ -433,6 +459,7 @@ public class KeycloakServiceTest {
 
     verify(keycloakClient).refreshAdminSession();
     verify(keycloakClient, times(2)).getBearerToken();
+    verify(outboundHttpMetrics).recordRetry("keycloak", "otp-delete");
   }
 
   @Test
@@ -1429,26 +1456,49 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void initiateEmailVerification_Should_ReturnEmptyOptional_When_RequestSucceeds() {
+  public void initiateEmailVerification_Should_ReturnTypedSuccess_When_RequestSucceeds() {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
     when(keycloakClient.putForEntity(any(), any(), any(), any()))
         .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
     var result = keycloakService.initiateEmailVerification(USERNAME, "mail@example.com");
 
-    assertThat(result.isPresent(), is(false));
+    assertThat(result.started(), is(true));
+    assertNull(result.failureMessage());
+    verify(keycloakClient).putForEntity(any(), any(), any(), any());
   }
 
   @Test
-  public void initiateEmailVerification_Should_ReturnMessage_When_KeycloakRejects() {
+  public void initiateEmailVerification_Should_ReturnTypedFailure_When_ProviderRejects() {
     when(keycloakClient.getBearerToken()).thenReturn(BEARER_TOKEN);
     when(keycloakClient.putForEntity(any(), any(), any(), any()))
         .thenThrow(new RestClientException("Keycloak said no"));
 
     var result = keycloakService.initiateEmailVerification(USERNAME, "mail@example.com");
 
-    assertThat(result.isPresent(), is(true));
-    assertThat(result.get().contains("Keycloak said no"), is(true));
+    assertThat(result.started(), is(false));
+    assertThat(result.failureMessage().contains("Keycloak said no"), is(true));
+  }
+
+  @Test
+  public void
+      initiateEmailVerification_Should_RecordOperationSpecificRetry_OnInitialUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.putForEntity(eq("stale-token"), any(), any(), any()))
+        .thenThrow(unauthorized);
+    when(keycloakClient.putForEntity(eq("fresh-token"), any(), any(), any()))
+        .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+    var result = keycloakService.initiateEmailVerification(USERNAME, "mail@example.com");
+
+    assertThat(result.started(), is(true));
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).putForEntity(any(), any(), any(), any());
+    verify(outboundHttpMetrics).recordRetry("keycloak", "email-verification-start");
   }
 
   @Test
@@ -1460,13 +1510,13 @@ public class KeycloakServiceTest {
     when(keycloakClient.postForEntity(
             any(), any(), any(), eq(de.caritas.cob.userservice.api.model.SuccessWithEmail.class)))
         .thenReturn(responseEntity);
-    var expected = new HashMap<String, String>();
-    expected.put("status", "ok");
-    when(keycloakMapper.mapOf(responseEntity)).thenReturn(expected);
+    var expected = new IdentityEmailVerification(false, true, false, "mail@example.com");
+    when(keycloakMapper.identityEmailVerificationOf(responseEntity)).thenReturn(expected);
 
     var result = keycloakService.finishEmailVerification(USERNAME, "123456");
 
     assertThat(result, is(expected));
+    verify(keycloakClient).postForEntity(any(), any(), any(), any());
   }
 
   @Test
@@ -1475,14 +1525,42 @@ public class KeycloakServiceTest {
     var exception =
         new org.springframework.web.client.HttpClientErrorException(HttpStatus.BAD_REQUEST);
     when(keycloakClient.postForEntity(any(), any(), any(), any())).thenThrow(exception);
-    var expected = new HashMap<String, String>();
-    expected.put("status", "error");
-    when(keycloakMapper.mapOf(exception)).thenReturn(expected);
+    var expected = new IdentityEmailVerification(false, false, true, null);
+    when(keycloakMapper.identityEmailVerificationOf(exception)).thenReturn(expected);
 
     var result = keycloakService.finishEmailVerification(USERNAME, "123456");
 
     assertThat(result, is(expected));
     verify(keycloakClient, never()).refreshAdminSession();
+  }
+
+  @Test
+  public void finishEmailVerification_Should_RecordOperationSpecificRetry_OnInitialUnauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    var unauthorized =
+        new org.springframework.web.client.HttpClientErrorException(HttpStatus.UNAUTHORIZED);
+    var responseEntity =
+        new ResponseEntity<>(
+            new de.caritas.cob.userservice.api.model.SuccessWithEmail(), HttpStatus.CREATED);
+    var expected = new IdentityEmailVerification(true, false, false, "mail@example.com");
+    when(keycloakClient.getBearerToken()).thenReturn("stale-token").thenReturn("fresh-token");
+    when(keycloakClient.postForEntity(eq("stale-token"), any(), any(), any()))
+        .thenThrow(unauthorized);
+    when(keycloakClient.postForEntity(
+            eq("fresh-token"),
+            any(),
+            any(),
+            eq(de.caritas.cob.userservice.api.model.SuccessWithEmail.class)))
+        .thenReturn(responseEntity);
+    when(keycloakMapper.identityEmailVerificationOf(responseEntity)).thenReturn(expected);
+
+    var result = keycloakService.finishEmailVerification(USERNAME, "123456");
+
+    assertThat(result, is(expected));
+    verify(keycloakClient).refreshAdminSession();
+    verify(keycloakClient, times(2)).postForEntity(any(), any(), any(), any());
+    verify(outboundHttpMetrics).recordRetry("keycloak", "email-verification-finish");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -38,8 +38,8 @@ import de.caritas.cob.userservice.api.facade.userdata.ConsultantDataProvider;
 import de.caritas.cob.userservice.api.facade.userdata.KeycloakUserDataProvider;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
@@ -100,7 +100,7 @@ class UserAccountControllerDelegateTest {
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenThrow(new RuntimeException("OTP down"));
     when(userDtoMapper.userDataOf(
-            eq(partialUserData), any(OtpInfoDTO.class), anyBoolean(), anyBoolean()))
+            eq(partialUserData), any(IdentityOtpCredential.class), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
     var response = delegate.getUserData();
@@ -108,7 +108,8 @@ class UserAccountControllerDelegateTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isSameAs(fullUserData);
     verify(userDtoMapper)
-        .userDataOf(eq(partialUserData), any(OtpInfoDTO.class), anyBoolean(), anyBoolean());
+        .userDataOf(
+            eq(partialUserData), any(IdentityOtpCredential.class), anyBoolean(), anyBoolean());
   }
 
   @Test
@@ -429,7 +430,7 @@ class UserAccountControllerDelegateTest {
     var roles = Set.of(UserRole.USER.getValue());
     var partialUserData = new UserDataResponseDTO();
     var fullUserData = new UserDataResponseDTO();
-    var otpInfo = new OtpInfoDTO().otpSecret("secret");
+    var otpInfo = new IdentityOtpCredential(false, "secret", null, null);
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(authenticatedUser.isAgencySuperAdmin()).thenReturn(false);
     when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(false);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -41,6 +41,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
@@ -135,6 +136,7 @@ class UserAdminControllerE2EIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
@@ -71,6 +72,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -84,6 +84,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -181,6 +182,7 @@ class UserControllerAuthorizationIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -58,6 +58,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.*;
@@ -301,6 +302,7 @@ class UserControllerIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -15,12 +15,13 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
+import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -54,7 +55,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, "person@example.org"))
         .thenReturn(true);
     when(identityManager.setUpOneTimePassword(ENCODED_USERNAME, "person@example.org"))
-        .thenReturn(Optional.empty());
+        .thenReturn(IdentityEmailVerificationStart.success());
 
     var response = delegate.startTwoFactorAuthByEmailSetup(new EmailDTO("PERSON@EXAMPLE.ORG"));
 
@@ -70,7 +71,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, "person@example.org"))
         .thenReturn(true);
     when(identityManager.setUpOneTimePassword(ENCODED_USERNAME, "person@example.org"))
-        .thenReturn(Optional.of("OTP setup failed"));
+        .thenReturn(IdentityEmailVerificationStart.failure("OTP setup failed"));
 
     assertThatThrownBy(
             () -> delegate.startTwoFactorAuthByEmailSetup(new EmailDTO("PERSON@EXAMPLE.ORG")))
@@ -99,7 +100,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
-        .thenReturn(Map.of("created", "true", "email", "person@example.org"));
+        .thenReturn(new IdentityEmailVerification(true, false, false, "person@example.org"));
     when(userDtoMapper.mapOf("person@example.org", authenticatedUser)).thenReturn(patchMap);
 
     var response = delegate.finishTwoFactorAuthByEmailSetup(OTP);
@@ -115,7 +116,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
-        .thenReturn(Map.of("created", "false", "attemptsLeft", "true"));
+        .thenReturn(new IdentityEmailVerification(false, false, true, null));
 
     var response = delegate.finishTwoFactorAuthByEmailSetup(OTP);
 
@@ -129,7 +130,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
-        .thenReturn(Map.of("created", "false", "attemptsLeft", "false", "createdBefore", "true"));
+        .thenReturn(new IdentityEmailVerification(false, true, false, null));
 
     var response = delegate.finishTwoFactorAuthByEmailSetup(OTP);
 
@@ -143,7 +144,7 @@ class UserTwoFactorAuthControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(ENCODED_USERNAME);
     when(identityManager.validateOneTimePassword(ENCODED_USERNAME, OTP))
-        .thenReturn(Map.of("created", "false", "attemptsLeft", "false", "createdBefore", "false"));
+        .thenReturn(new IdentityEmailVerification(false, false, false, null));
 
     var response = delegate.finishTwoFactorAuthByEmailSetup(OTP);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/UserDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/UserDtoMapperTest.java
@@ -11,7 +11,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.PatchUserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDataResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.identity.IdentityOtpType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,11 +61,7 @@ class UserDtoMapperTest {
   void userDataOf_Should_markIsActive_When_otpIsSetupWithAppType() {
     var userData = new UserDataResponseDTO();
     userData.setUserRoles(Set.of(UserRole.USER.getValue()));
-    var otp = new OtpInfoDTO();
-    otp.setOtpSetup(true);
-    otp.setOtpType(de.caritas.cob.userservice.api.model.OtpType.APP);
-    otp.setOtpSecret("secret");
-    otp.setOtpSecretQrCode("qr");
+    var otp = new IdentityOtpCredential(true, "secret", "qr", IdentityOtpType.APP);
 
     var result = mapper.userDataOf(userData, otp, false, false);
 
@@ -81,9 +78,7 @@ class UserDtoMapperTest {
   void userDataOf_Should_setEmailType_When_otpTypeIsNotApp() {
     var userData = new UserDataResponseDTO();
     userData.setUserRoles(Set.of(UserRole.CONSULTANT.getValue()));
-    var otp = new OtpInfoDTO();
-    otp.setOtpSetup(true);
-    otp.setOtpType(de.caritas.cob.userservice.api.model.OtpType.EMAIL);
+    var otp = new IdentityOtpCredential(true, null, null, IdentityOtpType.EMAIL);
 
     var result = mapper.userDataOf(userData, otp, true, true);
 
@@ -94,8 +89,7 @@ class UserDtoMapperTest {
   void userDataOf_Should_notMarkActive_When_otpSetupIsFalse() {
     var userData = new UserDataResponseDTO();
     userData.setUserRoles(Set.of(UserRole.USER.getValue()));
-    var otp = new OtpInfoDTO();
-    otp.setOtpSetup(false);
+    var otp = new IdentityOtpCredential(false, null, null, null);
 
     var result = mapper.userDataOf(userData, otp, false, true);
 
@@ -108,9 +102,7 @@ class UserDtoMapperTest {
   void userDataOf_Should_notSetOtpType_When_setupIsTrueButTypeIsNull() {
     var userData = new UserDataResponseDTO();
     userData.setUserRoles(Set.of(UserRole.CONSULTANT.getValue()));
-    var otp = new OtpInfoDTO();
-    otp.setOtpSetup(true);
-    otp.setOtpType(null);
+    var otp = new IdentityOtpCredential(true, null, null, null);
 
     var result = mapper.userDataOf(userData, otp, false, false);
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
@@ -60,6 +61,7 @@ class CreateAdminServiceIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,7 @@ public class UpdateAdminServiceIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -33,6 +33,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
@@ -89,6 +90,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   private IdentityClient identityClient;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
@@ -39,6 +40,7 @@ public class ConsultantUpdateServiceBase {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })
   protected IdentityClient identityClient;

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -278,6 +278,106 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "UserVerifier must not retain an unused broad identity dependency",
         )
 
+    def test_second_factor_verification_uses_typed_application_boundaries(self):
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        second_factor_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentitySecondFactor.java"
+        )
+        identity_input = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/in/"
+            "IdentityManaging.java"
+        ).read_text()
+        identity_manager = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java"
+        ).read_text()
+        two_factor_delegate = (
+            CONTROLLERS / "UserTwoFactorAuthControllerDelegate.java"
+        ).read_text()
+        typed_values = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/identity/"
+            "IdentityOtpCredential.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/identity/"
+            "IdentityOtpType.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/identity/"
+            "IdentityEmailVerification.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/identity/"
+            "IdentityEmailVerificationStart.java",
+        )
+
+        self.assertTrue(
+            second_factor_port.exists(),
+            "A focused IdentitySecondFactor port must own OTP and email verification",
+        )
+        self.assertTrue(
+            all(value.exists() for value in typed_values),
+            "Second-factor boundaries must use typed provider-neutral application values",
+        )
+        for method in (
+            "getOtpCredential(",
+            "setUpOtpCredential(",
+            "deleteOtpCredential(",
+            "initiateEmailVerification(",
+            "finishEmailVerification(",
+        ):
+            self.assertNotIn(
+                method,
+                identity_client,
+                "The broad identity command port must not expose second-factor verification",
+            )
+        self.assertNotIn(
+            "OtpInfoDTO",
+            identity_client,
+            "The broad identity command port must not import a generated web DTO",
+        )
+        self.assertIn(
+            "IdentitySecondFactor",
+            identity_manager,
+            "IdentityManager must use the focused second-factor output port",
+        )
+        for source in (identity_input, identity_manager):
+            self.assertNotIn(
+                "OtpInfoDTO",
+                source,
+                "The application identity boundary must not expose the generated OTP DTO",
+            )
+            self.assertNotIn(
+                "Map<String, String>",
+                source,
+                "The application identity boundary must not expose stringly verification maps",
+            )
+        self.assertNotIn(
+            'validationResult.get("',
+            two_factor_delegate,
+            "The web delegate must consume a typed email-verification result",
+        )
+        keycloak_adapter = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakService.java"
+        ).read_text()
+        for operation in (
+            "otp-fetch",
+            "otp-setup",
+            "otp-delete",
+            "email-verification-start",
+            "email-verification-finish",
+        ):
+            self.assertIn(
+                f'"{operation}"',
+                keycloak_adapter,
+                "Keycloak second-factor retries must retain stable per-operation tags",
+            )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- introduce a focused, provider-neutral `IdentitySecondFactor` output port
- replace generated OTP DTOs and string-key email-verification maps at application boundaries with typed values
- remove all five second-factor operations from the broad `IdentityClient`
- preserve encoded OTP-provider usernames and the decoded username used for the verified email update
- bound the normal path to one provider request and an initial 401 to one refresh plus one retry
- expose stable retry tags for OTP fetch/setup/delete and email-verification start/finish
- document the boundary, call bounds, runtime-proof gap, and Matrix-only target

## Verification

- Java 21 unit suite: 3,870 tests, 0 failures, 0 errors, 0 skipped
- Java 21 integration/contract/E2E suite with Redis 7: 969 tests, 0 failures, 0 errors, 5 environment-gated MariaDB skips
- focused second-factor suite: 195 tests, 0 failures, 0 errors, 0 skipped
- Python CI contracts: 39 tests, all passing
- zero-quarantine checker: passing
- Spotless and diff checks: passing

## Scope

This PR is stacked on #792 and is modular-monolith boundary work, not a service extraction. Nothing in this PR is merged or deployed yet. Live PreDev/SigNoz proof remains required after the stack reaches PreDev.

The target chat architecture remains Matrix only: the ORISO frontend, a controlled MatrixRTC/Element Call fork, and LiveKit. Rocket.Chat and Jitsi are removal targets, not fallbacks.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
