### PR TITLE
[Stability] Batch identity role removal

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -212,6 +212,13 @@ closed.
   Existing consultant group-role enablement retains the read-before-write
   `ensureRoles` behavior. The broad command client no longer exposes any
   role-assignment command.
+- Role removal uses the same focused port's idempotent batch operation. Empty
+  requests perform zero Keycloak calls. Non-empty requests read the complete
+  assigned-role set once per attempt and remove every present requested role
+  with at most one call, independent of role count. Already absent roles cause
+  no remove call. Consultant-identity rollback batches both possible roles,
+  and an unauthorized admin session refreshes and retries the complete batch
+  once.
 - Email-ownership validation now consumes the focused
   `IdentityEmailOwnerLookup` port and the typed `IdentityEmailOwner` result.
   Application code no longer interprets Keycloak adapter map keys. This is a
@@ -280,14 +287,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; all role assignment uses the batch-capable `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role assignment or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning, role removal and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`, leaving provisioning/reset password writes on their existing command. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; all role assignment and removal uses the batch-capable `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role writes or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
-The remaining broad client debt is provisioning, role removal and account
-lifecycle commands.
+The remaining broad client debt is provisioning and account lifecycle
+commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -312,10 +319,12 @@ role-membership checks behind the focused `IdentityRoleLookup` port, prevents
 per-candidate role checks from returning to consultant-agency validation and
 rejects role-membership or authority reads on the broad command client. The
 role-write contract requires all seven role writers to use the focused
-`IdentityRoleUpdater` batch port and rejects every role-assignment command on
-the broad command client. Adapter interaction tests enforce zero-call empty
-paths, one initial read for ensure semantics, deduplication, one batch add per
-attempt and one complete-set visibility read per bounded retry. The
+`IdentityRoleUpdater` batch port and rejects every role-write command on the
+broad command client. Both removal consumers must call the focused batch
+operation. Adapter interaction tests enforce zero-call empty paths, one
+initial read for ensure semantics, deduplication, one batch add per attempt,
+one complete-set visibility read per bounded assignment retry, and one
+complete-role read plus at most one removal per removal attempt. The
 email-owner contract likewise keeps the read off the broad command port and
 rejects application-level dependence on Keycloak adapter map keys. The
 email-mutation contract requires both active consumers and the Keycloak adapter

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -607,32 +607,42 @@ public class KeycloakService
   }
 
   @Override
-  public void removeRoleIfPresent(final String userId, final String roleName) {
-    // Get realm and user resources
-    var realmResource = keycloakClient.getRealmResource();
-    UsersResource userRessource = realmResource.users();
-    UserResource user = userRessource.get(userId);
-    // Remove role
-    var optionalRole = findRole(user, roleName);
-    if (optionalRole.isPresent()) {
-      RoleRepresentation roleRepresentation =
-          realmResource.roles().get(optionalRole.get()).toRepresentation();
-      if (roleRepresentation != null) {
-        user.roles().realmLevel().remove(Collections.singletonList(roleRepresentation));
-      }
+  public void removeRolesIfPresent(final String userId, final Collection<String> roleNames) {
+    var requestedRoles = new LinkedHashSet<>(roleNames);
+    if (requestedRoles.isEmpty()) {
+      return;
+    }
+
+    try {
+      removeRolesOnce(userId, requestedRoles);
+    } catch (NotAuthorizedException e) {
+      log.warn(
+          "Keycloak admin session was unauthorized while removing {} roles from user {}, forcing"
+              + " token refresh and retrying once",
+          requestedRoles.size(),
+          userId);
+      recordRetry("admin-session-refresh");
+      keycloakClient.refreshAdminSession();
+      removeRolesOnce(userId, requestedRoles);
     }
   }
 
-  Optional<String> findRole(UserResource user, String roleName) {
-
-    List<RoleRepresentation> userRoles = user.roles().realmLevel().listAll();
-    if (userRoles != null) {
-      return userRoles.stream()
-          .filter(role -> role.getName() != null && role.getName().equals(roleName))
-          .map(RoleRepresentation::getName)
-          .findFirst();
+  private void removeRolesOnce(final String userId, final Collection<String> roleNames) {
+    var realmResource = keycloakClient.getRealmResource();
+    var user = realmResource.users().get(userId);
+    var realmRoles = user.roles().realmLevel();
+    var assignedRoles = realmRoles.listAll();
+    if (assignedRoles == null) {
+      return;
     }
-    return Optional.empty();
+
+    var rolesToRemove =
+        assignedRoles.stream()
+            .filter(role -> role.getName() != null && roleNames.contains(role.getName()))
+            .toList();
+    if (!rolesToRemove.isEmpty()) {
+      realmRoles.remove(rolesToRemove);
+    }
   }
 
   private void updateRoles(final String userId, final Collection<String> roleNames) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityService.java
@@ -27,7 +27,6 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
@@ -62,7 +61,6 @@ public class GrantConsultantIdentityService {
 
   private final @NonNull AdminRepository adminRepository;
   private final @NonNull ConsultantRepository consultantRepository;
-  private final @NonNull IdentityClient identityClient;
   private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull MessageClient messageClient;
   private final @NonNull MatrixUserClient matrixUserClient;
@@ -263,10 +261,11 @@ public class GrantConsultantIdentityService {
   }
 
   private void removeGrantedRoles(String adminId, GrantConsultantIdentityDTO dto) {
-    identityClient.removeRoleIfPresent(adminId, CONSULTANT.getValue());
-    if (dto.isGroupchatConsultant()) {
-      identityClient.removeRoleIfPresent(adminId, GROUP_CHAT_CONSULTANT.getValue());
-    }
+    var grantedRoles =
+        dto.isGroupchatConsultant()
+            ? Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue())
+            : Set.of(CONSULTANT.getValue());
+    identityRoleUpdater.removeRolesIfPresent(adminId, grantedRoles);
   }
 
   private NotificationsSettingsDTO allActiveNotifications() {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
@@ -106,7 +106,8 @@ public class ConsultantUpdateService {
     }
     if (updateConsultantDTO.getIsGroupchatConsultant() != null
         && !updateConsultantDTO.getIsGroupchatConsultant()) {
-      identityClient.removeRoleIfPresent(consultant.getId(), GROUP_CHAT_CONSULTANT.getValue());
+      identityRoleUpdater.removeRolesIfPresent(
+          consultant.getId(), Set.of(GROUP_CHAT_CONSULTANT.getValue()));
     }
 
     // MATRIX MIGRATION: RocketChat update is optional, don't block on errors

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -8,8 +8,6 @@ public interface IdentityClient {
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);
 
-  void removeRoleIfPresent(final String userId, final String roleName);
-
   void updatePassword(final String userId, final String password);
 
   String updateDummyEmail(final String userId, UserDTO user);

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
@@ -8,4 +8,6 @@ public interface IdentityRoleUpdater {
   void assignRoles(String userId, Collection<String> roleNames);
 
   void ensureRoles(String userId, Collection<String> roleNames);
+
+  void removeRolesIfPresent(String userId, Collection<String> roleNames);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -54,6 +54,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
@@ -960,36 +961,91 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void removeRole_Should_removeRole_When_rolePresent() {
-    String validRole = "role";
+  public void removeRolesIfPresent_Should_doNothing_When_requestIsEmpty() {
+    this.keycloakService.removeRolesIfPresent("user", List.of());
 
+    verifyNoInteractions(keycloakClient);
+  }
+
+  @Test
+  public void removeRolesIfPresent_Should_removeAllPresentRolesWithOneCompleteReadAndOneWrite() {
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.get(anyString())).thenReturn(userResource);
     RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
-    RoleRepresentation keycloakRoleMock = mock(RoleRepresentation.class);
-    when(keycloakRoleMock.getName()).thenReturn(validRole);
-    when(roleScopeResource.listAll()).thenReturn(singletonList(keycloakRoleMock));
-    when(roleScopeResource.listAll()).thenReturn(singletonList(keycloakRoleMock));
+    RoleRepresentation consultantRole = mock(RoleRepresentation.class);
+    RoleRepresentation groupChatRole = mock(RoleRepresentation.class);
+    RoleRepresentation unrelatedRole = mock(RoleRepresentation.class);
+    when(consultantRole.getName()).thenReturn("consultant");
+    when(groupChatRole.getName()).thenReturn("group-chat-consultant");
+    when(unrelatedRole.getName()).thenReturn("user");
+    when(roleScopeResource.listAll())
+        .thenReturn(List.of(consultantRole, groupChatRole, unrelatedRole));
     RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
     when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
     when(userResource.roles()).thenReturn(roleMappingResource);
 
-    RoleRepresentation roleRepresentation = new EasyRandom().nextObject(RoleRepresentation.class);
-    roleRepresentation.setName("role");
-    RoleResource roleResource = mock(RoleResource.class);
-    when(roleResource.toRepresentation()).thenReturn(roleRepresentation);
-    RolesResource rolesResource = mock(RolesResource.class);
-    when(rolesResource.get(any())).thenReturn(roleResource);
-
     RealmResource realmResource = mock(RealmResource.class);
     when(realmResource.users()).thenReturn(usersResource);
-    when(realmResource.roles()).thenReturn(rolesResource);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    this.keycloakService.removeRoleIfPresent("user", validRole);
+    this.keycloakService.removeRolesIfPresent(
+        "user", List.of("consultant", "group-chat-consultant", "consultant"));
 
-    verify(roleScopeResource, times(1)).remove(any());
+    verify(roleScopeResource).listAll();
+    verify(roleScopeResource).remove(List.of(consultantRole, groupChatRole));
+    verify(realmResource, never()).roles();
+  }
+
+  @Test
+  public void removeRolesIfPresent_Should_notWrite_When_requestedRolesAreAbsent() {
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(anyString())).thenReturn(userResource);
+    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
+    RoleRepresentation assignedRole = mock(RoleRepresentation.class);
+    when(assignedRole.getName()).thenReturn("user");
+    when(roleScopeResource.listAll()).thenReturn(singletonList(assignedRole));
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+    when(userResource.roles()).thenReturn(roleMappingResource);
+    RealmResource realmResource = mock(RealmResource.class);
+    when(realmResource.users()).thenReturn(usersResource);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    this.keycloakService.removeRolesIfPresent("user", Set.of("consultant"));
+
+    verify(roleScopeResource).listAll();
+    verify(roleScopeResource, never()).remove(any());
+  }
+
+  @Test
+  public void removeRolesIfPresent_Should_refreshAndRetryCompleteBatchOnce_When_unauthorized() {
+    var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
+    keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(anyString())).thenReturn(userResource);
+    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
+    RoleRepresentation consultantRole = mock(RoleRepresentation.class);
+    when(consultantRole.getName()).thenReturn("consultant");
+    when(roleScopeResource.listAll()).thenReturn(singletonList(consultantRole));
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+    when(userResource.roles()).thenReturn(roleMappingResource);
+    RealmResource realmResource = mock(RealmResource.class);
+    when(realmResource.users()).thenReturn(usersResource);
+    when(keycloakClient.getRealmResource())
+        .thenThrow(new NotAuthorizedException("Bearer"))
+        .thenReturn(realmResource);
+
+    this.keycloakService.removeRolesIfPresent("user", Set.of("consultant"));
+
+    verify(keycloakClient).refreshAdminSession();
+    verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
+    verify(keycloakClient, times(2)).getRealmResource();
+    verify(roleScopeResource).listAll();
+    verify(roleScopeResource).remove(singletonList(consultantRole));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/GrantConsultantIdentityServiceTest.java
@@ -55,7 +55,6 @@ class GrantConsultantIdentityServiceTest {
 
   @Mock private AdminRepository adminRepository;
   @Mock private ConsultantRepository consultantRepository;
-  @Mock private de.caritas.cob.userservice.api.port.out.IdentityClient identityClient;
   @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private RocketChatService rocketChatService;
   @Mock private MatrixSynapseService matrixSynapseService;
@@ -259,7 +258,7 @@ class GrantConsultantIdentityServiceTest {
         DistributedTransactionException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient).removeRoleIfPresent(ADMIN_ID, CONSULTANT.getValue());
+    verify(identityRoleUpdater).removeRolesIfPresent(ADMIN_ID, Set.of(CONSULTANT.getValue()));
   }
 
   @Test
@@ -295,7 +294,7 @@ class GrantConsultantIdentityServiceTest {
         BadRequestException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient).removeRoleIfPresent(ADMIN_ID, CONSULTANT.getValue());
+    verify(identityRoleUpdater).removeRolesIfPresent(ADMIN_ID, Set.of(CONSULTANT.getValue()));
   }
 
   @Test
@@ -393,8 +392,9 @@ class GrantConsultantIdentityServiceTest {
         DistributedTransactionException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient).removeRoleIfPresent(ADMIN_ID, CONSULTANT.getValue());
-    verify(identityClient).removeRoleIfPresent(ADMIN_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(identityRoleUpdater)
+        .removeRolesIfPresent(
+            ADMIN_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
   }
 
   @Test
@@ -415,6 +415,8 @@ class GrantConsultantIdentityServiceTest {
         BadRequestException.class,
         () -> grantConsultantIdentityService.grantConsultantIdentityToAdmin(ADMIN_ID, dto));
 
-    verify(identityClient).removeRoleIfPresent(ADMIN_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(identityRoleUpdater)
+        .removeRolesIfPresent(
+            ADMIN_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAc
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -179,8 +180,8 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
     verify(this.keycloakService, Mockito.never()).ensureRoles(any(), any());
-    verify(this.keycloakService, Mockito.never())
-        .removeRoleIfPresent(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+    verify((IdentityRoleUpdater) this.keycloakService, Mockito.never())
+        .removeRolesIfPresent(any(), any());
 
     ArgumentCaptor<UserDTO> userDTOArgumentCaptor = ArgumentCaptor.forClass(UserDTO.class);
     verify(this.keycloakService, times(1))
@@ -221,7 +222,8 @@ public class ConsultantUpdateServiceTest {
 
     verify(this.keycloakService, Mockito.never()).updateUserData(any(), any(), any(), any());
     verify(this.keycloakService, Mockito.never()).ensureRoles(any(), any());
-    verify(this.keycloakService, Mockito.never()).removeRoleIfPresent(any(), any());
+    verify((IdentityRoleUpdater) this.keycloakService, Mockito.never())
+        .removeRolesIfPresent(any(), any());
     verify(this.appointmentService, Mockito.never()).syncConsultantData(any());
     verify(this.consultantPublicSlugService).requestSlug(consultant, "nikunnj-rohit");
     verify(this.consultantService, times(1)).saveConsultant(any());
@@ -264,8 +266,9 @@ public class ConsultantUpdateServiceTest {
 
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
-    verify(this.keycloakService)
-        .removeRoleIfPresent(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+    verify((IdentityRoleUpdater) this.keycloakService)
+        .removeRolesIfPresent(
+            consultant.getId(), Set.of(UserRole.GROUP_CHAT_CONSULTANT.getValue()));
 
     verify(this.keycloakService, times(1))
         .updateUserData(

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -116,7 +116,7 @@ public class KeycloakTestConfig {
       public void assignRoles(String userId, Collection<String> roleNames) {}
 
       @Override
-      public void removeRoleIfPresent(String userId, String roleName) {}
+      public void removeRolesIfPresent(String userId, Collection<String> roleNames) {}
 
       @Override
       public void updatePassword(String userId, String password) {}

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -613,11 +613,36 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             identity_client,
             "The broad identity command client must not own role assignment",
         )
+        self.assertNotIn(
+            "removeRoleIfPresent(",
+            identity_client,
+            "The broad identity command client must not own role removal",
+        )
         for source in consumers:
             self.assertNotIn(
                 "identityClient.ensureRole(",
                 source.read_text(),
                 f"{source.name} must batch role writes through IdentityRoleUpdater",
+            )
+        removal_consumers = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "create/GrantConsultantIdentityService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant"
+            / "update/ConsultantUpdateService.java",
+        )
+        for source in removal_consumers:
+            source_text = source.read_text()
+            self.assertIn(
+                "identityRoleUpdater.removeRolesIfPresent(",
+                source_text,
+                f"{source.relative_to(ROOT)} must use focused batch role removal",
+            )
+            self.assertNotIn(
+                "identityClient.removeRoleIfPresent(",
+                source_text,
+                f"{source.relative_to(ROOT)} must not use broad-client role removal",
             )
 
     def test_email_mutation_consumers_use_a_focused_identity_email_port(self):


### PR DESCRIPTION
## Summary

- move identity role removal from the broad `IdentityClient` to the focused `IdentityRoleUpdater`
- batch consultant rollback roles and remove every present requested role with one realm-level call per attempt
- preserve exact matching and add one bounded admin-session refresh/retry for the complete idempotent batch
- document and enforce the new outbound-call bounds

## Why

Role removal was the last realm-role write exposed by the broad identity client. The consultant rollback could repeat the full Keycloak lookup-and-remove sequence once per role, and the adapter reloaded role representations that were already available from the assigned-role list.

This slice keeps the target architecture explicit: ORISO frontend + an ORISO-controlled MatrixRTC/Element Call fork + LiveKit. Rocket.Chat and Jitsi are removal targets, not fallback dependencies.

## Call bounds

- empty request: zero Keycloak calls
- non-empty request: one complete assigned-role read per attempt
- absent roles: zero remove calls
- any number of present requested roles: at most one remove call per attempt
- unauthorized admin session: one refresh and one complete-batch retry

## Verification

- Java 21 unit suite: 3,875 tests, 0 failures, 0 errors, 0 skipped
- required integration contract: 97 reports, 969 tests, 0 failures, 0 errors, 5 skipped
- architecture/contract suite: 43 tests, all passing
- Spotless and `git diff --check`: passing
- isolated Redis integration dependency: healthy; standard local MariaDB was not reset

## Stack

This draft is stacked directly on #806 (`refactor/focused-batch-role-assignment-805`).

Closes OpenResilienceInitiative/ORISO-UserService#807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
