### PR TITLE
Read SMTP credentials from the authenticated settings source

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
@@ -56,6 +57,7 @@ public class MagicLinkLoginService {
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull OneTimeTokenStore oneTimeTokenStore;
+  private final @NonNull ApplicationSettingsService applicationSettingsService;
 
   @Value("${identity.email-dummy-suffix:@beratungcaritas.de}")
   private String emailDummySuffix;
@@ -330,21 +332,25 @@ public class MagicLinkLoginService {
       String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
       Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
       boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
-      String username = asStringSettingValue(settingsResponse.get("globalSmtpUsername"));
-      String password = asStringSettingValue(settingsResponse.get("globalSmtpPassword"));
       String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
       String emailThemeColor =
           asStringSettingValue(settingsResponse.get("globalSmtpEmailThemeColor"));
 
-      if (!systemEmailsEnabled
-          || !smtpEnabled
-          || isBlank(host)
-          || port == null
-          || isBlank(username)
-          || isBlank(password)
-          || isBlank(from)) {
+      if (!systemEmailsEnabled || !smtpEnabled || isBlank(host) || port == null || isBlank(from)) {
         return Optional.empty();
       }
+
+      // The public /settings payload deliberately omits the SMTP username and password since the
+      // CTS-C01 credential-leak fix, so they must come from the authenticated settings endpoint.
+      var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+      if (credentials.isEmpty()) {
+        log.warn(
+            "Magic link email not sent: global SMTP credentials are unavailable. "
+                + "Set the SMTP username and password in the platform settings.");
+        return Optional.empty();
+      }
+      String username = credentials.get().getGlobalSmtpUsername();
+      String password = credentials.get().getGlobalSmtpPassword();
 
       return Optional.of(
           new GlobalSmtpSettings(host, port, secure, username, password, from, emailThemeColor));

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginService.java
@@ -77,6 +77,13 @@ public class MagicLinkLoginService {
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
 
+  /** Operator-provided SMTP credentials; see {@link PasswordResetService}. */
+  @Value("${smtp.user:}")
+  private String configuredSmtpUsername;
+
+  @Value("${smtp.password:}")
+  private String configuredSmtpPassword;
+
   public MagicLinkRequestResult requestMagicLink(String usernameInput) {
     if (isBlank(usernameInput)) {
       return MagicLinkRequestResult.ACCEPTED;
@@ -341,16 +348,20 @@ public class MagicLinkLoginService {
       }
 
       // The public /settings payload deliberately omits the SMTP username and password since the
-      // CTS-C01 credential-leak fix, so they must come from the authenticated settings endpoint.
-      var credentials = applicationSettingsService.getGlobalSmtpCredentials();
-      if (credentials.isEmpty()) {
-        log.warn(
-            "Magic link email not sent: global SMTP credentials are unavailable. "
-                + "Set the SMTP username and password in the platform settings.");
-        return Optional.empty();
+      // CTS-C01 credential-leak fix, so they can never be read from there.
+      String username = configuredSmtpUsername;
+      String password = configuredSmtpPassword;
+      if (isBlank(username) || isBlank(password)) {
+        var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+        if (credentials.isEmpty()) {
+          log.warn(
+              "Magic link email not sent: no SMTP credentials available. Set SMTP_USER and "
+                  + "SMTP_PASSWORD on UserService.");
+          return Optional.empty();
+        }
+        username = credentials.get().getGlobalSmtpUsername();
+        password = credentials.get().getGlobalSmtpPassword();
       }
-      String username = credentials.get().getGlobalSmtpUsername();
-      String password = credentials.get().getGlobalSmtpPassword();
 
       return Optional.of(
           new GlobalSmtpSettings(host, port, secure, username, password, from, emailThemeColor));

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -65,6 +66,7 @@ public class PasswordResetService {
   private final @NonNull IdentityClient identityClient;
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull OneTimeTokenStore oneTimeTokenStore;
+  private final @NonNull ApplicationSettingsService applicationSettingsService;
 
   /**
    * Runs the (potentially slow) account lookup + mail dispatch off the request thread so the HTTP
@@ -430,21 +432,25 @@ public class PasswordResetService {
       String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
       Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
       boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
-      String username = asStringSettingValue(settingsResponse.get("globalSmtpUsername"));
-      String password = asStringSettingValue(settingsResponse.get("globalSmtpPassword"));
       String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
       String emailThemeColor =
           asStringSettingValue(settingsResponse.get("globalSmtpEmailThemeColor"));
 
-      if (!systemEmailsEnabled
-          || !smtpEnabled
-          || isBlank(host)
-          || port == null
-          || isBlank(username)
-          || isBlank(password)
-          || isBlank(from)) {
+      if (!systemEmailsEnabled || !smtpEnabled || isBlank(host) || port == null || isBlank(from)) {
         return Optional.empty();
       }
+
+      // The public /settings payload deliberately omits the SMTP username and password since the
+      // CTS-C01 credential-leak fix, so they must come from the authenticated settings endpoint.
+      var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+      if (credentials.isEmpty()) {
+        log.warn(
+            "Password reset email not sent: global SMTP credentials are unavailable. "
+                + "Set the SMTP username and password in the platform settings.");
+        return Optional.empty();
+      }
+      String username = credentials.get().getGlobalSmtpUsername();
+      String password = credentials.get().getGlobalSmtpPassword();
 
       return Optional.of(
           new GlobalSmtpSettings(host, port, secure, username, password, from, emailThemeColor));

--- a/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/auth/PasswordResetService.java
@@ -112,6 +112,17 @@ public class PasswordResetService {
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
 
+  /**
+   * Operator-provided SMTP credentials. Password reset is unauthenticated and dispatched off the
+   * request thread, so there is no user token and the super-admin-guarded credentials endpoint is
+   * unreachable; these are the primary source.
+   */
+  @Value("${smtp.user:}")
+  private String configuredSmtpUsername;
+
+  @Value("${smtp.password:}")
+  private String configuredSmtpPassword;
+
   @PostConstruct
   void logFeatureAvailability() {
     if (isBlank(passwordResetFrontendBaseUrl)) {
@@ -441,16 +452,22 @@ public class PasswordResetService {
       }
 
       // The public /settings payload deliberately omits the SMTP username and password since the
-      // CTS-C01 credential-leak fix, so they must come from the authenticated settings endpoint.
-      var credentials = applicationSettingsService.getGlobalSmtpCredentials();
-      if (credentials.isEmpty()) {
-        log.warn(
-            "Password reset email not sent: global SMTP credentials are unavailable. "
-                + "Set the SMTP username and password in the platform settings.");
-        return Optional.empty();
+      // CTS-C01 credential-leak fix, so they can never be read from there.
+      String username = configuredSmtpUsername;
+      String password = configuredSmtpPassword;
+      if (isBlank(username) || isBlank(password)) {
+        // Fallback for callers that do run inside an authenticated super-admin request.
+        var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+        if (credentials.isEmpty()) {
+          log.warn(
+              "Password reset email not sent: no SMTP credentials available. Set SMTP_USER and "
+                  + "SMTP_PASSWORD on UserService (the platform-settings credentials are only "
+                  + "readable by a super-admin token, which this unauthenticated flow never has).");
+          return Optional.empty();
+        }
+        username = credentials.get().getGlobalSmtpUsername();
+        password = credentials.get().getGlobalSmtpPassword();
       }
-      String username = credentials.get().getGlobalSmtpUsername();
-      String password = credentials.get().getGlobalSmtpPassword();
 
       return Optional.of(
           new GlobalSmtpSettings(host, port, secure, username, password, from, emailThemeColor));

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/MagicLinkLoginServiceTest.java
@@ -3,8 +3,10 @@ package de.caritas.cob.userservice.api.service.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,7 +16,9 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.auth.MagicLinkLoginService.MagicLinkRequestResult;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model.ApplicationSettingsSmtpCredentialsDTO;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +44,7 @@ class MagicLinkLoginServiceTest {
   @Mock private RestTemplate restTemplate;
   @Mock private IdentityClientConfig identityClientConfig;
   @Mock private OneTimeTokenStore oneTimeTokenStore;
+  @Mock private ApplicationSettingsService applicationSettingsService;
 
   @InjectMocks private MagicLinkLoginService magicLinkLoginService;
 
@@ -686,6 +691,60 @@ class MagicLinkLoginServiceTest {
 
     assertThat(magicLinkLoginService.requestMagicLink("testuser"))
         .isEqualTo(MagicLinkRequestResult.ACCEPTED);
+  }
+
+  // The public /settings payload deliberately omits globalSmtpUsername/globalSmtpPassword since the
+  // CTS-C01 credential-leak fix. Credentials must therefore come from the authenticated source.
+  @Test
+  @SuppressWarnings("unchecked")
+  void
+      requestMagicLink_Should_IssueToken_When_PublicSettingsOmitCredentialsButAuthenticatedSourceHasThem() {
+    ReflectionTestUtils.setField(
+        magicLinkLoginService, "consultingTypeServiceApiUrl", "http://cts");
+    when(userService.findUserByUsername("testuser"))
+        .thenReturn(Optional.of(validUserWithMagicLinkEnabled()));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(publicSmtpSettingsWithoutCredentials());
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(
+            Optional.of(
+                new ApplicationSettingsSmtpCredentialsDTO()
+                    .globalSmtpUsername("smtp-user")
+                    .globalSmtpPassword("smtp-pass")));
+
+    assertThat(magicLinkLoginService.requestMagicLink("testuser"))
+        .isEqualTo(MagicLinkRequestResult.ACCEPTED);
+    verify(oneTimeTokenStore)
+        .store(anyString(), anyString(), anyString(), any(Instant.class), anyBoolean());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void requestMagicLink_Should_NotIssueToken_When_AuthenticatedCredentialsAreUnavailable() {
+    ReflectionTestUtils.setField(
+        magicLinkLoginService, "consultingTypeServiceApiUrl", "http://cts");
+    when(userService.findUserByUsername("testuser"))
+        .thenReturn(Optional.of(validUserWithMagicLinkEnabled()));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(publicSmtpSettingsWithoutCredentials());
+    when(applicationSettingsService.getGlobalSmtpCredentials()).thenReturn(Optional.empty());
+
+    // Unavailable SMTP must not be observable to the caller — the result stays ACCEPTED so the
+    // endpoint cannot be used to enumerate accounts; only the token issue is skipped.
+    assertThat(magicLinkLoginService.requestMagicLink("testuser"))
+        .isEqualTo(MagicLinkRequestResult.ACCEPTED);
+    verify(oneTimeTokenStore, never())
+        .store(anyString(), anyString(), anyString(), any(Instant.class), anyBoolean());
+  }
+
+  private Map<String, Object> publicSmtpSettingsWithoutCredentials() {
+    Map<String, Object> settings = new HashMap<>();
+    settings.put("globalFeatureSystemNotificationEmailsEnabled", true);
+    settings.put("globalSmtpEnabled", true);
+    settings.put("globalSmtpHost", "smtp.example.com");
+    settings.put("globalSmtpPort", 587);
+    settings.put("globalSmtpFrom", "noreply@example.com");
+    return settings;
   }
 
   private OneTimeTokenStore.TokenClaim validClaim(String subjectId) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -20,7 +20,9 @@ import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.auth.PasswordResetService.PasswordResetMailSender;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.user.UserService;
+import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model.ApplicationSettingsSmtpCredentialsDTO;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +48,7 @@ class PasswordResetServiceTest {
   @Mock private IdentityClient identityClient;
   @Mock private RestTemplate restTemplate;
   @Mock private OneTimeTokenStore oneTimeTokenStore;
+  @Mock private ApplicationSettingsService applicationSettingsService;
 
   @InjectMocks private PasswordResetService passwordResetService;
 
@@ -137,6 +140,8 @@ class PasswordResetServiceTest {
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
     when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
     when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(Optional.of(smtpCredentials("smtp-user", "smtp-pass")));
 
     passwordResetService.requestPasswordReset("testuser", "en");
 
@@ -166,6 +171,8 @@ class PasswordResetServiceTest {
             "admin@example.com", "admin@example.com"))
         .thenReturn(Optional.of(admin));
     when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(Optional.of(smtpCredentials("smtp-user", "smtp-pass")));
 
     passwordResetService.requestPasswordReset(
         "admin@example.com", "en", PasswordResetApplication.ADMIN);
@@ -217,6 +224,8 @@ class PasswordResetServiceTest {
     ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
     when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
     when(restTemplate.getForObject(anyString(), any())).thenReturn(validSmtpSettings());
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(Optional.of(smtpCredentials("smtp-user", "smtp-pass")));
 
     passwordResetService.requestPasswordReset("testuser", "xx-unknown");
 
@@ -340,6 +349,57 @@ class PasswordResetServiceTest {
     verify(identityClient, never()).updatePassword(anyString(), anyString());
   }
 
+  // The public /settings payload deliberately omits globalSmtpUsername/globalSmtpPassword since the
+  // CTS-C01 credential-leak fix. Credentials must therefore come from the authenticated source.
+  @Test
+  void
+      requestPasswordReset_Should_SendMail_When_PublicSettingsOmitCredentialsButAuthenticatedSourceHasThem() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(publicSmtpSettingsWithoutCredentials());
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(Optional.of(smtpCredentials("smtp-user", "smtp-pass")));
+
+    passwordResetService.requestPasswordReset("testuser", "en");
+
+    assertThat(sentMails).hasSize(1);
+    assertThat(sentMails.get(0).recipient()).isEqualTo("real@example.com");
+  }
+
+  @Test
+  void requestPasswordReset_Should_NotSendMail_When_AuthenticatedCredentialsAreUnavailable() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(publicSmtpSettingsWithoutCredentials());
+    when(applicationSettingsService.getGlobalSmtpCredentials()).thenReturn(Optional.empty());
+
+    passwordResetService.requestPasswordReset("testuser", "en");
+
+    assertThat(sentMails).isEmpty();
+  }
+
+  private Map<String, Object> publicSmtpSettingsWithoutCredentials() {
+    return Map.of(
+        "globalFeatureSystemNotificationEmailsEnabled",
+        true,
+        "globalSmtpEnabled",
+        true,
+        "globalSmtpHost",
+        "smtp.invalid",
+        "globalSmtpPort",
+        587,
+        "globalSmtpFrom",
+        "noreply@example.com");
+  }
+
+  private ApplicationSettingsSmtpCredentialsDTO smtpCredentials(String username, String password) {
+    return new ApplicationSettingsSmtpCredentialsDTO()
+        .globalSmtpUsername(username)
+        .globalSmtpPassword(password);
+  }
+
   private User validUser() {
     User user = new User();
     user.setUserId("u-1");
@@ -349,14 +409,7 @@ class PasswordResetServiceTest {
   }
 
   private Map<String, Object> validSmtpSettings() {
-    return Map.of(
-        "globalFeatureSystemNotificationEmailsEnabled", true,
-        "globalSmtpEnabled", true,
-        "globalSmtpHost", "smtp.invalid",
-        "globalSmtpPort", 587,
-        "globalSmtpUsername", "user",
-        "globalSmtpPassword", "pass",
-        "globalSmtpFrom", "noreply@example.com");
+    return publicSmtpSettingsWithoutCredentials();
   }
 
   private OneTimeTokenStore.TokenClaim validClaim() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/auth/PasswordResetServiceTest.java
@@ -380,6 +380,24 @@ class PasswordResetServiceTest {
     assertThat(sentMails).isEmpty();
   }
 
+  // Password reset is unauthenticated and dispatched off the request thread, so no user token
+  // exists and the super-admin-guarded credentials endpoint is unreachable. Operator-provided
+  // SMTP credentials (env SMTP_USER / SMTP_PASSWORD) must therefore be enough on their own.
+  @Test
+  void requestPasswordReset_Should_SendMail_When_CredentialsComeFromOperatorConfiguration() {
+    ReflectionTestUtils.setField(passwordResetService, "consultingTypeServiceApiUrl", "http://cts");
+    ReflectionTestUtils.setField(passwordResetService, "configuredSmtpUsername", "env-user");
+    ReflectionTestUtils.setField(passwordResetService, "configuredSmtpPassword", "env-pass");
+    when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(validUser()));
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(publicSmtpSettingsWithoutCredentials());
+
+    passwordResetService.requestPasswordReset("testuser", "en");
+
+    assertThat(sentMails).hasSize(1);
+    verify(applicationSettingsService, never()).getGlobalSmtpCredentials();
+  }
+
   private Map<String, Object> publicSmtpSettingsWithoutCredentials() {
     return Map.of(
         "globalFeatureSystemNotificationEmailsEnabled",


### PR DESCRIPTION
## Summary

`PasswordResetService` and `MagicLinkLoginService` read `globalSmtpUsername` / `globalSmtpPassword` from the **public** ConsultingTypeService `/settings` payload and require both to be non-blank. That payload has not carried them since the CTS-C01 credential-leak fix (ORISO-ConsultingTypeService#7). Both services therefore resolved an empty SMTP configuration on every request and returned **silently** — no reset mail and no magic-link mail could be sent in any environment.

This PR:

- takes the two credentials from `smtp.user` / `smtp.password` (env `SMTP_USER` / `SMTP_PASSWORD`) — properties that already exist in `application.properties` but had no consumer
- keeps host, port, secure, from, theme colour and the feature toggles on the public payload, so Admin-panel branding still applies
- falls back to `ApplicationSettingsService.getGlobalSmtpCredentials()` for callers that do run inside a super-admin request
- warns, naming the knobs to set, instead of failing silently
- corrects the unit fixtures, which still described the old payload shape and are why the regression shipped green

## Why not the authenticated settings endpoint alone

`GET /settingsadmin/smtp-credentials` is guarded by `@PreAuthorize("@authorisationService.isSuperAdmin()")`, and `isSuperAdmin()` requires a JWT carrying `tenantId = 0`. `SecurityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()` forwards the **current request's** user token.

Password reset is unauthenticated and dispatched on a background executor, so there is no request scope and no token at all. That path can never satisfy the guard. Operator-provided configuration is the only source that works for it — and, given that both the CTS and TenantService public payloads have leaked SMTP credentials in the past (ORISO-TenantService#140 is still open), keeping these credentials out of an HTTP payload entirely is the safer design.

## Operator impact

Pre-Dev already has `SMTP_HOST`, `SMTP_PASSWORD`, `SMTP_PORT`, `SMTP_SECURE` and `SMTP_FROM` set on UserService; only `SMTP_USER` is empty. Dev has none of them. Both need `SMTP_USER` and `SMTP_PASSWORD` before reset mail can leave the service.

## Verification

- `mvn test` — 3378 tests, 0 failures, 0 errors
- focused: `PasswordResetServiceTest` 24/24, `MagicLinkLoginServiceTest` 39/39, `ApplicationSettingsServiceTest` 15/15
- `mvn spotless:apply` clean
- live evidence for the defect, from inside the Pre-Dev UserService pod: `GET …/settings` returns only `globalSmtpEmailThemeColor, globalSmtpEnabled, globalSmtpFrom, globalSmtpHost, globalSmtpPort, globalSmtpSecure`

Pre-Dev end-to-end verification is still blocked by the unset `PASSWORD_RESET_FRONTEND_BASE_URL` / `PASSWORD_RESET_ADMIN_FRONTEND_BASE_URL`; see OpenResilienceInitiative/ORISO-Helm#169.

Closes #863
Refs OpenResilienceInitiative/ORISO-Admin#392, OpenResilienceInitiative/ORISO-Frontend#3, OpenResilienceInitiative/ORISO-TenantService#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)