### PR TITLE
[Stability] Remove unused identity session-close surface

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,7 +30,7 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,868 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Unit | 3,866 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
 | Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
@@ -212,6 +212,10 @@ closed.
   update. The broad command client no longer exposes email-address mutations,
   and the adapter no longer reads the same representation twice before a
   write.
+- The unused identity session-close command was removed from the broad port,
+  the Keycloak facade and its authentication collaborator. It had no production
+  consumer, so this removes a misleading command surface and preserves an exact
+  zero-call bound without changing the active refresh-token logout flow.
 - Login, refresh-token logout and password verification now consume the focused,
   provider-neutral `IdentityAuthentication` port. The broad `IdentityClient`
   no longer exposes authentication operations. This is also a boundary
@@ -256,14 +260,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and session commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
 The remaining broad client debt is password/language mutation, provisioning,
-role writes, deactivation and the unused session-command surface.
+role writes and account lifecycle commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -292,6 +296,8 @@ rejects application-level dependence on Keycloak adapter map keys. The
 email-mutation contract requires both active consumers and the Keycloak adapter
 to use `IdentityEmailAddressUpdater`, and rejects current-account,
 post-verification or adapter-internal email writes on the broad client. The
+dead-surface contract rejects the unused identity session-close command on the
+broad port and both Keycloak wrappers. The
 authentication contract keeps login, logout and password verification off the
 broad command client and requires every production consumer to depend on the
 focused provider-neutral port. The

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
@@ -26,8 +26,8 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Keycloak OpenID Connect / session operations extracted from {@link KeycloakService} (issue #91
- * Keycloak refactor, PR1 auth slice). Keeps login/logout/OTP-verify/session close behind a focused
- * collaborator so {@link KeycloakService} can stay the {@code IdentityClient} facade.
+ * Keycloak refactor, PR1 auth slice). Keeps login, refresh-token logout and password verification
+ * behind a focused collaborator.
  */
 @Slf4j
 @Component
@@ -123,15 +123,6 @@ public class KeycloakAuthClient {
 
       return false;
     }
-  }
-
-  /**
-   * Closes the provided session.
-   *
-   * @param sessionId Keycloak session ID
-   */
-  public void closeSession(String sessionId) {
-    keycloakClient.getRealmResource().deleteSession(sessionId, false);
   }
 
   private HttpEntity<MultiValueMap<String, String>> loginRequest(String userName, String password) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -954,15 +954,6 @@ public class KeycloakService
   }
 
   /**
-   * Closes the provided session.
-   *
-   * @param sessionId Keycloak session ID
-   */
-  public void closeSession(String sessionId) {
-    keycloakAuthClient.closeSession(sessionId);
-  }
-
-  /**
    * Deactivates the user account.
    *
    * @param userId the user id to be deactivated

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -35,7 +35,5 @@ public interface IdentityClient {
 
   void deleteUser(String userId);
 
-  void closeSession(String sessionId);
-
   void deactivateUser(String userId);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.admin.client.resource.RealmResource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -194,15 +192,5 @@ class KeycloakAuthClientTest {
 
     assertThat(keycloakAuthClient.logoutUser(REFRESH_TOKEN), is(false));
     assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
-  }
-
-  @Test
-  void closeSession_Should_DeleteSession() {
-    var realmResource = mock(RealmResource.class);
-    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
-
-    keycloakAuthClient.closeSession("sessionId");
-
-    verify(realmResource, times(1)).deleteSession(eq("sessionId"), eq(false));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1154,16 +1154,6 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void closeSession_Should_deleteSession() {
-    RealmResource realmResource = mock(RealmResource.class);
-    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
-
-    this.keycloakService.closeSession("sessionId");
-
-    verify(realmResource, times(1)).deleteSession(anyString(), eq(false));
-  }
-
-  @Test
   public void deactivateUser_Should_deactivateUser() {
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = mock(UsersResource.class);

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -632,6 +632,29 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(missing_test_interface),
         )
 
+    def test_identity_boundary_has_no_unused_session_close_command(self):
+        sources = [
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakAuthClient.java",
+        ]
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in sources
+            if "closeSession(" in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "The unused identity session-close command must not remain on production surfaces:\n"
+            + "\n".join(offenders),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- remove the unused `closeSession` command from the broad `IdentityClient`
- remove the dead forwarding methods from `KeycloakService` and `KeycloakAuthClient`
- remove the two tests that only exercised the unused forwarding chain
- add an executable boundary contract that prevents the dead command surface from returning
- update the stability inventory and exact call bound

## Call-bound evidence

Repository-wide production tracing found no application consumer of
`closeSession`. The removed path therefore had an exact zero-call bound. The
active refresh-token logout flow remains unchanged and retains its focused
`IdentityAuthentication` boundary.

## Verification

- `./mvnw -B -Dskip.integration-tests=true clean test`
  - 3,866 tests, 0 failures, 0 errors, 0 skipped
- `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test`
  - 969 tests, 0 failures, 0 errors, 5 conditional infrastructure skips
- focused Keycloak tests
  - 110 tests, 0 failures, 0 errors, 0 skipped
- `python3 -m unittest discover -s tests/ci -p 'test_*.py'`
  - 41 tests, all passing
- `python3 scripts/ci/check-no-test-quarantine.py`
  - no quarantine annotations
- `./mvnw -B spotless:check`
- `git diff --check`

## Scope and rollout

This is dead-surface removal inside the modular monolith, stacked on #798. It
does not change active identity behavior, extract a microservice, merge, or
deploy anything. PreDev runtime and SigNoz evidence remain separate release
gates after the stack is reviewed and merged.

The product target remains Matrix-only chat with the ORISO frontend, a
controlled MatrixRTC/Element Call fork, and LiveKit. Rocket.Chat and Jitsi are
legacy removal targets, not fallback architecture.

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
