### PR TITLE
fix(tenancy): prevent technical tenant lookups (#476)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminBase;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
@@ -93,7 +94,7 @@ public class TenantAdminUserService {
   }
 
   private void enrichResponseWithSubdomain(Admin updatedAdmin, AdminResponseDTO responseDTO) {
-    if (updatedAdmin.getTenantId() != null) {
+    if (isConcreteTenantId(updatedAdmin.getTenantId())) {
       var tenantData = tenantService.getRestrictedTenantData(updatedAdmin.getTenantId());
       responseDTO.getEmbedded().setTenantSubdomain(tenantData.getSubdomain());
     }
@@ -127,12 +128,16 @@ public class TenantAdminUserService {
 
   private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {
     return fullAdmins.stream()
-        .filter(admin -> admin.getTenantId() != null)
+        .filter(admin -> isConcreteTenantId(admin.getTenantId()))
         .map(admin -> new AbstractMap.SimpleEntry<>(admin.getTenantId(), tenantName(admin)))
         .filter(entry -> entry.getValue() != null)
         .collect(
             Collectors.toMap(
                 Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing));
+  }
+
+  private boolean isConcreteTenantId(Long tenantId) {
+    return tenantId != null && !TenantContext.TECHNICAL_TENANT_ID.equals(tenantId);
   }
 
   private String tenantName(Admin admin) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.admin.service.tenant;
 
 import de.caritas.cob.userservice.api.config.CacheManagerConfig;
 import de.caritas.cob.userservice.api.config.apiclient.TenantServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class TenantService {
 
   @Cacheable(cacheNames = CacheManagerConfig.TENANT_CACHE, key = "#tenantId")
   public RestrictedTenantDTO getRestrictedTenantData(Long tenantId) {
+    requireConcreteTenantId(tenantId);
     log.info("Calling tenant service to get tenant data for tenantId {}", tenantId);
 
     return tenantServiceApiControllerFactory
@@ -34,9 +36,16 @@ public class TenantService {
   }
 
   public RestrictedTenantDTO getRestrictedTenantDataFresh(Long tenantId) {
+    requireConcreteTenantId(tenantId);
     log.info("Calling tenant service for current tenant data for tenantId {}", tenantId);
     return tenantServiceApiControllerFactory
         .createControllerApi()
         .getRestrictedTenantDataByTenantId(tenantId);
+  }
+
+  private void requireConcreteTenantId(Long tenantId) {
+    if (TenantContext.TECHNICAL_TENANT_ID.equals(tenantId)) {
+      throw new IllegalArgumentException("Concrete tenant id required");
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/WorkflowErrorMailService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/WorkflowErrorMailService.java
@@ -5,6 +5,7 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import de.caritas.cob.userservice.api.service.emailsupplier.TenantTemplateSupplier;
 import de.caritas.cob.userservice.api.service.helper.MailService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.mailservice.generated.web.model.ErrorMailDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
@@ -44,7 +45,7 @@ public class WorkflowErrorMailService {
       templateAttributes.add(
           new TemplateDataDTO().key("text").value(convertErrorsToHtmlText(workflowErrors)));
 
-      if (!multitenancyEnabled) {
+      if (!Boolean.TRUE.equals(multitenancyEnabled) || !hasConcreteTenantContext()) {
         templateAttributes.add(new TemplateDataDTO().key("url").value(applicationBaseUrl));
       } else {
         templateAttributes.addAll(tenantTemplateSupplier.getTemplateAttributes());
@@ -54,6 +55,10 @@ public class WorkflowErrorMailService {
           new ErrorMailDTO().template(TEMPLATE_FREE_TEXT).templateData(templateAttributes);
       this.mailService.sendErrorEmailNotification(errorMailDTO);
     }
+  }
+
+  private boolean hasConcreteTenantContext() {
+    return TenantContext.contextIsSet() && !TenantContext.isTechnicalOrSuperAdminContext();
   }
 
   private String convertErrorsToHtmlText(List<DeletionWorkflowError> workflowErrors) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -125,6 +125,21 @@ class TenantAdminUserServiceTest {
   }
 
   @Test
+  void updateTenantAdmin_Should_NotLookUpTechnicalTenant() {
+    UpdateTenantAdminDTO tenantAdminDTO = new EasyRandom().nextObject(UpdateTenantAdminDTO.class);
+    Admin platformAdmin = tenantAdmin("platform-admin", 0L);
+    when(updateAdminService.updateTenantAdmin("platform-admin", tenantAdminDTO))
+        .thenReturn(platformAdmin);
+
+    AdminResponseDTO response =
+        tenantAdminUserService.updateTenantAdmin("platform-admin", tenantAdminDTO);
+
+    Mockito.verify(tenantService, Mockito.never()).getRestrictedTenantData(0L);
+    assertThat(response.getEmbedded().getTenantId()).isEqualTo("0");
+    assertThat(response.getEmbedded().getTenantSubdomain()).isNull();
+  }
+
+  @Test
   void findTenantAdmins_Should_ReturnAllAdminsForSameTenant() {
     // given
     Long tenantId = 42L;
@@ -230,6 +245,39 @@ class TenantAdminUserServiceTest {
             Mockito.any());
     Assertions.assertEquals("Known tenant", tenantNameMapCaptor.getValue().get(1L));
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
+  }
+
+  @Test
+  void findTenantAdminsByInfix_Should_NotLookUpTechnicalTenant() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Admin.AdminBase platformAdminBase = adminBase("platform-admin", 0L);
+    Page<Admin.AdminBase> adminsPage = new PageImpl<>(List.of(platformAdminBase), pageRequest, 1);
+    Admin platformAdmin = tenantAdmin("platform-admin", 0L);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
+        .thenReturn(adminsPage);
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(List.of(platformAdmin));
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    tenantAdminUserService.findTenantAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(tenantService, Mockito.never()).getRestrictedTenantData(0L);
+    ArgumentCaptor<Map<Long, String>> tenantNameMapCaptor = ArgumentCaptor.forClass(Map.class);
+    Mockito.verify(userServiceMapper)
+        .mapOfAdmin(
+            Mockito.eq(adminsPage),
+            Mockito.eq(List.of(platformAdmin)),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            tenantNameMapCaptor.capture(),
+            Mockito.any());
+    assertThat(tenantNameMapCaptor.getValue()).isEmpty();
   }
 
   private Admin tenantAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantServiceTest.java
@@ -66,6 +66,14 @@ class TenantServiceTest {
     assertThat(tenantControllerApi.tenantIdCalls.get()).isEqualTo(1);
   }
 
+  @Test
+  void getRestrictedTenantData_technicalTenantId_rejectsBeforeApiCall() {
+    assertThatThrownBy(() -> tenantService.getRestrictedTenantData(0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Concrete tenant id required");
+    assertThat(tenantControllerApi.tenantIdCalls.get()).isZero();
+  }
+
   // Callers such as HttpTenantFilter rely on upstream errors surfacing unchanged.
   @Test
   void getRestrictedTenantData_subdomainApiFailure_propagatesRestClientException() {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/WorkflowErrorMailServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/WorkflowErrorMailServiceTest.java
@@ -15,10 +15,12 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.service.emailsupplier.TenantTemplateSupplier;
 import de.caritas.cob.userservice.api.service.helper.MailService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
 import de.caritas.cob.userservice.mailservice.generated.web.model.ErrorMailDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +44,11 @@ public class WorkflowErrorMailServiceTest {
     setField(workflowErrorMailService, "applicationBaseUrl", "www.host.de");
   }
 
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
   @Test
   public void buildAndSendErrorMail_Should_sendNoErrorMail_When_workflowErrorsAreNull() {
     this.workflowErrorMailService.buildAndSendErrorMail(null);
@@ -61,6 +68,7 @@ public class WorkflowErrorMailServiceTest {
       buildAndSendErrorMail_Should_buildAndSendExpectedErrorMail_When_workflowErrorsExists() {
     // given
     ReflectionTestUtils.setField(workflowErrorMailService, "multitenancyEnabled", true);
+    TenantContext.setCurrentTenant(1L);
     TemplateDataDTO tenantData = new TemplateDataDTO().key("tenantData");
     when(tenantTemplateSupplier.getTemplateAttributes()).thenReturn(Lists.newArrayList(tenantData));
     List<DeletionWorkflowError> workflowErrors =
@@ -88,5 +96,36 @@ public class WorkflowErrorMailServiceTest {
 
     // clean up
     ReflectionTestUtils.setField(workflowErrorMailService, "multitenancyEnabled", false);
+  }
+
+  @Test
+  void buildAndSendErrorMail_ShouldUseApplicationUrl_WhenSchedulerHasNoTenantContext() {
+    ReflectionTestUtils.setField(workflowErrorMailService, "multitenancyEnabled", true);
+    var workflowErrors = List.of(DeletionWorkflowError.builder().reason("reason").build());
+
+    workflowErrorMailService.buildAndSendErrorMail(workflowErrors);
+
+    verifyNoMoreInteractions(tenantTemplateSupplier);
+    ArgumentCaptor<ErrorMailDTO> errorMailDTOArgumentCaptor =
+        ArgumentCaptor.forClass(ErrorMailDTO.class);
+    verify(mailService).sendErrorEmailNotification(errorMailDTOArgumentCaptor.capture());
+    assertThat(errorMailDTOArgumentCaptor.getValue().getTemplateData())
+        .contains(new TemplateDataDTO().key("url").value("www.host.de"));
+  }
+
+  @Test
+  void buildAndSendErrorMail_ShouldUseApplicationUrl_ForTechnicalTenantContext() {
+    ReflectionTestUtils.setField(workflowErrorMailService, "multitenancyEnabled", true);
+    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+    var workflowErrors = List.of(DeletionWorkflowError.builder().reason("reason").build());
+
+    workflowErrorMailService.buildAndSendErrorMail(workflowErrors);
+
+    verifyNoMoreInteractions(tenantTemplateSupplier);
+    ArgumentCaptor<ErrorMailDTO> errorMailDTOArgumentCaptor =
+        ArgumentCaptor.forClass(ErrorMailDTO.class);
+    verify(mailService).sendErrorEmailNotification(errorMailDTOArgumentCaptor.capture());
+    assertThat(errorMailDTOArgumentCaptor.getValue().getTemplateData())
+        .contains(new TemplateDataDTO().key("url").value("www.host.de"));
   }
 }


### PR DESCRIPTION
## Outcome

Prevents UserService from treating the technical tenant ID `0` as a real TenantService resource.

## Runtime evidence

Aggregate-only PreDev tracing over the current six-hour window showed two `/id/0` TenantService calls. Their root operations were:

- tenant-admin search
- anonymous-user deletion scheduler

This PR addresses both roots without recording user, tenant or trace identifiers.

## Changes

- skip technical-tenant enrichment for platform-admin search and update responses
- use the configured application URL for deletion-workflow error mail when no concrete tenant context exists
- reject technical tenant IDs at the shared TenantService outbound boundary before any API call
- cover concrete, absent and technical tenant contexts with regression tests

## Verification

- exact head: `484d56d4909036aec2b04cdd660bf3eeadcfddc9`
- targeted regression suite: 27 tests, 0 failures/errors
- complete unit suite: 3,378 tests, 0 failures/errors, 4 skips
- required integration suite: 840 tests, 0 failures/errors, 3 skips
- CI contract suite: 13 tests, green
- Spotless and diff checks: green
- all 12 GitHub checks: terminal green
- local database reset: not required

## Coordination with #826 and #874

- #874 is conflict-free with this PR and should land first because it owns the urgent public TenantService timestamp outage
- #826 conflicts with this PR in `TenantAdminUserService`, `TenantService` and `TenantServiceTest`
- an exact-head disposable integration retained this PR's technical-tenant rejection and #826's bounded batch enrichment; the combined proof passed 74 focused Java tests, 13 CI contracts and 8 OpenAPI tests
- recommended order is #874, then this PR, then replay #826 on the updated `pre-dev`
- the replay must filter technical IDs before every batch call and keep the shared scalar outbound guard

This proves semantic compatibility, not order-independent mergeability. The PR remains draft pending human review; no merge or deployment is claimed.

## Runtime acceptance after deployment

- zero TenantService calls to `/id/0` in the agreed observation window
- non-technical TenantService 404s remain a separate signal and are not claimed as resolved here

Closes #476
Closes #481
