### PR TITLE
[Stability] Focus identity deactivation

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -30,7 +30,7 @@ suites serially:
 
 | Suite | Tests | Failures | Errors | Skipped | Command |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,868 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
+| Unit | 3,875 | 0 | 0 | 0 | `./mvnw -B -Dskip.integration-tests=true clean test` |
 | Integration + contract + E2E | 969 | 0 | 0 | 5 | `ORISO_LOCAL_REDIS_IT=true ./mvnw -B -Dskip.unit-tests=true clean integration-test` |
 | MariaDB schema + replica contracts | 9 | 0 | 0 | 0 | required fresh MariaDB 10.11 job |
 | Redis replica-safety contracts | 14 | 0 | 0 | 0 | required Redis 7 job |
@@ -262,6 +262,13 @@ closed.
   Keycloak adapter; password-reset token restoration and provisioning rollback
   sequencing remain application-owned. The broad command client no longer
   exposes password mutation.
+- Anonymous-user cleanup, asker administration, consultant pre-deletion and
+  current-user deletion now consume the focused `IdentityDeactivator` port.
+  Each deactivation resolves the target resource once, reads its representation
+  once and performs at most one provider update. Provider representation
+  handling stays inside the Keycloak adapter, the anonymous path remains
+  best-effort, and the three strict deletion flows retain their existing
+  sequencing. The broad command client no longer exposes deactivation.
 - Login, refresh-token logout and password verification now consume the focused,
   provider-neutral `IdentityAuthentication` port. The broad `IdentityClient`
   no longer exposes authentication operations. This is also a boundary
@@ -306,14 +313,14 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`. Provisioning, import and password-reset writes use the focused `IdentityPasswordUpdater`; the broad command client no longer exposes password mutation. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Admin and consultant profile writes use `IdentityProfileUpdater` and provider-neutral `IdentityProfileUpdate`; representation construction and email-conflict checks stay adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; all role assignment and removal uses the batch-capable `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role writes or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus mixed provisioning and lifecycle commands; outbound consumers still use `IdentityClientConfig`. |
+| Identity/profile | User web entry points use `AccountManaging`, `IdentityManaging` and the application-owned `IdentityPolicy`; web adapters no longer read outbound identity configuration for OTP permissions, consultant display names or Magic Link email classification. Consultant DTO mapping also asks `IdentityManaging` for role decisions instead of calling the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-login and password-reset tokens use the shared `OneTimeTokenStore` port with a two-instance Redis contract. Magic-link token exchange returns the provider-neutral `IdentitySession`; only the Keycloak adapter owns grant fields and provider DTO parsing, while the web adapter preserves the existing seven-field snake-case response. Identity creation returns a provider-neutral identifier; the Keycloak adapter owns response parsing and recovers a missing `Location` identifier only from one exact authoritative username match. Login, refresh-token logout and password verification use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin`; the broad command client no longer exposes authentication. Current-account password and preferred-language changes use the focused `IdentityAccountSettingsUpdater`. Provisioning, import and password-reset writes use the focused `IdentityPasswordUpdater`; the broad command client no longer exposes password mutation. Account deactivation uses the focused `IdentityDeactivator`; the adapter owns the bounded one-resource-read and at-most-one-update operation, while best-effort and strict application sequencing remain distinct. Username availability uses the focused `IdentityUsernameAvailability` port; four active consumers no longer depend on the broad command client for this read, and `UserVerifier` no longer retains an unused identity dependency. Profile lookup uses the focused `IdentityProfileLookup` port and returns `Optional<IdentityProfile>`; Keycloak not-found behavior is mapped to absence, and fuzzy username search stays adapter-internal. Admin and consultant profile writes use `IdentityProfileUpdater` and provider-neutral `IdentityProfileUpdate`; representation construction and email-conflict checks stay adapter-internal. Realm-role reads and application role-membership checks use the focused `IdentityRoleLookup` port; all role assignment and removal uses the batch-capable `IdentityRoleUpdater`. The broad command client no longer exposes full role lists, role-membership reads, role writes, deactivation or the unused authority evaluator. Email-owner reads use the focused `IdentityEmailOwnerLookup` port and return `Optional<IdentityEmailOwner>`; provider map keys stay inside the deleted adapter mapping instead of leaking into application logic. OTP and email-verification operations use the focused `IdentitySecondFactor` port and typed application values; generated Keycloak DTOs and string-key maps stay adapter-internal. The unused identity session-close command has been deleted across the broad port and both Keycloak wrappers. | The broad `IdentityClient` still exposes web-layer user command DTOs plus provisioning, dummy-account and lifecycle delete/rollback commands; outbound consumers still use `IdentityClientConfig`. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import Matrix/Rocket.Chat adapters. Admin and consultant creation now consume only the provider-neutral identity identifier. Legacy Rocket.Chat group-operation construction no longer carries a dead broad identity-client dependency. | The large admin controller still composes many services. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix/Rocket.Chat DTOs, credentials, configuration and legacy removal/rollback policy. Both protected application packages have executable import boundaries. | The session-list slice still exposes Rocket.Chat credentials and last-message transport DTOs. |
 
 The identity/profile seam also includes the focused
 `IdentityEmailAddressUpdater` for current-account and post-verification writes.
-The remaining broad client debt is provisioning and account lifecycle
-commands.
+The remaining broad client debt is provisioning, dummy-account and lifecycle
+delete/rollback commands.
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
 from reverting to concrete application/chat services and prevents the
@@ -361,7 +368,11 @@ mutations on the broad client and protects the shared Spring mocks. The
 password-write contract requires all five active application consumers to use
 `IdentityPasswordUpdater`, rejects password mutation on the broad client and
 protects the shared Spring mocks. Adapter interaction tests enforce one target
-lookup and at most one password reset. The
+lookup and at most one password reset. The deactivation contract requires all
+four active consumers to use `IdentityDeactivator`, rejects deactivation on the
+broad client and protects the shared Spring mocks. Adapter interaction tests
+enforce one target-resource lookup, one representation read and at most one
+provider update. The
 authentication contract keeps login, logout and password verification off the
 broad command client and requires every production consumer to depend on the
 focused provider-neutral port. The

--- a/src/main/java/de/caritas/cob/userservice/api/actions/user/DeactivateKeycloakUserActionCommand.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/user/DeactivateKeycloakUserActionCommand.java
@@ -4,7 +4,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 
 import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeactivateKeycloakUserActionCommand implements ActionCommand<User> {
 
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDeactivator identityDeactivator;
 
   /**
    * Deactivates a user in Keycloak.
@@ -26,7 +26,7 @@ public class DeactivateKeycloakUserActionCommand implements ActionCommand<User> 
   @Override
   public void execute(User user) {
     try {
-      this.identityClient.deactivateUser(user.getUserId());
+      this.identityDeactivator.deactivateUser(user.getUserId());
     } catch (Exception e) {
       log.error("Unable to deactivate User with id {}", user.getUserId());
       log.error(getStackTrace(e));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
@@ -86,6 +87,7 @@ public class KeycloakService
     implements IdentityAccountSettingsUpdater,
         IdentityAuthentication,
         IdentityClient,
+        IdentityDeactivator,
         IdentityEmailAddressUpdater,
         IdentityEmailOwnerLookup,
         IdentityPasswordUpdater,
@@ -1004,6 +1006,7 @@ public class KeycloakService
    *
    * @param userId the user id to be deactivated
    */
+  @Override
   public void deactivateUser(String userId) {
     var userResource = keycloakClient.getUsersResource().get(userId);
     var userRepresentation = userResource.toRepresentation();

--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/AskerUserAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/AskerUserAdminFacade.java
@@ -7,7 +7,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeletionLifecycleService;
 import lombok.NonNull;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AskerUserAdminFacade {
 
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDeactivator identityDeactivator;
   private final @NonNull UserService userService;
   private final @NonNull UsernameTranscoder usernameTranscoder;
   private final @NonNull DeletionLifecycleService deletionLifecycleService;
@@ -40,7 +40,7 @@ public class AskerUserAdminFacade {
           String.format("Asker with id %s is already marked for deletion", userId));
     }
 
-    this.identityClient.deactivateUser(userId);
+    this.identityDeactivator.deactivateUser(userId);
     this.deletionLifecycleService.beginUserDeletion(user, null);
     this.userService.saveUser(user);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/delete/ConsultantPreDeletionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/delete/ConsultantPreDeletionService.java
@@ -10,7 +10,7 @@ import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.admin.service.agency.ConsultantAgencyDeletionValidationService;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class ConsultantPreDeletionService {
 
   private final @NonNull ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
   private final @NonNull SessionRepository sessionRepository;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDeactivator identityDeactivator;
 
   /**
    * Validates if {@link Consultant} can be deleted and marks the account as inactive in keycloak.
@@ -44,7 +44,7 @@ public class ConsultantPreDeletionService {
           .getConsultantAgencies()
           .forEach(agencyDeletionValidationService::validateAndMarkForDeletion);
     }
-    this.identityClient.deactivateUser(consultant.getId());
+    this.identityDeactivator.deactivateUser(consultant.getId());
   }
 
   private boolean hasConsultantActiveSessions(Consultant consultant) {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -15,6 +15,4 @@ public interface IdentityClient {
   void rollBackUser(String userId);
 
   void deleteUser(String userId);
-
-  void deactivateUser(String userId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDeactivator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDeactivator.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Deactivates an identity without exposing provider-specific representation types. */
+public interface IdentityDeactivator {
+
+  void deactivateUser(String userId);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/UserAccountService.java
@@ -8,8 +8,8 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.json.JsonSerializationUtils;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.MessageClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -38,7 +38,7 @@ public class UserAccountService {
   private final @NonNull ConsultantService consultantService;
   private final @NonNull AppointmentService appointmentService;
   private final @NonNull AuthenticatedUser authenticatedUser;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDeactivator identityDeactivator;
   private final @NonNull IdentityEmailAddressUpdater identityEmailAddressUpdater;
   private final @NonNull MessageClient messageClient;
   private final @NonNull UserHelper userHelper;
@@ -239,7 +239,7 @@ public class UserAccountService {
    */
   public void deactivateAndFlagUserAccountForDeletion() {
     User user = retrieveValidatedUser();
-    this.identityClient.deactivateUser(user.getUserId());
+    this.identityDeactivator.deactivateUser(user.getUserId());
     deletionLifecycleService.beginUserDeletion(user, user.getUserId());
     userService.saveUser(user);
     fireAccountDeletionStatisticsEvent(user);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1249,6 +1249,9 @@ public class KeycloakServiceTest {
 
     this.keycloakService.deactivateUser("userId");
 
+    verify(keycloakClient, times(1)).getUsersResource();
+    verify(usersResource, times(1)).get("userId");
+    verify(userResource, times(1)).toRepresentation();
     verify(userRepresentation, times(1)).setEnabled(false);
     verify(userResource, times(1)).update(userRepresentation);
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -39,6 +39,7 @@ import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -139,6 +140,7 @@ class UserAdminControllerE2EIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -75,6 +76,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -82,6 +82,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -185,6 +186,7 @@ class UserControllerAuthorizationIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -56,6 +56,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -305,6 +306,7 @@ class UserControllerIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -64,6 +65,7 @@ class CreateAdminServiceIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -44,6 +45,7 @@ public class UpdateAdminServiceIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -29,6 +29,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -91,6 +92,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -43,6 +44,7 @@ public class ConsultantUpdateServiceBase {
       extraInterfaces = {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
+        IdentityDeactivator.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/UserAccountServiceTest.java
@@ -24,8 +24,8 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
@@ -53,7 +53,7 @@ public class UserAccountServiceTest {
   @Mock private UserService userService;
   @Mock private ConsultantService consultantService;
   @Mock private AuthenticatedUser authenticatedUser;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityDeactivator identityDeactivator;
   @Mock private IdentityEmailAddressUpdater identityEmailAddressUpdater;
   @Mock private RocketChatService rocketChatService;
   @Mock private UserHelper userHelper;
@@ -409,7 +409,7 @@ public class UserAccountServiceTest {
 
     this.accountProvider.deactivateAndFlagUserAccountForDeletion();
 
-    verify(identityClient, times(1)).deactivateUser(USER.getUserId());
+    verify(identityDeactivator, times(1)).deactivateUser(USER.getUserId());
     verify(deletionLifecycleService, times(1)).beginUserDeletion(USER, USER.getUserId());
     verify(userService, times(1)).saveUser(USER);
     verify(statisticsService).fireEvent(any(DeleteAccountStatisticsEvent.class));

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -821,6 +821,85 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(missing_test_interface),
         )
 
+    def test_identity_deactivation_consumers_use_a_focused_port(self):
+        port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityDeactivator.java"
+        )
+        self.assertTrue(
+            port.exists(),
+            "Identity deactivation needs a focused provider-neutral output port",
+        )
+        if not port.exists():
+            return
+
+        port_text = port.read_text()
+        self.assertNotIn(".adapters.web.", port_text)
+        self.assertNotIn("org.keycloak.", port_text)
+
+        consumers = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/actions/user/"
+            "DeactivateKeycloakUserActionCommand.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/facade/"
+            "AskerUserAdminFacade.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/"
+            "delete/ConsultantPreDeletionService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/user/"
+            "UserAccountService.java",
+        )
+        focused_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;"
+        )
+        for source in consumers:
+            source_text = source.read_text()
+            self.assertIn(
+                focused_import,
+                source_text,
+                f"{source.relative_to(ROOT)} must use the focused deactivation port",
+            )
+            self.assertIn(
+                "identityDeactivator.deactivateUser(",
+                source_text,
+                f"{source.relative_to(ROOT)} must call the focused deactivation port",
+            )
+            self.assertNotIn(
+                "identityClient.deactivateUser(",
+                source_text,
+                f"{source.relative_to(ROOT)} must not use broad-client deactivation",
+            )
+
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        self.assertNotIn(
+            "deactivateUser(",
+            identity_client,
+            "The broad identity command client must not own deactivation",
+        )
+        spring_identity_mocks = [
+            source
+            for source in (ROOT / "src/test/java").rglob("*.java")
+            if "extraInterfaces = {" in source.read_text()
+            and "IdentityClient identityClient" in source.read_text()
+        ]
+        missing_test_interface = [
+            str(source.relative_to(ROOT))
+            for source in spring_identity_mocks
+            if "IdentityDeactivator.class" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            missing_test_interface,
+            "Shared Spring identity mocks must implement the focused deactivation port:\n"
+            + "\n".join(missing_test_interface),
+        )
+
     def test_legacy_chat_and_supervision_paths_have_no_dead_identity_wiring(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- introduce the provider-neutral `IdentityDeactivator` output port
- route anonymous cleanup, asker administration, consultant pre-deletion and current-user deletion through the focused port
- remove deactivation from the broad `IdentityClient` while keeping the Keycloak read-modify-write operation adapter-owned
- enforce one resource lookup, one representation read and at most one provider update
- preserve best-effort anonymous cleanup and strict admin/user deletion sequencing

## Stack

This draft is stacked on #815 (`refactor/focused-identity-password-update-814`). Review the single commit in this PR after #815.

## Target architecture

This remains aligned with the Matrix-only target: the ORISO frontend plus an ORISO-controlled MatrixRTC/Element Call fork and LiveKit. Rocket.Chat and Jitsi are removal targets, not fallback dependencies.

## Verification

- focused Java tests: 140 passed, 0 failed, 0 skipped
- full Java 21 unit suite: 3,875 passed, 0 failed, 0 skipped
- integration, contract and E2E suite: 969 passed, 0 failed, 5 expected MariaDB environment skips
- architecture/CI contracts: 47 passed
- Spotless and `git diff --check`: passed
- local Redis contract container: running and healthy
- local MariaDB was not reset because no database failure was observed

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)