### PR TITLE
[Stability] Route consultant role lookup through identity input

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -230,12 +230,13 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. | The older broad `IdentityClient` contract still exposes provider transports in other identity operations. |
+| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; consultant DTO mapping asks `IdentityManaging` for role decisions instead of importing the outbound identity client. `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. | The older broad `IdentityClient` contract still exposes provider transports in other identity operations. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import concrete Matrix adapters. | The large admin controller still composes many services, and create-user validation still exposes an older Keycloak response DTO. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix DTOs, credentials and failure policy. Both protected application packages have executable import boundaries. | Session/consultant orchestration remains broad even though the Rocket.Chat transport has been removed. |
 
 `tests/ci/test_module_boundaries.py` prevents the stabilized user web slices
-from reverting to concrete application/chat services and prevents the
+from reverting to concrete application/chat services, prevents user web
+mappers from importing the outbound identity client, and prevents the
 `service.session` application package from importing concrete Matrix adapters. It also
 prevents the Identity/Profile packages and the Admin module from importing
 their protected concrete chat adapters. The separate removal contract prevents

--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api;
 
+import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
@@ -71,5 +72,10 @@ public class IdentityManager implements IdentityManaging {
     return user.isEmpty()
         || username.equals(user.get("encodedUsername"))
         || usernameTranscoder.decodeUsername(username).equals(user.get("decodedUsername"));
+  }
+
+  @Override
+  public boolean hasRole(String userId, UserRole role) {
+    return identityClient.userHasRole(userId, role.getValue());
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
@@ -19,8 +19,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.generated.api.adapters.web.controller.UseradminApi;
 import de.caritas.cob.userservice.topicservice.generated.web.model.TopicDTO;
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class ConsultantDtoMapper implements DtoMapperUtils {
-  @Autowired private IdentityClient identityClient;
+  @Autowired private IdentityManaging identityManager;
   @Autowired private ConsultantTopicRepository consultantTopicRepository;
   @Autowired private TopicService topicService;
 
@@ -184,13 +184,13 @@ public class ConsultantDtoMapper implements DtoMapperUtils {
                 .map(ConsultantDTO.OtherIdentityTypesEnum::fromValue)
                 .collect(Collectors.toList()));
 
-    // Handle missing Keycloak users gracefully
+    // Handle missing identity-provider users gracefully.
     boolean isGroupChatConsultant = false;
     try {
       isGroupChatConsultant =
-          identityClient.userHasRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+          identityManager.hasRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT);
     } catch (Exception e) {
-      // If user doesn't exist in Keycloak, assume they don't have the role
+      // If the identity provider cannot resolve the user, assume they do not have the role.
       log.debug("Could not check role for consultant {}: {}", consultant.getId(), e.getMessage());
     }
     consultant.setIsGroupchatConsultant(isGroupChatConsultant);

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityManaging.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.port.in;
 
+import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import java.util.Map;
 import java.util.Optional;
@@ -24,4 +25,6 @@ public interface IdentityManaging {
   OtpInfoDTO getOtpCredential(String username);
 
   boolean isEmailAvailableOrOwn(String username, String email);
+
+  boolean hasRole(String userId, UserRole role);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import java.util.Map;
@@ -99,5 +100,14 @@ class IdentityManagerTest {
     when(identityClient.findUserByEmail(EMAIL)).thenReturn(Map.of("email", EMAIL));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
+  }
+
+  @Test
+  void hasRoleShouldDelegateTheApplicationRoleValueToIdentityClient() {
+    when(identityClient.userHasRole("consultant-id", "group-chat-consultant")).thenReturn(true);
+
+    assertThat(identityManager.hasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT)).isTrue();
+
+    verify(identityClient).userHasRole("consultant-id", "group-chat-consultant");
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -11,8 +11,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
 import de.caritas.cob.userservice.topicservice.generated.web.model.TopicDTO;
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @ExtendWith(MockitoExtension.class)
 class ConsultantDtoMapperTest {
 
-  @Mock private IdentityClient identityClient;
+  @Mock private IdentityManaging identityManager;
   @Mock private ConsultantTopicRepository consultantTopicRepository;
   @Mock private TopicService topicService;
 
@@ -52,8 +52,8 @@ class ConsultantDtoMapperTest {
   void consultantDtoOf_Should_MapMasterTableFields() {
     // given
     ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
-    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
-    when(identityClient.userHasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT.getValue()))
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityManager", identityManager);
+    when(identityManager.hasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT))
         .thenReturn(false);
 
     // when
@@ -71,8 +71,8 @@ class ConsultantDtoMapperTest {
   void consultantDtoOf_Should_MapOtherIdentityFields_WhenPresentInMap() {
     // given
     ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
-    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
-    when(identityClient.userHasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT.getValue()))
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityManager", identityManager);
+    when(identityManager.hasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT))
         .thenReturn(false);
     var map = consultantMap();
     map.put("hasOtherIdentity", true);
@@ -93,8 +93,8 @@ class ConsultantDtoMapperTest {
   void consultantDtoOf_Should_DefaultOtherIdentityFields_WhenAbsentFromMap() {
     // given
     ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
-    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
-    when(identityClient.userHasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT.getValue()))
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityManager", identityManager);
+    when(identityManager.hasRole("consultant-id", UserRole.GROUP_CHAT_CONSULTANT))
         .thenReturn(false);
 
     // when
@@ -134,7 +134,7 @@ class ConsultantDtoMapperTest {
 
   private ConsultantDtoMapper givenAMapper() {
     ConsultantDtoMapper consultantDtoMapper = new ConsultantDtoMapper();
-    ReflectionTestUtils.setField(consultantDtoMapper, "identityClient", identityClient);
+    ReflectionTestUtils.setField(consultantDtoMapper, "identityManager", identityManager);
     ReflectionTestUtils.setField(
         consultantDtoMapper, "consultantTopicRepository", consultantTopicRepository);
     ReflectionTestUtils.setField(consultantDtoMapper, "topicService", topicService);
@@ -144,7 +144,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantDtoOf_Should_MapCounsellorRole_When_NotSupervisor() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     Map<String, Object> map = consultantMap();
     map.put("isSupervisor", false);
     map.put("deletedAt", null);
@@ -160,7 +160,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantDtoOf_Should_LeaveTenantIdNull_When_TenantIdIsNull() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     Map<String, Object> map = consultantMap();
     map.put("tenantId", null);
 
@@ -170,9 +170,9 @@ class ConsultantDtoMapperTest {
   }
 
   @Test
-  void consultantDtoOf_Should_SetGroupchatConsultantFalse_When_IdentityClientThrows() {
+  void consultantDtoOf_Should_SetGroupchatConsultantFalse_When_IdentityInputThrows() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString()))
+    when(identityManager.hasRole(anyString(), any(UserRole.class)))
         .thenThrow(new RuntimeException("keycloak user missing"));
 
     var consultant = consultantDtoMapper.consultantDtoOf(consultantMap());
@@ -183,7 +183,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantDtoOf_Should_MapAgencies_When_AgenciesPresent() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     Map<String, Object> map = consultantMap();
     Map<String, Object> agencyMap = new HashMap<>();
     agencyMap.put("id", 1L);
@@ -395,7 +395,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantSearchResultOf_Should_SkipTopicLookup_When_NoTopicIdsFoundForAnyConsultant() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(List.of());
 
     var result =
@@ -412,7 +412,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantSearchResultOf_Should_EnrichTopics_When_TopicIdsFoundForConsultant() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     List<Object[]> rows = java.util.Collections.singletonList(new Object[] {"consultant-id", 42L});
     when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(rows);
     var topicDto = new TopicDTO();
@@ -432,7 +432,7 @@ class ConsultantDtoMapperTest {
   @Test
   void consultantSearchResultOf_Should_AddPreviousAndNextLinks_When_NotFirstOrLastPage() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
-    when(identityClient.userHasRole(anyString(), anyString())).thenReturn(false);
+    when(identityManager.hasRole(anyString(), any(UserRole.class))).thenReturn(false);
     when(consultantTopicRepository.findTopicIdsByConsultantIdIn(any())).thenReturn(List.of());
 
     var result =

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -7,6 +7,10 @@ CONTROLLERS = (
     ROOT
     / "src/main/java/de/caritas/cob/userservice/api/adapters/web/controller"
 )
+WEB_MAPPINGS = (
+    ROOT
+    / "src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping"
+)
 
 
 class ModuleBoundaryContractTest(unittest.TestCase):
@@ -133,6 +137,23 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             offenders,
             "The magic-link web response must map an application/domain model, "
             "not expose the outbound-port package:\n" + "\n".join(offenders),
+        )
+
+    def test_user_web_mappers_do_not_import_outbound_identity_client(self):
+        forbidden_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityClient;"
+        )
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in WEB_MAPPINGS.glob("*.java")
+            if forbidden_import in source.read_text()
+        ]
+
+        self.assertEqual(
+            [],
+            offenders,
+            "User web mappers must ask the identity input port instead of calling "
+            "the outbound identity client:\n" + "\n".join(offenders),
         )
 
     def test_admin_module_depends_on_ports_not_chat_adapters(self):


### PR DESCRIPTION
## Summary

- expose the typed consultant-role decision through the application-owned `IdentityManaging` input port
- make `IdentityManager` the only delegate from consultant DTO mapping to the existing outbound identity client
- remove the outbound `IdentityClient` dependency from the web-mapping package
- preserve fail-closed behavior when the identity provider cannot resolve the user or role
- add an executable architecture ratchet and focused interaction coverage

## Current-state correction

This replacement is based directly on current `pre-dev` at `be15d12f6305f3370e626a0eec131293cceb5624` and contains only issue #779. It does not carry the old #778 parent stack from #780.

This change corrects dependency direction only. One consultant DTO mapping still performs at most one external role-membership read; call reduction belongs to the focused full-role lookup in #878 and its follow-up #795. No cache or speculative batching is introduced here.

The product target remains Matrix-only: the ORISO-owned frontend with the ORISO-controlled Element Call/MatrixRTC fork and LiveKit. Rocket.Chat and Jitsi are removal targets, not supported runtime paths or fallbacks.

## Verification

- focused Java tests: 29 passed; 0 failures, 0 errors, 0 skipped
- unit suite: 3,428 passed; 0 failures, 0 errors, 0 skipped
- integration, contract, and E2E suite: 850 passed; 0 failures, 0 errors, 9 environment-gated skips
- Python CI and architecture contracts: 51 passed
- OpenAPI contract gate tests: 8 passed
- Java 21 package and Spotless checks: passed
- clean diff and direct current `pre-dev` ancestry

No local database reset was needed; the integration suite used isolated test databases.

## Delivery truth

The source branch is pushed and local verification is complete. GitHub CI is pending. This PR is not merged or deployed, and no PreDev runtime claim is made.

Closes #779
Supersedes #780
