### PR TITLE
perf(admin): replay tenant-safe consultant agency read collapse (#764)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -191,8 +191,7 @@ public class ConsultantAdminFacade {
   public void setConsultantAgencies(
       String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
     var persistedAgencyIds =
-        consultantAgencyAdminService.findConsultantAgencies(consultantId).getEmbedded().stream()
-            .map(agencyAdminResponse -> agencyAdminResponse.getEmbedded().getId())
+        consultantAgencyAdminService.findConsultantAgencyIds(consultantId).stream()
             .collect(Collectors.toSet());
     var desiredAgencyIds =
         agencyList.stream().map(CreateConsultantAgencyDTO::getAgencyId).collect(Collectors.toSet());

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -171,7 +171,7 @@ public class ConsultantAgencyRelationCreatorService {
   }
 
   private AgencyDTO retrieveAgency(Long agencyId) {
-    var agencyDto = this.agencyService.getAgencyWithoutCaching(agencyId);
+    var agencyDto = this.agencyService.getAgency(agencyId);
     return Optional.ofNullable(agencyDto)
         .orElseThrow(
             () ->

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
@@ -125,7 +125,7 @@ public class ConsultantTopicAgencyCompatibilityValidator {
   }
 
   private List<AgencyDTO> agenciesFor(List<Long> selectedAgencyIds) {
-    var agencies = agencyService.getAgenciesWithoutCaching(selectedAgencyIds);
+    var agencies = agencyService.getAgencies(selectedAgencyIds);
     if (agencies == null) {
       return Collections.emptyList();
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyService.java
@@ -11,12 +11,15 @@ import de.caritas.cob.userservice.api.config.CacheManagerConfig;
 import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -31,6 +34,7 @@ public class AgencyService {
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
   private final @NonNull AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
+  private final @NonNull CacheManager cacheManager;
 
   /**
    * Returns the {@link AgencyDTO} for the provided agencyId. Agency will be cached for further
@@ -39,7 +43,12 @@ public class AgencyService {
    * @param agencyId {@link AgencyDTO#getId()}
    * @return AgencyDTO {@link AgencyDTO}
    */
-  @Cacheable(value = CacheManagerConfig.AGENCY_CACHE, key = "#agencyId", unless = "#result == null")
+  @Cacheable(
+      value = CacheManagerConfig.AGENCY_CACHE,
+      key =
+          "T(de.caritas.cob.userservice.api.service.agency.AgencyService)"
+              + ".tenantScopedAgencyKey(#agencyId)",
+      unless = "#result == null")
   public AgencyDTO getAgency(Long agencyId) {
     return getAgenciesFromAgencyService(Collections.singletonList(agencyId)).stream()
         .findFirst()
@@ -66,9 +75,40 @@ public class AgencyService {
    * @param agencyIds List of {@link AgencyDTO#getId()}
    * @return List<AgencyDTO> List of {@link AgencyDTO}
    */
-  @Cacheable(value = CacheManagerConfig.AGENCY_CACHE, key = "#agencyIds")
+  @Cacheable(
+      value = CacheManagerConfig.AGENCY_CACHE,
+      key =
+          "T(de.caritas.cob.userservice.api.service.agency.AgencyService)"
+              + ".tenantScopedAgencyListKey(#agencyIds)")
   public List<AgencyDTO> getAgencies(List<Long> agencyIds) {
-    return getAgenciesFromAgencyService(agencyIds);
+    if (!isNotEmpty(agencyIds)) {
+      return emptyList();
+    }
+    var agencies = getAgenciesFromAgencyService(agencyIds);
+    cacheAgenciesById(agencies);
+    return agencies;
+  }
+
+  private void cacheAgenciesById(List<AgencyDTO> agencies) {
+    if (agencies == null) {
+      return;
+    }
+    var agencyCache =
+        Objects.requireNonNull(
+            cacheManager.getCache(CacheManagerConfig.AGENCY_CACHE),
+            "Agency cache must be configured");
+    agencies.stream()
+        .filter(Objects::nonNull)
+        .filter(agency -> agency.getId() != null)
+        .forEach(agency -> agencyCache.put(tenantScopedAgencyKey(agency.getId()), agency));
+  }
+
+  public static String tenantScopedAgencyKey(Long agencyId) {
+    return "tenant:" + TenantContext.getCurrentTenant() + ":id:" + agencyId;
+  }
+
+  public static String tenantScopedAgencyListKey(List<Long> agencyIds) {
+    return "tenant:" + TenantContext.getCurrentTenant() + ":ids:" + agencyIds;
   }
 
   public List<AgencyDTO> getAgenciesNotCached(List<Long> agencyIds) {

--- a/src/test/java/cachetest/AgencyServiceCachingTest.java
+++ b/src/test/java/cachetest/AgencyServiceCachingTest.java
@@ -1,0 +1,154 @@
+package cachetest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.agencyserivce.generated.ApiClient;
+import de.caritas.cob.userservice.agencyserivce.generated.web.AgencyControllerApi;
+import de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO;
+import de.caritas.cob.userservice.api.config.CacheManagerConfig;
+import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.client.RestTemplate;
+
+@SpringJUnitConfig(classes = AgencyServiceCachingTest.CacheTestConfig.class)
+@TestPropertySource(
+    properties = {
+      "multitenancy.enabled=true",
+      "agency.service.api.url=http://localhost",
+      "csrf.header.property=X-CSRF",
+      "csrf.cookie.property=CSRF"
+    })
+class AgencyServiceCachingTest {
+
+  @Autowired private AgencyService agencyService;
+  @Autowired private AgencyControllerApi agencyControllerApi;
+  @Autowired private ApiClient apiClient;
+  @Autowired private SecurityHeaderSupplier securityHeaderSupplier;
+  @Autowired private CacheManager cacheManager;
+
+  @BeforeEach
+  void setUp() {
+    cacheManager.getCache(CacheManagerConfig.AGENCY_CACHE).clear();
+    reset(agencyControllerApi, apiClient, securityHeaderSupplier);
+    when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    when(securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders())
+        .thenReturn(new HttpHeaders());
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void batchLookup_WarmsTenantScopedSingleAgencyCacheWithoutNegativeCaching() {
+    TenantContext.setCurrentTenant(7L);
+    var agencyResponse = new AgencyResponseDTO().id(42L).name("Agency 42");
+    when(agencyControllerApi.getAgenciesByIds(List.of(42L, 43L)))
+        .thenReturn(List.of(agencyResponse));
+
+    var batchResult = agencyService.getAgencies(List.of(42L, 43L));
+    var cachedSingleResult = agencyService.getAgency(42L);
+
+    assertThat(batchResult).singleElement().isSameAs(cachedSingleResult);
+    assertThat(cacheManager.getCache(CacheManagerConfig.AGENCY_CACHE).get("tenant:7:id:43"))
+        .isNull();
+    verify(agencyControllerApi, times(1)).getAgenciesByIds(List.of(42L, 43L));
+  }
+
+  @Test
+  void singleAgencyCache_DoesNotLeakAcrossTenantScopes() {
+    TenantContext.setCurrentTenant(7L);
+    when(agencyControllerApi.getAgenciesByIds(List.of(42L)))
+        .thenReturn(List.of(new AgencyResponseDTO().id(42L).name("Tenant 7")));
+    assertThat(agencyService.getAgency(42L).getName()).isEqualTo("Tenant 7");
+
+    TenantContext.setCurrentTenant(8L);
+    when(agencyControllerApi.getAgenciesByIds(List.of(42L)))
+        .thenReturn(List.of(new AgencyResponseDTO().id(42L).name("Tenant 8")));
+    assertThat(agencyService.getAgency(42L).getName()).isEqualTo("Tenant 8");
+
+    verify(agencyControllerApi, times(2)).getAgenciesByIds(List.of(42L));
+  }
+
+  @TestConfiguration
+  @EnableCaching
+  static class CacheTestConfig {
+
+    @Bean
+    AgencyControllerApi agencyControllerApi() {
+      return mock(AgencyControllerApi.class);
+    }
+
+    @Bean
+    ApiClient apiClient() {
+      return mock(ApiClient.class);
+    }
+
+    @Bean
+    RestTemplate restTemplate() {
+      return new RestTemplate();
+    }
+
+    @Bean
+    SecurityHeaderSupplier securityHeaderSupplier() {
+      return mock(SecurityHeaderSupplier.class);
+    }
+
+    @Bean
+    TenantHeaderSupplier tenantHeaderSupplier() {
+      return mock(TenantHeaderSupplier.class);
+    }
+
+    @Bean
+    AgencyServiceApiControllerFactory agencyServiceApiControllerFactory(
+        AgencyControllerApi agencyControllerApi) {
+      var factory = mock(AgencyServiceApiControllerFactory.class);
+      when(factory.createControllerApi()).thenReturn(agencyControllerApi);
+      return factory;
+    }
+
+    @Bean
+    CacheManager cacheManager() {
+      var cacheManager = new SimpleCacheManager();
+      cacheManager.setCaches(List.of(new ConcurrentMapCache(CacheManagerConfig.AGENCY_CACHE)));
+      cacheManager.initializeCaches();
+      return cacheManager;
+    }
+
+    @Bean
+    AgencyService agencyService(
+        SecurityHeaderSupplier securityHeaderSupplier,
+        TenantHeaderSupplier tenantHeaderSupplier,
+        AgencyServiceApiControllerFactory agencyServiceApiControllerFactory,
+        CacheManager cacheManager) {
+      return new AgencyService(
+          securityHeaderSupplier,
+          tenantHeaderSupplier,
+          agencyServiceApiControllerFactory,
+          cacheManager);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -428,10 +428,8 @@ class ConsultantAdminFacadeTest {
 
   @Test
   void setConsultantAgencies_Should_createMissingAndDeleteRemovedAndSkipExisting() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(
-        Lists.newArrayList(agencyAdminFullResponse(1L), agencyAdminFullResponse(2L)));
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList(1L, 2L));
     // desired set: keep 1, drop 2, add 3
     List<CreateConsultantAgencyDTO> desired =
         Lists.newArrayList(
@@ -446,13 +444,13 @@ class ConsultantAdminFacadeTest {
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(3L));
     verify(relationCreatorService, never())
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(1L));
+    verify(consultantAgencyAdminService, never()).findConsultantAgencies(any());
   }
 
   @Test
   void setConsultantAgencies_Should_notDelete_When_NothingRemoved() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(Lists.newArrayList(agencyAdminFullResponse(1L)));
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList(1L));
 
     consultantAdminFacade.setConsultantAgencies(
         "consultantId",
@@ -464,13 +462,13 @@ class ConsultantAdminFacadeTest {
         .markConsultantAgenciesForDeletion(any(), anyList());
     verify(relationCreatorService)
         .createNewConsultantAgency(eq("consultantId"), argThatAgencyId(2L));
+    verify(consultantAgencyAdminService, never()).findConsultantAgencies(any());
   }
 
   @Test
   void setConsultantAgencies_Should_propagateValidationError() {
-    ConsultantAgencyResponseDTO persisted = new ConsultantAgencyResponseDTO();
-    persisted.setEmbedded(Lists.newArrayList());
-    when(consultantAgencyAdminService.findConsultantAgencies("consultantId")).thenReturn(persisted);
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList());
     doThrow(new BadRequestException("topic not covered"))
         .when(relationCreatorService)
         .createNewConsultantAgency(eq("consultantId"), any());

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -90,8 +90,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(0);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
 
@@ -128,8 +128,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(true);
     agencyDTO.setConsultingType(0);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(extendedConsultingTypeResponseDTO);
 
@@ -163,8 +163,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(consultingType);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     var consultant = createConsultantWithoutAgencyAndSession();
     when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
@@ -285,7 +285,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
-          when(this.agencyService.getAgencyWithoutCaching(any())).thenReturn(null);
+          when(this.agencyService.getAgency(any())).thenReturn(null);
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
@@ -303,8 +303,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
-          when(agencyService.getAgencyWithoutCaching(any()))
-              .thenThrow(new InternalServerErrorException(""));
+          when(agencyService.getAgency(any())).thenThrow(new InternalServerErrorException(""));
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
@@ -321,8 +320,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           AgencyDTO agencyDTO = new AgencyDTO().consultingType(1).id(2L);
 
-          when(agencyService.getAgencyWithoutCaching(1731L)).thenReturn(emigrationAgency);
-          when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+          when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
+          when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(1)).thenReturn(true);
 
@@ -345,8 +344,8 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           AgencyDTO agencyDTO = new AgencyDTO().consultingType(15).id(2L);
 
-          when(agencyService.getAgencyWithoutCaching(1731L)).thenReturn(emigrationAgency);
-          when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+          when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
+          when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
           when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(15)).thenReturn(true);
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -103,8 +103,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(0);
     agencyDTO.setTenantId(1L);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     Session enquirySessionWithoutConsultant =
         createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
@@ -142,8 +142,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("valid-role-set");
     when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0).tenantId(83L);
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(new ExtendedConsultingTypeResponseDTO());
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -69,7 +69,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(this.consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(new Consultant()));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO =
         new CreateConsultantAgencyDTO().roleSetKey("valid role set").agencyId(2L);
@@ -95,7 +95,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(this.consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
     doThrow(new BadRequestException("topic not covered"))
         .when(consultantTopicAgencyCompatibilityValidator)
         .validateCurrentTopicsAgainstAssignedAndAdditionalAgencies(anyString(), any(), any());
@@ -120,7 +120,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(eq(2L))).thenReturn(agencyDTO);
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
 
     var input =
         new CreateConsultantAgencyDTOInputAdapter(
@@ -144,7 +144,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(280L)).thenReturn(agency);
+    when(agencyService.getAgency(280L)).thenReturn(agency);
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(new ExtendedConsultingTypeResponseDTO());
     when(consultantAgencyService.saveConsultantAgency(any(ConsultantAgency.class)))
@@ -176,7 +176,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
   public void createNewConsultantAgency_Should_throwBadRequest_When_agencyDoesNotExist() {
     when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
         .thenReturn(Optional.of(new Consultant()));
-    when(agencyService.getAgencyWithoutCaching(99L)).thenReturn(null);
+    when(agencyService.getAgency(99L)).thenReturn(null);
 
     assertThrows(
         BadRequestException.class,
@@ -198,8 +198,8 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(newAgency);
-    when(agencyService.getAgencyWithoutCaching(3L)).thenReturn(existingAgency);
+    when(agencyService.getAgency(2L)).thenReturn(newAgency);
+    when(agencyService.getAgency(3L)).thenReturn(existingAgency);
     when(consultingTypeManager.isConsultantBoundedToAgency(2)).thenReturn(true);
 
     assertThrows(
@@ -232,7 +232,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
     when(identityClient.userHasRole("consultant Id", "consultant")).thenReturn(true);
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(1L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(1L)).thenReturn(agencyDTO);
     when(consultingTypeManager.getConsultingTypeSettings(1))
         .thenReturn(easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class));
 
@@ -253,7 +253,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(2L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
 
     var input =
         new CreateConsultantAgencyDTOInputAdapter(
@@ -275,7 +275,7 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
     when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
         .thenReturn(Optional.of(consultant));
-    when(agencyService.getAgencyWithoutCaching(15L)).thenReturn(agencyDTO);
+    when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(givenConsultingTypeWithRoles("main", List.of("consultant-role")));
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -33,7 +33,7 @@ public class ConsultantUpdateServiceBase {
 
   @BeforeEach
   void stubAssignedAgencies() {
-    when(agencyService.getAgenciesWithoutCaching(anyList()))
+    when(agencyService.getAgencies(anyList()))
         .thenAnswer(
             invocation ->
                 invocation.<List<Long>>getArgument(0).stream()

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.admin.service.consultant.validation;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
@@ -32,7 +33,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredAcrossActiveAgencies() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -44,7 +45,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredByOfflineAgency() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, true, List.of(7L))));
 
@@ -56,7 +57,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsAgencyFromDifferentTenant() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+    when(agencyService.getAgencies(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of(3L))));
 
     var exception =
@@ -71,7 +72,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsForeignAgencyWithoutTopics() {
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+    when(agencyService.getAgencies(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of())));
 
     var exception =
@@ -89,7 +90,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(Optional.of(consultant("consultant-id", 1L)));
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -106,7 +107,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(List.of());
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
+    when(agencyService.getAgencies(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -114,6 +115,20 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         () ->
             validator.validateCurrentTopicsAgainstAssignedAndAdditionalAgencies(
                 "consultant-id", List.of(10L, 20L), 1L));
+  }
+
+  @Test
+  void validateGrantTopicsAgainstSelectedAgencies_UsesTenantScopedCachedBatchLookup() {
+    when(agencyService.getAgencies(List.of(10L, 20L)))
+        .thenReturn(
+            List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
+
+    assertDoesNotThrow(
+        () ->
+            validator.validateGrantTopicsAgainstSelectedAgencies(
+                List.of(3L, 7L), List.of(10L, 20L), 1L));
+
+    verify(agencyService).getAgencies(List.of(10L, 20L));
   }
 
   private AgencyDTO agency(Long agencyId, Long tenantId, boolean offline, List<Long> topicIds) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +17,7 @@ import de.caritas.cob.userservice.agencyserivce.generated.ApiClient;
 import de.caritas.cob.userservice.agencyserivce.generated.web.AgencyControllerApi;
 import de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.config.CacheManagerConfig;
 import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.service.httpheader.HttpHeadersResolver;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -34,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -55,12 +59,17 @@ class AgencyServiceTest {
 
   @Mock ApiClient apiClient;
 
+  @Mock CacheManager cacheManager;
+
+  @Mock Cache agencyCache;
+
   @BeforeEach
   void setUp() {
     lenient()
         .when(agencyServiceApiControllerFactory.createControllerApi())
         .thenReturn(agencyControllerApi);
     lenient().when(agencyControllerApi.getApiClient()).thenReturn(apiClient);
+    lenient().when(cacheManager.getCache(CacheManagerConfig.AGENCY_CACHE)).thenReturn(agencyCache);
   }
 
   @AfterEach
@@ -124,6 +133,31 @@ class AgencyServiceTest {
     assertThat(result).isNotNull();
     assertThat(result.getId()).isEqualTo(AGENCY_ID);
     assertThat(result.getName()).isEqualTo(AGENCY_DTO_SUCHT.getName());
+  }
+
+  @Test
+  void getAgencies_ShouldWarmOnlyResolvedTenantScopedIdCacheEntries() {
+    TenantContext.setCurrentTenant(7L);
+    AgencyDTO resolvedAgency = new AgencyDTO().id(42L).name("Agency 42");
+    stubAgencyLookup(List.of(toAgencyResponseDTO(resolvedAgency)));
+
+    agencyService.getAgencies(List.of(42L, 43L));
+
+    verify(agencyCache).put("tenant:7:id:42", resolvedAgency);
+    verify(agencyCache, never()).put(eq("tenant:7:id:43"), any(AgencyDTO.class));
+  }
+
+  @Test
+  void agencyCacheKeys_ShouldSeparateTenantsAndBatchEntries() {
+    TenantContext.setCurrentTenant(7L);
+
+    assertThat(AgencyService.tenantScopedAgencyKey(42L)).isEqualTo("tenant:7:id:42");
+    assertThat(AgencyService.tenantScopedAgencyListKey(List.of(42L, 43L)))
+        .isEqualTo("tenant:7:ids:[42, 43]");
+
+    TenantContext.setCurrentTenant(8L);
+
+    assertThat(AgencyService.tenantScopedAgencyKey(42L)).isEqualTo("tenant:8:id:42");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/helper/AgencySecurityHeaderSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/helper/AgencySecurityHeaderSupplierTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -55,9 +57,14 @@ class AgencySecurityHeaderSupplierTest {
 
   @Mock private AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
+  @Mock private CacheManager cacheManager;
+
+  @Mock private Cache agencyCache;
+
   @BeforeEach
   void setup() throws NoSuchFieldException, SecurityException {
     when(agencyServiceApiControllerFactory.createControllerApi()).thenReturn(agencyControllerApi);
+    when(cacheManager.getCache("agencyCache")).thenReturn(agencyCache);
     this.agencyResponseDTOS =
         AGENCY_DTO_LIST.stream().map(this::toAgencyResponseDTO).collect(Collectors.toList());
     when(this.securityHeaderSupplier.getOptionalKeycloakAndCsrfHttpHeaders())
@@ -93,7 +100,8 @@ class AgencySecurityHeaderSupplierTest {
         new AgencyService(
             mock(SecurityHeaderSupplier.class),
             mock(TenantHeaderSupplier.class),
-            mock(AgencyServiceApiControllerFactory.class));
+            mock(AgencyServiceApiControllerFactory.class),
+            mock(CacheManager.class));
     Class classToTest = agencyService.getClass();
     Method methodToTest =
         classToTest.getMethod(GET_AGENCIES_METHOD_NAME, GET_AGENCIES_METHOD_PARAMS);
@@ -121,7 +129,8 @@ class AgencySecurityHeaderSupplierTest {
         new AgencyService(
             mock(SecurityHeaderSupplier.class),
             mock(TenantHeaderSupplier.class),
-            mock(AgencyServiceApiControllerFactory.class));
+            mock(AgencyServiceApiControllerFactory.class),
+            mock(CacheManager.class));
     Class classToTest = agencyService.getClass();
     Method methodToTest = classToTest.getMethod(GET_AGENCY_METHOD_NAME, GET_AGENCY_METHOD_PARAMS);
     Cacheable annotation = methodToTest.getAnnotation(Cacheable.class);


### PR DESCRIPTION
## Summary

- replays the consultant-agency read collapse from #765 directly on current `pre-dev`
- diffs desired assignments against locally persisted agency IDs instead of the AgencyAdmin full-list endpoint
- reuses cached AgencyService reads during topic validation and relation creation
- warms resolved per-ID cache entries from the bounded batch result
- keeps both single and batch cache keys tenant-scoped and never negative-caches missing IDs

## Current architecture

This replay is independent of #826 and does not import the stale
`SharedReadCache` work from #757. It uses the current Spring cache
implementation.

The cache-proxy test lives outside the application component-scan package. A
first integration attempt exposed that an in-package test configuration could
override real Spring beans; that attempt was stopped, the test was isolated,
and only the clean rerun below is used as evidence.

This slice remains aligned with the Matrix-only target: no Rocket.Chat or
Jitsi dependency is introduced.

## Verification

- exact head: `b9a564dc`
- fresh focused Java 21 rerun: 76 tests, 0 failures/errors/skips
- unit suite: 3,378 tests, 0 failures, 0 errors, 4 skipped
- required integration contract: 840 tests, 0 failures, 0 errors, 2 skipped
- CI contract tests: 13 passed
- OpenAPI contract tests: 8 passed
- Spring cache proof: batch-to-single reuse, missing-ID behavior, and tenant isolation passed
- all 12 GitHub checks are terminal green
- formatting and diff checks: clean

## Coordination

Exact-head merge-tree checks are clean with #828, #829, #834, #854, #856 and
#862. This is source-level integration evidence only; post-rollout aggregate
SigNoz acceptance must still prove that the measured assignment path performs
at most one AgencyService batch read.

No merge, deployment or database reset is included.

Refs #543
Refs #764
Supersedes #765
