### PR TITLE
[Stability] Remove unused identity session-close surface

### DIFF
--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -198,6 +198,10 @@ repair. Those require the branch image to be deployed and queried again.
 - Appointment deletion uses one conditional database `DELETE` and its affected
   row count. It preserves the 404 contract without a read-before-delete round
   trip.
+- The unused identity session-close command was removed from the broad output
+  port, the Keycloak facade and its authentication collaborator. Repository-wide
+  tracing found no production consumer, so the removed path has an exact
+  zero-call bound. The active refresh-token logout flow remains unchanged.
 
 The runtime metrics above are the gate for further optimization: prioritize a
 dependency only when PreDev shows high calls per request, payload volume or p95
@@ -230,7 +234,7 @@ whole codebase as modular:
 
 | Module | Enforced seam | Remaining debt |
 | --- | --- | --- |
-| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. | The older broad `IdentityClient` contract still exposes provider transports in other identity operations. |
+| Identity/profile | User web entry points use `AccountManaging` and `IdentityManaging`; `service.identity` and `service.user` cannot import concrete identity/chat adapters. Profile email propagation uses the `MessageClient` port. Magic-link exchange returns a provider-neutral `api.model.identity.IdentitySession`; only the Keycloak adapter owns grant fields and provider response parsing, while the web adapter maps the application model to the existing seven-field snake-case response. The unused session-close command is absent from the broad port and both Keycloak wrappers. | The older broad `IdentityClient` contract still exposes provider transports in other identity operations. |
 | Admin | Chat account creation/update, room checks and group membership use `MatrixUserClient`, `MessageClient` and transport-neutral member IDs; `api.admin` cannot import concrete Matrix adapters. | The large admin controller still composes many services, and create-user validation still exposes an older Keycloak response DTO. |
 | Session/consultant | Room provisioning and assignment depend on `SessionRoomGateway` and `SessionAssignmentChatGateway`; their adapters own Matrix DTOs, credentials and failure policy. Both protected application packages have executable import boundaries. | Session/consultant orchestration remains broad even though the Rocket.Chat transport has been removed. |
 
@@ -240,8 +244,9 @@ from reverting to concrete application/chat services and prevents the
 prevents the Identity/Profile packages and the Admin module from importing
 their protected concrete chat adapters. The separate removal contract prevents
 Rocket.Chat production packages, configuration, DTOs and schema fields from
-returning. The appointment deletion repair stays behind `Organizing` and
-`AppointmentRepository`.
+returning. A dead-surface contract prevents the unused identity session-close
+command from returning on the broad port or either Keycloak wrapper. The
+appointment deletion repair stays behind `Organizing` and `AppointmentRepository`.
 
 A dedicated magic-link boundary contract prevents the application service and
 both web entry points from importing Keycloak transport types. It also prevents

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClient.java
@@ -26,8 +26,8 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Keycloak OpenID Connect / session operations extracted from {@link KeycloakService} (issue #91
- * Keycloak refactor, PR1 auth slice). Keeps login/logout/OTP-verify/session close behind a focused
- * collaborator so {@link KeycloakService} can stay the {@code IdentityClient} facade.
+ * Keycloak refactor, PR1 auth slice). Keeps login, refresh-token logout and password verification
+ * behind a focused collaborator.
  */
 @Slf4j
 @Component
@@ -46,7 +46,6 @@ public class KeycloakAuthClient {
   private final @NonNull RestTemplate restTemplate;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull IdentityClientConfig identityClientConfig;
-  private final @NonNull KeycloakClient keycloakClient;
 
   private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
 
@@ -123,15 +122,6 @@ public class KeycloakAuthClient {
 
       return false;
     }
-  }
-
-  /**
-   * Closes the provided session.
-   *
-   * @param sessionId Keycloak session ID
-   */
-  public void closeSession(String sessionId) {
-    keycloakClient.getRealmResource().deleteSession(sessionId, false);
   }
 
   private HttpEntity<MultiValueMap<String, String>> loginRequest(String userName, String password) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -901,15 +901,6 @@ public class KeycloakService implements IdentityClient {
   }
 
   /**
-   * Closes the provided session.
-   *
-   * @param sessionId Keycloak session ID
-   */
-  public void closeSession(String sessionId) {
-    keycloakAuthClient.closeSession(sessionId);
-  }
-
-  /**
    * Deactivates the user account.
    *
    * @param userId the user id to be deactivated

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -77,8 +77,6 @@ public interface IdentityClient {
 
   List<UserRepresentation> findByUsername(String username);
 
-  void closeSession(String sessionId);
-
   void deactivateUser(String userId);
 
   boolean verifyIgnoringOtp(String username, String password);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakAuthClientTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.admin.client.resource.RealmResource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -54,8 +52,6 @@ class KeycloakAuthClientTest {
   @Mock private RestTemplate restTemplate;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private IdentityClientConfig identityClientConfig;
-  @Mock private KeycloakClient keycloakClient;
-
   private LogbackCaptor logCaptor;
 
   @BeforeEach
@@ -194,15 +190,5 @@ class KeycloakAuthClientTest {
 
     assertThat(keycloakAuthClient.logoutUser(REFRESH_TOKEN), is(false));
     assertTrue(logCaptor.contains(Level.ERROR, "Keycloak error: Could not log out user"));
-  }
-
-  @Test
-  void closeSession_Should_DeleteSession() {
-    var realmResource = mock(RealmResource.class);
-    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
-
-    keycloakAuthClient.closeSession("sessionId");
-
-    verify(realmResource, times(1)).deleteSession(eq("sessionId"), eq(false));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceLoggingTest.java
@@ -54,8 +54,7 @@ class KeycloakServiceLoggingTest {
   @BeforeEach
   void setUp() {
     var keycloakAuthClient =
-        new KeycloakAuthClient(
-            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+        new KeycloakAuthClient(restTemplate, authenticatedUser, identityClientConfig);
     setField(keycloakAuthClient, "keycloakClientId", "app");
     keycloakService =
         new KeycloakService(

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -121,8 +121,7 @@ public class KeycloakServiceTest {
     givenAKeycloakLoginUrl();
     givenAKeycloakLogoutUrl();
     var realAuthClient =
-        new KeycloakAuthClient(
-            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+        new KeycloakAuthClient(restTemplate, authenticatedUser, identityClientConfig);
     setField(realAuthClient, "keycloakClientId", "app");
     setField(keycloakService, "keycloakAuthClient", realAuthClient);
     setField(keycloakService, "usernameTranscoder", usernameTranscoder);
@@ -1130,16 +1129,6 @@ public class KeycloakServiceTest {
     boolean hasAuthority = this.keycloakService.userHasAuthority("user", AuthorityValue.USER_ADMIN);
 
     assertThat(hasAuthority, is(false));
-  }
-
-  @Test
-  public void closeSession_Should_deleteSession() {
-    RealmResource realmResource = mock(RealmResource.class);
-    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
-
-    this.keycloakService.closeSession("sessionId");
-
-    verify(realmResource, times(1)).deleteSession(anyString(), eq(false));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -37,8 +37,7 @@ public class KeycloakTestConfig {
       UserHelper userHelper) {
 
     var keycloakAuthClient =
-        new KeycloakAuthClient(
-            restTemplate, authenticatedUser, identityClientConfig, keycloakClient);
+        new KeycloakAuthClient(restTemplate, authenticatedUser, identityClientConfig);
 
     return new KeycloakService(
         authenticatedUser,

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -135,6 +135,29 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "not expose the outbound-port package:\n" + "\n".join(offenders),
         )
 
+    def test_identity_boundary_has_no_unused_session_close_command(self):
+        sources = [
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakService.java",
+            ROOT
+            / "src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/"
+            "KeycloakAuthClient.java",
+        ]
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in sources
+            if "closeSession(" in source.read_text()
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "The unused identity session-close command must not remain on production surfaces:\n"
+            + "\n".join(offenders),
+        )
+
     def test_admin_module_depends_on_ports_not_chat_adapters(self):
         admin_module = ROOT / "src/main/java/de/caritas/cob/userservice/api/admin"
         forbidden_prefixes = (


### PR DESCRIPTION
## Summary

- replay issue #799 directly on current `pre-dev`, without the obsolete identity stack
- remove the unused `closeSession` command from the broad `IdentityClient`
- remove the dead forwarding methods from `KeycloakService` and `KeycloakAuthClient`
- remove the now-unused `KeycloakClient` constructor dependency from the authentication wrapper
- remove the two tests that only exercised the dead forwarding chain and reconcile explicit test constructors
- add an executable boundary contract that prevents the command from returning
- record the exact zero-call bound in the stability documentation

## Call-bound evidence

Repository-wide production tracing found no `closeSession` consumer. The removed path therefore has an exact zero-call bound. Active refresh-token logout remains unchanged and no external API, schema, configuration or provider call changes.

## Verification

- Java 21 unit suite: 3,425 tests, 0 failures, 0 errors, 0 skipped
- Java 21 integration suite: 850 tests, 0 failures, 0 errors, 9 conditional environment skips
- focused Keycloak tests: 111 passed
- architecture and CI contracts: 51 passed, including 2 subtests
- OpenAPI contract gate: 8 passed
- Spotless, package build, and `git diff --check`: passed
- local database reset: not required
- GitHub: all 11 Actions checks successful, including both full integration jobs, both MariaDB contracts, Redis, OpenAPI, Docker validation and required PreDev CI
- CodeRabbit status is green because automatic reviews are disabled for the `pre-dev` base branch; this is not a content approval

The boundary contract was run before production removal and failed on all three command surfaces; it passes after the removal.

## Scope and rollout truth

This ready-for-review PR is direct on current `pre-dev` commit `be15d12f`, contains only #799 and supersedes obsolete stacked PR #800. It is clean and mergeable, with review requested from shazia-k, Hassan9215 and shanzaeimran. Nothing is merged, deployed, or runtime-verified on PreDev.

The architecture target remains Matrix-only chat through the ORISO-owned frontend, an ORISO-controlled Element Call/MatrixRTC fork, and LiveKit. Rocket.Chat and Jitsi are complete removal targets and are never fallback architecture.

Closes #799
Supersedes #800

