### PR TITLE
fix(lifecycle): replay account deletion lease (#841)

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -207,6 +207,12 @@ context or starting the irreversible deletion workflow. The red two-instance
 proof observed both replicas executing the workflow; the fixed regression
 observes one winner and no downstream work from the losing replica.
 
+The daily account-deletion scheduler claims `account-deletion` for 12 hours
+before establishing tenant context or starting database, Matrix and identity
+cleanup. This stays below the daily schedule interval. Its two-instance red
+proof observed duplicate workflow starts; the fixed regression observes one
+winner and no downstream work from the losing replica.
+
 ## Microservice decision
 
 Decision: keep UserService as a modular monolith for now.

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountScheduler.java
@@ -2,8 +2,11 @@ package de.caritas.cob.userservice.api.workflow.delete.scheduler;
 
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUserAccountService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,12 +15,21 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteUserAccountScheduler {
 
+  private static final String TASK_NAME = "account-deletion";
+
   private final @NonNull DeleteUserAccountService deleteUserAccountService;
   private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull ScheduledTaskClaimService taskClaimService;
+
+  @Value("${user.account.deleteworkflow.claim.duration:PT12H}")
+  private Duration claimDuration;
 
   /** Entry method to perform deletion workflow. */
   @Scheduled(cron = "${user.account.deleteworkflow.cron}")
   public void performDeletionWorkflow() {
+    if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+      return;
+    }
     tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
     this.deleteUserAccountService.deleteUserAccounts();
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,6 +61,7 @@ statistics.message-count.hmac-secret=${STATISTICS_MESSAGE_COUNT_HMAC_SECRET:}
 
 # ---------------- User Workflows ----------------
 user.account.deleteworkflow.cron=0 0 0 * * ?
+user.account.deleteworkflow.claim.duration=PT12H
 user.anonymous.deleteworkflow.cron=0 0 * * * ?
 user.anonymous.deleteworkflow.periodMinutes=2820
 user.anonymous.deleteworkflow.claim.duration=PT30M

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerReplicaIT.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.userservice.api.workflow.delete.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.port.out.ScheduledTaskClaimRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUserAccountService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class DeleteUserAccountSchedulerReplicaIT {
+
+  private static final String TASK_NAME = "account-deletion";
+
+  @Autowired private ScheduledTaskClaimRepository claimRepository;
+  @Autowired private ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  @AfterEach
+  void deleteReplicaProofClaim() {
+    claimRepository.findById(TASK_NAME).ifPresent(claimRepository::delete);
+  }
+
+  @Test
+  void twoSchedulerInstancesTriggerOneAccountDeletionWorkflow() throws Exception {
+    var deletionService = mock(DeleteUserAccountService.class);
+    var tenantContextProvider = mock(TenantContextProvider.class);
+    var first = newScheduler(deletionService, tenantContextProvider);
+    var second = newScheduler(deletionService, tenantContextProvider);
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var firstResult = executor.submit(() -> run(first, ready, start));
+      var secondResult = executor.submit(() -> run(second, ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      firstResult.get(5, TimeUnit.SECONDS);
+      secondResult.get(5, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+    }
+
+    verify(tenantContextProvider, times(1)).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(deletionService, times(1)).deleteUserAccounts();
+  }
+
+  private DeleteUserAccountScheduler newScheduler(
+      DeleteUserAccountService deletionService, TenantContextProvider tenantContextProvider) {
+    var scheduler =
+        new DeleteUserAccountScheduler(deletionService, tenantContextProvider, taskClaimService);
+    ReflectionTestUtils.setField(scheduler, "claimDuration", Duration.ofHours(12));
+    return scheduler;
+  }
+
+  private void run(
+      DeleteUserAccountScheduler scheduler, CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    scheduler.performDeletionWorkflow();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent replica proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerTest.java
@@ -1,9 +1,15 @@
 package de.caritas.cob.userservice.api.workflow.delete.scheduler;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUserAccountService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,11 +25,29 @@ public class DeleteUserAccountSchedulerTest {
 
   @Mock private TenantContextProvider tenantContextProvider;
 
+  @Mock private ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  void setUp() {
+    setField(deleteUserAccountScheduler, "claimDuration", Duration.ofHours(12));
+  }
+
   @Test
   public void performDeletionWorkflow_Should_executeDeleteUserAccounts() {
+    when(taskClaimService.tryClaim("account-deletion", Duration.ofHours(12))).thenReturn(true);
+
     this.deleteUserAccountScheduler.performDeletionWorkflow();
 
     verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
     verify(this.deleteUserAccountService).deleteUserAccounts();
+  }
+
+  @Test
+  void performDeletionWorkflow_Should_skipAllDownstreamCalls_When_claimIsLost() {
+    when(taskClaimService.tryClaim("account-deletion", Duration.ofHours(12))).thenReturn(false);
+
+    deleteUserAccountScheduler.performDeletionWorkflow();
+
+    verifyNoInteractions(tenantContextProvider, deleteUserAccountService);
   }
 }


### PR DESCRIPTION
## Why

The daily account-deletion scheduler runs on every UserService replica. On the current code, two concurrent instances both set the technical tenant context and start the irreversible database, Matrix and identity-provider cleanup workflow.

This PR replays only the account-deletion lease from old #757. It is intentionally stacked on #840 so the durable claim primitive and the preceding scheduler leases are not duplicated.

## What changed

- claims `account-deletion` before setting tenant context or invoking the deletion service;
- bounds the claim to 12 hours, below the daily scheduler interval;
- makes a losing replica perform zero tenant-context, database, Matrix or identity cleanup work;
- adds a real Spring/database two-instance regression proof and records the contract in the stability document.

## Dependency and review shape

- **Base/dependency:** #840 (`replay/anonymous-deletion-lease-839`)
- **Review delta:** five files, 136 added lines; no migration or generic claim code duplicated
- after #840 merges, this PR can be retargeted without changing its own commit

The old stack also seeded known claim rows. That is intentionally not replayed: #835 already proves and safely handles concurrent first insertion on real MariaDB, so this slice does not add scheduler-specific seed data or another migration.

The target architecture remains Matrix chat plus the ORISO frontend, an ORISO-controlled Element Call/MatrixRTC fork and LiveKit. Rocket.Chat and Jitsi are not supported fallbacks.

## Validation

- red proof before implementation: two concurrent scheduler instances triggered the tenant context twice and the account-deletion workflow twice;
- focused scheduler unit suite: 2 tests, green;
- real Spring/database two-instance replica proof: 1 test, green;
- full unit suite: 3,387 tests, 0 failures, 0 errors, 4 environment-gated skips;
- full required integration/contract/E2E suite: 80 reports, 842 tests, 0 failures, 0 errors, 4 environment-gated skips;
- Python CI/OpenAPI contracts: 21 tests, green;
- packaged application JAR, Spotless and `git diff --check`: green.

## Relationship to the old stack

This supersedes the scheduler behavior from commit `d3a1edf9` in #757, adapted to the current generic claim implementation. Other scheduler work remains separate. Nothing is merged or deployed, and #543 remains open.

Closes OpenResilienceInitiative/ORISO-UserService#841
Refs #543
Refs #757
Depends on #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
