### PR TITLE
fix(notification): replay group-chat reminder idempotency (#845)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,12 @@ import org.hibernate.type.SqlTypes;
 
 /** Persistent in-app notification event for a concrete recipient user. */
 @Entity
-@Table(name = "event_notification")
+@Table(
+    name = "event_notification",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_event_notification_recipient_deduplication",
+            columnNames = {"recipient_user_id", "deduplication_key"}))
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceReplicaIT.java
@@ -1,0 +1,119 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.liveevents.LiveEventNotificationService;
+import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class EventNotificationServiceReplicaIT {
+
+  private static final String RECIPIENT = "replica-proof-recipient";
+  private static final String DEDUPLICATION_KEY = "group-chat:group_chat.reminder:42:0";
+
+  @Autowired private EventNotificationRepository eventNotificationRepository;
+  @Autowired private SessionRepository sessionRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private ConsultantRepository consultantRepository;
+  @Autowired private IdentityTombstoneService identityTombstoneService;
+  @Autowired private EventNotificationDeduplicationWriter deduplicationWriter;
+  @MockitoBean private LiveEventNotificationService liveEventNotificationService;
+
+  @AfterEach
+  void deleteReplicaProofNotification() {
+    var notifications =
+        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(
+            RECIPIENT, Pageable.unpaged());
+    eventNotificationRepository.deleteAll(notifications);
+  }
+
+  @Test
+  void twoServiceInstancesPublishOneReminderAndOneLiveRefresh() throws Exception {
+    var firstInstance = newServiceInstance();
+    var secondInstance = newServiceInstance();
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var first = executor.submit(() -> publishReminder(firstInstance, ready, start));
+      var second = executor.submit(() -> publishReminder(secondInstance, ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      first.get(5, TimeUnit.SECONDS);
+      second.get(5, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+    }
+
+    var notifications =
+        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(
+            RECIPIENT, Pageable.unpaged());
+    assertThat(notifications)
+        .singleElement()
+        .extracting(notification -> notification.getDeduplicationKey())
+        .isEqualTo(DEDUPLICATION_KEY);
+    verify(liveEventNotificationService, times(1))
+        .sendEventNotificationCreatedEventToUser(RECIPIENT);
+  }
+
+  private EventNotificationService newServiceInstance() {
+    return new EventNotificationService(
+        eventNotificationRepository,
+        sessionRepository,
+        userRepository,
+        consultantRepository,
+        identityTombstoneService,
+        deduplicationWriter,
+        liveEventNotificationService);
+  }
+
+  private void publishReminder(
+      EventNotificationService service, CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    service.createEventOnce(
+        DEDUPLICATION_KEY,
+        RECIPIENT,
+        "group_chat.reminder",
+        EventNotificationService.CATEGORY_SYSTEM,
+        "Reminder",
+        "Soon",
+        "{\"seriesId\":42}",
+        null,
+        42L,
+        null);
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent replica proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}


### PR DESCRIPTION
## Why

The active group-chat reminder scheduler can execute on multiple UserService replicas. Liquibase already creates a unique recipient/deduplication index, but the JPA entity did not declare the same contract, so the normal Spring test schema accepted duplicate reminders.

The red two-instance regression observed two persisted events for one reminder identity.

## What

- align the `EventNotification` JPA table contract with the existing Liquibase unique index
- start two independent notification service instances concurrently against shared database state
- prove exactly one persisted reminder and one live refresh

This replay is intentionally independent and based directly on current `pre-dev`; it does not require the scheduler-lease stack.

The governing communications target is Matrix as the sole chat system, the ORISO-owned frontend, an ORISO-controlled Element Call / MatrixRTC fork, and LiveKit. Rocket.Chat and Jitsi are removal targets, never fallbacks. This change introduces no Rocket.Chat or Jitsi dependency, configuration, fallback, or schema.

## Review

The exact two-file diff was manually reviewed against the existing Liquibase index, JPA null semantics, independent `REQUIRES_NEW` transactions, the two-thread synchronization, duplicate-key containment, and live-refresh behavior. No blocking finding remains.

GitHub's successful CodeRabbit status is the configured draft skip for `pre-dev`, not a completed human review. No human review has been submitted.

## Validation

Exact head: `f05faef721ec36110154e1bac1cb80fe4277ff7f`

- focused red proof: 2 duplicate event rows before the fix
- focused green proof: 1 event row and 1 live refresh after the fix
- fresh Java 21 two-instance regression: 1 test, 0 failures/errors/skips
- 3,373 unit/contract tests: 0 failures, 0 errors, 4 existing skips
- 841 integration tests across 79 reports: 0 failures, 0 errors, 3 environment skips
- fresh MariaDB 10.11: 101 Liquibase changesets, Hibernate validation green
- MariaDB index verified unique on `recipient_user_id,deduplication_key`
- 13 fresh Python CI tests passed
- Java 21 package build, Spotless, and diff checks passed
- all 12 exact-head GitHub checks passed

## Merge-order audit

Exact synthetic merges are clean with #823, #825, #827, #828, #829, #830, #831, #832, #834, #854, #856 and #862.

## Runtime boundary

This is source, local, database-contract, and CI proof only. The change is not merged or deployed. After rollout, a bounded runtime check must confirm one stored reminder and one refresh signal for a duplicate scheduler attempt.

No database reset was needed.

Supersedes the group-chat reminder idempotency behavior from historical commit `1d53c7bd`.

Closes OpenResilienceInitiative/ORISO-UserService#845
Refs OpenResilienceInitiative/ORISO-UserService#543
Refs OpenResilienceInitiative/ORISO-UserService#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
