### PR TITLE
fix(lifecycle): replay registered-only deletion lease (#843)

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -213,6 +213,12 @@ cleanup. This stays below the daily schedule interval. Its two-instance red
 proof observed duplicate workflow starts; the fixed regression observes one
 winner and no downstream work from the losing replica.
 
+The daily registered-only-user deletion scheduler returns without even
+claiming when both deletion modes are disabled. When either mode is enabled,
+it claims `registered-only-user-deletion` for 12 hours before tenant context,
+database, Matrix or identity cleanup. Its real two-instance regression enables
+both modes and observes one execution of each mode and no work from the loser.
+
 ## Microservice decision
 
 Decision: keep UserService as a modular monolith for now.

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlyScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlyScheduler.java
@@ -2,6 +2,8 @@ package de.caritas.cob.userservice.api.workflow.delete.scheduler;
 
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUsersRegisteredOnlyService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,8 +15,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteUsersRegisteredOnlyScheduler {
 
+  private static final String TASK_NAME = "registered-only-user-deletion";
+
   private final @NonNull DeleteUsersRegisteredOnlyService deleteUsersRegisteredOnlyService;
   private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull ScheduledTaskClaimService taskClaimService;
 
   @Value("${user.registeredonly.deleteWorkflow.enabled}")
   private boolean userRegisteredOnlyDeleteWorkflowEnabled;
@@ -22,9 +27,19 @@ public class DeleteUsersRegisteredOnlyScheduler {
   @Value("${user.registeredonly.deleteWorkflow.afterSessionPurge.enabled}")
   private boolean userRegisteredOnlyDeleteWorkflowAfterSessionPurgeEnabled;
 
+  @Value("${user.registeredonly.deleteWorkflow.claim.duration:PT12H}")
+  private Duration claimDuration;
+
   /** Entry method to perform deletion workflow. */
   @Scheduled(cron = "${user.registeredonly.deleteWorkflow.cron}")
   public void performDeletionWorkflow() {
+    if (!userRegisteredOnlyDeleteWorkflowEnabled
+        && !userRegisteredOnlyDeleteWorkflowAfterSessionPurgeEnabled) {
+      return;
+    }
+    if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+      return;
+    }
     tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
     if (userRegisteredOnlyDeleteWorkflowEnabled) {
       deleteUsersRegisteredOnlyService.deleteUserAccountsTimeSensitive();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -78,6 +78,7 @@ group.chat.deactivateworkflow.periodMinutes=0
 
 user.registeredonly.deleteWorkflow.enabled=false
 user.registeredonly.deleteWorkflow.cron=0 0 3 * * ?
+user.registeredonly.deleteWorkflow.claim.duration=PT12H
 user.registeredonly.deleteWorkflow.check.days=30
 user.registeredonly.deleteWorkflow.afterSessionPurge.enabled=false
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerReplicaIT.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.userservice.api.workflow.delete.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.port.out.ScheduledTaskClaimRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUsersRegisteredOnlyService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class DeleteUsersRegisteredOnlySchedulerReplicaIT {
+
+  private static final String TASK_NAME = "registered-only-user-deletion";
+
+  @Autowired private ScheduledTaskClaimRepository claimRepository;
+  @Autowired private ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  @AfterEach
+  void deleteReplicaProofClaim() {
+    claimRepository.findById(TASK_NAME).ifPresent(claimRepository::delete);
+  }
+
+  @Test
+  void twoSchedulerInstancesTriggerOneRegisteredOnlyDeletionBatch() throws Exception {
+    var deletionService = mock(DeleteUsersRegisteredOnlyService.class);
+    var tenantContextProvider = mock(TenantContextProvider.class);
+    var first = newScheduler(deletionService, tenantContextProvider);
+    var second = newScheduler(deletionService, tenantContextProvider);
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var firstResult = executor.submit(() -> run(first, ready, start));
+      var secondResult = executor.submit(() -> run(second, ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      firstResult.get(5, TimeUnit.SECONDS);
+      secondResult.get(5, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+    }
+
+    verify(tenantContextProvider, times(1)).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(deletionService, times(1)).deleteUserAccountsTimeSensitive();
+    verify(deletionService, times(1)).deleteUserAccountsTimeInsensitive();
+  }
+
+  private DeleteUsersRegisteredOnlyScheduler newScheduler(
+      DeleteUsersRegisteredOnlyService deletionService,
+      TenantContextProvider tenantContextProvider) {
+    var scheduler =
+        new DeleteUsersRegisteredOnlyScheduler(
+            deletionService, tenantContextProvider, taskClaimService);
+    ReflectionTestUtils.setField(scheduler, "userRegisteredOnlyDeleteWorkflowEnabled", true);
+    ReflectionTestUtils.setField(
+        scheduler, "userRegisteredOnlyDeleteWorkflowAfterSessionPurgeEnabled", true);
+    ReflectionTestUtils.setField(scheduler, "claimDuration", Duration.ofHours(12));
+    return scheduler;
+  }
+
+  private void run(
+      DeleteUsersRegisteredOnlyScheduler scheduler, CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    scheduler.performDeletionWorkflow();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent replica proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerTest.java
@@ -1,11 +1,15 @@
 package de.caritas.cob.userservice.api.workflow.delete.scheduler;
 
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.delete.service.DeleteUsersRegisteredOnlyService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,10 +25,19 @@ public class DeleteUsersRegisteredOnlySchedulerTest {
 
   @Mock TenantContextProvider tenantContextProvider;
 
+  @Mock ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  void setUp() {
+    setField(deleteUsersRegisteredOnlyScheduler, "claimDuration", Duration.ofHours(12));
+  }
+
   @Test
   public void
       performDeletionWorkflow_Should_executeDeleteUserAccountsTimeSensitive_WhenFeatureIsEnabled() {
     setField(deleteUsersRegisteredOnlyScheduler, "userRegisteredOnlyDeleteWorkflowEnabled", true);
+    when(taskClaimService.tryClaim("registered-only-user-deletion", Duration.ofHours(12)))
+        .thenReturn(true);
     deleteUsersRegisteredOnlyScheduler.performDeletionWorkflow();
 
     verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
@@ -37,8 +50,7 @@ public class DeleteUsersRegisteredOnlySchedulerTest {
     setField(deleteUsersRegisteredOnlyScheduler, "userRegisteredOnlyDeleteWorkflowEnabled", false);
     deleteUsersRegisteredOnlyScheduler.performDeletionWorkflow();
 
-    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
-    verify(deleteUsersRegisteredOnlyService, never()).deleteUserAccountsTimeSensitive();
+    verifyNoInteractions(tenantContextProvider, deleteUsersRegisteredOnlyService, taskClaimService);
   }
 
   @Test
@@ -48,6 +60,8 @@ public class DeleteUsersRegisteredOnlySchedulerTest {
         deleteUsersRegisteredOnlyScheduler,
         "userRegisteredOnlyDeleteWorkflowAfterSessionPurgeEnabled",
         true);
+    when(taskClaimService.tryClaim("registered-only-user-deletion", Duration.ofHours(12)))
+        .thenReturn(true);
     deleteUsersRegisteredOnlyScheduler.performDeletionWorkflow();
 
     verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
@@ -63,7 +77,21 @@ public class DeleteUsersRegisteredOnlySchedulerTest {
         false);
     deleteUsersRegisteredOnlyScheduler.performDeletionWorkflow();
 
-    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
-    verify(deleteUsersRegisteredOnlyService, never()).deleteUserAccountsTimeInsensitive();
+    verifyNoInteractions(tenantContextProvider, deleteUsersRegisteredOnlyService, taskClaimService);
+  }
+
+  @Test
+  void performDeletionWorkflow_Should_skipAllDownstreamCalls_When_claimIsLost() {
+    setField(deleteUsersRegisteredOnlyScheduler, "userRegisteredOnlyDeleteWorkflowEnabled", true);
+    setField(
+        deleteUsersRegisteredOnlyScheduler,
+        "userRegisteredOnlyDeleteWorkflowAfterSessionPurgeEnabled",
+        true);
+    when(taskClaimService.tryClaim("registered-only-user-deletion", Duration.ofHours(12)))
+        .thenReturn(false);
+
+    deleteUsersRegisteredOnlyScheduler.performDeletionWorkflow();
+
+    verifyNoInteractions(tenantContextProvider, deleteUsersRegisteredOnlyService);
   }
 }


### PR DESCRIPTION
## Why

The daily registered-only-user deletion scheduler could run on every UserService replica. That duplicated tenant setup and both deletion modes under parallel deployment. It also entered tenant work when both modes were disabled.

## What

- return before claim, tenant, database, Matrix, or identity work when both deletion modes are disabled
- claim `registered-only-user-deletion` for 12 hours before running either mode
- add a real Spring/database two-replica regression proving exactly one execution of each enabled mode
- document the bounded scheduler behavior in the UserService stability record

This PR is stacked on #842. It intentionally does not replay the historical claim-row seed: the generic claim implementation introduced in #835 safely performs first insert against the real MariaDB contract.

The production boundary remains Matrix-only. This change introduces no Rocket.Chat or Jitsi dependency.

## Validation

- 3,388 unit/contract tests: 0 failures, 0 errors, 4 skipped
- 843 integration tests across 81 reports: 0 failures, 0 errors, 4 skipped
- 13 CI helper tests
- 8 Python contract tests
- focused real-database two-replica scheduler proof
- Java 21 package build
- diff and formatting checks

Supersedes the registered-only deletion lease behavior from historical commit `93d024fc`.

Closes OpenResilienceInitiative/ORISO-UserService#843
Refs OpenResilienceInitiative/ORISO-UserService#543
Refs OpenResilienceInitiative/ORISO-UserService#757
Depends on #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
