### PR TITLE
test(appointment): prove cleanup idempotency (#849)

### DIFF
--- a/.github/workflows/mariadb-contract.yml
+++ b/.github/workflows/mariadb-contract.yml
@@ -38,5 +38,5 @@ jobs:
     - name: Verify real MariaDB schema contracts
       run: >-
         ./mvnw -B -Dskip.unit-tests=true
-        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT
+        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,OrganizerMariaDbReplicaIT
         integration-test

--- a/documentation/APPOINTMENT_CLEANUP_REPLICA_SAFETY.md
+++ b/documentation/APPOINTMENT_CLEANUP_REPLICA_SAFETY.md
@@ -1,0 +1,14 @@
+# Appointment cleanup replica safety
+
+`Organizer.deleteObsoleteAppointments()` performs one native database delete over
+a fixed clock cutoff. It has no external side effects and does not require a
+distributed scheduler claim.
+
+`OrganizerMariaDbReplicaIT` runs two cleanup executions concurrently against the
+same MariaDB schema after seeding 120 expired and 30 current appointments. Both
+transactions complete successfully, every expired row is removed, and all current
+rows remain.
+
+The reusable MariaDB workflow runs this proof together with schema-drift and
+statistics contracts. Its CI contract explicitly requires the replica proof, so
+removing it makes the CI contract fail.

--- a/src/test/java/de/caritas/cob/userservice/api/OrganizerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/OrganizerMariaDbReplicaIT.java
@@ -1,0 +1,161 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.model.Appointment;
+import de.caritas.cob.userservice.api.model.Appointment.AppointmentStatus;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.port.out.AppointmentRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class OrganizerMariaDbReplicaIT {
+
+  private static final Instant NOW = Instant.parse("2026-07-26T05:00:00Z");
+  private static final String CONSULTANT_ID = "appointment-replica-proof";
+  private static final int EXPIRED_APPOINTMENTS = 120;
+  private static final int CURRENT_APPOINTMENTS = 30;
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.mariadb.jdbc.Driver");
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.liquibase.contexts", () -> "dev,seed");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MariaDBDialect");
+    registry.add("spring.jpa.defer-datasource-initialization", () -> "false");
+    registry.add("spring.sql.init.mode", () -> "never");
+    registry.add("appointments.delete-job-enabled", () -> "true");
+    registry.add("appointments.lifespan-in-hours", () -> "24");
+  }
+
+  @Autowired private Organizer organizer;
+  @Autowired private AppointmentRepository appointmentRepository;
+  @Autowired private ConsultantRepository consultantRepository;
+  @MockitoBean private Clock clock;
+
+  @BeforeEach
+  void setUp() {
+    appointmentRepository.deleteAll();
+    consultantRepository.deleteById(CONSULTANT_ID);
+    consultantRepository.save(
+        Consultant.builder()
+            .id(CONSULTANT_ID)
+            .matrixUserId("@appointment-replica-proof:oriso.invalid")
+            .username("appointment-replica-proof")
+            .firstName("Appointment")
+            .lastName("Replica")
+            .email("appointment-replica@example.invalid")
+            .encourage2fa(true)
+            .magicLinkLoginEnabled(false)
+            .notifyEnquiriesRepeating(true)
+            .notifyNewChatMessageFromAdviceSeeker(true)
+            .walkThroughEnabled(true)
+            .languageCode(LanguageCode.de)
+            .status(ConsultantStatus.IN_PROGRESS)
+            .createDate(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC))
+            .updateDate(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC))
+            .build());
+    when(clock.instant()).thenReturn(NOW);
+  }
+
+  @AfterEach
+  void cleanUp() {
+    appointmentRepository.deleteAll();
+    consultantRepository.deleteById(CONSULTANT_ID);
+  }
+
+  @Test
+  void concurrentCleanupTransactionsDeleteEveryExpiredAppointmentExactlyOnce() throws Exception {
+    var consultant = consultantRepository.findById(CONSULTANT_ID).orElseThrow();
+    saveAppointments(consultant, NOW.minus(48, ChronoUnit.HOURS), EXPIRED_APPOINTMENTS, "expired");
+    saveAppointments(consultant, NOW, CURRENT_APPOINTMENTS, "current");
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var firstResult = executor.submit(() -> runCleanup(ready, start));
+      var secondResult = executor.submit(() -> runCleanup(ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      firstResult.get(10, TimeUnit.SECONDS);
+      secondResult.get(10, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+    }
+
+    var remaining = appointmentRepository.findAll();
+    assertThat(remaining)
+        .hasSize(CURRENT_APPOINTMENTS)
+        .allSatisfy(appointment -> assertThat(appointment.getDatetime()).isEqualTo(NOW));
+  }
+
+  private void saveAppointments(
+      Consultant consultant, Instant datetime, int count, String description) {
+    var appointments = new ArrayList<Appointment>();
+    for (int index = 0; index < count; index++) {
+      var appointment = new Appointment();
+      appointment.setConsultant(consultant);
+      appointment.setDatetime(datetime);
+      appointment.setDescription(description + "-" + index);
+      appointment.setStatus(AppointmentStatus.CREATED);
+      appointments.add(appointment);
+    }
+    appointmentRepository.saveAll(appointments);
+  }
+
+  private void runCleanup(CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    organizer.deleteObsoleteAppointments();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent cleanup proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/OrganizerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/OrganizerMariaDbReplicaIT.java
@@ -26,10 +26,13 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @ActiveProfiles("testing")
@@ -68,11 +71,13 @@ class OrganizerMariaDbReplicaIT {
   @Autowired private Organizer organizer;
   @Autowired private AppointmentRepository appointmentRepository;
   @Autowired private ConsultantRepository consultantRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private PlatformTransactionManager transactionManager;
   @MockitoBean private Clock clock;
 
   @BeforeEach
   void setUp() {
-    appointmentRepository.deleteAll();
+    deleteOwnedAppointments();
     consultantRepository.deleteById(CONSULTANT_ID);
     consultantRepository.save(
         Consultant.builder()
@@ -97,12 +102,12 @@ class OrganizerMariaDbReplicaIT {
 
   @AfterEach
   void cleanUp() {
-    appointmentRepository.deleteAll();
+    deleteOwnedAppointments();
     consultantRepository.deleteById(CONSULTANT_ID);
   }
 
   @Test
-  void concurrentCleanupTransactionsDeleteEveryExpiredAppointmentExactlyOnce() throws Exception {
+  void concurrentCleanupTransactionsAreIdempotent() throws Exception {
     var consultant = consultantRepository.findById(CONSULTANT_ID).orElseThrow();
     saveAppointments(consultant, NOW.minus(48, ChronoUnit.HOURS), EXPIRED_APPOINTMENTS, "expired");
     saveAppointments(consultant, NOW, CURRENT_APPOINTMENTS, "current");
@@ -122,7 +127,7 @@ class OrganizerMariaDbReplicaIT {
       executor.shutdownNow();
     }
 
-    var remaining = appointmentRepository.findAll();
+    var remaining = appointmentRepository.findAllOrderByDatetimeAfter(Instant.EPOCH, CONSULTANT_ID);
     assertThat(remaining)
         .hasSize(CURRENT_APPOINTMENTS)
         .allSatisfy(appointment -> assertThat(appointment.getDatetime()).isEqualTo(NOW));
@@ -143,9 +148,17 @@ class OrganizerMariaDbReplicaIT {
   }
 
   private void runCleanup(CountDownLatch ready, CountDownLatch start) {
-    ready.countDown();
-    await(start);
-    organizer.deleteObsoleteAppointments();
+    new TransactionTemplate(transactionManager)
+        .executeWithoutResult(
+            status -> {
+              ready.countDown();
+              await(start);
+              organizer.deleteObsoleteAppointments();
+            });
+  }
+
+  private void deleteOwnedAppointments() {
+    jdbcTemplate.update("DELETE FROM appointment WHERE consultant_id = ?", CONSULTANT_ID);
   }
 
   private void await(CountDownLatch latch) {

--- a/tests/ci/test_required_ci_contract.py
+++ b/tests/ci/test_required_ci_contract.py
@@ -91,6 +91,7 @@ class RequiredCiContractTest(unittest.TestCase):
         self.assertIn("LIQUIBASE_IT_DB_URL", reusable)
         self.assertIn("DatabaseChangelogDriftIT", reusable)
         self.assertIn("AdminStatisticsRepositoryMariaDbIT", reusable)
+        self.assertIn("OrganizerMariaDbReplicaIT", reusable)
         self.assertNotIn("continue-on-error:", reusable)
 
         for relative_path in (


### PR DESCRIPTION
## Summary

- prove the active appointment cleanup is database-idempotent across two UserService replicas
- start two real MariaDB transactions before the shared release barrier, then run both cleanup calls against 120 expired and 30 current appointments
- scope all test setup, cleanup, and final assertions to the proof's own consultant so the reusable database lane cannot erase or count unrelated data
- require the proof in the reusable MariaDB CI workflow and its executable CI contract
- document why this single native delete needs no distributed scheduler lease

## TDD and review proof

The CI contract first failed because `OrganizerMariaDbReplicaIT` was absent from the required MariaDB workflow. After wiring the new proof into that workflow, the contract passes.

Independent review then found two valid gaps: the first test version used table-wide setup and assertions, and its start latch ran before the transactions began. The corrected test uses consultant-scoped data handling and begins both transactions before either delete is released.

The real MariaDB 10.11 proof applies all 101 Liquibase changesets, releases both cleanup transactions together, and confirms that both complete successfully with exactly the 30 current proof-owned rows remaining.

## Validation

- exact head: `56f6b31bd041a9be8657440dc096f76ac8d80f25`
- real MariaDB contract: 3 passed, 0 failures, 0 skips
- full Maven suite: 3,373 passed, 0 failures/errors, 4 skipped
- required integration contract: 841 passed across 79 reports, 0 failures/errors, 4 skipped
- required-CI contract: 7 passed
- package build: passed
- Spotless and diff checks: passed
- GitHub exact-head checks after publication: 12/12 passed; the successful hosted CodeRabbit status explicitly records that reviews are disabled for this base branch
- first CodeRabbit CLI review: 2 valid findings, both fixed; immediate follow-up was rate-limited, so no clean second CLI review is claimed
- disposable MariaDB was removed; persistent databases were untouched; local Redis remains healthy

## Coordination

Synthetic merges are clean with #823, #825, #827, #828, #829, #831, #832, #834, #846, #848, #852, #854, #856, and #862.

#830 has one mechanical conflict in the reusable MariaDB test list because both PRs add an independent real-MariaDB replica contract to the same line. Recommended order: land #830 first, then replay this single test-list addition while retaining both `TutorialProgressServiceMariaDbReplicaIT` and `OrganizerMariaDbReplicaIT`.

This is coordination evidence, not merge authorization.

## Architecture and delivery boundary

This test-only slice does not change the target architecture: Matrix is the sole chat system, with the ORISO-owned frontend, an ORISO-controlled Element Call / MatrixRTC fork, and LiveKit media. Rocket.Chat and Jitsi are removal targets and never fallbacks.

This PR proves source, local-test, CI, and merge-compatibility state only. It is not merged, deployed to PreDev, or runtime-proven.

It supersedes the bounded appointment-cleanup portion of historical commit `dc0538a7`.

Closes OpenResilienceInitiative/ORISO-UserService#849

Refs #543
Refs #757
