### PR TITLE
fix(deletion): delete consultant supervisions and mobile tokens

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantMobileTokenRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ConsultantMobileTokenRepository.java
@@ -1,6 +1,8 @@
 package de.caritas.cob.userservice.api.port.out;
 
+import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantMobileToken;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
@@ -8,4 +10,6 @@ public interface ConsultantMobileTokenRepository
     extends CrudRepository<ConsultantMobileToken, Long> {
 
   Optional<ConsultantMobileToken> findByMobileAppToken(String mobileAppToken);
+
+  List<ConsultantMobileToken> findByConsultant(Consultant consultant);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
@@ -63,4 +63,20 @@ public interface SessionSupervisorRepository extends JpaRepository<SessionSuperv
   @Modifying(flushAutomatically = true, clearAutomatically = true)
   @Query("delete from SessionSupervisor supervisor where supervisor.session.id = :sessionId")
   int deleteAllBySessionId(@Param("sessionId") Long sessionId);
+
+  /**
+   * Deletes every supervision row that references the given consultant, through either the
+   * supervisor or the "added by" column.
+   *
+   * <p>Both columns are {@code NOT NULL} in the schema, so a row cannot outlive either consultant
+   * it points at. Deleting is therefore forced rather than chosen.
+   *
+   * @param consultantId the consultant ID
+   * @return number of deleted rows
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query(
+      "delete from SessionSupervisor supervisor where supervisor.supervisorConsultant.id ="
+          + " :consultantId or supervisor.addedByConsultant.id = :consultantId")
+  int deleteAllByConsultantId(@Param("consultantId") String consultantId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
@@ -8,8 +8,10 @@ import de.caritas.cob.userservice.api.actions.ActionCommand;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.ConsultantMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
@@ -28,10 +30,20 @@ public class DeleteDatabaseConsultantAction
 
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  private final @NonNull ConsultantMobileTokenRepository consultantMobileTokenRepository;
   private final @NonNull IdentityTombstoneService identityTombstoneService;
 
   /**
-   * Deletes the given {@link Consultant} in database.
+   * Deletes the given {@link Consultant} in database, together with the dependencies that hold a
+   * restricting foreign key on it.
+   *
+   * <p>{@code session_supervisor} references the consultant through both {@code
+   * supervisor_consultant_id} and {@code added_by_consultant_id}, and both columns are {@code NOT
+   * NULL}. A supervision row therefore cannot outlive either consultant it points at, so the row is
+   * deleted rather than detached. Where the deleted consultant was only the one who <em>added</em>
+   * a supervision performed by somebody else, that supervision is lost as collateral — making
+   * {@code added_by_consultant_id} nullable in a migration would allow it to survive.
    *
    * @param actionTarget the {@link ConsultantDeletionWorkflowDTO} with the {@link Consultant} to
    *     delete
@@ -50,6 +62,23 @@ public class DeleteDatabaseConsultantAction
           actionTarget,
           e,
           "Unable to unassign consultant from his sessions with state NEW or INITIAL");
+      return;
+    }
+
+    try {
+      this.sessionSupervisorRepository.deleteAllByConsultantId(
+          actionTarget.getConsultant().getId());
+    } catch (Exception e) {
+      handleExceptionWithMessage(actionTarget, e, "Unable to delete consultant supervisions");
+      return;
+    }
+
+    try {
+      var mobileTokens =
+          this.consultantMobileTokenRepository.findByConsultant(actionTarget.getConsultant());
+      this.consultantMobileTokenRepository.deleteAll(mobileTokens);
+    } catch (Exception e) {
+      handleExceptionWithMessage(actionTarget, e, "Unable to delete consultant mobile tokens");
       return;
     }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantActionTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,9 +19,12 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantMobileToken;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
@@ -41,6 +45,10 @@ public class DeleteDatabaseConsultantActionTest {
   @InjectMocks private DeleteDatabaseConsultantAction deleteDatabaseConsultantAction;
 
   @Mock private ConsultantRepository consultantRepository;
+
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+
+  @Mock private ConsultantMobileTokenRepository consultantMobileTokenRepository;
 
   @Mock private SessionRepository sessionRepository;
 
@@ -140,5 +148,45 @@ public class DeleteDatabaseConsultantActionTest {
     assertThat(workflowErrors.get(0).getTimestamp(), notNullValue());
     assertThat(
         logAppender.list.stream().anyMatch(event -> event.getLevel() == Level.ERROR), is(true));
+  }
+
+  @Test
+  public void execute_Should_deleteSupervisionsAndMobileTokensBeforeConsultant() {
+    var consultant = new Consultant();
+    consultant.setId("consultant id");
+    var mobileToken = new ConsultantMobileToken();
+    when(this.consultantMobileTokenRepository.findByConsultant(consultant))
+        .thenReturn(List.of(mobileToken));
+    var workflowDTO = new ConsultantDeletionWorkflowDTO(consultant, new ArrayList<>());
+
+    this.deleteDatabaseConsultantAction.execute(workflowDTO);
+
+    var inOrder =
+        inOrder(
+            this.sessionSupervisorRepository,
+            this.consultantMobileTokenRepository,
+            this.consultantRepository);
+    inOrder.verify(this.sessionSupervisorRepository).deleteAllByConsultantId("consultant id");
+    inOrder.verify(this.consultantMobileTokenRepository).deleteAll(List.of(mobileToken));
+    inOrder.verify(this.consultantRepository).delete(consultant);
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+  }
+
+  @Test
+  public void execute_Should_reportWorkflowError_When_supervisionDeletionFails() {
+    var consultant = new Consultant();
+    consultant.setId("consultant id");
+    doThrow(new RuntimeException())
+        .when(this.sessionSupervisorRepository)
+        .deleteAllByConsultantId("consultant id");
+    var workflowDTO = new ConsultantDeletionWorkflowDTO(consultant, new ArrayList<>());
+
+    this.deleteDatabaseConsultantAction.execute(workflowDTO);
+
+    var workflowErrors = workflowDTO.getDeletionWorkflowErrors();
+    assertThat(workflowErrors, hasSize(1));
+    assertThat(workflowErrors.get(0).getReason(), is("Unable to delete consultant supervisions"));
+    assertThat(workflowErrors.get(0).getDeletionSourceType(), is(CONSULTANT));
+    assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
   }
 }


### PR DESCRIPTION
## What

Three `RESTRICT` foreign keys to `consultant` were never cleared by the consultant deletion chain:

- `session_supervisor.supervisor_consultant_id`
- `session_supervisor.added_by_consultant_id`
- `consultant_mobile_token.consultant_id`

`SessionSupervisorRepository` only offered `deleteAllBySessionId`, so supervision rows went when the *session* went but never when the *consultant* went. **A counsellor who had supervised any surviving session could not be deleted.** 12 such rows on PreDev.

## One decision a reviewer should confirm

Both supervision columns are `NOT NULL` in the schema:

```
supervisor_consultant_id   varchar(36)   NO
added_by_consultant_id     varchar(36)   NO
```

A supervision row therefore **cannot** outlive either consultant it points at, so deleting it is forced rather than chosen. The consequence: where the deleted consultant was only the person who *added* a supervision performed by somebody else, that still-valid supervision is lost as collateral.

The clean fix would be a migration making `added_by_consultant_id` nullable so those rows can survive with the attribution dropped. I did not include it here because it is a schema change with its own review surface. It is documented on the action and worth a follow-up decision.

## Verification

| | Result |
| --- | --- |
| Both new tests, before the change | **FAIL** — `Wanted but not invoked` |
| Both new tests, after the change | **PASS** |
| `api.workflow.delete.**` package | 157 tests, 0 failures, 0 errors |
| Spotless | applied, clean |

## Scope

Closes two of the six constraints in #866. Consultant deletion is still blocked by `session.consultant_id` for sessions in `IN_PROGRESS`/`DONE` — 160 rows on PreDev — which is #870 and needs a product decision first, so this PR does not make consultant deletion work end to end on its own.

Closes OpenResilienceInitiative/ORISO-UserService#868
Refs OpenResilienceInitiative/ORISO-UserService#866

🤖 Generated with [Claude Code](https://claude.com/claude-code)