### PR TITLE
[Stability] Type identity email-owner lookup

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -247,6 +247,15 @@ A dedicated magic-link boundary contract prevents the application service and
 both web entry points from importing Keycloak transport types. It also prevents
 the public magic-link response DTO from depending on an outbound-port package.
 
+Email-ownership validation now uses the focused
+`IdentityEmailOwnerLookup` output port and the application-owned
+`IdentityEmailOwner` value. `IdentityManager` no longer interprets Keycloak map
+keys, while the Keycloak adapter retains exact-email matching and representation
+mapping. The external-call bound is unchanged: one email-ownership check makes
+exactly one identity-provider lookup. An unused email remains accepted; raw and
+encoded representations of the same username remain accepted; incomplete owner
+data is rejected safely.
+
 This is a ratcheted incremental modularization, not a claim that all three
 domains are already isolated. Rocket.Chat removal is complete in production
 source. The next safe sequence is the remaining identity create-user DTO

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class IdentityManager implements IdentityManaging {
 
   private final IdentityClient identityClient;
+  private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
   private final UsernameTranscoder usernameTranscoder;
 
   @Override
@@ -66,10 +68,16 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean isEmailAvailableOrOwn(String username, String email) {
-    var user = identityClient.findUserByEmail(email);
+    var owner = identityEmailOwnerLookup.findByEmail(email);
+    if (owner.isEmpty()) {
+      return true;
+    }
 
-    return user.isEmpty()
-        || username.equals(user.get("encodedUsername"))
-        || usernameTranscoder.decodeUsername(username).equals(user.get("decodedUsername"));
+    var ownerUsername = owner.orElseThrow().username();
+    return ownerUsername != null
+        && (username.equals(ownerUsername)
+            || usernameTranscoder
+                .decodeUsername(username)
+                .equals(usernameTranscoder.decodeUsername(ownerUsername)));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakMapper.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.keycloak;
 
-import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpSetupDTO;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
 import java.util.Map;
@@ -13,8 +12,6 @@ import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 public class KeycloakMapper {
-
-  private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   public OtpSetupDTO otpSetupDtoOf(String initialCode, String secret, String email) {
     var otpSetupDTO = new OtpSetupDTO();
@@ -51,14 +48,5 @@ public class KeycloakMapper {
         "createdBefore", "false",
         "attemptsLeft", String.valueOf(!status.equals(HttpStatus.TOO_MANY_REQUESTS)),
         "email", "null");
-  }
-
-  public Map<String, String> mapOf(UserRepresentation userRepresentation) {
-    var username = userRepresentation.getUsername();
-
-    return Map.of(
-        "encodedUsername", username,
-        "decodedUsername", usernameTranscoder.decodeUsername(username),
-        "email", userRepresentation.getEmail());
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -26,6 +26,8 @@ import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
@@ -63,7 +65,7 @@ import org.springframework.web.client.RestClientResponseException;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KeycloakService implements IdentityClient {
+public class KeycloakService implements IdentityClient, IdentityEmailOwnerLookup {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -192,12 +194,11 @@ public class KeycloakService implements IdentityClient {
   }
 
   @Override
-  public Map<String, String> findUserByEmail(String email) {
+  public Optional<IdentityEmailOwner> findByEmail(String email) {
     return keycloakClient.getUsersResource().search(email, 0, Integer.MAX_VALUE).stream()
-        .filter(userRepresentation -> userRepresentation.getEmail().equals(email))
+        .filter(userRepresentation -> email.equals(userRepresentation.getEmail()))
         .findFirst()
-        .map(keycloakMapper::mapOf)
-        .orElseGet(Map::of);
+        .map(userRepresentation -> new IdentityEmailOwner(userRepresentation.getUsername()));
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -36,8 +36,6 @@ public interface IdentityClient {
 
   Map<String, String> finishEmailVerification(final String username, final String initialCode);
 
-  Map<String, String> findUserByEmail(String email);
-
   KeycloakCreateUserResponseDTO createKeycloakUser(final UserDTO user);
 
   KeycloakCreateUserResponseDTO createKeycloakUser(

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwner.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwner.java
@@ -1,0 +1,4 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral identity owning an email address. */
+public record IdentityEmailOwner(String username) {}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwnerLookup.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityEmailOwnerLookup.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import java.util.Optional;
+
+/** Focused outbound lookup for the identity owning an email address. */
+public interface IdentityEmailOwnerLookup {
+
+  Optional<IdentityEmailOwner> findByEmail(String email);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -6,7 +6,10 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +25,7 @@ class IdentityManagerTest {
   private static final String EMAIL = "consultant@example.org";
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
@@ -53,50 +57,39 @@ class IdentityManagerTest {
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptRawKeycloakUsernameForEncodedConsultant() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", RAW_USERNAME,
-                "decodedUsername", RAW_USERNAME,
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(RAW_USERNAME)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptEncodedKeycloakUsernameForEncodedConsultant() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", ENCODED_USERNAME,
-                "decodedUsername", RAW_USERNAME,
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(ENCODED_USERNAME)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldRejectEmailOwnedByDifferentUser() {
-    when(identityClient.findUserByEmail(EMAIL))
-        .thenReturn(
-            Map.of(
-                "encodedUsername", "other-user",
-                "decodedUsername", "other-user",
-                "email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner("other-user")));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldAcceptUnusedEmail() {
-    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of());
+    when(identityEmailOwnerLookup.findByEmail(EMAIL)).thenReturn(Optional.empty());
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isTrue();
   }
 
   @Test
   void isEmailAvailableOrOwnShouldRejectIncompleteOwnerDataWithoutThrowing() {
-    when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of("email", EMAIL));
+    when(identityEmailOwnerLookup.findByEmail(EMAIL))
+        .thenReturn(Optional.of(new IdentityEmailOwner(null)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -42,6 +42,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
 import jakarta.ws.rs.BadRequestException;
@@ -50,6 +51,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
@@ -1425,31 +1427,28 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void findUserByEmail_Should_ReturnMappedUser_When_MatchFound() {
+  public void findByEmail_Should_ReturnTypedOwner_When_ExactMatchFound() {
     var email = "mail@example.com";
     UserRepresentation userRepresentation = mock(UserRepresentation.class);
     when(userRepresentation.getEmail()).thenReturn(email);
+    when(userRepresentation.getUsername()).thenReturn(USERNAME);
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.search(email, 0, Integer.MAX_VALUE))
         .thenReturn(singletonList(userRepresentation));
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-    var expected = new HashMap<String, String>();
-    expected.put("email", email);
-    when(keycloakMapper.mapOf(userRepresentation)).thenReturn(expected);
+    var result = keycloakService.findByEmail(email);
 
-    var result = keycloakService.findUserByEmail(email);
-
-    assertThat(result, is(expected));
+    assertThat(result, is(Optional.of(new IdentityEmailOwner(USERNAME))));
   }
 
   @Test
-  public void findUserByEmail_Should_ReturnEmptyMap_When_NoMatchFound() {
+  public void findByEmail_Should_ReturnEmpty_When_NoMatchFound() {
     var email = "mail@example.com";
     UsersResource usersResource = mock(UsersResource.class);
     when(usersResource.search(email, 0, Integer.MAX_VALUE)).thenReturn(List.of());
     when(keycloakClient.getUsersResource()).thenReturn(usersResource);
 
-    var result = keycloakService.findUserByEmail(email);
+    var result = keycloakService.findByEmail(email);
 
     assertThat(result.isEmpty(), is(true));
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -37,6 +37,7 @@ import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.ConsultingTypeControllerApi;
@@ -118,7 +119,8 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean private Keycloak keycloak;
 
-  @MockitoBean IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -61,7 +62,8 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -74,6 +74,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.ChatService;
@@ -155,7 +156,10 @@ class UserControllerAuthorizationIT {
   @MockitoBean private EmailNotificationFacade emailNotificationFacade;
   @MockitoBean private ConsultantImportService consultantImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private IdentityManager identityManager;
   @MockitoBean private AccountInviteService accountInviteService;
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -51,6 +51,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
@@ -274,7 +275,10 @@ class UserControllerIT {
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private DecryptionService encryptionService;
   @MockitoBean private ConsultingTypeManager consultingTypeManager;
   @MockitoBean private UserHelper userHelper;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -48,7 +49,10 @@ class CreateAdminServiceIT {
   private static final String VALID_EMAIL_ADDRESS = "valid@emailaddress.de";
 
   @Autowired private CreateAdminService createAdminService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private AuthenticatedUser authenticatedUser;
   @Captor private ArgumentCaptor<UserDTO> userDTOArgumentCaptor;
   private final EasyRandom easyRandom = new EasyRandom();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminSe
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -28,7 +29,10 @@ public class UpdateAdminServiceIT {
   private final String VALID_ADMIN_ID = "164be67d-4d1b-4d80-bb6b-0ee057a1c59e";
 
   @Autowired private UpdateAdminService updateAdminService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  private IdentityClient identityClient;
+
   @Autowired private RetrieveAdminService retrieveAdminService;
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -74,7 +75,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean private IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  private IdentityClient identityClient;
 
   @MockitoBean private ConsultingTypeManager consultingTypeManager;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,7 +28,8 @@ public class ConsultantUpdateServiceBase {
 
   @Autowired protected ConsultantUpdateService consultantUpdateService;
 
-  @MockitoBean protected IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityEmailOwnerLookup.class)
+  protected IdentityClient identityClient;
 
   @MockitoBean protected AgencyService agencyService;
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -90,6 +90,36 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "concrete identity or chat adapters:\n" + "\n".join(offenders),
         )
 
+    def test_identity_email_owner_lookup_uses_a_focused_typed_port(self):
+        identity_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        identity_manager = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java"
+        ).read_text()
+
+        self.assertNotIn(
+            "findUserByEmail(",
+            identity_port,
+            "The broad identity command port must not expose email-owner reads",
+        )
+        self.assertIn(
+            "IdentityEmailOwnerLookup",
+            identity_manager,
+            "IdentityManager must use the focused typed email-owner lookup",
+        )
+        self.assertNotIn(
+            '"encodedUsername"',
+            identity_manager,
+            "Application code must not interpret Keycloak adapter map keys",
+        )
+        self.assertNotIn(
+            '"decodedUsername"',
+            identity_manager,
+            "Application code must not interpret Keycloak adapter map keys",
+        )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- replays issue #787 directly on the current `pre-dev` and replaces the stale stacked draft #788
- splits email-owner lookup out of the broad `IdentityClient`
- returns the provider-neutral `IdentityEmailOwner` value through the focused `IdentityEmailOwnerLookup`
- keeps exact-email matching and Keycloak representation mapping inside the adapter
- preserves raw/encoded ownership, unused-email acceptance, different-owner rejection, and safe rejection of incomplete owner data
- preserves the Matrix-only architecture boundary: no Rocket.Chat or Jitsi fallback; no deployment is part of this PR

## Why this is a replacement PR

The old draft #788 targets the superseded `perf/batch-identity-role-read-783` branch. This PR contains only issue #787, replayed on `pre-dev` SHA `be15d12f6305f3370e626a0eec131293cceb5624` without importing the old identity stack.

## Call bound

This is an internal boundary improvement, not a call-count reduction. One email-ownership validation still performs exactly one external identity lookup.

## Verification

Executed with Temurin JDK 21:

- focused Java tests: 104 passed
- full unit tests: 3,427 passed; 0 failures; 0 errors; 0 skipped
- required integration/contract/E2E tests: 850 passed; 0 failures; 0 errors; 9 environment-gated skips
- Python CI structure tests: 51 passed
- OpenAPI contract tests: 8 passed
- Spotless, package/build, and `git diff --check`: passed
- local database reset was not required; integration tests used and cleaned their isolated test databases

## Evidence boundary

This establishes source and local-test evidence only until GitHub CI is green. It does not claim merge, deployment, or PreDev runtime behavior.

Closes #787

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
