### PR TITLE
fix(security): clear fixable HIGH/CRITICAL image vulnerabilities and repair provider OpenAPI specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM eclipse-temurin:21-jre@sha256:273396ed5998598ed1091e8d72711c2d36980a0e65103859c55a4e977a41ffd3
+# Pebble is Canonical's service manager shipped with the Ubuntu base image.
+# It is unused by this single-process Java runtime and carries fixable
+# HIGH Go stdlib/x-net CVEs, so it is removed from the final filesystem.
+RUN rm -f /usr/bin/pebble
 VOLUME ["/tmp","/log"]
 EXPOSE 8082
 ARG JAR_FILE

--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -226,7 +226,7 @@ paths:
       tags:
         - conversation-controller
       summary: 'Set the status of the given session to done [Authorization: Role:
-      anonymous, consultant]'
+        anonymous, consultant]'
       operationId: finishAnonymousConversation
       parameters:
         - name: sessionId

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -251,7 +251,7 @@ paths:
       tags:
         - user-controller
       summary: 'Returns sessions for given Matrix room IDs.
-      [Authorization: Role: user, consultant]'
+        [Authorization: Role: user, consultant]'
       operationId: getSessionsForRoomIds
       parameters:
         - name: roomIds[]
@@ -287,7 +287,7 @@ paths:
       tags:
         - user-controller
       summary: 'Returns the session for given ID.
-      [Authorization: Role: user, consultant]'
+        [Authorization: Role: user, consultant]'
       operationId: getSessionForId
       parameters:
         - name: sessionId
@@ -464,7 +464,7 @@ paths:
       tags:
         - user-controller
       summary: 'Sets or updates the email, first and lastname of authorized consultant account
-      [Authorization:  Role: consultant]'
+        [Authorization:  Role: consultant]'
       operationId: updateConsultantData
       requestBody:
         content:
@@ -1460,7 +1460,7 @@ paths:
       tags:
         - user-controller
       summary: 'Returns the chat for given ID.
-      [Authorization: Role: user, consultant]'
+        [Authorization: Role: user, consultant]'
       operationId: getChatById
       parameters:
         - name: chatId
@@ -2600,7 +2600,7 @@ components:
           type: boolean
           example: true
           description: "Is true if consultant has at least one consulting type containing
-          anonymous conversations active"
+            anonymous conversations active"
         hasArchive:
           type: boolean
           example: true
@@ -2730,7 +2730,7 @@ components:
           pa, pi, pl, ps, pt, qu, rm, rn, ro, ru, rw, sa, sc, sd, se, sg, si, sk, sl, sm, sn,
           so, sq, sr, ss, st, su, sv, sw, ta, te, tg, th, ti, tk, tl, tn, to, tr, ts, tt, tw,
           ty, ug, uk, ur, uz, ve, vi, vo, wa, wo, xh, yi, yo, za, zh, zu
-      ]
+        ]
 
     LanguageResponseDTO:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -15,13 +15,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.7</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties> <!-- upper version is used to add the new features with the new versions of Java and spring boot, basic code changes are already made and as new features arrive they will use the upper version -->
 		<java.upper.version>21</java.upper.version>
-		<springboot.upper.version>4.0.1</springboot.upper.version>
+		<springboot.upper.version>4.0.7</springboot.upper.version>
 		<spring.upper.version>7.0.x</spring.upper.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -30,9 +30,8 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<skip.unit-tests>false</skip.unit-tests>
 		<skip.integration-tests>false</skip.integration-tests>
-		<keycloak.version>17.0.0</keycloak.version>
-		<!-- Admin client decoupled from the deprecated keycloak.version adapter:
-		     server is Keycloak 26.x; the 17.0.0 admin client 401s against it (create-user). -->
+		<!-- Server is Keycloak 26.x; the deprecated 17.x spring adapters were removed
+		     (unused since the resource-server migration, flagged by the image CVE gate). -->
 		<keycloak-admin-client.version>26.0.4</keycloak-admin-client.version>
 		<springfox.version>2.9.2</springfox.version>
 		<spring-plugin-core.version>4.0.0</spring-plugin-core.version>
@@ -45,13 +44,15 @@
 		</adapters.web.dto.path>
 		<log4j.version>2.25.4</log4j.version> <!-- force safe version due to https://logging.apache.org/log4j/2.x/security.html -->
 		<commons-text.version>1.10.0</commons-text.version>
-		<commons-validator.version>1.7</commons-validator.version>
+		<commons-validator.version>1.10.1</commons-validator.version>
 		<liquibase-maven-plugin.version>4.8.0</liquibase-maven-plugin.version>
 		<jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
 		<javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
-		<json-smart.version>2.4.7</json-smart.version>
+		<json-smart.version>2.6.0</json-smart.version>
+		<!-- Spring Boot 4.0.7 still manages Netty 4.2.15; 4.2.16 fixes CVE-2026-59901,
+		     CVE-2026-55831, CVE-2026-55833 and CVE-2026-56745 (image CVE gate). -->
+		<netty.version>4.2.16.Final</netty.version>
 		<springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
-		<ehcache.version>2.10.9.2</ehcache.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 		<lombok.version>1.18.42</lombok.version>
 	</properties>
@@ -225,16 +226,6 @@
 		<!-- Keycloak dependencies -->
 		<dependency>
 			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-spring-security-adapter</artifactId>
-			<version>${keycloak.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-spring-boot-starter</artifactId>
-			<version>${keycloak.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-admin-client</artifactId>
 			<version>${keycloak-admin-client.version}</version>
 		</dependency>
@@ -289,11 +280,6 @@
 		    <artifactId>commons-codec</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.liquibase</groupId>
-			<artifactId>liquibase-maven-plugin</artifactId>
-			<version>${liquibase-maven-plugin.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
@@ -355,15 +341,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>net.sf.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-			<version>${ehcache.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -374,7 +353,7 @@
 		<dependency>
 			<groupId>com.google.firebase</groupId>
 			<artifactId>firebase-admin</artifactId>
-			<version>8.1.0</version>
+			<version>9.10.0</version>
 		</dependency>
 
 		<!-- Test scope dependencies -->

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/config/KeycloakConfig.java
@@ -19,6 +19,7 @@ import org.hibernate.validator.constraints.URL;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,6 +44,7 @@ public class KeycloakConfig {
   @Bean("keycloakRestTemplate")
   public RestTemplate keycloakRestTemplate(RestTemplateBuilder restTemplateBuilder) {
     return restTemplateBuilder
+        .requestFactoryBuilder(ClientHttpRequestFactoryBuilder.jdk())
         .connectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
         .readTimeout(RestTemplateTimeouts.READ_TIMEOUT)
         .build();

--- a/src/main/java/de/caritas/cob/userservice/api/config/AppConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/AppConfig.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Clock;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -37,6 +38,7 @@ public class AppConfig {
   @Primary
   public RestTemplate restTemplate(RestTemplateBuilder builder) {
     return builder
+        .requestFactoryBuilder(ClientHttpRequestFactoryBuilder.jdk())
         .connectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
         .readTimeout(RestTemplateTimeouts.READ_TIMEOUT)
         .build();
@@ -45,6 +47,7 @@ public class AppConfig {
   @Bean("matrixLongPollRestTemplate")
   public RestTemplate matrixLongPollRestTemplate(RestTemplateBuilder builder) {
     return builder
+        .requestFactoryBuilder(ClientHttpRequestFactoryBuilder.jdk())
         .connectTimeout(RestTemplateTimeouts.CONNECT_TIMEOUT)
         .readTimeout(RestTemplateTimeouts.MATRIX_LONG_POLL_READ_TIMEOUT)
         .build();

--- a/src/main/java/de/caritas/cob/userservice/api/config/CacheManagerConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/CacheManagerConfig.java
@@ -1,20 +1,21 @@
 package de.caritas.cob.userservice.api.config;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.Callable;
-import net.sf.ehcache.Ehcache;
-import net.sf.ehcache.Element;
-import net.sf.ehcache.config.CacheConfiguration;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.support.AbstractCacheManager;
-import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Caffeine-backed cache configuration. Replaces the former Ehcache 2 bridge: the EOL Ehcache 2
+ * uber-jar bundled vulnerable Jetty 9.4 and Jackson 2.11 classes (flagged by the image CVE gate)
+ * and Spring Boot 4 no longer ships an Ehcache 2 integration.
+ */
 @Configuration
 @EnableCaching
 public class CacheManagerConfig {
@@ -88,179 +89,65 @@ public class CacheManagerConfig {
   private long appSettingsTimeToLiveSeconds;
 
   @Bean
-  public CacheManager cacheManager(net.sf.ehcache.CacheManager ehCacheManager) {
-    return new EhCache2CacheManager(ehCacheManager);
+  public CacheManager cacheManager() {
+    var cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(
+        List.of(
+            buildCache(
+                AGENCY_CACHE,
+                agenciesMaxEntriesLocalHeap,
+                agenciesEternal,
+                agenciesTimeToIdleSeconds,
+                agenciesTimeToLiveSeconds),
+            buildCache(
+                CONSULTING_TYPE_CACHE,
+                consultingTypeMaxEntriesLocalHeap,
+                consultingTypeEternal,
+                consultingTypeTimeToIdleSeconds,
+                consultingTypeTimeToLiveSeconds),
+            buildCache(
+                TENANT_CACHE,
+                tenantMaxEntriesLocalHeap,
+                tenantEternal,
+                tenantTimeToIdleSeconds,
+                tenantTimeToLiveSeconds),
+            buildCache(
+                TENANT_ADMIN_CACHE,
+                tenantMaxEntriesLocalHeap,
+                tenantEternal,
+                tenantTimeToIdleSeconds,
+                tenantTimeToLiveSeconds),
+            buildCache(
+                TOPICS_CACHE,
+                topicMaxEntriesLocalHeap,
+                topicEternal,
+                topicTimeToIdleSeconds,
+                topicTimeToLiveSeconds),
+            buildCache(
+                APPLICATION_SETTINGS_CACHE,
+                appSettingsMaxEntriesLocalHeap,
+                appSettingsEternal,
+                appSettingsTimeToIdleSeconds,
+                appSettingsTimeToLiveSeconds)));
+
+    return cacheManager;
   }
 
-  @Bean(destroyMethod = "shutdown")
-  public net.sf.ehcache.CacheManager ehCacheManager() {
-    var config = new net.sf.ehcache.config.Configuration();
-    config.addCache(buildAgencyCacheConfiguration());
-    config.addCache(buildConsultingTypeCacheConfiguration());
-    config.addCache(buildTenantCacheConfiguration());
-    config.addCache(buildTenantAdminCacheConfiguration());
-    config.addCache(buildTopicCacheConfiguration());
-    config.addCache(buildApplicationSettingsCacheConfiguration());
-
-    return net.sf.ehcache.CacheManager.newInstance(config);
-  }
-
-  private CacheConfiguration buildAgencyCacheConfiguration() {
-    var agencyCacheConfiguration = new CacheConfiguration();
-    agencyCacheConfiguration.setName(AGENCY_CACHE);
-    agencyCacheConfiguration.setMaxEntriesLocalHeap(agenciesMaxEntriesLocalHeap);
-    agencyCacheConfiguration.setEternal(agenciesEternal);
-    agencyCacheConfiguration.setTimeToIdleSeconds(agenciesTimeToIdleSeconds);
-    agencyCacheConfiguration.setTimeToLiveSeconds(agenciesTimeToLiveSeconds);
-    return agencyCacheConfiguration;
-  }
-
-  private CacheConfiguration buildConsultingTypeCacheConfiguration() {
-    var consultingTypeCacheConfiguration = new CacheConfiguration();
-    consultingTypeCacheConfiguration.setName(CONSULTING_TYPE_CACHE);
-    consultingTypeCacheConfiguration.setMaxEntriesLocalHeap(consultingTypeMaxEntriesLocalHeap);
-    consultingTypeCacheConfiguration.setEternal(consultingTypeEternal);
-    consultingTypeCacheConfiguration.setTimeToIdleSeconds(consultingTypeTimeToIdleSeconds);
-    consultingTypeCacheConfiguration.setTimeToLiveSeconds(consultingTypeTimeToLiveSeconds);
-    return consultingTypeCacheConfiguration;
-  }
-
-  private CacheConfiguration buildTenantCacheConfiguration() {
-    var tenantCacheConfiguration = new CacheConfiguration();
-    tenantCacheConfiguration.setName(TENANT_CACHE);
-    tenantCacheConfiguration.setMaxEntriesLocalHeap(tenantMaxEntriesLocalHeap);
-    tenantCacheConfiguration.setEternal(tenantEternal);
-    tenantCacheConfiguration.setTimeToIdleSeconds(tenantTimeToIdleSeconds);
-    tenantCacheConfiguration.setTimeToLiveSeconds(tenantTimeToLiveSeconds);
-    return tenantCacheConfiguration;
-  }
-
-  private CacheConfiguration buildTenantAdminCacheConfiguration() {
-    var tenantCacheConfiguration = new CacheConfiguration();
-    tenantCacheConfiguration.setName(TENANT_ADMIN_CACHE);
-    tenantCacheConfiguration.setMaxEntriesLocalHeap(tenantMaxEntriesLocalHeap);
-    tenantCacheConfiguration.setEternal(tenantEternal);
-    tenantCacheConfiguration.setTimeToIdleSeconds(tenantTimeToIdleSeconds);
-    tenantCacheConfiguration.setTimeToLiveSeconds(tenantTimeToLiveSeconds);
-    return tenantCacheConfiguration;
-  }
-
-  private CacheConfiguration buildTopicCacheConfiguration() {
-    var topicCacheConfiguration = new CacheConfiguration();
-    topicCacheConfiguration.setName(TOPICS_CACHE);
-    topicCacheConfiguration.setMaxEntriesLocalHeap(topicMaxEntriesLocalHeap);
-    topicCacheConfiguration.setEternal(topicEternal);
-    topicCacheConfiguration.setTimeToIdleSeconds(topicTimeToIdleSeconds);
-    topicCacheConfiguration.setTimeToLiveSeconds(topicTimeToLiveSeconds);
-    return topicCacheConfiguration;
-  }
-
-  private CacheConfiguration buildApplicationSettingsCacheConfiguration() {
-    var appSettingsCacheConfiguration = new CacheConfiguration();
-    appSettingsCacheConfiguration.setName(APPLICATION_SETTINGS_CACHE);
-    appSettingsCacheConfiguration.setMaxEntriesLocalHeap(appSettingsMaxEntriesLocalHeap);
-    appSettingsCacheConfiguration.setEternal(appSettingsEternal);
-    appSettingsCacheConfiguration.setTimeToIdleSeconds(appSettingsTimeToIdleSeconds);
-    appSettingsCacheConfiguration.setTimeToLiveSeconds(appSettingsTimeToLiveSeconds);
-    return appSettingsCacheConfiguration;
-  }
-
-  private static final class EhCache2CacheManager extends AbstractCacheManager {
-
-    private final net.sf.ehcache.CacheManager cacheManager;
-
-    private EhCache2CacheManager(net.sf.ehcache.CacheManager cacheManager) {
-      this.cacheManager = cacheManager;
-    }
-
-    @Override
-    protected Collection<? extends Cache> loadCaches() {
-      var caches = new ArrayList<Cache>();
-      for (String name : cacheManager.getCacheNames()) {
-        caches.add(new EhCache2Cache(cacheManager.getEhcache(name)));
+  private CaffeineCache buildCache(
+      String name,
+      long maxEntries,
+      boolean eternal,
+      long timeToIdleSeconds,
+      long timeToLiveSeconds) {
+    var builder = Caffeine.newBuilder().maximumSize(maxEntries);
+    if (!eternal) {
+      if (timeToLiveSeconds > 0) {
+        builder.expireAfterWrite(Duration.ofSeconds(timeToLiveSeconds));
       }
-      return caches;
-    }
-
-    @Override
-    protected Cache getMissingCache(String name) {
-      Ehcache cache = cacheManager.getEhcache(name);
-      return cache == null ? null : new EhCache2Cache(cache);
-    }
-  }
-
-  private static final class EhCache2Cache extends AbstractValueAdaptingCache {
-
-    private final Ehcache cache;
-
-    private EhCache2Cache(Ehcache cache) {
-      super(true);
-      this.cache = cache;
-    }
-
-    @Override
-    public String getName() {
-      return cache.getName();
-    }
-
-    @Override
-    public Object getNativeCache() {
-      return cache;
-    }
-
-    @Override
-    protected Object lookup(Object key) {
-      Element element = cache.get(key);
-      return element == null ? null : element.getObjectValue();
-    }
-
-    @Override
-    public <T> T get(Object key, Callable<T> valueLoader) {
-      Element element = cache.get(key);
-      if (element != null) {
-        @SuppressWarnings("unchecked")
-        T value = (T) fromStoreValue(element.getObjectValue());
-        return value;
-      }
-      try {
-        T value = valueLoader.call();
-        put(key, value);
-        return value;
-      } catch (Exception ex) {
-        throw new ValueRetrievalException(key, valueLoader, ex);
+      if (timeToIdleSeconds > 0) {
+        builder.expireAfterAccess(Duration.ofSeconds(timeToIdleSeconds));
       }
     }
-
-    @Override
-    public void put(Object key, Object value) {
-      cache.put(new Element(key, toStoreValue(value)));
-    }
-
-    @Override
-    public ValueWrapper putIfAbsent(Object key, Object value) {
-      Element existing = cache.putIfAbsent(new Element(key, toStoreValue(value)));
-      return existing == null ? null : toValueWrapper(existing.getObjectValue());
-    }
-
-    @Override
-    public void evict(Object key) {
-      cache.remove(key);
-    }
-
-    @Override
-    public boolean evictIfPresent(Object key) {
-      return cache.remove(key);
-    }
-
-    @Override
-    public void clear() {
-      cache.removeAll();
-    }
-
-    @Override
-    public boolean invalidate() {
-      cache.removeAll();
-      return true;
-    }
+    return new CaffeineCache(name, builder.build(), true);
   }
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,4 +1,4 @@
 java.upper.version=21
-springboot.upper.version=4.0.1
+springboot.upper.version=4.0.7
 spring.upper.version=6.2.0
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentControllerE2EIT.java
@@ -38,7 +38,6 @@ import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.KeycloakConfigResolver;
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockitoAnnotations;
 import org.springframework.amqp.core.Message;
@@ -78,8 +77,6 @@ class AppointmentControllerE2EIT {
   @MockitoBean private AuthenticatedUser authenticatedUser;
 
   @MockitoBean private Clock clock;
-
-  @MockitoBean private KeycloakConfigResolver keycloakConfigResolver;
 
   @MockitoBean private SessionTopicEnrichmentService sessionTopicEnrichmentService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/ConversationControllerIT.java
@@ -22,7 +22,6 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.KeycloakConfigResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -73,8 +72,6 @@ class ConversationControllerIT {
   @SuppressWarnings("unused")
   @MockitoBean
   private AuthenticatedUser authenticatedUser;
-
-  @MockitoBean private KeycloakConfigResolver keycloakConfigResolver;
 
   @Test
   void getAnonymousEnquiries_Should_returnOk_When_requestParamsAreValid() throws Exception {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/LiveProxyControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/LiveProxyControllerIT.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import de.caritas.cob.userservice.api.config.auth.RoleAuthorizationAuthorityMapper;
 import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.KeycloakConfigResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -33,8 +32,6 @@ class LiveProxyControllerIT {
   @MockitoBean private RoleAuthorizationAuthorityMapper roleAuthorizationAuthorityMapper;
 
   @MockitoBean private LinkDiscoverers linkDiscoverers;
-
-  @MockitoBean private KeycloakConfigResolver keycloakConfigResolver;
 
   @Test
   void sendLiveEvent_Should_returnBadRequest_When_matrixRoomIdIsNotProvided() throws Exception {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerIT.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.UUID;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.KeycloakConfigResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.hateoas.autoconfigure.HypermediaAutoConfiguration;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -121,8 +120,6 @@ class UserAdminControllerIT {
   @MockitoBean private GrantConsultantIdentityService grantConsultantIdentityService;
 
   @MockitoBean private UserIdentitiesService userIdentitiesService;
-
-  @MockitoBean private KeycloakConfigResolver keycloakConfigResolver;
 
   @Test
   void getSessions_Should_returnBadRequest_When_requiredPaginationParamsAreMissing()

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -71,7 +71,6 @@ import org.hibernate.service.spi.ServiceException;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.KeycloakConfigResolver;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -289,8 +288,6 @@ class UserControllerIT {
   @MockitoBean private StopChatFacade stopChatFacade;
   @MockitoBean private GetChatMembersFacade getChatMembersFacade;
   @MockitoBean private CreateUserFacade createUserFacade;
-
-  @MockitoBean KeycloakConfigResolver resolver;
 
   @MockitoBean
   @SuppressWarnings("unused")

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/RoleAuthorizationAuthorityMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/RoleAuthorizationAuthorityMapperTest.java
@@ -2,56 +2,35 @@ package de.caritas.cob.userservice.api.config.auth;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.mockito.Mockito.mock;
 
-import java.security.Principal;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.adapters.RefreshableKeycloakSecurityContext;
-import org.keycloak.adapters.spi.KeycloakAccount;
-import org.keycloak.adapters.springsecurity.account.SimpleKeycloakAccount;
-import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-@ExtendWith(MockitoExtension.class)
 public class RoleAuthorizationAuthorityMapperTest {
 
-  private final KeycloakAuthenticationProvider provider = new KeycloakAuthenticationProvider();
   private final Set<String> roles =
       Stream.of(UserRole.values()).map(UserRole::getValue).collect(Collectors.toSet());
 
   @Test
   public void roleAuthorizationAuthorityMapper_Should_GrantCorrectAuthorities() {
+    var grantedRoleAuthorities =
+        roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
 
-    Principal principal = mock(Principal.class);
-    RefreshableKeycloakSecurityContext securityContext =
-        mock(RefreshableKeycloakSecurityContext.class);
-    KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, securityContext);
-
-    KeycloakAuthenticationToken token = new KeycloakAuthenticationToken(account, false);
-
-    RoleAuthorizationAuthorityMapper roleAuthorizationAuthorityMapper =
-        new RoleAuthorizationAuthorityMapper();
-    provider.setGrantedAuthoritiesMapper(roleAuthorizationAuthorityMapper);
-
-    Authentication result = provider.authenticate(token);
+    var roleAuthorizationAuthorityMapper = new RoleAuthorizationAuthorityMapper();
+    var result = roleAuthorizationAuthorityMapper.mapAuthorities(grantedRoleAuthorities);
 
     Set<SimpleGrantedAuthority> expectedGrantendAuthorities = new HashSet<>();
     roles.forEach(
-        roleName -> {
-          expectedGrantendAuthorities.addAll(
-              Authority.getAuthoritiesByUserRole(UserRole.getRoleByValue(roleName).get()).stream()
-                  .map(SimpleGrantedAuthority::new)
-                  .collect(Collectors.toSet()));
-        });
+        roleName ->
+            expectedGrantendAuthorities.addAll(
+                Authority.getAuthoritiesByUserRole(UserRole.getRoleByValue(roleName).get()).stream()
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toSet())));
 
-    assertThat(expectedGrantendAuthorities, containsInAnyOrder(result.getAuthorities().toArray()));
+    assertThat(expectedGrantendAuthorities, containsInAnyOrder(result.toArray()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/tenant/TenantResolverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/tenant/TenantResolverServiceTest.java
@@ -8,12 +8,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 @ExtendWith(MockitoExtension.class)
 class TenantResolverServiceTest {
@@ -29,7 +29,7 @@ class TenantResolverServiceTest {
   @Mock HttpServletRequest nonAuthenticatedRequest;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  KeycloakAuthenticationToken token;
+  JwtAuthenticationToken token;
 
   @InjectMocks TenantResolverService tenantResolverService;
 


### PR DESCRIPTION
## Why

The image CVE gate ("Reject fixable high or critical image vulnerabilities") introduced together with the Matrix-only attestation pipeline in #756 turned the pre-dev **UserService Build and Publish** workflow red: [run 30264852600](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/30264852600) reports **55 fixable HIGH/CRITICAL findings in app.jar** and 5 in the base image's `/usr/bin/pebble`.

Root cause analysis: #756 did **not** introduce the vulnerable jars — it introduced the *gate*. The 09:54 green run predates the gate. The findings themselves are long-standing dependency debt:

| Finding cluster | Actual root cause |
| --- | --- |
| `jackson-core`/`jackson-databind` **2.11.1** (CVE-2020-36518, CVE-2021-46877, CVE-2022-42003/4, CVE-2025-52999, GHSA-r7wm-3cxj-wff9) and `jetty-http/security/server` **9.4.39** (CVE-2026-2332, CVE-2024-13009, CVE-2026-10050) | Not Maven dependencies at all — they are class trees **bundled inside the EOL `net.sf.ehcache:ehcache:2.10.9.2` uber-jar** (`rest-management-private-classpath/`). Unfixable by exclusion; Ehcache 2 is EOL. |
| `maven-core`/`maven-compat` **3.3.9** (CVE-2021-26291, CRITICAL) | `org.liquibase:liquibase-maven-plugin` declared as a **runtime `<dependency>`** — a build plugin shipped inside the fat jar. |
| `keycloak-core` **17.0.0** (CVE-2023-6841, CVE-2024-10039) | Dead `keycloak-spring-security-adapter`/`keycloak-spring-boot-starter` 17.0.0 — no `org.keycloak.adapters.*` import exists since the resource-server migration. |
| `google-oauth-client` 1.31.5 (CVE-2021-22573), `grpc-netty-shaded` 1.39.0 (CVE-2025-55163) | `firebase-admin` 8.1.0 (2021). |
| spring-boot 4.0.1, spring-security 7.0.2, tomcat 11.0.15, jackson 2.20.1/3.0.3, netty 4.2.9 | Stale Spring Boot parent patch level. |
| `json-smart` 2.4.7 (CVE-2023-1370), `commons-beanutils` 1.9.4 (CVE-2025-48734) | Explicit pin / `commons-validator` 1.7. |
| `usr/bin/pebble` (Go stdlib + golang.org/x/net HIGHs) | Canonical's service manager in the Ubuntu base image — unused by the single-process Java entrypoint. |

## What

**Commit 1 — CVE remediation (root causes, no per-CVE pinning):**
- Ehcache 2 removed; `CacheManagerConfig` rebuilt on **Caffeine** (BOM-managed) with identical cache names and size/eternal/TTI/TTL semantics — same migration AgencyService already did.
- Keycloak 17 spring adapters removed (admin client 26.x untouched).
- `liquibase-maven-plugin` removed from `<dependencies>` (build-plugin entry untouched).
- `firebase-admin` 8.1.0 → 9.10.0; RestTemplate beans now explicitly pin the JDK request factory, because firebase 9 drags in `httpclient5` which `RestTemplateBuilder` would silently auto-prefer.
- Spring Boot parent 4.0.1 → **4.0.7** (spring-security 7.0.6, tomcat 11.0.22, jackson 2.21.4 / tools.jackson 3.1.4), `netty.version` override **4.2.16.Final** (Boot 4.0.7 still manages 4.2.15), json-smart 2.6.0, commons-validator 1.10.1 (beanutils 1.11.0).
- `RUN rm -f /usr/bin/pebble` in the (still digest-pinned) runtime image.
- Tests referencing removed adapter classes migrated to `JwtAuthenticationToken` / direct `GrantedAuthoritiesMapper` calls.

**Commit 2 — OpenAPI Contracts repair (in-repo part):**
The pre-dev **OpenAPI Contracts** workflow fails at *Bundle provider-owned contracts* ([run 30264852410](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/30264852410)) because Redocly rejects `api/conversationservice.yaml` ("deficient indentation", 229:7) — quoted-scalar continuation lines at key indent, introduced with the Rocket.Chat removal edits. `api/userservice.yaml` had four more occurrences plus a flow-sequence `]` at key indent. All fixed, no semantic change; all five provider specs now pass `scripts/contracts/publish-provider-contracts.sh` locally.

⚠️ Note: the contracts workflow will **still fail on pre-dev** at *Verify AgencyService admin consumer compatibility* — the same class of YAML defect lives in **ORISO-AgencyService** `api/agencyadminservice.yaml` (29:7) and must be fixed there (pre-existing since 09:05 today, unrelated to this repo's changes).

## Verification

- 3373 unit tests green (JDK 21, CI parity)
- Required integration contract green locally: 78 reports / 840 tests / 0 failures (Redis 7)
- `docker build` + Trivy with the exact gate flags (`--severity HIGH,CRITICAL --ignore-unfixed`): **0 findings** — `app.jar: 0`, `ubuntu 26.04: 0`, `usr/bin/pebble` target gone
- Fat jar inspected: no ehcache/keycloak-17/maven-3.3.9/jetty/jackson-2.11 artifacts remain

Part of Task 2b of the Element-Call Matryoshka recovery plan (2026-07-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)