### PR TITLE
fix(notification): serialize inactive email dispatch (#847)

### DIFF
--- a/documentation/INACTIVE_ACCOUNT_NOTIFICATION_REPLICA_SAFETY.md
+++ b/documentation/INACTIVE_ACCOUNT_NOTIFICATION_REPLICA_SAFETY.md
@@ -1,0 +1,28 @@
+# Inactive-account notification replica safety
+
+`InactiveAccountNotificationService` uses the audit table's unique
+`notification_fingerprint` as a database-backed claim. The claim is committed in a
+new transaction before UserService calls MailService. When two UserService replicas
+scan the same account concurrently, one claim succeeds and the other replica skips
+the external mail side effect.
+
+This is an **at-most-once dispatch** contract:
+
+- a duplicate scan does not submit the same fingerprint twice;
+- a rejected MailService call leaves `email_dispatched=false`;
+- an accepted MailService call is followed by a separate update to
+  `email_dispatched=true`.
+
+It is not a crash-safe replay contract. The current MailService OpenAPI request has
+no provider idempotency key. If UserService stops after MailService accepts the
+request but before the audit update commits, the claim remains undispatched and is
+not automatically retried. Adding retries without a provider idempotency key could
+send duplicate email.
+
+End-to-end exactly-once processing therefore requires either:
+
+1. a stable fingerprint accepted and deduplicated by MailService, or
+2. a durable outbox with an idempotent MailService consumer.
+
+Until that contract exists, operators can inspect undispatched audit rows, but must
+not replay them automatically.

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
@@ -4,4 +4,7 @@ import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InactiveAccountNotificationAuditLogRepository
-    extends JpaRepository<InactiveAccountNotificationAuditLog, Long> {}
+    extends JpaRepository<InactiveAccountNotificationAuditLog, Long> {
+
+  boolean existsByNotificationFingerprint(String notificationFingerprint);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/InactiveAccountNotificationAuditLogRepository.java
@@ -4,7 +4,4 @@ import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InactiveAccountNotificationAuditLogRepository
-    extends JpaRepository<InactiveAccountNotificationAuditLog, Long> {
-
-  boolean existsByNotificationFingerprint(String notificationFingerprint);
-}
+    extends JpaRepository<InactiveAccountNotificationAuditLog, Long> {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/helper/MailService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/helper/MailService.java
@@ -28,9 +28,9 @@ public class MailService {
    * @return whether MailService accepted the request
    */
   public boolean sendEmailNotification(MailsDTO mailsDTO) {
-    MailsControllerApi controllerApi = mailServiceApiControllerFactory.createControllerApi();
-    addSecurityHeaders(controllerApi);
     try {
+      MailsControllerApi controllerApi = mailServiceApiControllerFactory.createControllerApi();
+      addSecurityHeaders(controllerApi);
       controllerApi.sendMails(mailsDTO);
       return true;
     } catch (Exception e) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/helper/MailService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/helper/MailService.java
@@ -25,14 +25,17 @@ public class MailService {
    * Send a email notification via the MailService.
    *
    * @param mailsDTO the transfer object to be handled in MailService
+   * @return whether MailService accepted the request
    */
-  public void sendEmailNotification(MailsDTO mailsDTO) {
+  public boolean sendEmailNotification(MailsDTO mailsDTO) {
     MailsControllerApi controllerApi = mailServiceApiControllerFactory.createControllerApi();
     addSecurityHeaders(controllerApi);
     try {
       controllerApi.sendMails(mailsDTO);
+      return true;
     } catch (Exception e) {
       log.error("MailServiceHelper error: Error while calling the MailService", e);
+      return false;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriter.java
@@ -20,14 +20,21 @@ public class InactiveAccountNotificationClaimWriter {
     return auditLogRepository.saveAndFlush(auditLog);
   }
 
+  @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+  public boolean isClaimed(String notificationFingerprint) {
+    return auditLogRepository.existsByNotificationFingerprint(notificationFingerprint);
+  }
+
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void markEmailDispatched(Long auditLogId) {
-    auditLogRepository
-        .findById(auditLogId)
-        .ifPresent(
-            auditLog -> {
-              auditLog.setEmailDispatched(true);
-              auditLogRepository.saveAndFlush(auditLog);
-            });
+    InactiveAccountNotificationAuditLog auditLog =
+        auditLogRepository
+            .findById(auditLogId)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Inactive account notification audit log not found: " + auditLogId));
+    auditLog.setEmailDispatched(true);
+    auditLogRepository.saveAndFlush(auditLog);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriter.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
+import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Claims one notification fingerprint before any external email side effect is attempted. */
+@Service
+@RequiredArgsConstructor
+public class InactiveAccountNotificationClaimWriter {
+
+  private final @NonNull InactiveAccountNotificationAuditLogRepository auditLogRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public InactiveAccountNotificationAuditLog claim(InactiveAccountNotificationAuditLog auditLog) {
+    return auditLogRepository.saveAndFlush(auditLog);
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markEmailDispatched(Long auditLogId) {
+    auditLogRepository
+        .findById(auditLogId)
+        .ifPresent(
+            auditLog -> {
+              auditLog.setEmailDispatched(true);
+              auditLogRepository.saveAndFlush(auditLog);
+            });
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
@@ -6,7 +6,6 @@ import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.helper.MailService;
 import de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.model.InactiveAccountRole;
@@ -22,6 +21,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +40,7 @@ public class InactiveAccountNotificationService {
   private final @NonNull ConsultantActivityCalculator consultantActivityCalculator;
   private final @NonNull AdminActivityCalculator adminActivityCalculator;
   private final @NonNull InactiveAccountNotificationRecipientResolver recipientResolver;
-  private final @NonNull InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  private final @NonNull InactiveAccountNotificationClaimWriter claimWriter;
   private final @NonNull MailService mailService;
 
   @Value("${inactive.account.notification.threshold.days:365}")
@@ -117,32 +117,36 @@ public class InactiveAccountNotificationService {
       String fingerprint =
           buildFingerprint(
               role, accountId, recipient.getId(), lastActivityAt, inactivityThresholdDays);
-      if (auditLogRepository.existsByNotificationFingerprint(fingerprint)) {
+      InactiveAccountNotificationAuditLog auditLog;
+      try {
+        auditLog =
+            claimWriter.claim(
+                InactiveAccountNotificationAuditLog.builder()
+                    .notificationFingerprint(fingerprint)
+                    .accountRole(role)
+                    .accountId(accountId)
+                    .accountTenantId(accountTenantId)
+                    .lastActivityAt(lastActivityAt)
+                    .thresholdDays((int) inactivityThresholdDays)
+                    .recipientAdminId(recipient.getId())
+                    .recipientEmail(recipient.getEmail())
+                    .emailDispatched(false)
+                    .createDate(now)
+                    .tenantId(accountTenantId)
+                    .build());
+      } catch (DataIntegrityViolationException duplicateClaim) {
+        log.debug("Inactive account notification {} already claimed", fingerprint);
         continue;
       }
-      boolean dispatched = false;
       if (emailDispatchEnabled) {
-        dispatchEmail(recipient, role, accountId, accountTenantId, lastActivityAt);
-        dispatched = true;
+        if (dispatchEmail(recipient, role, accountId, accountTenantId, lastActivityAt)) {
+          claimWriter.markEmailDispatched(auditLog.getId());
+        }
       }
-      auditLogRepository.save(
-          InactiveAccountNotificationAuditLog.builder()
-              .notificationFingerprint(fingerprint)
-              .accountRole(role)
-              .accountId(accountId)
-              .accountTenantId(accountTenantId)
-              .lastActivityAt(lastActivityAt)
-              .thresholdDays((int) inactivityThresholdDays)
-              .recipientAdminId(recipient.getId())
-              .recipientEmail(recipient.getEmail())
-              .emailDispatched(dispatched)
-              .createDate(now)
-              .tenantId(accountTenantId)
-              .build());
     }
   }
 
-  private void dispatchEmail(
+  private boolean dispatchEmail(
       Admin recipient,
       InactiveAccountRole role,
       String accountId,
@@ -167,12 +171,21 @@ public class InactiveAccountNotificationService {
                     new TemplateDataDTO().key("subject").value(subject),
                     new TemplateDataDTO().key("text").value(body),
                     new TemplateDataDTO().key("url").value(appBaseUrl)));
-    mailService.sendEmailNotification(new MailsDTO().mails(List.of(mail)));
-    log.info(
-        "Inactive account notification dispatched to adminId={} role={} accountId={}",
-        recipient.getId(),
-        role,
-        accountId);
+    boolean accepted = mailService.sendEmailNotification(new MailsDTO().mails(List.of(mail)));
+    if (accepted) {
+      log.info(
+          "Inactive account notification dispatched to adminId={} role={} accountId={}",
+          recipient.getId(),
+          role,
+          accountId);
+    } else {
+      log.warn(
+          "Inactive account notification was not accepted by MailService for adminId={} role={} accountId={}",
+          recipient.getId(),
+          role,
+          accountId);
+    }
+    return accepted;
   }
 
   private String buildFingerprint(

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationService.java
@@ -134,9 +134,12 @@ public class InactiveAccountNotificationService {
                     .createDate(now)
                     .tenantId(accountTenantId)
                     .build());
-      } catch (DataIntegrityViolationException duplicateClaim) {
-        log.debug("Inactive account notification {} already claimed", fingerprint);
-        continue;
+      } catch (DataIntegrityViolationException claimFailure) {
+        if (claimWriter.isClaimed(fingerprint)) {
+          log.debug("Inactive account notification {} already claimed", fingerprint);
+          continue;
+        }
+        throw claimFailure;
       }
       if (emailDispatchEnabled) {
         if (dispatchEmail(recipient, role, accountId, accountTenantId, lastActivityAt)) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/helper/MailServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/helper/MailServiceTest.java
@@ -48,9 +48,10 @@ public class MailServiceTest {
   public void sendEmailNotification_Should_CallMailService() {
     when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(getCsrfHttpHeaders());
 
-    mailService.sendEmailNotification(new MailsDTO());
+    boolean accepted = mailService.sendEmailNotification(new MailsDTO());
 
     verify(mailsControllerApi, times(1)).sendMails(any());
+    assertThat(accepted).isTrue();
   }
 
   @Test
@@ -60,9 +61,10 @@ public class MailServiceTest {
     doThrow(new RuntimeException()).when(this.mailsControllerApi).sendMails(any());
 
     try (var logCaptor = LogbackCaptor.forClass(MailService.class)) {
-      mailService.sendEmailNotification(new MailsDTO());
+      boolean accepted = mailService.sendEmailNotification(new MailsDTO());
 
       assertThat(logCaptor.contains(Level.ERROR, "Error while calling the MailService")).isTrue();
+      assertThat(accepted).isFalse();
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/helper/MailServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/helper/MailServiceTest.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.service.helper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,7 +42,7 @@ public class MailServiceTest {
   @BeforeEach
   public void setup() throws NoSuchFieldException, SecurityException {
     when(mailServiceApiControllerFactory.createControllerApi()).thenReturn(mailsControllerApi);
-    when(this.mailsControllerApi.getApiClient()).thenReturn(this.apiClient);
+    lenient().when(this.mailsControllerApi.getApiClient()).thenReturn(this.apiClient);
   }
 
   @Test
@@ -59,6 +60,19 @@ public class MailServiceTest {
       sendEmailNotification_ShouldLogException_WhenExceptionOccursWhileCallingTheMailService() {
     when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(getCsrfHttpHeaders());
     doThrow(new RuntimeException()).when(this.mailsControllerApi).sendMails(any());
+
+    try (var logCaptor = LogbackCaptor.forClass(MailService.class)) {
+      boolean accepted = mailService.sendEmailNotification(new MailsDTO());
+
+      assertThat(logCaptor.contains(Level.ERROR, "Error while calling the MailService")).isTrue();
+      assertThat(accepted).isFalse();
+    }
+  }
+
+  @Test
+  public void sendEmailNotification_ShouldReturnFalse_WhenControllerSetupFails() {
+    when(mailServiceApiControllerFactory.createControllerApi())
+        .thenThrow(new RuntimeException("controller setup failed"));
 
     try (var logCaptor = LogbackCaptor.forClass(MailService.class)) {
       boolean accepted = mailService.sendEmailNotification(new MailsDTO());

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationClaimWriterTest.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InactiveAccountNotificationClaimWriterTest {
+
+  @Mock private InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  @InjectMocks private InactiveAccountNotificationClaimWriter claimWriter;
+
+  @Test
+  void markEmailDispatched_ShouldFail_WhenAuditLogIsMissing() {
+    when(auditLogRepository.findById(42L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> claimWriter.markEmailDispatched(42L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("42");
+
+    verify(auditLogRepository, never()).saveAndFlush(any());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceReplicaIT.java
@@ -1,0 +1,169 @@
+package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.service;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.helper.MailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class InactiveAccountNotificationServiceReplicaIT {
+
+  private static final String ACCOUNT_ID = "replica-inactive-asker";
+  private static final String RECIPIENT_ID = "replica-inactive-admin";
+
+  @Autowired private InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  @Autowired private InactiveAccountNotificationClaimWriter claimWriter;
+
+  @AfterEach
+  void deleteReplicaProofAuditRows() {
+    var rows =
+        auditLogRepository.findAll().stream()
+            .filter(row -> ACCOUNT_ID.equals(row.getAccountId()))
+            .toList();
+    auditLogRepository.deleteAll(rows);
+  }
+
+  @Test
+  void twoServiceInstancesDispatchOneEmailAndPersistOneAuditClaim() throws Exception {
+    var userRepository = mock(UserRepository.class);
+    var consultantRepository = mock(ConsultantRepository.class);
+    var adminRepository = mock(AdminRepository.class);
+    var askerActivityCalculator = mock(AskerActivityCalculator.class);
+    var consultantActivityCalculator = mock(ConsultantActivityCalculator.class);
+    var adminActivityCalculator = mock(AdminActivityCalculator.class);
+    var recipientResolver = mock(InactiveAccountNotificationRecipientResolver.class);
+    var mailService = mock(MailService.class);
+    var inactiveUser = new User(ACCOUNT_ID, null, "inactive", "inactive@example.invalid", true);
+    inactiveUser.setTenantId(1L);
+    var recipient =
+        Admin.builder()
+            .id(RECIPIENT_ID)
+            .username("replica-admin")
+            .firstName("Replica")
+            .lastName("Admin")
+            .email("replica-admin@example.invalid")
+            .type(Admin.AdminType.TENANT)
+            .tenantId(1L)
+            .build();
+    var lastActivity = LocalDateTime.now().minusDays(400);
+    when(userRepository.findAllByDeleteDateIsNull()).thenReturn(List.of(inactiveUser));
+    when(consultantRepository.findByDeleteDateIsNull()).thenReturn(emptyList());
+    when(adminRepository.findAll()).thenReturn(emptyList());
+    when(askerActivityCalculator.lastActivity(inactiveUser)).thenReturn(Optional.of(lastActivity));
+    when(recipientResolver.resolveRecipients(any())).thenReturn(List.of(recipient));
+    when(mailService.sendEmailNotification(any())).thenReturn(true);
+    var firstInstance =
+        newServiceInstance(
+            userRepository,
+            consultantRepository,
+            adminRepository,
+            askerActivityCalculator,
+            consultantActivityCalculator,
+            adminActivityCalculator,
+            recipientResolver,
+            mailService);
+    var secondInstance =
+        newServiceInstance(
+            userRepository,
+            consultantRepository,
+            adminRepository,
+            askerActivityCalculator,
+            consultantActivityCalculator,
+            adminActivityCalculator,
+            recipientResolver,
+            mailService);
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var first = executor.submit(() -> scan(firstInstance, ready, start));
+      var second = executor.submit(() -> scan(secondInstance, ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      first.get(5, TimeUnit.SECONDS);
+      second.get(5, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+    }
+
+    assertThat(
+            auditLogRepository.findAll().stream()
+                .filter(row -> ACCOUNT_ID.equals(row.getAccountId())))
+        .singleElement()
+        .satisfies(row -> assertThat(row.isEmailDispatched()).isTrue());
+    verify(mailService, times(1)).sendEmailNotification(any());
+  }
+
+  private InactiveAccountNotificationService newServiceInstance(
+      UserRepository userRepository,
+      ConsultantRepository consultantRepository,
+      AdminRepository adminRepository,
+      AskerActivityCalculator askerActivityCalculator,
+      ConsultantActivityCalculator consultantActivityCalculator,
+      AdminActivityCalculator adminActivityCalculator,
+      InactiveAccountNotificationRecipientResolver recipientResolver,
+      MailService mailService) {
+    var service =
+        new InactiveAccountNotificationService(
+            userRepository,
+            consultantRepository,
+            adminRepository,
+            askerActivityCalculator,
+            consultantActivityCalculator,
+            adminActivityCalculator,
+            recipientResolver,
+            claimWriter,
+            mailService);
+    setField(service, "inactivityThresholdDays", 365L);
+    setField(service, "emailDispatchEnabled", true);
+    setField(service, "appBaseUrl", "https://app.oriso.org");
+    return service;
+  }
+
+  private void scan(
+      InactiveAccountNotificationService service, CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    service.scanAndNotifyInactiveAccounts();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent replica proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
@@ -3,7 +3,9 @@ package de.caritas.cob.userservice.api.workflow.inactiveaccountnotification.serv
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -202,10 +204,31 @@ class InactiveAccountNotificationServiceTest {
     doThrow(new DataIntegrityViolationException("duplicate fingerprint"))
         .when(claimWriter)
         .claim(any());
+    when(claimWriter.isClaimed(anyString())).thenReturn(true);
 
     service.scanAndNotifyInactiveAccounts();
 
     verify(claimWriter).claim(any());
+    verify(claimWriter).isClaimed(anyString());
+    verify(mailService, never()).sendEmailNotification(any());
+  }
+
+  @Test
+  void scanAndNotifyInactiveAccounts_Should_propagateUnrelatedClaimIntegrityFailure() {
+    User user = new User("user-1", null, "user1", "u1@example.com", true);
+    user.setTenantId(1L);
+    LocalDateTime now = LocalDateTime.now();
+    when(userRepository.findAllByDeleteDateIsNull()).thenReturn(singletonList(user));
+    when(askerActivityCalculator.lastActivity(user)).thenReturn(Optional.of(now.minusDays(400)));
+    doThrow(new DataIntegrityViolationException("recipient email exceeds column length"))
+        .when(claimWriter)
+        .claim(any());
+
+    assertThatThrownBy(service::scanAndNotifyInactiveAccounts)
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("recipient email exceeds column length");
+
+    verify(claimWriter).isClaimed(anyString());
     verify(mailService, never()).sendEmailNotification(any());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/inactiveaccountnotification/service/InactiveAccountNotificationServiceTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,7 +16,6 @@ import de.caritas.cob.userservice.api.model.InactiveAccountNotificationAuditLog;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
-import de.caritas.cob.userservice.api.port.out.InactiveAccountNotificationAuditLogRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.helper.MailService;
 import de.caritas.cob.userservice.mailservice.generated.web.model.MailsDTO;
@@ -31,10 +31,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 // LENIENT is required: @BeforeEach registers default stubs for recipientResolver and
-// auditLogRepository that are only exercised when inactive accounts are actually found.
+// claimWriter that are only exercised when inactive accounts are actually found.
 // Tests that verify "no notification" paths (e.g. activity below threshold) do not reach
 // those call sites, so Mockito would otherwise report UnnecessaryStubbingException.
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -49,7 +50,7 @@ class InactiveAccountNotificationServiceTest {
   @Mock private ConsultantActivityCalculator consultantActivityCalculator;
   @Mock private AdminActivityCalculator adminActivityCalculator;
   @Mock private InactiveAccountNotificationRecipientResolver recipientResolver;
-  @Mock private InactiveAccountNotificationAuditLogRepository auditLogRepository;
+  @Mock private InactiveAccountNotificationClaimWriter claimWriter;
   @Mock private MailService mailService;
 
   private Admin recipientAdmin;
@@ -74,7 +75,13 @@ class InactiveAccountNotificationServiceTest {
     when(consultantRepository.findByDeleteDateIsNull()).thenReturn(emptyList());
     when(adminRepository.findAll()).thenReturn(emptyList());
     when(recipientResolver.resolveRecipients(any())).thenReturn(singletonList(recipientAdmin));
-    when(auditLogRepository.existsByNotificationFingerprint(any())).thenReturn(false);
+    when(claimWriter.claim(any()))
+        .thenAnswer(
+            invocation -> {
+              InactiveAccountNotificationAuditLog auditLog = invocation.getArgument(0);
+              auditLog.setId(1L);
+              return auditLog;
+            });
   }
 
   @Test
@@ -91,7 +98,7 @@ class InactiveAccountNotificationServiceTest {
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository).save(any());
+    verify(claimWriter).claim(any());
     verify(mailService, never()).sendEmailNotification(any());
   }
 
@@ -121,7 +128,7 @@ class InactiveAccountNotificationServiceTest {
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository).save(any());
+    verify(claimWriter).claim(any());
   }
 
   // ---------------------------------------------------------------------------
@@ -150,7 +157,7 @@ class InactiveAccountNotificationServiceTest {
 
     ArgumentCaptor<InactiveAccountNotificationAuditLog> captor =
         ArgumentCaptor.forClass(InactiveAccountNotificationAuditLog.class);
-    verify(auditLogRepository).save(captor.capture());
+    verify(claimWriter).claim(captor.capture());
     assertThat(captor.getValue().getAccountId()).isEqualTo("admin-target");
   }
 
@@ -163,7 +170,7 @@ class InactiveAccountNotificationServiceTest {
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository, never()).save(any());
+    verify(claimWriter, never()).claim(any());
   }
 
   @Test
@@ -182,7 +189,7 @@ class InactiveAccountNotificationServiceTest {
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository, never()).save(any());
+    verify(claimWriter, never()).claim(any());
   }
 
   @Test
@@ -192,11 +199,14 @@ class InactiveAccountNotificationServiceTest {
     LocalDateTime now = LocalDateTime.now();
     when(userRepository.findAllByDeleteDateIsNull()).thenReturn(singletonList(user));
     when(askerActivityCalculator.lastActivity(user)).thenReturn(Optional.of(now.minusDays(400)));
-    when(auditLogRepository.existsByNotificationFingerprint(any())).thenReturn(true);
+    doThrow(new DataIntegrityViolationException("duplicate fingerprint"))
+        .when(claimWriter)
+        .claim(any());
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository, never()).save(any());
+    verify(claimWriter).claim(any());
+    verify(mailService, never()).sendEmailNotification(any());
   }
 
   @Test
@@ -221,12 +231,13 @@ class InactiveAccountNotificationServiceTest {
 
     service.scanAndNotifyInactiveAccounts();
 
-    verify(auditLogRepository, org.mockito.Mockito.times(2)).save(any());
+    verify(claimWriter, org.mockito.Mockito.times(2)).claim(any());
   }
 
   @Test
   void scanAndNotifyInactiveAccounts_Should_dispatchEmail_When_emailDispatchEnabled() {
     setField(service, "emailDispatchEnabled", true);
+    when(mailService.sendEmailNotification(any())).thenReturn(true);
     User user = new User("user-1", null, "user1", "u1@example.com", true);
     user.setTenantId(1L);
     LocalDateTime now = LocalDateTime.now();
@@ -242,8 +253,26 @@ class InactiveAccountNotificationServiceTest {
         .isEqualTo(recipientAdmin.getEmail());
     ArgumentCaptor<InactiveAccountNotificationAuditLog> auditCaptor =
         ArgumentCaptor.forClass(InactiveAccountNotificationAuditLog.class);
-    verify(auditLogRepository).save(auditCaptor.capture());
-    assertThat(auditCaptor.getValue().isEmailDispatched()).isTrue();
+    verify(claimWriter).claim(auditCaptor.capture());
+    assertThat(auditCaptor.getValue().isEmailDispatched()).isFalse();
+    verify(claimWriter).markEmailDispatched(1L);
+  }
+
+  @Test
+  void scanAndNotifyInactiveAccounts_Should_keepAuditUndispatched_When_mailTransportRejects() {
+    setField(service, "emailDispatchEnabled", true);
+    when(mailService.sendEmailNotification(any())).thenReturn(false);
+    User user = new User("user-1", null, "user1", "u1@example.com", true);
+    user.setTenantId(1L);
+    LocalDateTime now = LocalDateTime.now();
+    when(userRepository.findAllByDeleteDateIsNull()).thenReturn(singletonList(user));
+    when(askerActivityCalculator.lastActivity(user)).thenReturn(Optional.of(now.minusDays(400)));
+
+    service.scanAndNotifyInactiveAccounts();
+
+    verify(mailService).sendEmailNotification(any());
+    verify(claimWriter).claim(any());
+    verify(claimWriter, never()).markEmailDispatched(any());
   }
 
   @Test
@@ -259,7 +288,8 @@ class InactiveAccountNotificationServiceTest {
     verify(mailService, never()).sendEmailNotification(any());
     ArgumentCaptor<InactiveAccountNotificationAuditLog> auditCaptor =
         ArgumentCaptor.forClass(InactiveAccountNotificationAuditLog.class);
-    verify(auditLogRepository).save(auditCaptor.capture());
+    verify(claimWriter).claim(auditCaptor.capture());
     assertThat(auditCaptor.getValue().isEmailDispatched()).isFalse();
+    verify(claimWriter, never()).markEmailDispatched(any());
   }
 }


### PR DESCRIPTION
## Summary

- claim each inactive-account notification fingerprint in a committed MariaDB transaction before contacting MailService
- use the existing unique fingerprint constraint so concurrent UserService replicas submit at most one mail request
- suppress only proven duplicate claims; surface unrelated database integrity failures
- record MailService acceptance separately, keep rejected requests marked undispatched, and fail explicitly if the claimed audit row disappears
- treat MailService client-setup and submission failures uniformly as a rejected request
- document the remaining crash window because the current MailService OpenAPI contract has no idempotency key

## TDD proof

On unchanged `pre-dev`, the new two-instance proof failed with two calls to `MailService.sendEmailNotification` where one was expected. After the claim boundary, the same proof passes with one audit row and one accepted mail call.

The follow-up regression tests first proved that an unrelated integrity failure was swallowed as a duplicate, MailService client setup could escape the boolean acceptance contract, and a missing audit row was silently ignored. All three cases now fail safely and explicitly.

## Validation

- exact head: `c3323981b550015da7b8c1d1a336cf57ec92fd2c`
- focused notification and MailService tests: 18 passed
- full Maven suite: 3,377 passed, 0 failures/errors, 4 skipped
- required integration contract: 841 passed across 79 reports, 0 failures/errors, 2 skipped
- CI/load-test contracts: 13 passed
- package build: passed
- Spotless and diff checks: passed
- CodeRabbit CLI follow-up review: 0 findings after fixing its two valid findings
- GitHub exact-head checks after publication: 12/12 passed; the successful CodeRabbit status explicitly records that hosted reviews are disabled for this base branch
- synthetic merge audit: conflict-free with PRs #823, #825, #827, #828, #829, #830, #831, #832, #834, #846, #854, #856, and #862
- local Redis remained healthy; no persistent database reset was required

## Delivery boundary

This is an at-most-once UserService replica guarantee, not end-to-end exactly-once email delivery. A process stop after MailService accepts the request and before the audit update commits cannot be replayed safely until MailService accepts a stable idempotency key or the boundary is replaced with a durable outbox and idempotent consumer.

The target architecture remains Matrix as the sole chat system, the ORISO-owned frontend, an ORISO-controlled Element Call / MatrixRTC fork, and LiveKit for media. Rocket.Chat and Jitsi are removal targets and are not fallbacks.

This PR proves source, local-test, CI, and merge-compatibility state only. It is not merged, deployed to PreDev, or runtime-proven.

This slice supersedes the bounded inactive-notification portion of historical commit `867c9925`.

Closes OpenResilienceInitiative/ORISO-UserService#847

Refs #543
Refs #757
