### PR TITLE
[Stability] Split identity authentication port

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -230,7 +230,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. | The older broad `IdentityClient` contract still exposes provider transports in other identity operations. |
+| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. Interactive and technical-user authentication use the focused `IdentityAuthentication` port and provider-neutral `IdentityLogin` value. | The older broad `IdentityClient` contract still exposes provider transports in non-authentication identity operations. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import concrete Matrix adapters. | The large admin controller still composes many services, and create-user validation still exposes an older Keycloak response DTO. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix DTOs, credentials and failure policy. Both protected application packages have executable import boundaries. | Session/consultant orchestration remains broad even though the Rocket.Chat transport has been removed. |
 
@@ -247,12 +247,23 @@ A dedicated magic-link boundary contract prevents the application service and
 both web entry points from importing Keycloak transport types. It also prevents
 the public magic-link response DTO from depending on an outbound-port package.
 
+A separate authentication boundary contract removes login, logout and
+password verification from the broad `IdentityClient`. The five live
+consumers—`IdentityManager`, anonymous-user creation, the agency Matrix
+credential client, appointment synchronization and account validation—now use
+`IdentityAuthentication`. `KeycloakService` alone maps the provider response to
+`IdentityLogin`. This changes ownership and transport coupling, not call count:
+each login, logout or password-verification operation still performs exactly
+one outbound Keycloak operation. The removed legacy alias-message consumer is
+not restored.
+
 This is a ratcheted incremental modularization, not a claim that all three
 domains are already isolated. Rocket.Chat removal is complete in production
 source. The next safe sequence is the remaining identity create-user DTO
-decoupling, then the Admin controller composition boundary, then smaller
-Session orchestration boundaries. Each step must add a failing boundary
-contract before moving dependencies.
+decoupling and further non-authentication identity transport cleanup, then the
+Admin controller composition boundary, then smaller Session orchestration
+boundaries. Each step must add a failing boundary contract before moving
+dependencies.
 
 ## Microservice decision
 

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import java.util.Map;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class IdentityManager implements IdentityManaging {
 
   private final IdentityClient identityClient;
+  private final IdentityAuthentication identityAuthentication;
   private final UsernameTranscoder usernameTranscoder;
 
   @Override
@@ -41,7 +43,7 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean validatePasswordIgnoring2fa(String username, String password) {
-    return identityClient.verifyIgnoringOtp(username, password);
+    return identityAuthentication.verifyPasswordIgnoringSecondFactor(username, password);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -69,8 +69,7 @@ import org.springframework.web.client.RestClientResponseException;
 @Slf4j
 @RequiredArgsConstructor
 public class KeycloakService
-    implements
-        IdentityAuthentication,
+    implements IdentityAuthentication,
         IdentityClient,
         IdentityEmailOwnerLookup,
         IdentityUsernameAvailability {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -24,8 +24,10 @@ import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
@@ -63,7 +65,7 @@ import org.springframework.web.client.RestClientResponseException;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KeycloakService implements IdentityClient {
+public class KeycloakService implements IdentityAuthentication, IdentityClient {
 
   private static final String ENDPOINT_OTP_INFO = "/fetch-otp-setup-info/{username}";
   private static final String ENDPOINT_OTP_SETUP = "/setup-otp/{username}";
@@ -139,30 +141,23 @@ public class KeycloakService implements IdentityClient {
         || !userRepresentation.getAttributes().get(LOCALE).contains(locale);
   }
 
-  /**
-   * Performs a Keycloak login and returns the Keycloak {@link KeycloakLoginResponseDTO} on success.
-   *
-   * @param userName the username
-   * @param password the password
-   * @return {@link KeycloakLoginResponseDTO}
-   */
-  public KeycloakLoginResponseDTO loginUser(final String userName, final String password) {
-    return keycloakAuthClient.loginUser(userName, password);
+  @Override
+  public IdentityLogin login(final String userName, final String password) {
+    KeycloakLoginResponseDTO response = keycloakAuthClient.loginUser(userName, password);
+    return new IdentityLogin(
+        response.getAccessToken(),
+        response.getExpiresIn(),
+        response.getRefreshExpiresIn(),
+        response.getRefreshToken());
   }
 
   @Override
-  public boolean verifyIgnoringOtp(String username, String password) {
+  public boolean verifyPasswordIgnoringSecondFactor(String username, String password) {
     return keycloakAuthClient.verifyIgnoringOtp(username, password);
   }
 
-  /**
-   * Performs a Keycloak logout. This only destroys the Keycloak session, the (offline) access token
-   * will still be valid until expiration date/time ends.
-   *
-   * @param refreshToken the refreshToken
-   * @return true if logout was successful
-   */
-  public boolean logoutUser(final String refreshToken) {
+  @Override
+  public boolean logout(final String refreshToken) {
     return keycloakAuthClient.logoutUser(refreshToken);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/service/user/anonymous/AnonymousUserCreatorService.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.conversation.service.user.anonymous;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.conversation.model.AnonymousUserCredentials;
@@ -10,7 +9,9 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackUserAccountInformation;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.LogService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class AnonymousUserCreatorService {
 
   private final @NonNull CreateUserFacade createUserFacade;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull RollbackFacade rollbackFacade;
 
   /**
@@ -39,13 +41,13 @@ public class AnonymousUserCreatorService {
     // subsequent login fails with 401 (breaking invite-link redeem). The anonymous chat endpoints
     // in SecurityConfig all accept USER_DEFAULT, matching how /users/askers/new already registers
     // anonymous chat users (see CreateUserFacade).
-    KeycloakLoginResponseDTO identityLogin;
+    IdentityLogin identityLogin;
     try {
       var user =
           createUserFacade.updateIdentityAndCreateAccount(
               response.getUserId(), userDto, UserRole.USER);
       createUserFacade.provisionMatrixUser(user, userDto.getUsername());
-      identityLogin = identityClient.loginUser(userDto.getUsername(), userDto.getPassword());
+      identityLogin = identityAuthentication.login(userDto.getUsername(), userDto.getPassword());
     } catch (BadRequestException | InternalServerErrorException e) {
       rollBackAnonymousUserAccount(response.getUserId());
       throw new InternalServerErrorException(e.getMessage(), LogService::logInternalServerError);
@@ -53,10 +55,10 @@ public class AnonymousUserCreatorService {
 
     return AnonymousUserCredentials.builder()
         .userId(response.getUserId())
-        .accessToken(identityLogin.getAccessToken())
-        .expiresIn(identityLogin.getExpiresIn())
-        .refreshToken(identityLogin.getRefreshToken())
-        .refreshExpiresIn(identityLogin.getRefreshExpiresIn())
+        .accessToken(identityLogin.accessToken())
+        .expiresIn(identityLogin.expiresIn())
+        .refreshToken(identityLogin.refreshToken())
+        .refreshExpiresIn(identityLogin.refreshExpiresIn())
         .build();
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAuthentication.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAuthentication.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral identity authentication contract. */
+public interface IdentityAuthentication {
+
+  IdentityLogin login(String username, String password);
+
+  boolean logout(String refreshToken);
+
+  boolean verifyPasswordIgnoringSecondFactor(String username, String password);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
@@ -15,10 +14,6 @@ public interface IdentityClient {
   boolean changePassword(final String userId, final String password);
 
   void changeLanguage(final String userId, final String language);
-
-  KeycloakLoginResponseDTO loginUser(final String userName, final String password);
-
-  boolean logoutUser(final String refreshToken);
 
   void changeEmailAddress(final String emailAddress);
 
@@ -80,8 +75,6 @@ public interface IdentityClient {
   void closeSession(String sessionId);
 
   void deactivateUser(String userId);
-
-  boolean verifyIgnoringOtp(String username, String password);
 
   UserRepresentation getById(String userId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityLogin.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityLogin.java
@@ -1,0 +1,5 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/** Provider-neutral credentials returned after an identity login. */
+public record IdentityLogin(
+    String accessToken, int expiresIn, int refreshExpiresIn, String refreshToken) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClient.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
 
 import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
@@ -48,7 +48,7 @@ public class OperatorDpaContentClient {
   static final Duration CACHE_TTL = Duration.ofMinutes(5);
 
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   private final @NonNull TenantAdminServiceApiControllerFactory
@@ -60,12 +60,12 @@ public class OperatorDpaContentClient {
 
   public OperatorDpaContentClient(
       @NonNull SecurityHeaderSupplier securityHeaderSupplier,
-      @NonNull IdentityClient identityClient,
+      @NonNull IdentityAuthentication identityAuthentication,
       @NonNull IdentityClientConfig identityClientConfig,
       @NonNull TenantAdminServiceApiControllerFactory tenantAdminServiceApiControllerFactory,
       @Value("${account.invite.onboarding.operator-dpa.tenant-id:1}") long operatorTenantId) {
     this.securityHeaderSupplier = securityHeaderSupplier;
-    this.identityClient = identityClient;
+    this.identityAuthentication = identityAuthentication;
     this.identityClientConfig = identityClientConfig;
     this.tenantAdminServiceApiControllerFactory = tenantAdminServiceApiControllerFactory;
     this.operatorTenantId = operatorTenantId;
@@ -154,9 +154,10 @@ public class OperatorDpaContentClient {
 
   private void addTechnicalUserHeaders(ApiClient apiClient) {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var identityLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
     HttpHeaders headers =
-        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(identityLogin.accessToken());
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantCreationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantCreationClient.java
@@ -2,7 +2,7 @@ package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
 
 import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
@@ -31,7 +31,7 @@ import org.springframework.web.client.HttpClientErrorException;
 public class TenantCreationClient {
 
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   private final @NonNull TenantAdminServiceApiControllerFactory
@@ -60,9 +60,10 @@ public class TenantCreationClient {
 
   private void addTechnicalUserHeaders(ApiClient apiClient) {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    var identityLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
     HttpHeaders headers =
-        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(identityLogin.accessToken());
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClient.java
@@ -1,6 +1,6 @@
 package de.caritas.cob.userservice.api.service.agency;
 
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -26,7 +26,7 @@ public class AgencyMatrixCredentialClient {
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   @Value("${agency.service.api.url}")
@@ -66,9 +66,9 @@ public class AgencyMatrixCredentialClient {
 
   private HttpHeaders technicalUserHeaders() {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
-    var headers =
-        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+    var identityLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
+    var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(identityLogin.accessToken());
     tenantHeaderSupplier.addTenantHeader(headers);
     return headers;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/appointment/AppointmentService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/appointment/AppointmentService.java
@@ -10,7 +10,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AppointmentAgencyServiceA
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentAskerServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentConsultantServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
@@ -48,7 +48,7 @@ public class AppointmentService {
 
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
   private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
-  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityAuthentication identityAuthentication;
   private final @NonNull IdentityClientConfig identityClientConfig;
 
   @Value("${feature.appointment.enabled}")
@@ -164,9 +164,9 @@ public class AppointmentService {
   @SuppressWarnings("Duplicates")
   private void addTechnicalUserHeaders(ApiClient apiClient) {
     var techUser = identityClientConfig.getTechnicalUser();
-    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
-    var headers =
-        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+    var identityLogin =
+        identityAuthentication.login(techUser.getUsername(), techUser.getPassword());
+    var headers = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(identityLogin.accessToken());
     tenantHeaderSupplier.addTenantHeader(headers);
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidator.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.service.user.validation;
 
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,17 +11,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserAccountValidator {
 
-  private final @NotNull IdentityClient identityClient;
+  private final @NotNull IdentityAuthentication identityAuthentication;
 
   /**
    * Checks if user can be logged in via the provided credentials. If password is wrong a {@link
-   * BadRequestException} is thrown by {@link IdentityClient}.
+   * BadRequestException} is thrown by {@link IdentityAuthentication}.
    *
    * @param username username
    * @param password password
    */
   public void checkPasswordValidity(String username, String password) {
-    var loginResponse = identityClient.loginUser(username, password);
-    identityClient.logoutUser(loginResponse.getRefreshToken());
+    var loginResponse = identityAuthentication.login(username, password);
+    identityAuthentication.logout(loginResponse.refreshToken());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,9 +23,20 @@ class IdentityManagerTest {
   private static final String EMAIL = "consultant@example.org";
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
   @InjectMocks private IdentityManager identityManager;
+
+  @Test
+  void validatePasswordIgnoring2faShouldPreserveEncodedUsernameForIdentityAuthentication() {
+    when(identityAuthentication.verifyPasswordIgnoringSecondFactor(ENCODED_USERNAME, "password"))
+        .thenReturn(true);
+
+    assertThat(identityManager.validatePasswordIgnoring2fa(ENCODED_USERNAME, "password")).isTrue();
+
+    verify(identityAuthentication).verifyPasswordIgnoringSecondFactor(ENCODED_USERNAME, "password");
+  }
 
   @Test
   void validateOneTimePasswordShouldUseRawUsernameForKeycloakEmailUpdate() {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
@@ -84,12 +84,16 @@ class KeycloakServiceLoggingTest {
   }
 
   @Test
-  void loginUser_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging() {
+  void login_ShouldRedactPassword_WhenRequestBodyIsRenderedForDebugLogging() {
     var loginResponse = new KeycloakLoginResponseDTO();
+    loginResponse.setAccessToken("access-token");
+    loginResponse.setRefreshToken("refresh-token");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenReturn(new ResponseEntity<>(loginResponse, HttpStatus.OK));
 
-    assertThat(keycloakService.loginUser(USERNAME, PASSWORD)).isSameAs(loginResponse);
+    var identityLogin = keycloakService.login(USERNAME, PASSWORD);
+    assertThat(identityLogin.accessToken()).isEqualTo("access-token");
+    assertThat(identityLogin.refreshToken()).isEqualTo("refresh-token");
 
     var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     verify(restTemplate)
@@ -103,31 +107,31 @@ class KeycloakServiceLoggingTest {
   }
 
   @Test
-  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutThrowsException() {
+  void logout_ShouldNotLogRefreshToken_WhenKeycloakLogoutThrowsException() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenThrow(new RestClientException("keycloak unavailable"));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isFalse();
 
     assertRefreshTokenWasNotLogged();
   }
 
   @Test
-  void logoutUser_ShouldNotLogRefreshToken_WhenKeycloakLogoutReturnsUnexpectedStatus() {
+  void logout_ShouldNotLogRefreshToken_WhenKeycloakLogoutReturnsUnexpectedStatus() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isFalse();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isFalse();
 
     assertRefreshTokenWasNotLogged();
   }
 
   @Test
-  void logoutUser_ShouldRedactRefreshToken_WhenRequestBodyIsRenderedForDebugLogging() {
+  void logout_ShouldRedactRefreshToken_WhenRequestBodyIsRenderedForDebugLogging() {
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class)))
         .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
-    assertThat(keycloakService.logoutUser(REFRESH_TOKEN)).isTrue();
+    assertThat(keycloakService.logout(REFRESH_TOKEN)).isTrue();
 
     var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     verify(restTemplate).postForEntity(anyString(), requestCaptor.capture(), eq(Void.class));

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -8,7 +8,6 @@ import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,6 +41,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.testutils.LogbackCaptor;
 import jakarta.ws.rs.BadRequestException;
@@ -157,7 +157,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void loginUser_Should_ReturnKeycloakLoginResponseDTO_When_KeycloakLoginWasSuccessful() {
+  public void login_Should_MapKeycloakResponseToProviderNeutralCredentials() {
     KeycloakLoginResponseDTO loginResponseDTO =
         new EasyRandom().nextObject(KeycloakLoginResponseDTO.class);
     when(restTemplate.postForEntity(
@@ -166,13 +166,16 @@ public class KeycloakServiceTest {
             ArgumentMatchers.<Class<KeycloakLoginResponseDTO>>any()))
         .thenReturn(new ResponseEntity<>(loginResponseDTO, HttpStatus.OK));
 
-    KeycloakLoginResponseDTO response = keycloakService.loginUser(USER_ID, OLD_PW);
+    IdentityLogin response = keycloakService.login(USER_ID, OLD_PW);
 
-    assertThat(response, instanceOf(KeycloakLoginResponseDTO.class));
+    assertThat(response.accessToken(), is(loginResponseDTO.getAccessToken()));
+    assertThat(response.expiresIn(), is(loginResponseDTO.getExpiresIn()));
+    assertThat(response.refreshExpiresIn(), is(loginResponseDTO.getRefreshExpiresIn()));
+    assertThat(response.refreshToken(), is(loginResponseDTO.getRefreshToken()));
   }
 
   @Test
-  public void loginUser_Should_ReturnBadRequest_When_KeycloakLoginFails() {
+  public void login_Should_ReturnBadRequest_When_KeycloakLoginFails() {
     var exception =
         new RestClientResponseException("some exception", 500, "text", null, null, null);
     when(restTemplate.postForEntity(
@@ -182,7 +185,7 @@ public class KeycloakServiceTest {
         .thenThrow(exception);
 
     try {
-      keycloakService.loginUser(USER_ID, OLD_PW);
+      keycloakService.login(USER_ID, OLD_PW);
       fail("Expected exception: BadRequestException");
     } catch (BadRequestException badRequestException) {
       assertTrue(true, "Excepted BadRequestException thrown");
@@ -190,33 +193,33 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void logoutUser_Should_ReturnTrue_When_KeycloakLoginWasSuccessful() {
+  public void logout_Should_ReturnTrue_When_KeycloakLoginWasSuccessful() {
     when(restTemplate.postForEntity(
             ArgumentMatchers.anyString(), any(), ArgumentMatchers.<Class<Void>>any()))
         .thenReturn(new ResponseEntity<>(HttpStatus.NO_CONTENT));
 
-    assertTrue(keycloakService.logoutUser(REFRESH_TOKEN));
+    assertTrue(keycloakService.logout(REFRESH_TOKEN));
   }
 
   @Test
-  public void logoutUser_Should_ReturnFalseAndLogError_WhenKeycloakLogoutFailsWithException() {
+  public void logout_Should_ReturnFalseAndLogError_WhenKeycloakLogoutFailsWithException() {
     RestClientException exception = new RestClientException("error");
     when(restTemplate.postForEntity(ArgumentMatchers.anyString(), any(), any()))
         .thenThrow(exception);
 
-    boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
+    boolean response = keycloakService.logout(REFRESH_TOKEN);
 
     assertFalse(response);
     assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
   }
 
   @Test
-  public void logoutUser_Should_ReturnFalseAndLogError_When_KeycloakLogoutFails() {
+  public void logout_Should_ReturnFalseAndLogError_When_KeycloakLogoutFails() {
     when(restTemplate.postForEntity(
             ArgumentMatchers.anyString(), any(), ArgumentMatchers.<Class<Void>>any()))
         .thenReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
 
-    boolean response = keycloakService.logoutUser(REFRESH_TOKEN);
+    boolean response = keycloakService.logout(REFRESH_TOKEN);
 
     assertFalse(response);
     assertTrue(authLogCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
@@ -1308,33 +1311,35 @@ public class KeycloakServiceTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrue_When_MissingTotpButPasswordCorrect() {
     var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
     when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
     when(exception.getResponseBodyAsString()).thenReturn("Missing totp");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenThrow(exception);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnFalse_When_OtherBadRequest() {
+  public void verifyPasswordIgnoringSecondFactor_Should_ReturnFalse_When_OtherBadRequest() {
     var exception = mock(org.springframework.web.client.HttpClientErrorException.class);
     when(exception.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
     when(exception.getResponseBodyAsString()).thenReturn("Invalid credentials");
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenThrow(exception);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(false));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrueAndLogout_When_LoginSucceedsWithRefreshToken() {
     var loginResponse = mock(KeycloakLoginResponseDTO.class);
     when(loginResponse.getRefreshToken()).thenReturn(REFRESH_TOKEN);
     ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
@@ -1345,14 +1350,15 @@ public class KeycloakServiceTest {
     ResponseEntity<Void> logoutResponse = new ResponseEntity<>(HttpStatus.NO_CONTENT);
     when(restTemplate.postForEntity(anyString(), any(), eq(Void.class))).thenReturn(logoutResponse);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
     verify(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
   }
 
   @Test
-  public void verifyIgnoringOtp_Should_ReturnTrueWithoutLogout_When_NoRefreshToken() {
+  public void
+      verifyPasswordIgnoringSecondFactor_Should_ReturnTrueWithoutLogout_When_NoRefreshToken() {
     var loginResponse = mock(KeycloakLoginResponseDTO.class);
     when(loginResponse.getRefreshToken()).thenReturn(null);
     ResponseEntity<KeycloakLoginResponseDTO> responseEntity =
@@ -1360,7 +1366,7 @@ public class KeycloakServiceTest {
     when(restTemplate.postForEntity(anyString(), any(), eq(KeycloakLoginResponseDTO.class)))
         .thenReturn(responseEntity);
 
-    boolean result = keycloakService.verifyIgnoringOtp(USERNAME, OLD_PW);
+    boolean result = keycloakService.verifyPasswordIgnoringSecondFactor(USERNAME, OLD_PW);
 
     assertThat(result, is(true));
     verify(restTemplate, org.mockito.Mockito.never())

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
@@ -118,7 +119,8 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean private Keycloak keycloak;
 
-  @MockitoBean IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControlle
 import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
@@ -61,7 +62,8 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -73,6 +73,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -155,7 +156,10 @@ class UserControllerAuthorizationIT {
   @MockitoBean private EmailNotificationFacade emailNotificationFacade;
   @MockitoBean private ConsultantImportService consultantImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private IdentityManager identityManager;
   @MockitoBean private AccountInviteService accountInviteService;
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -49,6 +49,7 @@ import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.*;
@@ -274,7 +275,10 @@ class UserControllerIT {
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private DecryptionService encryptionService;
   @MockitoBean private ConsultingTypeManager consultingTypeManager;
   @MockitoBean private UserHelper userHelper;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
@@ -48,7 +49,10 @@ class CreateAdminServiceIT {
   private static final String VALID_EMAIL_ADDRESS = "valid@emailaddress.de";
 
   @Autowired private CreateAdminService createAdminService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  private IdentityClient identityClient;
+
   @MockitoBean private AuthenticatedUser authenticatedUser;
   @Captor private ArgumentCaptor<UserDTO> userDTOArgumentCaptor;
   private final EasyRandom easyRandom = new EasyRandom();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAgencyAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +29,10 @@ public class UpdateAdminServiceIT {
   private final String VALID_ADMIN_ID = "164be67d-4d1b-4d80-bb6b-0ee057a1c59e";
 
   @Autowired private UpdateAdminService updateAdminService;
-  @MockitoBean private IdentityClient identityClient;
+
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  private IdentityClient identityClient;
+
   @Autowired private RetrieveAdminService retrieveAdminService;
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -25,6 +25,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
@@ -74,7 +75,8 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean private IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  private IdentityClient identityClient;
 
   @MockitoBean private ConsultingTypeManager consultingTypeManager;
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
@@ -27,7 +28,8 @@ public class ConsultantUpdateServiceBase {
 
   @Autowired protected ConsultantUpdateService consultantUpdateService;
 
-  @MockitoBean protected IdentityClient identityClient;
+  @MockitoBean(extraInterfaces = IdentityAuthentication.class)
+  protected IdentityClient identityClient;
 
   @MockitoBean protected AgencyService agencyService;
 

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/service1/user/anonymous/AnonymousUserCreatorServiceTest.java
@@ -12,14 +12,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.conversation.service.user.anonymous.AnonymousUserCreatorService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.facade.CreateUserFacade;
 import de.caritas.cob.userservice.api.facade.rollback.RollbackFacade;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,23 +33,20 @@ class AnonymousUserCreatorServiceTest {
   @InjectMocks private AnonymousUserCreatorService anonymousUserCreatorService;
   @Mock private CreateUserFacade createUserFacade;
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
   @Mock private RollbackFacade rollbackFacade;
 
   @Test
   void createAnonymousUserCreatesIdentityAccountAndMatrixUser() {
     var createdIdentity = new KeycloakCreateUserResponseDTO();
     createdIdentity.setUserId("user-id");
-    var identityLogin = new KeycloakLoginResponseDTO();
-    identityLogin.setAccessToken("access-token");
-    identityLogin.setExpiresIn(300);
-    identityLogin.setRefreshToken("refresh-token");
-    identityLogin.setRefreshExpiresIn(600);
+    var identityLogin = new IdentityLogin("access-token", 300, 600, "refresh-token");
     var user = new User();
 
     when(identityClient.createKeycloakUser(USER_DTO_SUCHT)).thenReturn(createdIdentity);
     when(createUserFacade.updateIdentityAndCreateAccount(anyString(), any(), any()))
         .thenReturn(user);
-    when(identityClient.loginUser(USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
+    when(identityAuthentication.login(USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
         .thenReturn(identityLogin);
 
     var credentials = anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT);
@@ -79,7 +77,7 @@ class AnonymousUserCreatorServiceTest {
         .isInstanceOf(InternalServerErrorException.class);
 
     verify(rollbackFacade).rollBackUserAccount(any());
-    verify(identityClient, never()).loginUser(anyString(), anyString());
+    verify(identityAuthentication, never()).login(anyString(), anyString());
   }
 
   @Test
@@ -91,7 +89,7 @@ class AnonymousUserCreatorServiceTest {
     when(identityClient.createKeycloakUser(USER_DTO_SUCHT)).thenReturn(createdIdentity);
     when(createUserFacade.updateIdentityAndCreateAccount(anyString(), any(), any()))
         .thenReturn(user);
-    when(identityClient.loginUser(USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
+    when(identityAuthentication.login(USER_DTO_SUCHT.getUsername(), USER_DTO_SUCHT.getPassword()))
         .thenThrow(new BadRequestException("login failed"));
 
     assertThatThrownBy(() -> anonymousUserCreatorService.createAnonymousUser(USER_DTO_SUCHT))

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClientTest.java
@@ -9,11 +9,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.TenantControllerApi;
@@ -45,7 +45,7 @@ class OperatorDpaContentClientTest {
       "{\"de\":\"<h2>Auftragsverarbeitung</h2>\",\"en\":\"<h2>Data processing</h2>\"}";
 
   @Mock private SecurityHeaderSupplier securityHeaderSupplier;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityClientConfig identityClientConfig;
   @Mock private TenantAdminServiceApiControllerFactory controllerFactory;
   @Mock private TenantControllerApi tenantControllerApi;
@@ -57,9 +57,8 @@ class OperatorDpaContentClientTest {
     technicalUser.setUsername("technical");
     technicalUser.setPassword("secret");
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    KeycloakLoginResponseDTO keycloakLogin = new KeycloakLoginResponseDTO();
-    keycloakLogin.setAccessToken("token");
-    when(identityClient.loginUser(anyString(), anyString())).thenReturn(keycloakLogin);
+    IdentityLogin identityLogin = new IdentityLogin("token", 0, 0, null);
+    when(identityAuthentication.login(anyString(), anyString())).thenReturn(identityLogin);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(anyString()))
         .thenReturn(new HttpHeaders());
     when(controllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
@@ -69,7 +68,7 @@ class OperatorDpaContentClientTest {
   private OperatorDpaContentClient clientFor(long operatorTenantId) {
     return new OperatorDpaContentClient(
         securityHeaderSupplier,
-        identityClient,
+        identityAuthentication,
         identityClientConfig,
         controllerFactory,
         operatorTenantId);
@@ -165,7 +164,7 @@ class OperatorDpaContentClientTest {
     assertNull(clientFor(0L).fetchPublishedDpaContent());
 
     verifyNoInteractions(controllerFactory);
-    verifyNoInteractions(identityClient);
+    verifyNoInteractions(identityAuthentication);
   }
 
   @Test
@@ -219,7 +218,7 @@ class OperatorDpaContentClientTest {
 
     clientFor(OPERATOR_TENANT_ID).fetchPublishedDpaContent();
 
-    verify(identityClient).loginUser("technical", "secret");
+    verify(identityAuthentication).login("technical", "secret");
     verify(securityHeaderSupplier).getKeycloakAndCsrfHttpHeaders("token");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agency/AgencyMatrixCredentialClientTest.java
@@ -10,12 +10,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
 import de.caritas.cob.userservice.api.service.httpheader.HttpHeadersResolver;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
@@ -37,7 +37,7 @@ class AgencyMatrixCredentialClientTest {
 
   private RestTemplate restTemplate;
   private MockRestServiceServer mockServer;
-  private IdentityClient identityClient;
+  private IdentityAuthentication identityAuthentication;
   private IdentityClientConfig identityClientConfig;
   private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
 
@@ -45,7 +45,7 @@ class AgencyMatrixCredentialClientTest {
   void setUp() {
     restTemplate = new RestTemplate();
     mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-    identityClient = mock(IdentityClient.class);
+    identityAuthentication = mock(IdentityAuthentication.class);
     identityClientConfig = mock(IdentityClientConfig.class);
 
     var securityHeaderSupplier = new SecurityHeaderSupplier(new AuthenticatedUser());
@@ -60,7 +60,7 @@ class AgencyMatrixCredentialClientTest {
             restTemplate,
             securityHeaderSupplier,
             tenantHeaderSupplier,
-            identityClient,
+            identityAuthentication,
             identityClientConfig);
     ReflectionTestUtils.setField(
         agencyMatrixCredentialClient, "agencyServiceBaseUrl", AGENCY_SERVICE_URL);
@@ -101,7 +101,7 @@ class AgencyMatrixCredentialClientTest {
     technicalUser.setPassword("secret");
 
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    when(identityClient.loginUser("technical", "secret"))
+    when(identityAuthentication.login("technical", "secret"))
         .thenThrow(new BadRequestException("Keycloak unavailable"));
 
     assertThat(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).isEmpty();
@@ -139,10 +139,9 @@ class AgencyMatrixCredentialClientTest {
     technicalUser.setUsername("technical");
     technicalUser.setPassword("secret");
 
-    var loginResponse = new KeycloakLoginResponseDTO();
-    loginResponse.setAccessToken(accessToken);
+    var loginResponse = new IdentityLogin(accessToken, 0, 0, "refresh-token");
 
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
-    when(identityClient.loginUser("technical", "secret")).thenReturn(loginResponse);
+    when(identityAuthentication.login("technical", "secret")).thenReturn(loginResponse);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/appointment/AppointmentServiceTest.java
@@ -11,15 +11,15 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentAgencyServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentAskerServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.apiclient.AppointmentConsultantServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.model.Consultant;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
 import de.caritas.cob.userservice.appointmentservice.generated.ApiClient;
@@ -63,7 +63,7 @@ class AppointmentServiceTest {
   @Mock SecurityHeaderSupplier securityHeaderSupplier;
 
   @Mock TenantHeaderSupplier tenantHeaderSupplier;
-  @Mock IdentityClient identityClient;
+  @Mock IdentityAuthentication identityAuthentication;
 
   @SuppressWarnings("unused")
   @Mock
@@ -75,7 +75,7 @@ class AppointmentServiceTest {
 
   @Mock ConsultantAdminResponseDTO consultantAdminResponseDTO;
 
-  @Mock KeycloakLoginResponseDTO keycloakLoginResponseDTO;
+  @Mock IdentityLogin identityLogin;
 
   @Mock org.springframework.http.HttpHeaders httpHeaders;
 
@@ -91,7 +91,7 @@ class AppointmentServiceTest {
     appointmentService = spy(createAppointmentService());
     nonSpiedAppointmentService = createAppointmentService();
 
-    when(identityClient.loginUser(any(), any())).thenReturn(keycloakLoginResponseDTO);
+    when(identityAuthentication.login(any(), any())).thenReturn(identityLogin);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(any())).thenReturn(httpHeaders);
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(httpHeaders);
     when(consultantDTO.getId()).thenReturn("testId");
@@ -108,7 +108,7 @@ class AppointmentServiceTest {
         new StubAppointmentAskerServiceApiControllerFactory(appointmentAskerApi),
         securityHeaderSupplier,
         tenantHeaderSupplier,
-        identityClient,
+        identityAuthentication,
         identityClientConfig);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/user/validation/UserAccountValidatorTest.java
@@ -4,15 +4,13 @@ import static de.caritas.cob.userservice.api.testHelper.TestConstants.ERROR;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.PASSWORD;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.USERNAME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
-import org.jeasy.random.EasyRandom;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,14 +21,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class UserAccountValidatorTest {
 
   @InjectMocks private UserAccountValidator userAccountValidator;
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityAuthentication identityAuthentication;
 
   @Test
   public void checkPasswordValidity_Should_ThrowBadRequestException_When_KeycloakLoginFails() {
     assertThrows(
         BadRequestException.class,
         () -> {
-          when(identityClient.loginUser(anyString(), anyString()))
+          when(identityAuthentication.login(USERNAME, PASSWORD))
               .thenThrow(new BadRequestException(ERROR));
 
           this.userAccountValidator.checkPasswordValidity(USERNAME, PASSWORD);
@@ -39,12 +37,12 @@ public class UserAccountValidatorTest {
 
   @Test
   public void checkPasswordValidity_Should_LogOutUser_When_LoginWasSuccessful() {
-    KeycloakLoginResponseDTO loginResponseDTO =
-        new EasyRandom().nextObject(KeycloakLoginResponseDTO.class);
-    when(identityClient.loginUser(anyString(), anyString())).thenReturn(loginResponseDTO);
+    IdentityLogin identityLogin = new IdentityLogin("access-token", 300, 600, "refresh-token");
+    when(identityAuthentication.login(USERNAME, PASSWORD)).thenReturn(identityLogin);
 
     this.userAccountValidator.checkPasswordValidity(USERNAME, PASSWORD);
 
-    verify(identityClient, times(1)).logoutUser(anyString());
+    verify(identityAuthentication, times(1)).login(USERNAME, PASSWORD);
+    verify(identityAuthentication, times(1)).logout("refresh-token");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -6,13 +6,13 @@ import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakClient;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakMapper;
 import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakCreateUserResponseDTO;
-import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.keycloak.admin.client.resource.UserResource;
@@ -71,12 +71,12 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public KeycloakLoginResponseDTO loginUser(String userName, String password) {
-        return new KeycloakLoginResponseDTO("", 0, 0, "", "", "", "");
+      public IdentityLogin login(String userName, String password) {
+        return new IdentityLogin("", 0, 0, "");
       }
 
       @Override
-      public boolean logoutUser(String refreshToken) {
+      public boolean logout(String refreshToken) {
         return true;
       }
 

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -231,7 +231,6 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             identity_manager,
             "Application code must not interpret Keycloak adapter map keys",
         )
->>>>>>> origin/pre-dev
 
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -90,6 +90,64 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "concrete identity or chat adapters:\n" + "\n".join(offenders),
         )
 
+    def test_identity_authentication_uses_a_focused_provider_neutral_port(self):
+        identity_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        ).read_text()
+        authentication_port = (
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/"
+            "IdentityAuthentication.java"
+        )
+        consumers = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/conversation/service/user/"
+            "anonymous/AnonymousUserCreatorService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/agency/"
+            "AgencyMatrixCredentialClient.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/appointment/"
+            "AppointmentService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/service/user/validation/"
+            "UserAccountValidator.java",
+        )
+
+        self.assertTrue(
+            authentication_port.exists(),
+            "A focused IdentityAuthentication port must own authentication",
+        )
+        authentication_contract = authentication_port.read_text()
+        self.assertIn(
+            "IdentityLogin login(",
+            authentication_contract,
+            "Authentication must return the provider-neutral login value",
+        )
+        self.assertNotIn("adapters.keycloak", authentication_contract)
+        self.assertNotIn("org.keycloak", authentication_contract)
+
+        for method in ("loginUser(", "logoutUser(", "verifyIgnoringOtp("):
+            self.assertNotIn(
+                method,
+                identity_port,
+                "The broad identity command port must not expose authentication",
+            )
+
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in consumers
+            if "IdentityAuthentication" not in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "All live production authentication consumers must use the focused port:\n"
+            + "\n".join(offenders),
+        )
+
     def test_magic_link_application_and_web_boundaries_do_not_import_keycloak_transport(self):
         sources = (
             ROOT


### PR DESCRIPTION
## Summary

- introduce the focused, provider-neutral `IdentityAuthentication` output port and `IdentityLogin` value
- move the five live authentication consumers off the broad `IdentityClient`
- keep Keycloak response mapping, OTP-aware password verification and logout behavior inside the adapter
- ratchet the boundary with unit, integration and executable architecture contracts
- document the unchanged outbound-call behavior and remaining identity transport debt

## Current-state correction

This replacement is based directly on current `pre-dev` and supersedes #790. Current Matrix-only production code has five authentication consumers; the sixth consumer described by the old stacked PR was the removed legacy alias-message path and is deliberately not restored.

The target remains Matrix-only with the ORISO frontend and the controlled Element Call/MatrixRTC plus LiveKit calling stack. This change introduces no Rocket.Chat or Jitsi runtime, dependency or fallback.

## Behavior and dependency impact

- login still performs exactly one outbound Keycloak login operation
- logout still performs exactly one outbound Keycloak logout operation
- password verification still performs exactly one OTP-aware Keycloak verification operation
- no API, database schema or configuration contract changes
- internal modular-monolith boundary work only; no microservice extraction claim

## Local verification

- 3,428 unit tests: 0 failures, 0 errors, 0 skipped
- 850 integration/contract/E2E tests: 0 failures, 0 errors, 9 environment-gated skips
- 51 CI and architecture contract tests: passed
- 8 OpenAPI contract tests: passed
- Spotless, package build and diff audit: passed
- no local database reset was required

## Release truth

Source and local verification are complete. GitHub CI is pending. This PR is not merged or deployed, and this body makes no PreDev runtime claim.

Closes #789

Supersedes #790.