### PR TITLE
fix(runtime): remove obsolete MongoDB stack (#855)

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -55,7 +55,7 @@ runtime dependency set is:
 | Boundary | Dependencies | Transport |
 | --- | --- | --- |
 | Identity | Keycloak, identity extensions | Keycloak client + HTTP |
-| Chat | Matrix; Rocket.Chat only when explicitly enabled | HTTP long-poll + HTTP; optional MongoDB |
+| Chat | Matrix | HTTP long-poll + HTTP |
 | ORISO services | Agency, Tenant, Consulting Type/Topic/Application Settings, Appointment, Message, Mail, Live | HTTP |
 | State/event infrastructure | MariaDB, Redis, RabbitMQ | JDBC, Redis, AMQP |
 
@@ -113,9 +113,8 @@ repair. Those require the branch image to be deployed and queried again.
 
 ## Chatty-call reductions
 
-- With the default `rocket-chat.enabled=false`, account and availability reads
-  no longer call Rocket.Chat. Matrix-only deployments also do not create the
-  Rocket.Chat MongoDB client or credential job.
+- Account and availability reads no longer call Rocket.Chat. The Matrix-only
+  runtime has no Rocket.Chat adapter, MongoDB client or credential job.
 - Anonymous live-chat queue visibility is topic-only and therefore avoids an
   AgencyService lookup merely to resolve consulting-type visibility.
 - Appointment deletion uses one conditional database `DELETE` and its affected

--- a/pom.xml
+++ b/pom.xml
@@ -470,12 +470,6 @@
 			<version>1.2026.0</version>
 		</dependency>
 
-		<!-- MongoDB dependencies -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -22,13 +22,6 @@ export KEYCLOAK_AUTH_SERVER_URL="https://auth.oriso-dev.site"
 export IDENTITY_TECHNICAL_USER_USERNAME="technical"
 export IDENTITY_TECHNICAL_USER_PASSWORD='CHANGE_ME'
 
-export ROCKET_CHAT_BASE_URL="http://localhost:3000/api/v1"
-export ROCKET_CHAT_MONGO_URL="mongodb://localhost:27017/rocketchat?retryWrites=false"
-export ROCKET_TECHNICAL_USERNAME="rocket-chat-technical-user"
-export ROCKET_TECHNICAL_PASSWORD="technical"
-
-export SPRING_DATA_MONGODB_URI="mongodb://localhost:27017/userservice"
-
 if [ -f config.env ]; then
   set -a
   # shellcheck disable=SC1091

--- a/src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java
+++ b/src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java
@@ -6,14 +6,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.data.mongodb.autoconfigure.DataMongoAutoConfiguration;
-import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@SpringBootApplication(exclude = {MongoAutoConfiguration.class, DataMongoAutoConfiguration.class})
+@SpringBootApplication
 @EnableAsync
 @EnableScheduling
 @EnableConfigurationProperties({CsrfSecurityProperties.class})

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -80,10 +80,6 @@ csrf.whitelist.config-uris=/users/data,\
   /actuator/loggers/**
 tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
-# ---------------- Spring Boot MongoDB connection ----------------
-# Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/userservice
-# NOT hardcoded IPs like mongodb://10.43.61.124:27017/userservice
-spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -81,10 +81,6 @@ csrf.whitelist.config-uris=/users/data,\
   /actuator/loggers/**
 tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
-# ---------------- Spring Boot MongoDB connection ----------------
-# Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/userservice
-# NOT hardcoded IPs like mongodb://10.43.61.124:27017/userservice
-spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -69,10 +69,6 @@ csrf.whitelist.config-uris=/users/data,\
   /actuator/loggers/**
 tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
-# ---------------- Spring Boot MongoDB connection ----------------
-# Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/userservice
-# NOT hardcoded IPs like mongodb://10.43.61.124:27017/userservice
-spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -81,10 +81,6 @@ csrf.whitelist.config-uris=/users/data,\
 tenant.service.api.url=${TENANT_SERVICE_API_URL:http://localhost:8084}
 consulting.type.service.api.url=${CONSULTING_TYPE_SERVICE_API_URL:http://localhost:8083}
 
-# ---------------- Spring Boot MongoDB connection ----------------
-# Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/userservice
-# NOT hardcoded IPs like mongodb://10.43.61.124:27017/userservice
-spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,6 @@ consultant.availability.redis.ttlSeconds=${CONSULTANT_AVAILABILITY_REDIS_TTL_SEC
 consultant.availability.redis.keyPrefix=${CONSULTANT_AVAILABILITY_REDIS_KEY_PREFIX:livechat:consultant:available:}
 auth.one-time-token.redis.keyPrefix=${AUTH_ONE_TIME_TOKEN_REDIS_KEY_PREFIX:auth:one-time:}
 spring.main.banner-mode=off
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration
 
 # ---------------- Server ----------------
 server.port=8082

--- a/src/test/java/de/caritas/cob/userservice/api/MatrixOnlyRuntimeConfigurationContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/MatrixOnlyRuntimeConfigurationContractTest.java
@@ -12,6 +12,7 @@ class MatrixOnlyRuntimeConfigurationContractTest {
   private static final Path RESOURCES = Path.of("src/main/resources");
   private static final Path APPLICATION =
       Path.of("src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java");
+  private static final Path LOCAL_RUN_EXAMPLE = Path.of("run-local-remote-db.sh.example");
 
   @Test
   void releaseWorkflowMustPublishImmutableMultiPlatformImagesWithEvidence() throws IOException {
@@ -56,6 +57,13 @@ class MatrixOnlyRuntimeConfigurationContractTest {
 
     assertThat(configurationValidator).doesNotContain("rocket", "Rocket");
     assertThat(cacheManager).doesNotContain("rocket", "Rocket");
+    assertThat(Files.readString(LOCAL_RUN_EXAMPLE))
+        .as(LOCAL_RUN_EXAMPLE.toString())
+        .doesNotContain(
+            "ROCKET_CHAT_BASE_URL",
+            "ROCKET_CHAT_MONGO_URL",
+            "ROCKET_TECHNICAL_USERNAME",
+            "ROCKET_TECHNICAL_PASSWORD");
 
     try (var propertyFiles = Files.list(RESOURCES)) {
       for (var propertyFile :
@@ -76,6 +84,9 @@ class MatrixOnlyRuntimeConfigurationContractTest {
         .doesNotContain("spring-boot-starter-data-mongodb");
     assertThat(Files.readString(APPLICATION))
         .doesNotContain("MongoAutoConfiguration", "DataMongoAutoConfiguration");
+    assertThat(Files.readString(LOCAL_RUN_EXAMPLE))
+        .as(LOCAL_RUN_EXAMPLE.toString())
+        .doesNotContain("SPRING_DATA_MONGODB_URI", "mongodb://");
 
     try (var propertyFiles = Files.list(RESOURCES)) {
       for (var propertyFile :

--- a/src/test/java/de/caritas/cob/userservice/api/MatrixOnlyRuntimeConfigurationContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/MatrixOnlyRuntimeConfigurationContractTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 class MatrixOnlyRuntimeConfigurationContractTest {
 
   private static final Path RESOURCES = Path.of("src/main/resources");
+  private static final Path APPLICATION =
+      Path.of("src/main/java/de/caritas/cob/userservice/api/UserServiceApplication.java");
 
   @Test
   void releaseWorkflowMustPublishImmutableMultiPlatformImagesWithEvidence() throws IOException {
@@ -64,6 +66,31 @@ class MatrixOnlyRuntimeConfigurationContractTest {
             .as(propertyFile.toString())
             .doesNotContain("rocket-chat.", "rocket.technical.", "rocket.systemuser.")
             .doesNotContain("cache.rocketchat.");
+      }
+    }
+  }
+
+  @Test
+  void matrixOnlyRuntimeMustNotShipTheRetiredMongoDbStack() throws IOException {
+    assertThat(Files.readString(Path.of("pom.xml")))
+        .doesNotContain("spring-boot-starter-data-mongodb");
+    assertThat(Files.readString(APPLICATION))
+        .doesNotContain("MongoAutoConfiguration", "DataMongoAutoConfiguration");
+
+    try (var propertyFiles = Files.list(RESOURCES)) {
+      for (var propertyFile :
+          propertyFiles
+              .filter(path -> path.getFileName().toString().endsWith(".properties"))
+              .toList()) {
+        assertThat(Files.readString(propertyFile))
+            .as(propertyFile.toString())
+            .doesNotContain(
+                "spring.data.mongodb",
+                "SPRING_DATA_MONGODB_URI",
+                "mongodb://",
+                "MongoAutoConfiguration",
+                "MongoDataAutoConfiguration",
+                "MongoRepositoriesAutoConfiguration");
       }
     }
   }


### PR DESCRIPTION
## Summary

- remove the unused Spring Data MongoDB starter left behind by the Rocket.Chat cutover
- delete MongoDB auto-configuration exclusions and all active-profile MongoDB URI settings
- remove Rocket.Chat and MongoDB exports from the tracked local-run example
- ratchet the Matrix-only runtime contract so MongoDB dependencies and configuration cannot return

## Architecture effect

The UserService runtime now has no MongoDB seam at all: no driver, repository
module, auto-configuration, active-profile setting or tracked local-run export.
MariaDB, Redis, RabbitMQ, Matrix and the explicit HTTP service adapters remain
unchanged.

Rocket.Chat and Jitsi are removal targets, not fallbacks. The supported target
is Matrix chat through the ORISO-owned frontend with an ORISO-controlled
Element Call/MatrixRTC fork and LiveKit.

## Red-Green evidence

- Red: `MatrixOnlyRuntimeConfigurationContractTest` failed on the MongoDB starter, then on the remaining global auto-configuration exclusions and local-run exports.
- Green: the same contract passes after removing all obsolete wiring.

## Verification

- exact head: `231fc724`
- fresh runtime-source scan: no Rocket.Chat, MongoDB or Jitsi operational reference outside migration/history boundaries
- fresh `MatrixOnlyRuntimeConfigurationContractTest`: 4 passed, 0 failures/errors/skips
- fresh Maven dependency tree for `org.mongodb:*`, `spring-data-mongodb` and the MongoDB starter: empty
- full Java 21 unit suite: 3,374 tests, 0 failures, 0 errors, 4 existing skips
- full Java 21 integration/contract/E2E suite: 840 tests, 0 failures, 0 errors, 3 environment-gated skips
- Python CI contracts: 13 passed
- packaged Spring Boot application: success
- all 12 GitHub checks are terminal green
- formatting and `git diff --check`: clean

## Coordination

The runtime changes are independent of #829 and #834. Those PRs overlap only
in `documentation/USER_SERVICE_STABILITY.md`; land #829 first, then replay this
Matrix-only cleanup record together with #834's load section on updated
`pre-dev`.

No merge, deployment or database reset is included.

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)
