### PR TITLE
[Stability] Batch identity role assignment

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -198,6 +198,13 @@ closed.
   in-process. Each check therefore performs exactly one external full-role
   read; the broad command client no longer exposes role-membership or authority
   reads.
+- Consultant role assignment now uses the focused `IdentityRoleUpdater` batch
+  port. Empty requests stop without an identity call. Non-empty requests
+  deduplicate role names, perform one initial full-role read and add every
+  missing role in one Keycloak call per attempt. Post-write visibility is also
+  checked for the complete requested set with one full-role read per bounded
+  retry, independent of role count. The broad command client no longer exposes
+  role ensuring.
 - Email-ownership validation now consumes the focused
   `IdentityEmailOwnerLookup` port and the typed `IdentityEmailOwner` result.
   Application code no longer interprets Keycloak adapter map keys. This is a
@@ -266,14 +273,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; the broad command client no longer exposes full role lists, role-membership reads or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, role-write and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; batched consultant role assignment uses `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role ensuring or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, singular role assignment/removal and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
-The remaining broad client debt is provisioning, role writes and account
-lifecycle commands.
+The remaining broad client debt is provisioning, singular role
+assignment/removal and account lifecycle commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -297,6 +304,11 @@ The role-read contract keeps full realm-role reads and application
 role-membership checks behind the focused `IdentityRoleLookup` port, prevents
 per-candidate role checks from returning to consultant-agency validation and
 rejects role-membership or authority reads on the broad command client. The
+role-write contract requires both consultant-role writers to use the focused
+`IdentityRoleUpdater` batch port and rejects role ensuring on the broad command
+client. Adapter interaction tests enforce the zero-call empty path, one initial
+read, deduplication, one batch add per attempt and one complete-set visibility
+read per bounded retry. The
 email-owner contract likewise keeps the read off the broad command port and
 rejects application-level dependence on Keycloak adapter map keys. The
 email-mutation contract requires both active consumers and the Keycloak adapter

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -35,6 +35,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -43,13 +44,16 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -83,6 +87,7 @@ public class KeycloakService
         IdentityEmailOwnerLookup,
         IdentityProfileLookup,
         IdentityRoleLookup,
+        IdentityRoleUpdater,
         IdentitySecondFactor,
         IdentityUsernameAvailability {
 
@@ -588,9 +593,17 @@ public class KeycloakService
     updateRole(userId, "user");
   }
 
-  public void ensureRole(final String userId, final String roleName) {
-    if (!userHasRole(userId, roleName)) {
-      updateRole(userId, roleName);
+  @Override
+  public void ensureRoles(final String userId, final Collection<String> roleNames) {
+    var requestedRoles = new LinkedHashSet<>(roleNames);
+    if (requestedRoles.isEmpty()) {
+      return;
+    }
+
+    var assignedRoles = new LinkedHashSet<>(findAllByUserId(userId));
+    requestedRoles.removeAll(assignedRoles);
+    if (!requestedRoles.isEmpty()) {
+      updateRoles(userId, requestedRoles);
     }
   }
 
@@ -640,35 +653,44 @@ public class KeycloakService
    * @param roleName Keycloak role name
    */
   public void updateRole(final String userId, final String roleName) {
+    updateRoles(userId, Collections.singletonList(roleName));
+  }
+
+  private void updateRoles(final String userId, final Collection<String> roleNames) {
     try {
-      updateRoleOnce(userId, roleName);
+      updateRolesOnce(userId, roleNames);
     } catch (NotAuthorizedException e) {
       log.warn(
-          "Keycloak admin session was unauthorized while assigning role {} to user {}, forcing"
+          "Keycloak admin session was unauthorized while assigning {} roles to user {}, forcing"
               + " token refresh and retrying once",
-          roleName,
+          roleNames.size(),
           userId);
       recordRetry("admin-session-refresh");
       keycloakClient.refreshAdminSession();
-      updateRoleOnce(userId, roleName);
+      updateRolesOnce(userId, roleNames);
     }
   }
 
-  private void updateRoleOnce(final String userId, final String roleName) {
+  private void updateRolesOnce(final String userId, final Collection<String> roleNames) {
     // Get realm and user resources
     var realmResource = keycloakClient.getRealmResource();
     UsersResource userRessource = realmResource.users();
     UserResource user = userRessource.get(userId);
 
-    // Assign role
-    var roleRepresentation = realmResource.roles().get(roleName).toRepresentation();
-    if (isNull(roleRepresentation.getAttributes())) {
-      roleRepresentation.setAttributes(new LinkedHashMap<>());
-    }
-    user.roles().realmLevel().add(Collections.singletonList(roleRepresentation));
+    var roleRepresentations =
+        roleNames.stream()
+            .map(roleName -> realmResource.roles().get(roleName).toRepresentation())
+            .peek(
+                roleRepresentation -> {
+                  if (isNull(roleRepresentation.getAttributes())) {
+                    roleRepresentation.setAttributes(new LinkedHashMap<>());
+                  }
+                })
+            .toList();
+    user.roles().realmLevel().add(roleRepresentations);
 
-    if (isRoleAssigned(user, roleName)) {
-      log.debug("Added role \"{}\" to {}", roleName, userId);
+    if (areRolesAssigned(user, roleNames)) {
+      log.debug("Added {} roles to {}", roleNames.size(), userId);
       return;
     }
 
@@ -681,8 +703,8 @@ public class KeycloakService
         throw new KeycloakException(
             "Interrupted while verifying role assignment for user " + userId);
       }
-      if (isRoleAssigned(user, roleName)) {
-        log.debug("Added role \"{}\" to {} after retry {}", roleName, userId, attempt + 1);
+      if (areRolesAssigned(user, roleNames)) {
+        log.debug("Added {} roles to {} after retry {}", roleNames.size(), userId, attempt + 1);
         return;
       }
     }
@@ -696,14 +718,16 @@ public class KeycloakService
     }
   }
 
-  private boolean isRoleAssigned(UserResource user, String roleName) {
-    List<RoleRepresentation> userRoles = user.roles().realmLevel().listAll();
-    for (RoleRepresentation role : userRoles) {
-      if (role.getName() != null && role.getName().equalsIgnoreCase(roleName)) {
-        return true;
-      }
-    }
-    return false;
+  private boolean areRolesAssigned(UserResource user, Collection<String> roleNames) {
+    Set<String> assignedRoleNames =
+        user.roles().realmLevel().listAll().stream()
+            .map(RoleRepresentation::getName)
+            .filter(roleName -> nonNull(roleName))
+            .map(roleName -> roleName.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+    return roleNames.stream()
+        .map(roleName -> roleName.toLowerCase(Locale.ROOT))
+        .allMatch(assignedRoleNames::contains);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityService.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -62,6 +63,7 @@ public class GrantConsultantIdentityService {
   private final @NonNull AdminRepository adminRepository;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull MessageClient messageClient;
   private final @NonNull MatrixUserClient matrixUserClient;
   private final @NonNull ConsultantService consultantService;
@@ -124,10 +126,11 @@ public class GrantConsultantIdentityService {
   }
 
   private void assignKeycloakRoles(String adminId, GrantConsultantIdentityDTO dto) {
-    identityClient.ensureRole(adminId, CONSULTANT.getValue());
-    if (dto.isGroupchatConsultant()) {
-      identityClient.ensureRole(adminId, GROUP_CHAT_CONSULTANT.getValue());
-    }
+    var requestedRoles =
+        dto.isGroupchatConsultant()
+            ? Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue())
+            : Set.of(CONSULTANT.getValue());
+    identityRoleUpdater.ensureRoles(adminId, requestedRoles);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -14,14 +14,15 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantAgencyStatus;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -38,8 +39,8 @@ public class ConsultantAgencyRelationCreatorService {
   private final @NonNull ConsultantAgencyService consultantAgencyService;
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull AgencyService agencyService;
-  private final @NonNull IdentityClient identityClient;
   private final @NonNull IdentityRoleLookup identityRoleLookup;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull ConsultingTypeManager consultingTypeManager;
   private final @NonNull RocketChatAsyncHelper rocketChatAsyncHelper;
   private final @NonNull ConsultantTopicAgencyCompatibilityValidator
@@ -152,11 +153,11 @@ public class ConsultantAgencyRelationCreatorService {
         consultingTypeManager.getConsultingTypeSettings(agency.getConsultingType()).getRoles();
     if (nonNull(roles) && nonNull(roles.getConsultant())) {
       var roleSets = roles.getConsultant().getRoleSets();
+      var requestedRoles = new LinkedHashSet<String>();
       for (var roleSetName : input.getRoleSetNames()) {
-        roleSets
-            .getOrDefault(roleSetName, Collections.emptyList())
-            .forEach(roleName -> identityClient.ensureRole(input.getConsultantId(), roleName));
+        requestedRoles.addAll(roleSets.getOrDefault(roleSetName, Collections.emptyList()));
       }
+      identityRoleUpdater.ensureRoles(input.getConsultantId(), requestedRoles);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -11,8 +11,6 @@ public interface IdentityClient {
 
   void updateUserRole(final String userId);
 
-  void ensureRole(final String userId, final String roleName);
-
   void updateRole(final String userId, final UserRole role);
 
   void removeRoleIfPresent(final String userId, final String roleName);

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import java.util.Collection;
+
+/** Focused outbound identity realm-role write contract. */
+public interface IdentityRoleUpdater {
+
+  void ensureRoles(String userId, Collection<String> roleNames);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1692,41 +1692,119 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void ensureRole_Should_SkipUpdate_When_UserAlreadyHasRole() {
-    UserResource userResource = givenUserResourceWithRealmRoles("consultant");
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+  public void ensureRoles_Should_NotCallKeycloak_When_NoRolesAreRequested() {
+    keycloakService.ensureRoles(USER_ID, List.of());
 
-    keycloakService.ensureRole(USER_ID, "consultant");
-
-    verify(usersResource, times(1)).get(USER_ID);
+    verifyNoInteractions(keycloakClient);
   }
 
   @Test
-  public void ensureRole_Should_UpdateRole_When_UserDoesNotHaveRole() {
-    // ensureRole's own userHasRole pre-check goes through keycloakClient.getUsersResource() —
-    // report no roles so the check fails and updateRole proceeds.
-    UserResource userResourceForCheck = givenUserResourceWithRealmRoles();
-    UsersResource usersResourceForCheck = givenUsersResourceWithAnyUserId(userResourceForCheck);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResourceForCheck);
+  public void ensureRoles_Should_DeduplicateAndAddOnlyMissingRolesInOneCall() {
+    UserResource userResource = givenUserResourceWithRealmRoles("consultant");
+    RoleScopeResource currentRoles = userResource.roles().realmLevel();
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    // updateRole goes through keycloakClient.getRealmResource().users() — report the role as
-    // already assigned so the post-add verification loop succeeds immediately.
     var realmResource = mock(RealmResource.class);
     var rolesResource = mock(RolesResource.class);
     var roleResource = mock(RoleResource.class);
     var roleRepresentation = new RoleRepresentation();
+    roleRepresentation.setName("group-chat-consultant");
     when(roleResource.toRepresentation()).thenReturn(roleRepresentation);
-    when(rolesResource.get("consultant")).thenReturn(roleResource);
+    when(rolesResource.get("group-chat-consultant")).thenReturn(roleResource);
     when(realmResource.roles()).thenReturn(rolesResource);
-    UserResource userResourceForUpdate = givenUserResourceWithRealmRoles("consultant");
+    UserResource userResourceForUpdate =
+        givenUserResourceWithRealmRoles("consultant", "group-chat-consultant");
+    RoleScopeResource updatedRoles = userResourceForUpdate.roles().realmLevel();
     UsersResource usersResourceForUpdate = givenUsersResourceWithAnyUserId(userResourceForUpdate);
     when(realmResource.users()).thenReturn(usersResourceForUpdate);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    keycloakService.ensureRole(USER_ID, "consultant");
+    keycloakService.ensureRoles(
+        USER_ID, List.of("consultant", "group-chat-consultant", "group-chat-consultant"));
 
-    verify(userResourceForUpdate.roles().realmLevel()).add(singletonList(roleRepresentation));
+    verify(currentRoles, times(1)).listAll();
+    verify(rolesResource, never()).get("consultant");
+    verify(rolesResource, times(1)).get("group-chat-consultant");
+    verify(updatedRoles).add(singletonList(roleRepresentation));
+    verify(updatedRoles, times(1)).listAll();
+  }
+
+  @Test
+  public void ensureRoles_Should_VerifyAllMissingRolesWithOneReadPerAttempt() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    UserResource userResourceForCheck = givenUserResourceWithRealmRoles();
+    RoleScopeResource currentRoles = userResourceForCheck.roles().realmLevel();
+    UsersResource usersResourceForCheck = givenUsersResourceWithAnyUserId(userResourceForCheck);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResourceForCheck);
+
+    var realmResource = mock(RealmResource.class);
+    var rolesResource = mock(RolesResource.class);
+    var consultantRoleResource = mock(RoleResource.class);
+    var groupChatRoleResource = mock(RoleResource.class);
+    var consultantRole = new RoleRepresentation();
+    consultantRole.setName("consultant");
+    var groupChatRole = new RoleRepresentation();
+    groupChatRole.setName("group-chat-consultant");
+    when(consultantRoleResource.toRepresentation()).thenReturn(consultantRole);
+    when(groupChatRoleResource.toRepresentation()).thenReturn(groupChatRole);
+    when(rolesResource.get("consultant")).thenReturn(consultantRoleResource);
+    when(rolesResource.get("group-chat-consultant")).thenReturn(groupChatRoleResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+
+    RoleScopeResource updatedRoles = mock(RoleScopeResource.class);
+    when(updatedRoles.listAll())
+        .thenReturn(List.of())
+        .thenReturn(List.of(consultantRole, groupChatRole));
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(updatedRoles);
+    UserResource userResourceForUpdate = mock(UserResource.class);
+    when(userResourceForUpdate.roles()).thenReturn(roleMappingResource);
+    UsersResource usersResourceForUpdate = givenUsersResourceWithAnyUserId(userResourceForUpdate);
+    when(realmResource.users()).thenReturn(usersResourceForUpdate);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    keycloakService.ensureRoles(USER_ID, List.of("consultant", "group-chat-consultant"));
+
+    verify(currentRoles, times(1)).listAll();
+    verify(updatedRoles).add(List.of(consultantRole, groupChatRole));
+    verify(updatedRoles, times(2)).listAll();
+    verify(outboundHttpMetrics).recordRetry("keycloak", "role-visibility");
+  }
+
+  @Test
+  public void ensureRoles_Should_RefreshAdminSessionAndRetryBatchOnce_When_Unauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    UserResource userResourceForCheck = givenUserResourceWithRealmRoles();
+    UsersResource usersResourceForCheck = givenUsersResourceWithAnyUserId(userResourceForCheck);
+    when(keycloakClient.getUsersResource()).thenReturn(usersResourceForCheck);
+
+    var realmResource = mock(RealmResource.class);
+    var rolesResource = mock(RolesResource.class);
+    var roleResource = mock(RoleResource.class);
+    var roleRepresentation = new RoleRepresentation();
+    roleRepresentation.setName("consultant");
+    when(roleResource.toRepresentation()).thenReturn(roleRepresentation);
+    when(rolesResource.get("consultant")).thenReturn(roleResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+    RoleScopeResource updatedRoles = mock(RoleScopeResource.class);
+    doThrow(new NotAuthorizedException("Bearer")).doNothing().when(updatedRoles).add(any());
+    when(updatedRoles.listAll()).thenReturn(List.of(roleRepresentation));
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(updatedRoles);
+    UserResource userResourceForUpdate = mock(UserResource.class);
+    when(userResourceForUpdate.roles()).thenReturn(roleMappingResource);
+    UsersResource usersResourceForUpdate = givenUsersResourceWithAnyUserId(userResourceForUpdate);
+    when(realmResource.users()).thenReturn(usersResourceForUpdate);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    keycloakService.ensureRoles(USER_ID, List.of("consultant"));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(updatedRoles, times(2)).add(singletonList(roleRepresentation));
+    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -43,6 +43,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
@@ -140,6 +141,7 @@ class UserAdminControllerE2EIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
@@ -76,6 +77,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -86,6 +86,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -186,6 +187,7 @@ class UserControllerAuthorizationIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -60,6 +60,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentitySession;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
@@ -306,6 +307,7 @@ class UserControllerIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -27,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -65,6 +66,7 @@ class CreateAdminServiceIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -18,6 +18,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ public class UpdateAdminServiceIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
@@ -30,9 +30,11 @@ import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +56,7 @@ class GrantConsultantIdentityServiceTest {
   @Mock private AdminRepository adminRepository;
   @Mock private ConsultantRepository consultantRepository;
   @Mock private de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private RocketChatService rocketChatService;
   @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private ConsultantService consultantService;
@@ -98,7 +101,7 @@ class GrantConsultantIdentityServiceTest {
         BadRequestException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient, never()).ensureRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).ensureRoles(anyString(), any());
     verify(consultantService, never()).saveConsultant(any());
   }
 
@@ -116,7 +119,7 @@ class GrantConsultantIdentityServiceTest {
     assertThat(
         ex.getCustomHttpHeaders().get("X-Reason").get(0),
         is("CONSULTANT_IDENTITY_ALREADY_GRANTED"));
-    verify(identityClient, never()).ensureRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).ensureRoles(anyString(), any());
     verify(consultantService, never()).saveConsultant(any());
   }
 
@@ -135,7 +138,7 @@ class GrantConsultantIdentityServiceTest {
     assertThat(
         ex.getCustomHttpHeaders().get("X-Reason").get(0),
         is("CONSULTANT_IDENTITY_ALREADY_GRANTED"));
-    verify(identityClient, never()).ensureRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).ensureRoles(anyString(), any());
   }
 
   @Test
@@ -150,7 +153,7 @@ class GrantConsultantIdentityServiceTest {
 
     var response = grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
 
-    verify(identityClient).ensureRole(ADMIN_ID, CONSULTANT.getValue());
+    verify(identityRoleUpdater).ensureRoles(ADMIN_ID, Set.of(CONSULTANT.getValue()));
 
     ArgumentCaptor<Consultant> consultantCaptor = ArgumentCaptor.forClass(Consultant.class);
     verify(consultantService).saveConsultant(consultantCaptor.capture());
@@ -183,7 +186,7 @@ class GrantConsultantIdentityServiceTest {
         BadRequestException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient, never()).ensureRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).ensureRoles(anyString(), any());
     verify(consultantService, never()).saveConsultant(any());
   }
 
@@ -200,8 +203,8 @@ class GrantConsultantIdentityServiceTest {
 
     grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto);
 
-    verify(identityClient).ensureRole(ADMIN_ID, CONSULTANT.getValue());
-    verify(identityClient).ensureRole(ADMIN_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(identityRoleUpdater)
+        .ensureRoles(ADMIN_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -10,6 +10,8 @@ import static org.hibernate.search.util.impl.CollectionHelper.asSet;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -185,7 +187,10 @@ class ConsultantAgencyRelationCreatorServiceIT {
     consultantAgencyRelationCreatorService.createNewConsultantAgency(
         consultant.getId(), createConsultantAgencyDTO);
 
-    roles.forEach(role -> verify(keycloakService).ensureRole(consultant.getId(), role));
+    verify(keycloakService)
+        .ensureRoles(
+            eq(consultant.getId()),
+            argThat(roleNames -> Set.copyOf(roleNames).equals(Set.copyOf(roles))));
     var result =
         consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull(consultant.getId());
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -33,6 +33,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -92,6 +93,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -21,8 +21,8 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -57,9 +57,9 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Mock private AgencyService agencyService;
 
-  @Mock private IdentityClient identityClient;
-
   @Mock private IdentityRoleLookup identityRoleLookup;
+
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
 
   @Mock private RocketChatAsyncHelper rocketChatAsyncHelper;
 
@@ -337,7 +337,9 @@ public class ConsultantAgencyRelationCreatorServiceTest {
         .thenReturn(Optional.of(consultant));
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
     when(consultingTypeManager.getConsultingTypeSettings(0))
-        .thenReturn(givenConsultingTypeWithRoles("main", List.of("consultant-role")));
+        .thenReturn(
+            givenConsultingTypeWithRoles(
+                "main", List.of("consultant-role", "u25-consultant", "consultant-role")));
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO =
         new CreateConsultantAgencyDTO().roleSetKey("main").agencyId(15L);
@@ -345,7 +347,8 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     consultantAgencyRelationCreatorService.createNewConsultantAgency(
         "consultant Id", createConsultantAgencyDTO);
 
-    verify(identityClient).ensureRole("consultant Id", "consultant-role");
+    verify(identityRoleUpdater)
+        .ensureRoles("consultant Id", Set.of("consultant-role", "u25-consultant"));
     verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -44,6 +45,7 @@ public class ConsultantUpdateServiceBase {
         IdentityEmailOwnerLookup.class,
         IdentityProfileLookup.class,
         IdentityRoleLookup.class,
+        IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
       })

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -557,6 +557,46 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "The unused provider-specific authority evaluator must be removed",
         )
 
+    def test_role_write_consumers_use_the_focused_batch_identity_port(self):
+        focused_updater_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;"
+        )
+        consumers = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "create/GrantConsultantIdentityService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "create/agencyrelation/ConsultantAgencyRelationCreatorService.java",
+        )
+        missing_focused_port = [
+            str(source.relative_to(ROOT))
+            for source in consumers
+            if focused_updater_import not in source.read_text()
+        ]
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+
+        self.assertEqual(
+            [],
+            missing_focused_port,
+            "Realm-role writers must depend on the focused batch role-write port:\n"
+            + "\n".join(missing_focused_port),
+        )
+        self.assertNotIn(
+            "ensureRole(",
+            identity_client,
+            "The broad identity command client must not own role ensuring",
+        )
+        for source in consumers:
+            self.assertNotIn(
+                "identityClient.ensureRole(",
+                source.read_text(),
+                f"{source.name} must batch role writes through IdentityRoleUpdater",
+            )
+
     def test_email_mutation_consumers_use_a_focused_identity_email_port(self):
         port = (
             ROOT


### PR DESCRIPTION
## Summary

- introduce the focused `IdentityRoleUpdater` outbound port
- batch consultant realm-role assignment into one Keycloak add operation per attempt
- deduplicate requested roles and skip identity traffic for empty requests
- verify post-write visibility for the complete role set with bounded retries
- remove role ensuring from the broad `IdentityClient`
- document and enforce the new module boundary

## Why

The two consultant role writers issued one read/write/visibility sequence per role. That made outbound call volume scale with role count and kept application services coupled to the broad identity command client.

This slice makes the contract explicit:

- empty request: zero identity calls
- non-empty request: one initial role read
- write path: one batch add per attempt, independent of role count
- visibility: one complete-set read per bounded retry
- unauthorized admin session: one refresh and one batch retry

## Verification

- JDK 21 unit suite: 3,870 tests, 0 failures, 0 errors, 0 skipped
- required integration contract: 97 reports, 969 tests, 0 failures, 0 errors, 5 skipped
- CI architecture contracts: 43 tests, all passing
- Spotless: passing
- `git diff --check`: passing

The dedicated Redis integration container was used. The normal local MariaDB database was not reset.

## Stack and product direction

- stacked on draft PR #802
- Rocket.Chat and Jitsi remain removal targets, never fallbacks
- the target remains the ORISO frontend with controlled MatrixRTC/Element Call and LiveKit

Closes OpenResilienceInitiative/ORISO-UserService#803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
