### PR TITLE
refactor: focus identity dummy-email updates

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -30,6 +30,8 @@ import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
@@ -90,6 +92,7 @@ public class KeycloakService
         IdentityAuthentication,
         IdentityClient,
         IdentityDeactivator,
+        IdentityDummyEmailUpdater,
         IdentityEmailAddressUpdater,
         IdentityEmailOwnerLookup,
         IdentityPasswordUpdater,
@@ -235,7 +238,8 @@ public class KeycloakService
 
   @Override
   public void deleteCurrentUserEmail() {
-    updateDummyEmail(authenticatedUser.getUserId());
+    var userId = authenticatedUser.getUserId();
+    updateEmail(userId, userHelper.getDummyEmail(userId));
   }
 
   @Override
@@ -810,29 +814,17 @@ public class KeycloakService
             || lowerMessage.contains("does not match"));
   }
 
-  /**
-   * If user didn't provide an email, set to dummy address (userId@online-beratung.de). No *
-   * success/error status possible, because the Keycloak Client doesn't provide one either. *
-   *
-   * @param userId Keycloak user ID
-   * @param user {@link UserDTO}
-   * @return the (dummy) email address
-   */
-  public String updateDummyEmail(final String userId, UserDTO user) {
-    user.setEmail(userHelper.getDummyEmail(userId));
+  /** Replaces a blank email with the configured dummy address while retaining identity metadata. */
+  @Override
+  public String updateDummyEmail(
+      final String userId, final IdentityDummyEmailUpdate identityUpdate) {
+    var dummyEmail = userHelper.getDummyEmail(userId);
     var userResource = keycloakClient.getUsersResource().get(userId);
-    userResource.update(getUserRepresentation(user, null, null));
-    log.debug("Set email dummy for {} to {}", userId, userHelper.getDummyEmail(userId));
-    return userHelper.getDummyEmail(userId);
-  }
-
-  /**
-   * Sets a user's dummy email
-   *
-   * @param userId user ID
-   */
-  public void updateDummyEmail(String userId) {
-    updateEmail(userId, userHelper.getDummyEmail(userId));
+    userResource.update(
+        getUserRepresentation(
+            identityUpdate.username(), dummyEmail, identityUpdate.tenantId(), null, null, null));
+    log.debug("Set email dummy for {} to {}", userId, dummyEmail);
+    return dummyEmail;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -23,6 +23,8 @@ import de.caritas.cob.userservice.api.model.NewSessionValidationConstraint;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -54,6 +56,7 @@ import org.springframework.web.client.RestClientException;
 public class CreateUserFacade {
   private final @NonNull UserVerifier userVerifier;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDummyEmailUpdater identityDummyEmailUpdater;
   private final @NonNull IdentityPasswordUpdater identityPasswordUpdater;
   private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull UserService userService;
@@ -363,7 +366,8 @@ public class CreateUserFacade {
 
   private String returnDummyEmailIfNoneGiven(UserDTO userDTO, String userId) {
     if (isBlank(userDTO.getEmail())) {
-      return identityClient.updateDummyEmail(userId, userDTO);
+      return identityDummyEmailUpdater.updateDummyEmail(
+          userId, new IdentityDummyEmailUpdate(userDTO.getUsername(), userDTO.getTenantId()));
     }
 
     return userDTO.getEmail();

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -7,8 +7,4 @@ public interface IdentityClient {
   String createKeycloakUser(final UserDTO user);
 
   String createKeycloakUser(final UserDTO user, final String firstName, final String lastName);
-
-  String updateDummyEmail(final String userId, UserDTO user);
-
-  void updateDummyEmail(String userId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDummyEmailUpdate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDummyEmailUpdate.java
@@ -1,0 +1,4 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral identity values retained while replacing a blank email with a dummy address. */
+public record IdentityDummyEmailUpdate(String username, Long tenantId) {}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDummyEmailUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityDummyEmailUpdater.java
@@ -1,0 +1,6 @@
+package de.caritas.cob.userservice.api.port.out;
+
+public interface IdentityDummyEmailUpdater {
+
+  String updateDummyEmail(String userId, IdentityDummyEmailUpdate update);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java
@@ -31,6 +31,8 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
@@ -86,6 +88,7 @@ public class AskerImportService {
   private final String IMPORT_LOG_CHARSET = "UTF-8";
   private final String DUMMY_POSTCODE = "00000";
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityDummyEmailUpdater identityDummyEmailUpdater;
   private final @NonNull IdentityPasswordUpdater identityPasswordUpdater;
   private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityUsernameAvailability identityUsernameAvailability;
@@ -166,8 +169,10 @@ public class AskerImportService {
         String keycloakUserId = identityClient.createKeycloakUser(userDTO, "", "");
 
         if (record.getEmail() == null || record.getEmail().equals(StringUtils.EMPTY)) {
-          userDTO.setEmail(userHelper.getDummyEmail(keycloakUserId));
-          identityClient.updateDummyEmail(keycloakUserId, userDTO);
+          userDTO.setEmail(
+              identityDummyEmailUpdater.updateDummyEmail(
+                  keycloakUserId,
+                  new IdentityDummyEmailUpdate(userDTO.getUsername(), userDTO.getTenantId())));
         }
 
         // Set Keycloak password
@@ -356,8 +361,10 @@ public class AskerImportService {
         String keycloakUserId = identityClient.createKeycloakUser(userDTO, "", "");
 
         if (record.getEmail() == null || record.getEmail().equals(StringUtils.EMPTY)) {
-          userDTO.setEmail(userHelper.getDummyEmail(keycloakUserId));
-          identityClient.updateDummyEmail(keycloakUserId, userDTO);
+          userDTO.setEmail(
+              identityDummyEmailUpdater.updateDummyEmail(
+                  keycloakUserId,
+                  new IdentityDummyEmailUpdate(userDTO.getUsername(), userDTO.getTenantId())));
         }
 
         // Set Keycloak password

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -42,6 +42,7 @@ import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.identity.IdentityOtpType;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.IdentityProfile;
@@ -292,10 +293,8 @@ public class KeycloakServiceTest {
 
   @Test
   public void deleteEmailAddress_Should_useServicesCorrectly() {
-    // deleteEmailAddress -> updateDummyEmail(userId) -> updateEmail(...), which now persists the
-    // dummy email to Keycloak (verifyEmail + setEmail + userResource.update). Verify the dummy
-    // email
-    // is resolved and actually written via UserResource#update.
+    // Current-user deletion stays on the focused email-address boundary and persists the resolved
+    // dummy email through the normal verified email update path.
     var userId = random(16);
     when(authenticatedUser.getUserId()).thenReturn(userId);
     when(userHelper.getDummyEmail(userId)).thenReturn("dummy");
@@ -1113,31 +1112,37 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void updateDummyMail_id_dto_Should_callServicesCorrectly() {
+  public void updateDummyEmail_Should_updateOnceWithProviderNeutralIdentityValues() {
+    setField(keycloakService, "multiTenancyEnabled", true);
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
     when(this.userHelper.getDummyEmail(anyString())).thenReturn("dummy");
+    var representationCaptor = ArgumentCaptor.forClass(UserRepresentation.class);
 
-    String dummyMail = this.keycloakService.updateDummyEmail("userId", new UserDTO());
+    String dummyMail =
+        this.keycloakService.updateDummyEmail(
+            "userId", new IdentityDummyEmailUpdate("username", 2L));
 
-    verify(userResource, times(1)).update(any());
+    verify(usersResource, times(1)).get("userId");
+    verify(userResource, times(1)).update(representationCaptor.capture());
+    var representation = representationCaptor.getValue();
+    assertThat(representation.getUsername(), is("username"));
+    assertThat(representation.getEmail(), is("dummy"));
+    assertThat(representation.getAttributes().get("tenantId"), is(singletonList("2")));
     assertThat(dummyMail, is("dummy"));
   }
 
   @Test
-  public void updateDummyMail_id_Should_callServicesCorrectly() {
-    // updateDummyEmail(String) -> updateEmail(...), which now persists the dummy email to Keycloak
-    // (verifyEmail + setEmail + userResource.update). Verify the dummy email is computed and
-    // written
-    // via UserResource#update.
+  public void deleteCurrentUserEmail_Should_callServicesCorrectly() {
     when(userHelper.getDummyEmail("userId")).thenReturn("dummy");
+    when(authenticatedUser.getUserId()).thenReturn("userId");
     UserRepresentation userRepresentation = givenUserRepresentation("oldEmail");
     UserResource userResource = givenUserResourceWithRepresentation(userRepresentation);
     UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    keycloakService.updateDummyEmail("userId");
+    keycloakService.deleteCurrentUserEmail();
 
     verify(userHelper).getDummyEmail("userId");
     verify(userRepresentation).setEmail("dummy");

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -41,6 +41,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -143,6 +144,7 @@ class UserAdminControllerE2EIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -79,6 +80,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -84,6 +84,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -189,6 +190,7 @@ class UserControllerAuthorizationIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -58,6 +58,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -309,6 +310,7 @@ class UserControllerIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -68,6 +69,7 @@ class CreateAdminServiceIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -48,6 +49,7 @@ public class UpdateAdminServiceIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -31,6 +31,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -95,6 +96,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
@@ -47,6 +48,7 @@ public class ConsultantUpdateServiceBase {
         IdentityAccountSettingsUpdater.class,
         IdentityAuthentication.class,
         IdentityDeactivator.class,
+        IdentityDummyEmailUpdater.class,
         IdentityEmailAddressUpdater.class,
         IdentityEmailOwnerLookup.class,
         IdentityPasswordUpdater.class,

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.helper.UserVerifier;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -56,6 +57,7 @@ class CreateUserFacadeMatrixUserTest {
 
   @Mock private UserVerifier userVerifier;
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityDummyEmailUpdater identityDummyEmailUpdater;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private UserService userService;

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -46,6 +46,7 @@ import de.caritas.cob.userservice.api.helper.UserVerifier;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
@@ -521,7 +522,7 @@ public class CreateUserFacadeTest {
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
     doNothing().when(keycloakService).updatePassword(anyString(), anyString());
-    when(keycloakService.updateDummyEmail(anyString(), any(UserDTO.class)))
+    when(keycloakService.updateDummyEmail(anyString(), any(IdentityDummyEmailUpdate.class)))
         .thenReturn("dummy@example.com");
     UserDTO userDtoWithBlankEmail =
         UserDTO.builder()
@@ -533,7 +534,12 @@ public class CreateUserFacadeTest {
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, userDtoWithBlankEmail, UserRole.USER);
 
-    verify(keycloakService, times(1)).updateDummyEmail(eq(USER_ID), any(UserDTO.class));
+    verify(keycloakService, times(1))
+        .updateDummyEmail(
+            eq(USER_ID),
+            eq(
+                new IdentityDummyEmailUpdate(
+                    userDtoWithBlankEmail.getUsername(), userDtoWithBlankEmail.getTenantId())));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/AskerImportServiceTest.java
@@ -24,12 +24,15 @@ import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatLoginExcept
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatPostWelcomeMessageException;
 import de.caritas.cob.userservice.api.exception.rocketchat.RocketChatRemoveSystemMessagesException;
 import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
@@ -66,6 +69,7 @@ class AskerImportServiceTest {
   @InjectMocks private AskerImportService askerImportService;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityDummyEmailUpdater identityDummyEmailUpdater;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityUsernameAvailability identityUsernameAvailability;
@@ -231,7 +235,8 @@ class AskerImportServiceTest {
     String keycloakResponse = "kc-user-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString()))
         .thenReturn(keycloakResponse);
-    when(userHelper.getDummyEmail("kc-user-id")).thenReturn("dummy@example.com");
+    when(identityDummyEmailUpdater.updateDummyEmail(eq("kc-user-id"), any()))
+        .thenReturn("dummy@example.com");
     when(consultingTypeManager.getConsultingTypeSettings(1))
         .thenReturn(extendedConsultingType(true));
     User dbUser = new User();
@@ -244,8 +249,12 @@ class AskerImportServiceTest {
 
     askerImportService.startImportForAskersWithoutSession();
 
-    verify(userHelper).getDummyEmail("kc-user-id");
-    verify(identityClient).updateDummyEmail(eq("kc-user-id"), any(UserDTO.class));
+    verify(identityDummyEmailUpdater)
+        .updateDummyEmail(
+            eq("kc-user-id"),
+            eq(
+                new IdentityDummyEmailUpdate(
+                    new UsernameTranscoder().encodeUsername("newasker"), null)));
   }
 
   // ---------------------------------------------------------------------------
@@ -839,7 +848,8 @@ class AskerImportServiceTest {
     when(identityUsernameAvailability.isUsernameAvailable("validuser")).thenReturn(true);
     String kc = "kc-id";
     when(identityClient.createKeycloakUser(any(), anyString(), anyString())).thenReturn(kc);
-    when(userHelper.getDummyEmail("kc-id")).thenReturn("dummy@example.com");
+    when(identityDummyEmailUpdater.updateDummyEmail(eq("kc-id"), any()))
+        .thenReturn("dummy@example.com");
     when(consultingTypeManager.getConsultingTypeSettings(1))
         .thenReturn(extendedConsultingType(false));
     User dbUser = new User();
@@ -852,8 +862,12 @@ class AskerImportServiceTest {
 
     askerImportService.startImport();
 
-    verify(userHelper).getDummyEmail("kc-id");
-    verify(identityClient).updateDummyEmail(eq("kc-id"), any(UserDTO.class));
+    verify(identityDummyEmailUpdater)
+        .updateDummyEmail(
+            eq("kc-id"),
+            eq(
+                new IdentityDummyEmailUpdate(
+                    new UsernameTranscoder().encodeUsername("validuser"), null)));
   }
 
   // --- startImport — blank password → getRandomPassword called ---

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import java.util.Collection;
 import java.util.List;
@@ -106,9 +107,8 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public String updateDummyEmail(String userId, UserDTO user) {
+      public String updateDummyEmail(String userId, IdentityDummyEmailUpdate update) {
         var dummyMail = userId + "@dummy.du";
-        user.setEmail(dummyMail);
         return dummyMail;
       }
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -1036,6 +1036,65 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(dead_wiring),
         )
 
+    def test_dummy_email_consumers_use_a_focused_provider_neutral_port(self):
+        port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityDummyEmailUpdater.java"
+        )
+        value = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityDummyEmailUpdate.java"
+        )
+        self.assertTrue(port.exists(), "Dummy-email updates need a focused output port")
+        self.assertTrue(value.exists(), "Dummy-email updates need provider-neutral values")
+        if not port.exists() or not value.exists():
+            return
+
+        for boundary in (port, value):
+            boundary_text = boundary.read_text()
+            self.assertNotIn(".adapters.web.", boundary_text)
+            self.assertNotIn("org.keycloak.", boundary_text)
+
+        consumers = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/AskerImportService.java",
+        )
+        for source in consumers:
+            source_text = source.read_text()
+            self.assertIn("IdentityDummyEmailUpdater", source_text)
+            self.assertNotIn("identityClient.updateDummyEmail(", source_text)
+
+        identity_client = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        self.assertNotIn(
+            "updateDummyEmail(",
+            identity_client,
+            "The broad identity command client must not own dummy-email updates",
+        )
+        spring_identity_mocks = [
+            source
+            for source in (ROOT / "src/test/java").rglob("*.java")
+            if "extraInterfaces = {" in source.read_text()
+            and "IdentityClient identityClient" in source.read_text()
+        ]
+        missing_test_interface = [
+            str(source.relative_to(ROOT))
+            for source in spring_identity_mocks
+            if "IdentityDummyEmailUpdater.class" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            missing_test_interface,
+            "Shared Spring identity mocks must implement the focused dummy-email port:\n"
+            + "\n".join(missing_test_interface),
+        )
+
     def test_email_mutation_consumers_use_a_focused_identity_email_port(self):
         port = (
             ROOT


### PR DESCRIPTION
## Summary

- introduce a focused `IdentityDummyEmailUpdater` port with provider-neutral `IdentityDummyEmailUpdate` values
- route registration and both asker-import paths through the focused boundary
- remove both dummy-email commands from the broad `IdentityClient`; only account creation remains there
- keep current-user email deletion on the existing focused email-address boundary
- preserve the Keycloak call bound of one target lookup and one update
- update shared Spring identity mocks and executable architecture contracts

## Verification

- 3,875 JDK 21 unit tests: 0 failures, 0 errors, 0 skips
- 969 integration/contract/E2E tests: 0 failures, 0 errors, 5 conditional environment skips
- 49 Python CI contracts
- 14 Redis replica-state contract tests against the healthy local Redis container
- Spotless, diff checks, and package build
- no database reset was needed

## Stack

- closes #820
- parent #335
- stacked directly on draft PR #819
- nothing in this PR is merged or proven deployed to PreDev yet

## Architecture target

This focused identity-boundary slice is part of the broader migration toward Matrix-only chat, the ORISO-owned frontend, the ORISO-controlled Element Call/MatrixRTC fork, and LiveKit. Rocket.Chat and Jitsi are removal targets, never fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)