### PR TITLE
[Stability] Focus identity account settings

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,7 +30,7 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,866 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Unit | 3,868 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
 | Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
@@ -216,6 +216,12 @@ closed.
   the Keycloak facade and its authentication collaborator. It had no production
   consumer, so this removes a misleading command surface and preserves an exact
   zero-call bound without changing the active refresh-token logout flow.
+- Current-account password and preferred-language changes now consume the
+  focused `IdentityAccountSettingsUpdater` port. A password attempt resolves
+  one user resource and performs at most one password reset. A language change
+  reads one representation and performs at most one update; an unchanged
+  language stops after the read. General provisioning and password-reset flows
+  retain their separate `updatePassword` command.
 - Login, refresh-token logout and password verification now consume the focused,
   provider-neutral `IdentityAuthentication` port. The broad `IdentityClient`
   no longer exposes authentication operations. This is also a boundary
@@ -260,14 +266,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed account, provisioning, role-write and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, role-write and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
-The remaining broad client debt is password/language mutation, provisioning,
-role writes and account lifecycle commands.
+The remaining broad client debt is provisioning, role writes and account
+lifecycle commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -297,7 +303,10 @@ email-mutation contract requires both active consumers and the Keycloak adapter
 to use `IdentityEmailAddressUpdater`, and rejects current-account,
 post-verification or adapter-internal email writes on the broad client. The
 dead-surface contract rejects the unused identity session-close command on the
-broad port and both Keycloak wrappers. The
+broad port and both Keycloak wrappers. The account-settings contract requires
+`IdentityManager` and the Keycloak adapter to use
+`IdentityAccountSettingsUpdater`, rejects current-account password/language
+mutations on the broad client and protects the shared Spring mocks. The
 authentication contract keeps login, logout and password verification off the
 broad command client and requires every production consumer to depend on the
 focused provider-neutral port. The

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -6,8 +6,8 @@ import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
 import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
@@ -22,8 +22,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IdentityManager implements IdentityManaging {
 
+  private final IdentityAccountSettingsUpdater identityAccountSettingsUpdater;
   private final IdentityAuthentication identityAuthentication;
-  private final IdentityClient identityClient;
   private final IdentityEmailAddressUpdater identityEmailAddressUpdater;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
   private final IdentityRoleLookup identityRoleLookup;
@@ -60,12 +60,12 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean changePassword(String userId, String password) {
-    return identityClient.changePassword(userId, password);
+    return identityAccountSettingsUpdater.changePassword(userId, password);
   }
 
   @Override
   public void changeLanguage(String userId, String language) {
-    identityClient.changeLanguage(userId, language);
+    identityAccountSettingsUpdater.changePreferredLanguage(userId, language);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -24,6 +24,7 @@ import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
@@ -75,7 +76,8 @@ import org.springframework.web.client.RestClientResponseException;
 @Slf4j
 @RequiredArgsConstructor
 public class KeycloakService
-    implements IdentityAuthentication,
+    implements IdentityAccountSettingsUpdater,
+        IdentityAuthentication,
         IdentityClient,
         IdentityEmailAddressUpdater,
         IdentityEmailOwnerLookup,
@@ -125,6 +127,7 @@ public class KeycloakService
    * @param password Keycloak password
    * @return true if password change was successful
    */
+  @Override
   public boolean changePassword(final String userId, final String password) {
     try {
       updatePassword(userId, password);
@@ -136,7 +139,8 @@ public class KeycloakService
     return true;
   }
 
-  public void changeLanguage(final String userId, final String locale) {
+  @Override
+  public void changePreferredLanguage(final String userId, final String locale) {
     UserResource userResource = keycloakClient.getUsersResource().get(userId);
     var user = userResource.toRepresentation();
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAccountSettingsUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAccountSettingsUpdater.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.port.out;
+
+public interface IdentityAccountSettingsUpdater {
+
+  boolean changePassword(String userId, String password);
+
+  void changePreferredLanguage(String userId, String language);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -5,10 +5,6 @@ import de.caritas.cob.userservice.api.config.auth.UserRole;
 
 public interface IdentityClient {
 
-  boolean changePassword(final String userId, final String password);
-
-  void changeLanguage(final String userId, final String language);
-
   String createKeycloakUser(final UserDTO user);
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -9,8 +9,8 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
 import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
@@ -33,7 +33,7 @@ class IdentityManagerTest {
   private static final String ENCODED_USERNAME = "enc.MNXW443VNR2GC3TUGJTGC...";
   private static final String EMAIL = "consultant@example.org";
 
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityAccountSettingsUpdater identityAccountSettingsUpdater;
   @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailAddressUpdater identityEmailAddressUpdater;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
@@ -43,6 +43,22 @@ class IdentityManagerTest {
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
+
+  @Test
+  void changePasswordShouldUseFocusedAccountSettingsPort() {
+    when(identityAccountSettingsUpdater.changePassword("userId", "new-password")).thenReturn(true);
+
+    assertThat(identityManager.changePassword("userId", "new-password")).isTrue();
+
+    verify(identityAccountSettingsUpdater).changePassword("userId", "new-password");
+  }
+
+  @Test
+  void changeLanguageShouldUseFocusedAccountSettingsPort() {
+    identityManager.changeLanguage("userId", "de");
+
+    verify(identityAccountSettingsUpdater).changePreferredLanguage("userId", "de");
+  }
 
   @Test
   void validatePasswordIgnoring2faShouldPreserveEncodedUsernameForIdentityAuthentication() {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -151,6 +151,10 @@ public class KeycloakServiceTest {
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
     assertTrue(keycloakService.changePassword(USER_ID, NEW_PW));
+
+    verify(keycloakClient).getUsersResource();
+    verify(usersResource).get(USER_ID);
+    verify(userResource).resetPassword(any());
   }
 
   @Test
@@ -1213,9 +1217,10 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
+    verify(userResource).toRepresentation();
     verify(userResource, Mockito.never()).update(userRepresentation);
   }
 
@@ -1237,9 +1242,10 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
+    verify(userResource).toRepresentation();
     verify(userResource).update(userRepresentation);
   }
 
@@ -1266,9 +1272,10 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
+    verify(userResource).toRepresentation();
     verify(userResource).update(userRepresentation);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -133,6 +134,7 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControlle
 import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -69,6 +70,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -79,6 +79,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -179,6 +180,7 @@ class UserControllerAuthorizationIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -53,6 +53,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -299,6 +300,7 @@ class UserControllerIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
@@ -1750,7 +1752,8 @@ class UserControllerIT {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
 
-    verify(identityClient, times(0)).changePassword(anyString(), anyString());
+    verify((IdentityAccountSettingsUpdater) identityClient, times(0))
+        .changePassword(anyString(), anyString());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -58,6 +59,7 @@ class CreateAdminServiceIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAgencyAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -38,6 +39,7 @@ public class UpdateAdminServiceIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -85,6 +86,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -37,6 +38,7 @@ public class ConsultantUpdateServiceBase {
 
   @MockitoBean(
       extraInterfaces = {
+        IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -53,7 +53,7 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public void changeLanguage(String userId, String locale) {
+      public void changePreferredLanguage(String userId, String locale) {
         UserResource userResource = keycloakClient.getUsersResource().get(userId);
         UserRepresentation user = getUserRepresentationAndCreateNewUserIfNotExist(userResource);
         super.changeLanguageForTheUser(locale, userResource, user);

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -655,6 +655,60 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_current_account_settings_use_a_focused_identity_port(self):
+        port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityAccountSettingsUpdater.java"
+        )
+        self.assertTrue(
+            port.exists(),
+            "Current-account password and language changes need a focused output port",
+        )
+        if not port.exists():
+            return
+
+        identity_manager = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java"
+        ).read_text()
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        keycloak_adapter = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakService.java"
+        ).read_text()
+        focused_type = "IdentityAccountSettingsUpdater"
+
+        self.assertIn(focused_type, identity_manager)
+        self.assertIn(focused_type, keycloak_adapter)
+        self.assertNotIn("IdentityClient", identity_manager)
+        for method in ("changePassword(", "changeLanguage("):
+            self.assertNotIn(
+                method,
+                identity_client,
+                "The broad identity command client must not own current-account settings",
+            )
+        spring_identity_mocks = [
+            source
+            for source in (ROOT / "src/test/java").rglob("*.java")
+            if "extraInterfaces = {" in source.read_text()
+            and "IdentityClient identityClient" in source.read_text()
+        ]
+        missing_test_interface = [
+            str(source.relative_to(ROOT))
+            for source in spring_identity_mocks
+            if "IdentityAccountSettingsUpdater.class" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            missing_test_interface,
+            "Shared Spring identity mocks must implement the focused account-settings port:\n"
+            + "\n".join(missing_test_interface),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- introduce the provider-neutral `IdentityAccountSettingsUpdater` output port
- route current-account password and preferred-language changes through the focused port
- remove both operations from the broad `IdentityClient`, leaving general provisioning/password-reset writes unchanged
- remove the last broad-client dependency from `IdentityManager`
- protect the boundary and shared Spring identity mocks with executable contracts

## Measured call bounds

- current-account password attempt: one user-resource resolution and at most one password reset; existing boolean success/failure behavior is preserved
- preferred-language change: one representation read and at most one update
- unchanged preferred language: one representation read and no update
- general provisioning and password-reset consumers retain the existing `updatePassword` command

## Verification

- `./mvnw -B -Dskip.integration-tests=true clean test`
  - 3,868 tests, 0 failures, 0 errors, 0 skipped
- `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test`
  - 969 tests, 0 failures, 0 errors, 5 conditional infrastructure skips
- focused manager, Keycloak and web tests
  - 154 tests, 0 failures, 0 errors, 0 skipped
- `python3 -m unittest discover -s tests/ci -p 'test_*.py'`
  - 42 tests, all passing
- `python3 scripts/ci/check-no-test-quarantine.py`
  - no quarantine annotations
- `./mvnw -B spotless:check`
- `git diff --check`

## Scope and rollout

This is a modular-monolith boundary change stacked on #800. It does not extract
a microservice, merge, or deploy anything. PreDev runtime and SigNoz evidence
remain separate release gates after the stack is reviewed and merged.

The product target remains Matrix-only chat with the ORISO frontend, a
controlled MatrixRTC/Element Call fork, and LiveKit. Rocket.Chat and Jitsi are
legacy removal targets, not fallback architecture.

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
