### PR TITLE
ci: scope the GHA build cache per image

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -59,5 +59,8 @@ runs:
       sbom: true
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
+      # Scope the GHA cache per image so images built from this shared action
+      # can't collide on one cache namespace — future-proofs against a second
+      # image being added (root cause of OpenResilienceInitiative/ORISO-Admin#424).
+      cache-from: type=gha,scope=${{ inputs.image_name }}
+      cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}


### PR DESCRIPTION
Preventive fix for the same CI cache pattern as OpenResilienceInitiative/ORISO-Admin#424 (fixed in ORISO-Admin#556).

**Problem:** the shared `docker-build-push` action used `cache-from/to: type=gha` with **no `scope`**. This repo currently builds a single image, so there is no cross-image collision today — but any second image added later (e.g. a storybook or migration image) would silently share one cache namespace and could restore the wrong `COPY` layer, exactly the failure that shipped a stale bundle in ORISO-Admin.

**What changed:** scope the GHA cache per image — `type=gha,scope=${{ inputs.image_name }}` on `cache-from` and `cache-to`. No behavior change for the single image today; it makes the cache key explicit and future-proof.

**Verification:** YAML parses (`yaml.safe_load`). One-time cost: the first build after merge gets a cache miss on the new scope key, then normal.
