### PR TITLE
[Stability] Move identity role assignment to focused port

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -205,6 +205,13 @@ closed.
   checked for the complete requested set with one full-role read per bounded
   retry, independent of role count. The broad command client no longer exposes
   role ensuring.
+- Newly provisioned admin, consultant and user identities use the same focused
+  port's explicit batch assignment. An empty assignment performs zero Keycloak
+  calls; a non-empty assignment performs one role-add call per attempt and one
+  complete-set visibility read per bounded retry, independent of role count.
+  Existing consultant group-role enablement retains the read-before-write
+  `ensureRoles` behavior. The broad command client no longer exposes any
+  role-assignment command.
 - Email-ownership validation now consumes the focused
   `IdentityEmailOwnerLookup` port and the typed `IdentityEmailOwner` result.
   Application code no longer interprets Keycloak adapter map keys. This is a
@@ -273,14 +280,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; batched consultant role assignment uses `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role ensuring or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, singular role assignment/removal and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; all role assignment uses the batch-capable `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role assignment or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, role removal and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
-The remaining broad client debt is provisioning, singular role
-assignment/removal and account lifecycle commands.
+The remaining broad client debt is provisioning, role removal and account
+lifecycle commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -304,11 +311,11 @@ The role-read contract keeps full realm-role reads and application
 role-membership checks behind the focused `IdentityRoleLookup` port, prevents
 per-candidate role checks from returning to consultant-agency validation and
 rejects role-membership or authority reads on the broad command client. The
-role-write contract requires both consultant-role writers to use the focused
-`IdentityRoleUpdater` batch port and rejects role ensuring on the broad command
-client. Adapter interaction tests enforce the zero-call empty path, one initial
-read, deduplication, one batch add per attempt and one complete-set visibility
-read per bounded retry. The
+role-write contract requires all seven role writers to use the focused
+`IdentityRoleUpdater` batch port and rejects every role-assignment command on
+the broad command client. Adapter interaction tests enforce zero-call empty
+paths, one initial read for ensure semantics, deduplication, one batch add per
+attempt and one complete-set visibility read per bounded retry. The
 email-owner contract likewise keeps the read off the broad command port and
 rejects application-level dependence on Keycloak adapter map keys. The
 email-mutation contract requires both active consumers and the Keycloak adapter

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -584,15 +584,6 @@ public class KeycloakService
     throw new KeycloakException("ERROR: Keycloak user id is missing");
   }
 
-  /**
-   * Assigns the role "user" to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   */
-  public void updateUserRole(final String userId) {
-    updateRole(userId, "user");
-  }
-
   @Override
   public void ensureRoles(final String userId, final Collection<String> roleNames) {
     var requestedRoles = new LinkedHashSet<>(roleNames);
@@ -603,18 +594,16 @@ public class KeycloakService
     var assignedRoles = new LinkedHashSet<>(findAllByUserId(userId));
     requestedRoles.removeAll(assignedRoles);
     if (!requestedRoles.isEmpty()) {
-      updateRoles(userId, requestedRoles);
+      assignRoles(userId, requestedRoles);
     }
   }
 
-  /**
-   * Assigns the given {@link UserRole} to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   * @param role {@link UserRole}
-   */
-  public void updateRole(final String userId, final UserRole role) {
-    this.updateRole(userId, role.getValue());
+  @Override
+  public void assignRoles(final String userId, final Collection<String> roleNames) {
+    var requestedRoles = new LinkedHashSet<>(roleNames);
+    if (!requestedRoles.isEmpty()) {
+      updateRoles(userId, requestedRoles);
+    }
   }
 
   @Override
@@ -644,16 +633,6 @@ public class KeycloakService
           .findFirst();
     }
     return Optional.empty();
-  }
-
-  /**
-   * Assigns the role with the given name to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   * @param roleName Keycloak role name
-   */
-  public void updateRole(final String userId, final String roleName) {
-    updateRoles(userId, Collections.singletonList(roleName));
   }
 
   private void updateRoles(final String userId, final Collection<String> roleNames) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.NotFoundException;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ public class CreateAdminService {
   private boolean multitenancyWithSingleDomain;
 
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull UserAccountInputValidator userAccountInputValidator;
   private final @NonNull UserHelper userHelper;
   private final @NonNull AdminRepository adminRepository;
@@ -96,7 +98,8 @@ public class CreateAdminService {
             : userHelper.getRandomPassword();
     try {
       identityClient.updatePassword(keycloakUserId, password);
-      getDefaultRoles(adminType).forEach(role -> identityClient.updateRole(keycloakUserId, role));
+      identityRoleUpdater.assignRoles(
+          keycloakUserId, getDefaultRoles(adminType).stream().map(UserRole::getValue).toList());
       return adminRepository.save(buildAdmin(createAdminDTO, adminType, keycloakUserId));
     } catch (CustomValidationHttpStatusException e) {
       identityClient.rollBackUser(keycloakUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
@@ -66,6 +67,7 @@ public class CreateConsultantSaga {
 
   private static final String CREATE_CONSULTANT = "createConsultant";
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull MessageClient messageClient;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull ConsultantPublicSlugService consultantPublicSlugService;
@@ -355,7 +357,7 @@ public class CreateConsultantSaga {
   private void updateKeyloakRolesOrRollback(
       Set<String> roles, String keycloakUserId, ConsultantCreationInput consultantCreationInput) {
     try {
-      roles.forEach(roleName -> identityClient.updateRole(keycloakUserId, roleName));
+      identityRoleUpdater.assignRoles(keycloakUserId, roles);
     } catch (Exception e) {
       log.error(
           "Unable to update roles for user with keycloak id {}. Initiating user rollback.",

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Language;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
@@ -40,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConsultantUpdateService {
 
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull ConsultantPublicSlugService consultantPublicSlugService;
   private final @NonNull UserAccountInputValidator userAccountInputValidator;
@@ -100,7 +102,7 @@ public class ConsultantUpdateService {
 
     if (updateConsultantDTO.getIsGroupchatConsultant() != null
         && updateConsultantDTO.getIsGroupchatConsultant()) {
-      identityClient.updateRole(consultant.getId(), GROUP_CHAT_CONSULTANT.getValue());
+      identityRoleUpdater.ensureRoles(consultant.getId(), Set.of(GROUP_CHAT_CONSULTANT.getValue()));
     }
     if (updateConsultantDTO.getIsGroupchatConsultant() != null
         && !updateConsultantDTO.getIsGroupchatConsultant()) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.model.NewSessionValidationConstraint;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
@@ -52,6 +53,7 @@ import org.springframework.web.client.RestClientException;
 public class CreateUserFacade {
   private final @NonNull UserVerifier userVerifier;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull UserService userService;
   private final @NonNull RollbackFacade rollbackFacade;
   private final @NonNull ConsultingTypeManager consultingTypeManager;
@@ -346,7 +348,7 @@ public class CreateUserFacade {
 
   private void updateKeycloakRoleAndPassword(String userId, UserDTO userDTO, UserRole role) {
     checkIfUserIdNotNull(userId, userDTO);
-    identityClient.updateRole(userId, role);
+    identityRoleUpdater.assignRoles(userId, List.of(role.getValue()));
     identityClient.updatePassword(userId, userDTO.getPassword());
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
-import de.caritas.cob.userservice.api.config.auth.UserRole;
 
 public interface IdentityClient {
 
@@ -9,13 +8,7 @@ public interface IdentityClient {
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);
 
-  void updateUserRole(final String userId);
-
-  void updateRole(final String userId, final UserRole role);
-
   void removeRoleIfPresent(final String userId, final String roleName);
-
-  void updateRole(final String userId, final String roleName);
 
   void updatePassword(final String userId, final String password);
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
@@ -5,5 +5,7 @@ import java.util.Collection;
 /** Focused outbound identity realm-role write contract. */
 public interface IdentityRoleUpdater {
 
+  void assignRoles(String userId, Collection<String> roleNames);
+
   void ensureRoles(String userId, Collection<String> roleNames);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.service;
 
+import static de.caritas.cob.userservice.api.config.auth.UserRole.USER;
 import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
 import static de.caritas.cob.userservice.api.helper.SessionDataProvider.fromUserDTO;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
@@ -30,6 +31,7 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
@@ -83,6 +85,7 @@ public class AskerImportService {
   private final String IMPORT_LOG_CHARSET = "UTF-8";
   private final String DUMMY_POSTCODE = "00000";
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityUsernameAvailability identityUsernameAvailability;
   private final @NonNull UserService userService;
   private final @NonNull SessionService sessionService;
@@ -169,7 +172,7 @@ public class AskerImportService {
         identityClient.updatePassword(keycloakUserId, record.getPassword());
 
         // Set asker/user role
-        identityClient.updateUserRole(keycloakUserId);
+        identityRoleUpdater.assignRoles(keycloakUserId, List.of(USER.getValue()));
 
         // Create user in MariaDB
         ExtendedConsultingTypeResponseDTO extendedConsultingTypeResponseDTO =
@@ -359,7 +362,7 @@ public class AskerImportService {
         identityClient.updatePassword(keycloakUserId, record.getPassword());
 
         // Set asker/user role
-        identityClient.updateUserRole(keycloakUserId);
+        identityRoleUpdater.assignRoles(keycloakUserId, List.of(USER.getValue()));
 
         // Create user in MariaDB
         ExtendedConsultingTypeResponseDTO extendedConsultingTypeResponseDTO =

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -863,7 +863,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void updateRole_Should_throwKeycloakException_When_roleCouldNotBeUpdated() {
+  public void assignRoles_Should_throwKeycloakException_When_roleCouldNotBeUpdated() {
     assertThrows(
         KeycloakException.class,
         () -> {
@@ -887,12 +887,12 @@ public class KeycloakServiceTest {
           when(realmResource.roles()).thenReturn(rolesResource);
           when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-          this.keycloakService.updateRole("user", "role");
+          this.keycloakService.assignRoles("user", List.of("role"));
         });
   }
 
   @Test
-  public void updateRole_Should_updateRole_When_roleUpdateIsValid() {
+  public void assignRoles_Should_updateRole_When_roleUpdateIsValid() {
     String validRole = "role";
 
     UserResource userResource = mock(UserResource.class);
@@ -919,13 +919,13 @@ public class KeycloakServiceTest {
     when(realmResource.roles()).thenReturn(rolesResource);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    this.keycloakService.updateRole("user", validRole);
+    this.keycloakService.assignRoles("user", List.of(validRole));
 
     verify(roleScopeResource, times(1)).add(any());
   }
 
   @Test
-  public void updateRole_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
+  public void assignRoles_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
     var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
     keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     String validRole = "role";
@@ -951,7 +951,7 @@ public class KeycloakServiceTest {
         .thenThrow(new NotAuthorizedException("Bearer"))
         .thenReturn(realmResource);
 
-    keycloakService.updateRole("user", validRole);
+    keycloakService.assignRoles("user", List.of(validRole));
 
     verify(keycloakClient).refreshAdminSession();
     verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
@@ -993,7 +993,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void updateRole_Should_updateUserWithProvidedRole() {
+  public void assignRoles_Should_updateUserWithProvidedRole() {
     UserRole validRole = UserRole.USER;
 
     UserResource userResource = mock(UserResource.class);
@@ -1020,7 +1020,7 @@ public class KeycloakServiceTest {
     when(realmResource.roles()).thenReturn(rolesResource);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    this.keycloakService.updateRole("user", validRole);
+    this.keycloakService.assignRoles("user", List.of(validRole.getValue()));
 
     verify(roleScopeResource, times(1)).add(any());
     verify(rolesResource, times(1)).get(validRole.getValue());
@@ -1696,6 +1696,45 @@ public class KeycloakServiceTest {
     keycloakService.ensureRoles(USER_ID, List.of());
 
     verifyNoInteractions(keycloakClient);
+  }
+
+  @Test
+  public void assignRoles_Should_NotCallKeycloak_When_NoRolesAreRequested() {
+    keycloakService.assignRoles(USER_ID, List.of());
+
+    verifyNoInteractions(keycloakClient);
+  }
+
+  @Test
+  public void assignRoles_Should_DeduplicateAndAddRolesInOneCall() {
+    var realmResource = mock(RealmResource.class);
+    var rolesResource = mock(RolesResource.class);
+    var consultantRoleResource = mock(RoleResource.class);
+    var groupChatRoleResource = mock(RoleResource.class);
+    var consultantRole = new RoleRepresentation();
+    consultantRole.setName("consultant");
+    var groupChatRole = new RoleRepresentation();
+    groupChatRole.setName("group-chat-consultant");
+    when(consultantRoleResource.toRepresentation()).thenReturn(consultantRole);
+    when(groupChatRoleResource.toRepresentation()).thenReturn(groupChatRole);
+    when(rolesResource.get("consultant")).thenReturn(consultantRoleResource);
+    when(rolesResource.get("group-chat-consultant")).thenReturn(groupChatRoleResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+
+    UserResource userResource =
+        givenUserResourceWithRealmRoles("consultant", "group-chat-consultant");
+    RoleScopeResource assignedRoles = userResource.roles().realmLevel();
+    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
+    when(realmResource.users()).thenReturn(usersResource);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    keycloakService.assignRoles(
+        USER_ID, List.of("consultant", "group-chat-consultant", "consultant"));
+
+    verify(assignedRoles).add(List.of(consultantRole, groupChatRole));
+    verify(assignedRoles, times(1)).listAll();
+    verify(rolesResource, times(1)).get("consultant");
+    verify(rolesResource, times(1)).get("group-chat-consultant");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -106,8 +106,9 @@ class CreateAdminServiceIT {
     assertNull(userDTOArgumentCaptor.getValue().getTenantId());
 
     verify(identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isNull();
@@ -142,8 +143,9 @@ class CreateAdminServiceIT {
     assertEquals(1L, (long) userDTOArgumentCaptor.getValue().getTenantId());
 
     verify(identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isEqualTo(1L);
@@ -180,8 +182,9 @@ class CreateAdminServiceIT {
     assertEquals(1L, (long) userDTOArgumentCaptor.getValue().getTenantId());
 
     verify(identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isEqualTo(1L);
@@ -210,8 +213,9 @@ class CreateAdminServiceIT {
     assertNull(userDTOArgumentCaptor.getValue().getTenantId());
 
     verify(identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isNull();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
@@ -24,6 +24,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -40,6 +41,7 @@ class CreateAdminServiceTest {
   @InjectMocks private CreateAdminService createAdminService;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
 
   @Mock private UserAccountInputValidator userAccountInputValidator;
 
@@ -77,8 +79,8 @@ class CreateAdminServiceTest {
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenReturn(keycloakResponse);
     doThrow(new RuntimeException("role assignment failed"))
-        .when(identityClient)
-        .updateRole(anyString(), any(UserRole.class));
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), any());
 
     CreateAdminDTO createAdminDTO = easyRandom.nextObject(CreateAdminDTO.class);
     createAdminDTO.setUsername("valid_username");
@@ -97,8 +99,8 @@ class CreateAdminServiceTest {
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenReturn(keycloakResponse);
     doThrow(new NotFoundException("HTTP 404 Not Found"))
-        .when(identityClient)
-        .updateRole(anyString(), any(UserRole.class));
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), any());
 
     CreateAdminDTO createAdminDTO = easyRandom.nextObject(CreateAdminDTO.class);
     createAdminDTO.setUsername("valid_username");

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaIT.java
@@ -12,9 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -104,7 +102,7 @@ public class CreateConsultantSagaIT {
         this.createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     ConsultantDTO consultant = consultantAdminResponseDTO.getEmbedded();
-    verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
+    verify(keycloakService).assignRoles(IDENTITY_ID, asSet(CONSULTANT.getValue()));
 
     assertThat(consultant, notNullValue());
     assertThat(consultant.getId(), is(IDENTITY_ID));
@@ -160,7 +158,7 @@ public class CreateConsultantSagaIT {
           ex.getCustomHttpHeaders().get("X-Reason").get(0),
           is(
               "DISTRIBUTED_TRANSACTION_FAILED_ON_STEP_CREATE_ACCOUNT_IN_CALCOM_OR_APPOINTMENTSERVICE"));
-      verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
+      verify(keycloakService).assignRoles(IDENTITY_ID, asSet(CONSULTANT.getValue()));
       verify(rocketChatService).getUserID(anyString(), anyString(), anyBoolean());
       verify(rollbackFacade).rollbackConsultantAccount(Mockito.any(Consultant.class));
     }
@@ -182,7 +180,7 @@ public class CreateConsultantSagaIT {
       fail("Exception should be thrown");
     } catch (CustomValidationHttpStatusException ex) {
       assertThat(ex.getCustomHttpHeaders().get("X-Reason").get(0), is("PASSWORD_NOT_VALID"));
-      verify(keycloakService, Mockito.never()).updateRole(anyString(), eq(CONSULTANT.getValue()));
+      verify(keycloakService, Mockito.never()).assignRoles(anyString(), any());
       verify(rollbackFacade).rollbackConsultantAccount(Mockito.any(Consultant.class));
     }
   }
@@ -191,7 +189,7 @@ public class CreateConsultantSagaIT {
   public void createNewConsultant_Should_callRollback_When_KeycloakUpdateRoleThrowsException()
       throws RocketChatLoginException {
     when(keycloakService.createKeycloakUser(any(), anyString(), any())).thenReturn(IDENTITY_ID);
-    doThrow(BadRequestException.class).when(keycloakService).updateRole(anyString(), anyString());
+    doThrow(BadRequestException.class).when(keycloakService).assignRoles(anyString(), any());
     CreateConsultantDTO createConsultantDTO = this.easyRandom.nextObject(CreateConsultantDTO.class);
     createConsultantDTO.setUsername(VALID_USERNAME);
     createConsultantDTO.setEmail(VALID_EMAILADDRESS);
@@ -230,9 +228,8 @@ public class CreateConsultantSagaIT {
     var consultantAdminResponseDTO = createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     // then
-    verify(keycloakService, times(2)).updateRole(anyString(), anyString());
-    verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
-    verify(keycloakService).updateRole(IDENTITY_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(keycloakService)
+        .assignRoles(IDENTITY_ID, asSet(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
 
     assertThat(consultantAdminResponseDTO.getEmbedded(), notNullValue());
     assertThat(consultantAdminResponseDTO.getEmbedded().getId(), is(IDENTITY_ID));
@@ -254,7 +251,7 @@ public class CreateConsultantSagaIT {
 
     assertThat(consultant, notNullValue());
     assertThat(consultant.getId(), is(IDENTITY_ID));
-    verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
+    verify(keycloakService).assignRoles(IDENTITY_ID, asSet(CONSULTANT.getValue()));
     assertThat(consultant.getRocketChatId(), is(DUMMY_RC_ID));
     assertThat(consultant.getAbsenceMessage(), notNullValue());
     assertThat(consultant.getCreateDate(), notNullValue());
@@ -277,12 +274,13 @@ public class CreateConsultantSagaIT {
     CreateConsultantDTO createConsultantDTO = this.easyRandom.nextObject(CreateConsultantDTO.class);
     createConsultantDTO.setUsername(VALID_USERNAME);
     createConsultantDTO.setEmail(VALID_EMAILADDRESS);
+    createConsultantDTO.setIsGroupchatConsultant(false);
 
     var response = this.createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     assertThat(response, notNullValue());
     assertThat(response.getEmbedded().getId(), is(IDENTITY_ID));
-    verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
+    verify(keycloakService).assignRoles(IDENTITY_ID, asSet(CONSULTANT.getValue()));
     verify(rollbackFacade, Mockito.never()).rollbackConsultantAccount(any());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +27,7 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantData;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.Licensing;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -157,9 +157,8 @@ public class CreateConsultantSagaTenantAwareIT {
         createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     // then
-    verify(keycloakService, times(2)).updateRole(anyString(), anyString());
-    verify(keycloakService).updateRole(IDENTITY_ID, CONSULTANT.getValue());
-    verify(keycloakService).updateRole(IDENTITY_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(keycloakService)
+        .assignRoles(IDENTITY_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
 
     assertThat(consultant.getEmbedded(), notNullValue());
     assertThat(consultant.getEmbedded().getId(), is(IDENTITY_ID));

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
@@ -38,6 +38,7 @@ import de.caritas.cob.userservice.api.helper.PlainCredentialsHolder;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -74,6 +75,7 @@ class CreateConsultantSagaTest {
   @InjectMocks private CreateConsultantSaga createConsultantSaga;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private ConsultantPublicSlugService consultantPublicSlugService;
   @Mock private RocketChatService rocketChatService;
   @Mock private ConsultantService consultantService;
@@ -119,7 +121,7 @@ class CreateConsultantSagaTest {
     assertThat(response, notNullValue());
     assertThat(response.getEmbedded(), notNullValue());
     assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
+    verify(identityRoleUpdater).assignRoles(KEYCLOAK_USER_ID, Set.of(CONSULTANT.getValue()));
     verify(appointmentService, never()).createConsultant(any());
   }
 
@@ -240,7 +242,7 @@ class CreateConsultantSagaTest {
         () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
 
     verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
-    verify(identityClient, never()).updateRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).assignRoles(anyString(), any());
   }
 
   @Test
@@ -248,8 +250,8 @@ class CreateConsultantSagaTest {
       throws Exception {
     stubKeycloakUserCreation();
     doThrow(new RuntimeException("role update failed"))
-        .when(identityClient)
-        .updateRole(anyString(), anyString());
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), any());
 
     assertThrows(
         DistributedTransactionException.class,
@@ -299,8 +301,9 @@ class CreateConsultantSagaTest {
 
     createConsultantSaga.createNewConsultant(dto);
 
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(identityRoleUpdater)
+        .assignRoles(
+            KEYCLOAK_USER_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -177,8 +178,7 @@ public class ConsultantUpdateServiceTest {
 
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
-    verify(this.keycloakService, Mockito.never())
-        .updateRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+    verify(this.keycloakService, Mockito.never()).ensureRoles(any(), any());
     verify(this.keycloakService, Mockito.never())
         .removeRoleIfPresent(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
 
@@ -220,7 +220,7 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant(consultant.getId(), updateConsultant, false);
 
     verify(this.keycloakService, Mockito.never()).updateUserData(any(), any(), any(), any());
-    verify(this.keycloakService, Mockito.never()).updateRole(any(), any(String.class));
+    verify(this.keycloakService, Mockito.never()).ensureRoles(any(), any());
     verify(this.keycloakService, Mockito.never()).removeRoleIfPresent(any(), any());
     verify(this.appointmentService, Mockito.never()).syncConsultantData(any());
     verify(this.consultantPublicSlugService).requestSlug(consultant, "nikunnj-rohit");
@@ -240,7 +240,7 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
     verify(this.keycloakService)
-        .updateRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+        .ensureRoles(consultant.getId(), Set.of(UserRole.GROUP_CHAT_CONSULTANT.getValue()));
 
     verify(this.keycloakService, times(1))
         .updateUserData(

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.helper.UserVerifier;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
@@ -54,6 +55,7 @@ class CreateUserFacadeMatrixUserTest {
 
   @Mock private UserVerifier userVerifier;
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private UserService userService;
   @Mock private RollbackFacade rollbackFacade;
   @Mock private ConsultingTypeManager consultingTypeManager;

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -182,7 +182,7 @@ public class CreateUserFacadeTest {
     createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
     TenantContext.clear();
     verify(keycloakService, times(1)).createKeycloakUser(any(UserDTO.class));
-    verify(keycloakService, times(1)).updateRole(any(), any(UserRole.class));
+    verify(keycloakService, times(1)).assignRoles(any(), any());
     verify(keycloakService, times(1)).updatePassword(anyString(), anyString());
     verify(createNewSessionFacade, times(1))
         .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
@@ -237,7 +237,7 @@ public class CreateUserFacadeTest {
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, USER_DTO_SUCHT, UserRole.USER);
 
-    verify(keycloakService, times(1)).updateRole(any(), any(UserRole.class));
+    verify(keycloakService, times(1)).assignRoles(any(), any());
     verify(keycloakService, times(1)).updatePassword(anyString(), anyString());
     verify(rollbackFacade, times(0)).rollBackUserAccount(any());
   }
@@ -264,9 +264,7 @@ public class CreateUserFacadeTest {
     // logged and swallowed, and the database user account is still created.
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
-    doThrow(new RuntimeException())
-        .when(keycloakService)
-        .updateRole(anyString(), any(UserRole.class));
+    doThrow(new RuntimeException()).when(keycloakService).assignRoles(anyString(), any());
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, USER_DTO_SUCHT, UserRole.USER);
 
@@ -486,9 +484,7 @@ public class CreateUserFacadeTest {
   @Test
   void
       updateIdentityAndCreateAccount_Should_ThrowInternalServerError_When_KeycloakFailsForAnonymousUser() {
-    doThrow(new RuntimeException("kc down"))
-        .when(keycloakService)
-        .updateRole(anyString(), any(UserRole.class));
+    doThrow(new RuntimeException("kc down")).when(keycloakService).assignRoles(anyString(), any());
 
     assertThrows(
         InternalServerErrorException.class,

--- a/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.message.MessageServiceProvider;
@@ -64,6 +65,7 @@ class AskerImportServiceTest {
   @InjectMocks private AskerImportService askerImportService;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Mock private UserService userService;
   @Mock private SessionService sessionService;

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
+import java.util.Collection;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -112,13 +113,7 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public void updateUserRole(String userId) {}
-
-      @Override
-      public void updateRole(String userId, UserRole role) {}
-
-      @Override
-      public void updateRole(String userId, String roleName) {}
+      public void assignRoles(String userId, Collection<String> roleNames) {}
 
       @Override
       public void removeRoleIfPresent(String userId, String roleName) {}

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -568,6 +568,19 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             ROOT
             / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
             / "create/agencyrelation/ConsultantAgencyRelationCreatorService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "create/CreateConsultantSaga.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/admin"
+            / "create/CreateAdminService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "update/ConsultantUpdateService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java",
         )
         missing_focused_port = [
             str(source.relative_to(ROOT))
@@ -589,6 +602,16 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "ensureRole(",
             identity_client,
             "The broad identity command client must not own role ensuring",
+        )
+        self.assertNotIn(
+            "updateUserRole(",
+            identity_client,
+            "The broad identity command client must not own default role assignment",
+        )
+        self.assertNotIn(
+            "updateRole(",
+            identity_client,
+            "The broad identity command client must not own role assignment",
         )
         for source in consumers:
             self.assertNotIn(


### PR DESCRIPTION
## Summary

- add an explicit batch assignment operation to the focused `IdentityRoleUpdater`
- route all seven active identity role writers through the focused port
- remove every role-assignment command from the broad `IdentityClient`
- preserve bounded Keycloak admin-session refresh and complete-set visibility verification
- document and enforce the exact outbound-call bounds

## Why

Identity role assignment was split across three broad client commands. Admin and consultant provisioning issued one Keycloak add-and-visibility sequence per configured role, so outbound request volume grew with the role count. This slice makes that dependency explicit and bounded.

This is stacked on #804 and remains aligned with the Matrix-only target architecture: the ORISO frontend plus an ORISO-controlled MatrixRTC/Element Call fork and LiveKit. Rocket.Chat and Jitsi remain removal targets, not fallbacks.

## Call bounds

- empty batch: zero Keycloak calls
- non-empty batch: one role-add request per attempt, independent of role count
- visibility verification: one complete assigned-role read per bounded retry
- ensure semantics: one initial complete assigned-role read, followed only by the missing-role batch
- unauthorized admin session: one refresh and one retry of the complete batch

## Verification

- Java 21 unit suite: 3,872 tests, 0 failures, 0 errors, 0 skipped
- required integration contract: 97 reports, 969 tests, 0 failures, 0 errors, 5 skipped
- Python architecture/contract suite: 43 tests passed
- Spotless check passed
- `git diff --check` passed

Closes OpenResilienceInitiative/ORISO-UserService#805

🤖 Generated with [Claude Code](https://claude.com/claude-code)
