### PR TITLE
test(group-chat): prove Matrix deactivation serialization

### DIFF
--- a/.github/workflows/mariadb-contract.yml
+++ b/.github/workflows/mariadb-contract.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   verify:
-    name: MariaDB schema and statistics contract
+    name: MariaDB schema, statistics and replica contracts
     runs-on: ubuntu-latest
     services:
       mariadb:
@@ -38,5 +38,5 @@ jobs:
     - name: Verify real MariaDB schema contracts
       run: >-
         ./mvnw -B -Dskip.unit-tests=true
-        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,OrganizerMariaDbReplicaIT
+        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,OrganizerMariaDbReplicaIT,DeactivateGroupChatSchedulerMariaDbReplicaIT
         integration-test

--- a/documentation/GROUP_CHAT_DEACTIVATION_REPLICA_SAFETY.md
+++ b/documentation/GROUP_CHAT_DEACTIVATION_REPLICA_SAFETY.md
@@ -5,10 +5,17 @@ claim. `ChatRepository.findAllByActiveIsTrue()` takes a pessimistic database row
 lock, so concurrent scheduler instances serialize each active chat while its
 database transition and Matrix room purge are in progress.
 
-`DeactivateGroupChatSchedulerMariaDbReplicaIT` starts two scheduler instances
-against one expired Matrix chat on MariaDB. Both instances enter the workflow,
-but the second remains blocked while the first purge is held open. The chat is
-deleted once and its Matrix room is purged exactly once.
+`DeactivateGroupChatSchedulerMariaDbReplicaIT` opens two transactions and then
+starts two scheduler instances against one expired Matrix chat on MariaDB. Both
+instances enter the workflow, but the second remains blocked while the first
+purge is held open. The test scopes all setup and cleanup data to its own Matrix
+room. The chat is deleted once and its Matrix room is purged exactly once.
+
+This is a concurrent-replica serialization guarantee, not crash-safe exactly
+once delivery. A process stop after Matrix accepts the purge but before the
+database transaction commits can replay the purge. Removing that crash window
+requires an idempotent Matrix operation plus a durable state transition or
+outbox; the database row lock alone cannot provide it.
 
 The reusable MariaDB workflow requires this proof. The coordination is scoped to
 the Matrix-only deactivation path; no Rocket.Chat or Jitsi fallback is involved.

--- a/documentation/GROUP_CHAT_DEACTIVATION_REPLICA_SAFETY.md
+++ b/documentation/GROUP_CHAT_DEACTIVATION_REPLICA_SAFETY.md
@@ -1,0 +1,14 @@
+# Matrix group-chat deactivation replica safety
+
+The one-minute group-chat deactivation scheduler does not use a coarse global
+claim. `ChatRepository.findAllByActiveIsTrue()` takes a pessimistic database row
+lock, so concurrent scheduler instances serialize each active chat while its
+database transition and Matrix room purge are in progress.
+
+`DeactivateGroupChatSchedulerMariaDbReplicaIT` starts two scheduler instances
+against one expired Matrix chat on MariaDB. Both instances enter the workflow,
+but the second remains blocked while the first purge is held open. The chat is
+deleted once and its Matrix room is purged exactly once.
+
+The reusable MariaDB workflow requires this proof. The coordination is scoped to
+the Matrix-only deactivation path; no Rocket.Chat or Jitsi fallback is involved.

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateGroupChatSchedulerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateGroupChatSchedulerMariaDbReplicaIT.java
@@ -29,10 +29,13 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @ActiveProfiles("testing")
@@ -70,18 +73,20 @@ class DeactivateGroupChatSchedulerMariaDbReplicaIT {
   @Autowired private DeactivateGroupChatService deactivationService;
   @Autowired private ChatRepository chatRepository;
   @Autowired private ConsultantRepository consultantRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private PlatformTransactionManager transactionManager;
   @MockitoBean private MatrixSynapseService matrixSynapseService;
 
   @BeforeEach
   void setUp() {
-    chatRepository.deleteAll();
+    deleteProofChat();
     consultantRepository.deleteById(CONSULTANT_ID);
     consultantRepository.save(createConsultant());
   }
 
   @AfterEach
   void cleanUp() {
-    chatRepository.deleteAll();
+    deleteProofChat();
     consultantRepository.deleteById(CONSULTANT_ID);
   }
 
@@ -180,9 +185,17 @@ class DeactivateGroupChatSchedulerMariaDbReplicaIT {
 
   private void run(
       DeactivateGroupChatScheduler scheduler, CountDownLatch ready, CountDownLatch start) {
-    ready.countDown();
-    await(start);
-    scheduler.performDeactivationWorkflow();
+    new TransactionTemplate(transactionManager)
+        .executeWithoutResult(
+            status -> {
+              ready.countDown();
+              await(start);
+              scheduler.performDeactivationWorkflow();
+            });
+  }
+
+  private void deleteProofChat() {
+    jdbcTemplate.update("DELETE FROM chat WHERE matrix_room_id = ?", ROOM_ID);
   }
 
   private void await(CountDownLatch latch) {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateGroupChatSchedulerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/scheduler/DeactivateGroupChatSchedulerMariaDbReplicaIT.java
@@ -1,0 +1,198 @@
+package de.caritas.cob.userservice.api.workflow.deactivate.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Chat.ChatModality;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.model.ConversationType;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.deactivate.service.DeactivateGroupChatService;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class DeactivateGroupChatSchedulerMariaDbReplicaIT {
+
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 26, 5, 0);
+  private static final String CONSULTANT_ID = "group-chat-replica-proof";
+  private static final String ROOM_ID = "!group-chat-replica:matrix.test";
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.mariadb.jdbc.Driver");
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.liquibase.contexts", () -> "dev,seed");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MariaDBDialect");
+    registry.add("spring.jpa.defer-datasource-initialization", () -> "false");
+    registry.add("spring.sql.init.mode", () -> "never");
+    registry.add("group.chat.deactivateworkflow.periodMinutes", () -> "0");
+    registry.add("group.chat.deactivateworkflow.cron", () -> "0 0 0 1 1 ?");
+  }
+
+  @Autowired private DeactivateGroupChatService deactivationService;
+  @Autowired private ChatRepository chatRepository;
+  @Autowired private ConsultantRepository consultantRepository;
+  @MockitoBean private MatrixSynapseService matrixSynapseService;
+
+  @BeforeEach
+  void setUp() {
+    chatRepository.deleteAll();
+    consultantRepository.deleteById(CONSULTANT_ID);
+    consultantRepository.save(createConsultant());
+  }
+
+  @AfterEach
+  void cleanUp() {
+    chatRepository.deleteAll();
+    consultantRepository.deleteById(CONSULTANT_ID);
+  }
+
+  @Test
+  void twoSchedulerInstancesShutdownOneExpiredMatrixChatExactlyOnce() throws Exception {
+    var persistedChat = chatRepository.save(createExpiredChat());
+    var bothSchedulersEntered = new CountDownLatch(2);
+    var firstMatrixShutdownEntered = new CountDownLatch(1);
+    var releaseFirstMatrixShutdown = new CountDownLatch(1);
+    var tenantContextProvider = mock(TenantContextProvider.class);
+    doAnswer(
+            ignored -> {
+              bothSchedulersEntered.countDown();
+              await(bothSchedulersEntered);
+              return null;
+            })
+        .when(tenantContextProvider)
+        .setTechnicalContextIfMultiTenancyIsEnabled();
+    when(matrixSynapseService.purgeRoom(ROOM_ID))
+        .thenAnswer(
+            ignored -> {
+              firstMatrixShutdownEntered.countDown();
+              await(releaseFirstMatrixShutdown);
+              return true;
+            });
+    var first = new DeactivateGroupChatScheduler(deactivationService, tenantContextProvider);
+    var second = new DeactivateGroupChatScheduler(deactivationService, tenantContextProvider);
+    var ready = new CountDownLatch(2);
+    var start = new CountDownLatch(1);
+    var executor = Executors.newFixedThreadPool(2);
+    try {
+      var firstResult = executor.submit(() -> run(first, ready, start));
+      var secondResult = executor.submit(() -> run(second, ready, start));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+      assertThat(bothSchedulersEntered.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(firstMatrixShutdownEntered.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(firstResult.isDone()).isFalse();
+      assertThat(secondResult.isDone()).isFalse();
+      releaseFirstMatrixShutdown.countDown();
+      firstResult.get(10, TimeUnit.SECONDS);
+      secondResult.get(10, TimeUnit.SECONDS);
+    } finally {
+      start.countDown();
+      releaseFirstMatrixShutdown.countDown();
+      executor.shutdownNow();
+    }
+
+    assertThat(chatRepository.findById(persistedChat.getId())).isEmpty();
+    verify(matrixSynapseService, times(1)).purgeRoom(ROOM_ID);
+    verify(tenantContextProvider, times(2)).setTechnicalContextIfMultiTenancyIsEnabled();
+  }
+
+  private Chat createExpiredChat() {
+    var owner = consultantRepository.findById(CONSULTANT_ID).orElseThrow();
+    var chat = new Chat();
+    chat.setTopic("Replica-safe Matrix group chat");
+    chat.setConsultingTypeId(1);
+    chat.setInitialStartDate(NOW.minusHours(2));
+    chat.setStartDate(NOW.minusHours(2));
+    chat.setDuration(30);
+    chat.setRepetitive(false);
+    chat.setRepeatCount(1);
+    chat.setCurrentOccurrenceIndex(0);
+    chat.setTimezone("UTC");
+    chat.setChatModality(ChatModality.TEXT);
+    chat.setConversationType(ConversationType.SELF_HELP);
+    chat.setActive(true);
+    chat.setMatrixRoomId(ROOM_ID);
+    chat.setChatOwner(owner);
+    chat.setCreateDate(NOW.minusHours(2));
+    chat.setUpdateDate(NOW.minusHours(2));
+    return chat;
+  }
+
+  private Consultant createConsultant() {
+    var consultant = new Consultant();
+    consultant.setId(CONSULTANT_ID);
+    consultant.setMatrixUserId("@group-chat-owner:matrix.test");
+    consultant.setUsername("group-chat-replica-proof");
+    consultant.setFirstName("Group Chat");
+    consultant.setLastName("Replica");
+    consultant.setEmail("group-chat-replica@example.invalid");
+    consultant.setEncourage2fa(true);
+    consultant.setMagicLinkLoginEnabled(false);
+    consultant.setNotifyEnquiriesRepeating(true);
+    consultant.setNotifyNewChatMessageFromAdviceSeeker(true);
+    consultant.setWalkThroughEnabled(true);
+    consultant.setLanguageCode(LanguageCode.de);
+    consultant.setStatus(ConsultantStatus.IN_PROGRESS);
+    consultant.setCreateDate(NOW);
+    consultant.setUpdateDate(NOW);
+    return consultant;
+  }
+
+  private void run(
+      DeactivateGroupChatScheduler scheduler, CountDownLatch ready, CountDownLatch start) {
+    ready.countDown();
+    await(start);
+    scheduler.performDeactivationWorkflow();
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for concurrent group-chat proof");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(exception);
+    }
+  }
+}

--- a/tests/ci/test_required_ci_contract.py
+++ b/tests/ci/test_required_ci_contract.py
@@ -92,6 +92,7 @@ class RequiredCiContractTest(unittest.TestCase):
         self.assertIn("DatabaseChangelogDriftIT", reusable)
         self.assertIn("AdminStatisticsRepositoryMariaDbIT", reusable)
         self.assertIn("OrganizerMariaDbReplicaIT", reusable)
+        self.assertIn("DeactivateGroupChatSchedulerMariaDbReplicaIT", reusable)
         self.assertNotIn("continue-on-error:", reusable)
 
         for relative_path in (


### PR DESCRIPTION
## Summary
- require the real-MariaDB replica contract for Matrix group-chat deactivation
- prove two scheduler instances open overlapping database transactions and serialize on the existing pessimistic row lock
- scope setup and cleanup to the proof Matrix room so the contract cannot delete unrelated shared-database rows
- document the delivery boundary: one purge during healthy concurrent execution, not crash-safe exactly-once delivery

## Architecture context
This is part of the complete Rocket.Chat and Jitsi removal target:

- Matrix is the sole chat system
- ORISO uses its own frontend
- calls use an ORISO-controlled Element Call / MatrixRTC fork
- LiveKit provides the media layer
- Rocket.Chat and Jitsi are removal targets, never fallbacks

This change covers only the UserService Matrix group-chat deactivation scheduler. It supersedes the historical Rocket.Chat-oriented scheduler replay from commit `13d12f18` and introduces no Rocket.Chat or Jitsi dependency.

## Delivery boundary
The MariaDB row lock proves serialization while both replicas and their transactions are healthy. It does **not** make the external Matrix purge crash-safe exactly once: a stop after Matrix accepts the purge but before the database transaction commits can replay that purge. Closing that window requires an idempotent Matrix operation plus a durable transition or outbox.

## Stack
This PR is stacked on #850 at exact base `56f6b31bd041a9be8657440dc096f76ac8d80f25`; review the #852 top changes at exact head `195caa09071eedf064be9ce6fe697368c6170cc4`.

## Verification
- 3,373 unit/package tests: 0 failures, 0 errors, 4 skipped
- 842 integration tests across 80 reports: 0 failures, 0 errors, 5 skipped
- 4 disposable-MariaDB 10.11 contract tests with all 101 Liquibase changesets: 4 passed
- required CI contract: 7 passed
- package build, Spotless, and diff check passed
- temporary MariaDB removed; shared Redis healthy; persistent local database untouched

## Open-PR compatibility
Synthetic merges are clean with #823, #825, #827, #828, #829, #831, #832, #834, #846, #848, #854, #856, and #862.

#830 has one mechanical conflict in `.github/workflows/mariadb-contract.yml` because both branches extend the same required-test list. Merge #830 first, then replay #850/#852 and retain both `TutorialProgressServiceMariaDbReplicaIT` and `OrganizerMariaDbReplicaIT` plus `DeactivateGroupChatSchedulerMariaDbReplicaIT`.

## Release status
This evidence applies to the exact source head and local/CI verification only. The PR is not merged, not deployed to pre-dev, and not runtime-proven there.

Closes OpenResilienceInitiative/ORISO-UserService#851
Refs #543
Refs #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
