### PR TITLE
[Stability] Complete identity role membership read boundary

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,7 +30,7 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,870 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Unit | 3,867 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
 | Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
@@ -193,6 +193,11 @@ closed.
   and performs the requested-set intersection in-process. The code-level bound
   is therefore zero identity calls for an empty role set and exactly one for a
   non-empty set, instead of up to one `userHasRole` request per candidate role.
+- Application-level single-role checks now use the same focused
+  `IdentityRoleLookup` list read and compare the requested application role
+  in-process. Each check therefore performs exactly one external full-role
+  read; the broad command client no longer exposes role-membership or authority
+  reads.
 - Email-ownership validation now consumes the focused
   `IdentityEmailOwnerLookup` port and the typed `IdentityEmailOwner` result.
   Application code no longer interprets Keycloak adapter map keys. This is a
@@ -242,7 +247,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and session commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and session commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
@@ -264,13 +269,15 @@ entry points. The user-web identity-policy contract rejects direct imports of
 outbound identity configuration from the controller and its user delegates.
 The web-mapper contract rejects direct imports of the outbound identity client.
 The user-data facade contract keeps profile reads off that broad command port.
-The role-read contract keeps full realm-role reads behind the focused
-`IdentityRoleLookup` port and prevents per-candidate role checks from returning
-to consultant-agency validation. The email-owner contract likewise keeps the
-read off the broad command port and rejects application-level dependence on
-Keycloak adapter map keys. The authentication contract keeps login, logout and
-password verification off the broad command client and requires every
-production consumer to depend on the focused provider-neutral port. The
+The role-read contract keeps full realm-role reads and application
+role-membership checks behind the focused `IdentityRoleLookup` port, prevents
+per-candidate role checks from returning to consultant-agency validation and
+rejects role-membership or authority reads on the broad command client. The
+email-owner contract likewise keeps the read off the broad command port and
+rejects application-level dependence on Keycloak adapter map keys. The
+authentication contract keeps login, logout and password verification off the
+broad command client and requires every production consumer to depend on the
+focused provider-neutral port. The
 username-availability contract likewise protects its focused port, names all
 four active direct consumers and rejects the unused broad dependency in
 `UserVerifier`. The second-factor contract keeps all five OTP and email

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class IdentityManager implements IdentityManaging {
   private final IdentityAuthentication identityAuthentication;
   private final IdentityClient identityClient;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final IdentityRoleLookup identityRoleLookup;
   private final IdentitySecondFactor identitySecondFactor;
   private final IdentityUsernameAvailability identityUsernameAvailability;
   private final UsernameTranscoder usernameTranscoder;
@@ -95,6 +97,6 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean hasRole(String userId, UserRole role) {
-    return identityClient.userHasRole(userId, role.getValue());
+    return identityRoleLookup.findAllByUserId(userId).stream().anyMatch(role.getValue()::equals);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -10,7 +10,6 @@ import static java.util.Objects.nonNull;
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
-import de.caritas.cob.userservice.api.config.auth.Authority;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -853,28 +852,6 @@ public class KeycloakService
           userId);
       keycloakClient.refreshAdminSession();
       keycloakClient.getUsersResource().get(userId).remove();
-    }
-  }
-
-  /**
-   * Returns true if the given user has the provided authority.
-   *
-   * @param userId Keycloak user ID
-   * @param authority Keycloak authority
-   * @return true if user hast provided authority
-   */
-  public boolean userHasAuthority(String userId, String authority) {
-    try {
-      return getUserRoles(userId).stream()
-          .map(role -> UserRole.getRoleByValue(role.getName()))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .map(Authority::getAuthoritiesByUserRole)
-          .anyMatch(currentAuthority -> currentAuthority.contains(authority));
-    } catch (Exception ex) {
-      var error = String.format("Could not get roles for user id %s", userId);
-      log.error("Keycloak error: " + error, ex);
-      throw new KeycloakException(error);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -43,10 +43,6 @@ public interface IdentityClient {
 
   void deleteUser(String userId);
 
-  boolean userHasAuthority(String userId, String authority);
-
-  boolean userHasRole(String userId, String userRole);
-
   void closeSession(String sessionId);
 
   void deactivateUser(String userId);

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -13,8 +13,10 @@ import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +35,7 @@ class IdentityManagerTest {
   @Mock private IdentityClient identityClient;
   @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private IdentityRoleLookup identityRoleLookup;
   @Mock private IdentitySecondFactor identitySecondFactor;
   @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
@@ -160,11 +163,12 @@ class IdentityManagerTest {
   }
 
   @Test
-  void hasRoleShouldDelegateTheApplicationRoleValueToIdentityClient() {
-    when(identityClient.userHasRole("consultant-id", "group-chat-consultant")).thenReturn(true);
+  void hasRoleShouldReadAllRolesOnceAndEvaluateTheApplicationRoleInProcess() {
+    when(identityRoleLookup.findAllByUserId("consultant-id"))
+        .thenReturn(List.of("user", "group-chat-consultant"));
 
     assertThat(identityManager.hasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT)).isTrue();
 
-    verify(identityClient).userHasRole("consultant-id", "group-chat-consultant");
+    verify(identityRoleLookup).findAllByUserId("consultant-id");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Maps;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
-import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -1151,56 +1150,6 @@ public class KeycloakServiceTest {
 
     assertTrue(
         logCaptor.contains(Level.ERROR, "Keycloak error: User could not be removed/rolled back:"));
-  }
-
-  @Test
-  public void userHasAuthority_Should_returnTrue_When_userHasAuthority() {
-    RoleRepresentation roleRepresentation = mock(RoleRepresentation.class);
-    when(roleRepresentation.getName()).thenReturn("user");
-    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
-    when(roleScopeResource.listAll()).thenReturn(singletonList(roleRepresentation));
-    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
-    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
-    UserResource userResource = mock(UserResource.class);
-    when(userResource.roles()).thenReturn(roleMappingResource);
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    boolean hasAuthority =
-        this.keycloakService.userHasAuthority("user", AuthorityValue.USER_DEFAULT);
-
-    assertThat(hasAuthority, is(true));
-  }
-
-  @Test
-  public void userHasAuthority_Should_returnThrowKeycloakException_When_userHasNoRoles() {
-    assertThrows(
-        KeycloakException.class,
-        () -> {
-          UserResource userResource = mock(UserResource.class);
-          UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-          when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-          this.keycloakService.userHasAuthority("user", "authority");
-        });
-  }
-
-  @Test
-  public void userHasAuthority_Should_returnFalse_When_userHasNotAuthority() {
-    RoleRepresentation roleRepresentation = mock(RoleRepresentation.class);
-    when(roleRepresentation.getName()).thenReturn("user");
-    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
-    when(roleScopeResource.listAll()).thenReturn(singletonList(roleRepresentation));
-    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
-    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
-    UserResource userResource = mock(UserResource.class);
-    when(userResource.roles()).thenReturn(roleMappingResource);
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    boolean hasAuthority = this.keycloakService.userHasAuthority("user", AuthorityValue.USER_ADMIN);
-
-    assertThat(hasAuthority, is(false));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -10,7 +10,6 @@ import static org.hibernate.search.util.impl.CollectionHelper.asSet;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -91,8 +90,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
-
     AgencyDTO agencyDTO = new AgencyDTO();
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
@@ -133,7 +130,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     ExtendedConsultingTypeResponseDTO extendedConsultingTypeResponseDTO =
         new ExtendedConsultingTypeResponseDTO();
     AgencyDTO agencyDTO = new AgencyDTO();
@@ -184,7 +180,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     var consultant = createConsultantWithoutAgencyAndSession();
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     var roles = givenRoleSets(consultingType, roleSetName);
 
     consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -283,8 +278,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
           Consultant consultant = createConsultantWithoutAgencyAndSession();
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO = new CreateConsultantAgencyDTO();
-          when(keycloakService.userHasRole(any(), any())).thenReturn(false);
-
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
         });
@@ -300,7 +293,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(this.agencyService.getAgency(any())).thenReturn(null);
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -318,7 +310,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(agencyService.getAgency(any())).thenThrow(new InternalServerErrorException(""));
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -338,7 +329,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
           when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(1)).thenReturn(true);
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
@@ -362,7 +352,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
           when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(15)).thenReturn(true);
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -121,8 +119,6 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
-
     AgencyDTO agencyDTO = new AgencyDTO();
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
@@ -170,7 +166,6 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO =
         new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("valid-role-set");
-    when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0).tenantId(83L);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
     when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -242,7 +242,6 @@ public class ConsultantAgencyRelationCreatorServiceTest {
                 LogService::logInfo));
 
     verify(identityRoleLookup).findAllByUserId("consultant Id");
-    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService, never()).saveConsultantAgency(any());
   }
 
@@ -268,7 +267,6 @@ public class ConsultantAgencyRelationCreatorServiceTest {
         LogService::logInfo);
 
     verify(identityRoleLookup).findAllByUserId("consultant Id");
-    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.keycloak.admin.client.resource.UserResource;
@@ -138,6 +139,11 @@ public class KeycloakTestConfig {
       @Override
       public boolean userHasRole(String userId, String userRole) {
         return true;
+      }
+
+      @Override
+      public List<String> findAllByUserId(String userId) {
+        return List.of(UserRole.values()).stream().map(UserRole::getValue).toList();
       }
     };
   }

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -499,6 +499,7 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;"
         )
         consumers = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java",
             ROOT
             / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
             / "create/agencyrelation/ConsultantAgencyRelationCreatorService.java",
@@ -511,8 +512,8 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             for source in consumers
             if focused_lookup_import not in source.read_text()
         ]
-        user_identities_service = consumers[1].read_text()
-        agency_relation_service = consumers[0].read_text()
+        agency_relation_service = consumers[1].read_text()
+        user_identities_service = consumers[2].read_text()
         identity_client = (
             ROOT
             / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
@@ -538,6 +539,22 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "getRealmRoles(",
             identity_client,
             "The broad identity command client must not own realm-role reads",
+        )
+        for method in ("userHasRole(", "userHasAuthority("):
+            self.assertNotIn(
+                method,
+                identity_client,
+                "The broad identity command client must not own role membership reads",
+            )
+        keycloak_adapter = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakService.java"
+        ).read_text()
+        self.assertNotIn(
+            "userHasAuthority(",
+            keycloak_adapter,
+            "The unused provider-specific authority evaluator must be removed",
         )
 
     def test_admin_module_depends_on_ports_not_chat_adapters(self):


### PR DESCRIPTION
## Summary

- route `IdentityManager.hasRole` through the existing focused `IdentityRoleLookup`
- perform exactly one external full-role list read and compare the requested application role in-process
- remove `userHasRole` and the unused `userHasAuthority` evaluator from the broad `IdentityClient` boundary
- remove three obsolete authority tests and stale role-check test stubs
- update the shared Keycloak integration-test double for the focused role lookup
- strengthen the executable module-boundary contract and stability documentation

## Verification

- JDK 21 unit suite: 3,867 tests, 0 failures, 0 errors, 0 skipped
- integration + contract + E2E suite: 969 tests, 0 failures, 0 errors, 5 environment-gated skips
- focused Java tests: 125 tests, 0 failures, 0 errors, 0 skipped
- affected Spring integration tests: 12 tests, 0 failures, 0 errors, 0 skipped
- isolated regression test after correcting the shared test double: 1 test, green
- Python structural contracts: 39 tests, green
- zero-quarantine checker: green
- Spotless and `git diff --check`: green

## Scope

- stacked on draft PR #794
- continues the modular-monolith-first boundary work; it does not extract a service
- nothing is merged or deployed by this PR
- live PreDev and SigNoz call-frequency/latency evidence remains a later release gate
- the target architecture is Matrix chat through the ORISO frontend with an ORISO-controlled MatrixRTC/Element Call fork and LiveKit; Rocket.Chat and Jitsi are removal targets, not fallback dependencies

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
