### PR TITLE
feat(matrix): join the agency's counsellors into the enquiry room at creation (FE#811)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
@@ -25,6 +25,7 @@ public class AgencyPreAssignmentRoomService {
   private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
   private final @NonNull SessionRoomGateway sessionRoomGateway;
   private final @NonNull SessionService sessionService;
+  private final @NonNull AgencySilentMembershipService agencySilentMembershipService;
 
   public void ensureHoldingRoom(Session session, User user) {
     if (session == null || user == null) {
@@ -98,6 +99,7 @@ public class AgencyPreAssignmentRoomService {
       }
 
       inviteUser(roomId, user, agencyToken);
+      joinAgencyConsultants(session, roomId, agencyToken);
 
       session.setMatrixRoomId(roomId);
       sessionService.saveSession(session);
@@ -114,6 +116,26 @@ public class AgencyPreAssignmentRoomService {
           session.getId(),
           ex.getMessage());
     }
+  }
+
+  /**
+   * FE#811 / ADR-002 §1: the agency's counsellors become real room members here, while the room is
+   * still empty, so an enquiry is readable to everyone entitled to pick it up and no one ever joins
+   * after a Megolm session was already handed out.
+   *
+   * <p>A directly addressed enquiry (public counsellor link, appointment booking) is deliberately
+   * excluded — the advice seeker chose one counsellor, and fanning that case out to the whole
+   * department would widen its audience beyond what they consented to.
+   */
+  private void joinAgencyConsultants(Session session, String roomId, String agencyToken) {
+    if (Boolean.TRUE.equals(session.getIsConsultantDirectlySet())) {
+      log.debug(
+          "Session {} is directly assigned to a consultant, skipping department membership.",
+          session.getId());
+      return;
+    }
+
+    agencySilentMembershipService.joinAgencyConsultants(session.getAgencyId(), roomId, agencyToken);
   }
 
   private void inviteUser(String roomId, User user, String agencyToken) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
@@ -1,0 +1,157 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * ADR-002 §1 "real members from room creation": joins every counsellor of the enquiry's agency into
+ * the conversation room as a <em>silent member</em>, at the moment the room is created.
+ *
+ * <p>Why membership has to exist this early (FE#811): a counsellor's browser only ever sees rooms
+ * its own Matrix client syncs, and {@code /sync} returns nothing for a non-member. Before this
+ * service existed the holding room held only the agency service account and the advice seeker, so
+ * every counsellor looking at an enquiry got an empty conversation with no error — they could not
+ * judge whether the case was theirs to take.
+ *
+ * <p>Joining <em>before the first message</em> is the load-bearing detail, not an optimisation.
+ * Rooms are Megolm-encrypted, and a Megolm session is only shared with the devices present when the
+ * message is sent. A counsellor joined afterwards holds no key for anything sent earlier and has to
+ * beg other devices for it ({@code matrixRoomHistoryKeyTransfer}), which only works while the
+ * asker's browser happens to be online. Joining at creation removes that race entirely.
+ *
+ * <p>"Silent" is a client-side property: membership grants the technical ability to read, and the
+ * confidentiality boundary is the app's own visibility rules plus the reveal gate and audit log
+ * described in ADR-002 — not Matrix ACLs.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AgencySilentMembershipService {
+
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull SessionRoomGateway sessionRoomGateway;
+  private final @NonNull UserHelper userHelper;
+  private final @NonNull UsernameTranscoder usernameTranscoder;
+
+  /**
+   * Invites and joins every active counsellor of the given agency into the room.
+   *
+   * <p>Best-effort per counsellor: one counsellor without a resolvable Matrix account must never
+   * cost the remaining counsellors their membership, and must never fail the advice seeker's
+   * enquiry. Callers treat this as a side effect, not as a precondition.
+   *
+   * @param agencyId the enquiry's agency
+   * @param roomId the Matrix room to join them into
+   * @param agencyToken access token of the agency service account that created the room
+   * @return number of counsellors that ended up joined
+   */
+  public int joinAgencyConsultants(Long agencyId, String roomId, String agencyToken) {
+    if (agencyId == null || isBlank(roomId) || isBlank(agencyToken)) {
+      return 0;
+    }
+
+    var consultants =
+        consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(agencyId);
+    if (consultants.isEmpty()) {
+      log.warn("Agency {} has no consultants to join into room {}", agencyId, roomId);
+      return 0;
+    }
+
+    int joined = 0;
+    for (Consultant consultant : consultants) {
+      if (joinSilently(consultant, roomId, agencyToken)) {
+        joined++;
+      }
+    }
+
+    log.info(
+        "Joined {} of {} consultants of agency {} as silent members of room {}",
+        joined,
+        consultants.size(),
+        agencyId,
+        roomId);
+    return joined;
+  }
+
+  private boolean joinSilently(Consultant consultant, String roomId, String agencyToken) {
+    try {
+      var matrixUserId = ensureMatrixAccount(consultant);
+      if (isBlank(matrixUserId)) {
+        log.warn(
+            "Consultant {} has no Matrix account, cannot join room {}", consultant.getId(), roomId);
+        return false;
+      }
+
+      try {
+        sessionRoomGateway.inviteUser(roomId, matrixUserId, agencyToken);
+      } catch (Exception inviteError) {
+        // An already-invited or already-joined member answers with an error here. The join below
+        // is the actual assertion, so let it decide rather than bailing out on a benign 403.
+        log.debug(
+            "Invite of consultant {} to room {} did not succeed: {}",
+            matrixUserId,
+            roomId,
+            inviteError.getMessage());
+      }
+
+      var consultantToken = sessionRoomGateway.loginAsUser(matrixUserId);
+      if (isBlank(consultantToken)) {
+        log.warn("Could not mint Matrix token for consultant {}", matrixUserId);
+        return false;
+      }
+
+      return sessionRoomGateway.joinRoom(roomId, consultantToken);
+    } catch (Exception ex) {
+      log.warn(
+          "Could not join consultant {} into room {}: {}",
+          consultant.getId(),
+          roomId,
+          ex.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Counsellor Matrix accounts are provisioned lazily elsewhere (on accept, or on direct-session
+   * creation), so a counsellor who has never handled a case yet has none. Without one they cannot
+   * be a room member and the enquiry stays invisible to them, which is the very bug being fixed —
+   * so provision here too.
+   */
+  private String ensureMatrixAccount(Consultant consultant) {
+    if (!isBlank(consultant.getMatrixUserId())) {
+      return consultant.getMatrixUserId();
+    }
+
+    var localpart = usernameTranscoder.decodeUsername(consultant.getUsername());
+    var displayName = consultant.getFirstName() + " " + consultant.getLastName();
+
+    String matrixUserId;
+    try {
+      matrixUserId =
+          sessionRoomGateway.createUser(localpart, userHelper.getRandomPassword(), displayName);
+    } catch (Exception ex) {
+      // Most commonly the account already exists from an earlier flow — verify by login probe
+      // rather than trusting the error text.
+      var candidate = sessionRoomGateway.userIdFor(localpart);
+      matrixUserId = isBlank(sessionRoomGateway.loginAsUser(candidate)) ? null : candidate;
+    }
+
+    if (isBlank(matrixUserId)) {
+      return null;
+    }
+
+    consultant.setMatrixUserId(matrixUserId);
+    consultantRepository.save(consultant);
+    log.info("Ensured Matrix account {} for consultant {}", matrixUserId, consultant.getId());
+    return matrixUserId;
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
@@ -107,6 +107,11 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
   // Room-provisioning collaborators of the REAL AgencyPreAssignmentRoomService.
   @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
 
+  // Collaborators of the REAL AgencySilentMembershipService (FE#811 department membership).
+  @Mock private de.caritas.cob.userservice.api.port.out.ConsultantRepository consultantRepository;
+
+  @Mock private de.caritas.cob.userservice.api.helper.UsernameTranscoder usernameTranscoder;
+
   private Session session;
   private User user;
 
@@ -114,11 +119,14 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
   void setUp() {
     // Wire a REAL room-provisioning service around the mocked Matrix collaborators so the
     // create/invite/join/persist orchestration actually executes when the facade calls it.
+    var gateway = new MatrixSessionRoomGateway(matrixSynapseService, matrixConfig);
     var realRoomService =
         new AgencyPreAssignmentRoomService(
             matrixCredentialClient,
-            new MatrixSessionRoomGateway(matrixSynapseService, matrixConfig),
-            sessionService);
+            gateway,
+            sessionService,
+            new de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService(
+                consultantRepository, gateway, userHelper, usernameTranscoder));
     setField(createEnquiryMessageFacade, "agencyPreAssignmentRoomService", realRoomService);
 
     user = new User();
@@ -198,6 +206,61 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
     assertEquals(NEW_ROOM_ID, response.getMatrixRoomId());
     assertEquals(SESSION_ID, response.getSessionId());
     assertEquals(MATRIX_EVENT_ID, response.getT());
+
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  @DisplayName(
+      "FE#811: the agency's counsellors are room members before the enquiry message is sent")
+  void createEnquiryMessage_joinsAgencyConsultantsBeforeSendingTheEnquiry() throws Exception {
+    var consultantMatrixId = "@counsellor:oriso.org";
+    var consultantToken = "counsellor-token";
+
+    var consultant = new Consultant();
+    consultant.setId("consultant-1");
+    consultant.setUsername("counsellor");
+    consultant.setFirstName("Cora");
+    consultant.setLastName("Counsellor");
+    consultant.setMatrixUserId(consultantMatrixId);
+    var consultantAgency = new ConsultantAgency();
+    consultantAgency.setConsultant(consultant);
+
+    when(sessionService.getSession(SESSION_ID)).thenReturn(Optional.of(session));
+    when(consultantAgencyService.findConsultantsByAgencyId(AGENCY_ID))
+        .thenReturn(List.of(consultantAgency));
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(consultant));
+
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(validCredentials()));
+    when(matrixSynapseService.loginUser(AGENCY_MATRIX_LOCALPART, AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+    var createBody = new MatrixCreateRoomResponseDTO();
+    createBody.setRoomId(NEW_ROOM_ID);
+    when(matrixSynapseService.createRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenReturn(ResponseEntity.ok(createBody));
+    when(matrixSynapseService.inviteUserToRoom(anyString(), anyString(), eq(AGENCY_TOKEN)))
+        .thenReturn(ResponseEntity.ok(new MatrixInviteUserResponseDTO()));
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(matrixSynapseService.loginAsUserAccessToken(consultantMatrixId))
+        .thenReturn(consultantToken);
+    when(matrixSynapseService.joinRoom(eq(NEW_ROOM_ID), anyString())).thenReturn(true);
+    when(matrixSynapseService.sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN))
+        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+
+    createEnquiryMessageFacade.createEnquiryMessage(
+        new EnquiryData(user, SESSION_ID, MESSAGE, null));
+
+    // The counsellor is a real member of the room...
+    verify(matrixSynapseService).inviteUserToRoom(NEW_ROOM_ID, consultantMatrixId, AGENCY_TOKEN);
+    verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, consultantToken);
+
+    // ...and joined BEFORE the enquiry message exists. Reversing this order is exactly the bug:
+    // a member who joins later holds no Megolm key for what was sent before them.
+    var inOrder = Mockito.inOrder(matrixSynapseService);
+    inOrder.verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, consultantToken);
+    inOrder.verify(matrixSynapseService).sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN);
 
     RequestContextHolder.resetRequestAttributes();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
@@ -57,6 +57,7 @@ class AgencyPreAssignmentRoomServiceTest {
   @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
   @Mock private SessionRoomGateway sessionRoomGateway;
   @Mock private SessionService sessionService;
+  @Mock private AgencySilentMembershipService agencySilentMembershipService;
 
   @InjectMocks private AgencyPreAssignmentRoomService underTest;
 
@@ -227,6 +228,39 @@ class AgencyPreAssignmentRoomServiceTest {
 
     verify(sessionService, never()).saveSession(any());
     assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName(
+      "FE#811: the agency's consultants join the fresh room, before any message can be sent")
+  void ensureHoldingRoom_joinsAgencyConsultantsAsSilentMembers() throws Exception {
+    stubHappyPathUntilRoomCreation();
+
+    underTest.ensureHoldingRoom(session, user);
+
+    // Membership must be established while the room is still empty: a consultant joined after the
+    // first message holds no Megolm key for it (FE#811 / ADR-002 §1).
+    var inOrder =
+        org.mockito.Mockito.inOrder(
+            sessionRoomGateway, agencySilentMembershipService, sessionService);
+    inOrder.verify(sessionRoomGateway).createRoom(anyString(), anyString(), eq(AGENCY_TOKEN));
+    inOrder
+        .verify(agencySilentMembershipService)
+        .joinAgencyConsultants(AGENCY_ID, NEW_ROOM_ID, AGENCY_TOKEN);
+    inOrder.verify(sessionService).saveSession(session);
+  }
+
+  @Test
+  @DisplayName("a directly addressed enquiry is not fanned out to the whole department")
+  void ensureHoldingRoom_skipsDepartment_whenConsultantDirectlySet() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    session.setIsConsultantDirectlySet(true);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verifyNoInteractions(agencySilentMembershipService);
+    // the room itself is still provisioned for the asker
+    assertEquals(NEW_ROOM_ID, session.getMatrixRoomId());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipServiceTest.java
@@ -1,0 +1,181 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * FE#811 / ADR-002 §1. A counsellor can only read an enquiry their own Matrix client syncs, and
+ * {@code /sync} is empty for a non-member — so "the department are real members from room creation"
+ * is the whole fix. These tests pin the membership contract: everyone joins, one broken counsellor
+ * never costs the others their membership, and the advice seeker's enquiry never fails because of
+ * it.
+ */
+@ExtendWith(MockitoExtension.class)
+class AgencySilentMembershipServiceTest {
+
+  private static final Long AGENCY_ID = 4711L;
+  private static final String ROOM_ID = "!holding:oriso.org";
+  private static final String AGENCY_TOKEN = "agency-access-token";
+
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private SessionRoomGateway sessionRoomGateway;
+  @Mock private UserHelper userHelper;
+  @Mock private UsernameTranscoder usernameTranscoder;
+
+  @InjectMocks private AgencySilentMembershipService underTest;
+
+  private Consultant consultantWithAccount(String id, String matrixUserId) {
+    var consultant = new Consultant();
+    consultant.setId(id);
+    consultant.setUsername(id);
+    consultant.setFirstName("First");
+    consultant.setLastName("Last");
+    consultant.setMatrixUserId(matrixUserId);
+    return consultant;
+  }
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(userHelper.getRandomPassword()).thenReturn("generated-password");
+  }
+
+  @Test
+  @DisplayName("every active consultant of the agency is invited and joined into the room")
+  void joinAgencyConsultants_joinsEveryConsultantOfTheAgency() throws Exception {
+    var first = consultantWithAccount("c-1", "@c1:oriso.org");
+    var second = consultantWithAccount("c-2", "@c2:oriso.org");
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(first, second));
+    when(sessionRoomGateway.loginAsUser("@c1:oriso.org")).thenReturn("token-1");
+    when(sessionRoomGateway.loginAsUser("@c2:oriso.org")).thenReturn("token-2");
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-1")).thenReturn(true);
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-2")).thenReturn(true);
+
+    var joined = underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN);
+
+    assertEquals(2, joined);
+    verify(sessionRoomGateway).inviteUser(ROOM_ID, "@c1:oriso.org", AGENCY_TOKEN);
+    verify(sessionRoomGateway).inviteUser(ROOM_ID, "@c2:oriso.org", AGENCY_TOKEN);
+    verify(sessionRoomGateway).joinRoom(ROOM_ID, "token-1");
+    verify(sessionRoomGateway).joinRoom(ROOM_ID, "token-2");
+  }
+
+  @Test
+  @DisplayName("a consultant without a Matrix account gets one provisioned and persisted")
+  void joinAgencyConsultants_provisionsMissingMatrixAccount() throws Exception {
+    var fresh = consultantWithAccount("c-new", null);
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(fresh));
+    when(usernameTranscoder.decodeUsername("c-new")).thenReturn("c-new");
+    when(sessionRoomGateway.createUser("c-new", "generated-password", "First Last"))
+        .thenReturn("@c-new:oriso.org");
+    when(sessionRoomGateway.loginAsUser("@c-new:oriso.org")).thenReturn("token-new");
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-new")).thenReturn(true);
+
+    var joined = underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN);
+
+    assertEquals(1, joined);
+    assertEquals("@c-new:oriso.org", fresh.getMatrixUserId());
+    verify(consultantRepository).save(fresh);
+    verify(sessionRoomGateway).joinRoom(ROOM_ID, "token-new");
+  }
+
+  @Test
+  @DisplayName("an already-registered Matrix account is resolved via login probe, not duplicated")
+  void joinAgencyConsultants_resolvesExistingMatrixAccountAfterCreateRejection() throws Exception {
+    var fresh = consultantWithAccount("c-known", null);
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(fresh));
+    when(usernameTranscoder.decodeUsername("c-known")).thenReturn("c-known");
+    when(sessionRoomGateway.createUser(eq("c-known"), anyString(), anyString()))
+        .thenThrow(new MatrixCreateUserException("already exists"));
+    when(sessionRoomGateway.userIdFor("c-known")).thenReturn("@c-known:oriso.org");
+    when(sessionRoomGateway.loginAsUser("@c-known:oriso.org")).thenReturn("token-known");
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-known")).thenReturn(true);
+
+    var joined = underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN);
+
+    assertEquals(1, joined);
+    assertEquals("@c-known:oriso.org", fresh.getMatrixUserId());
+  }
+
+  @Test
+  @DisplayName("an invite rejection (already invited) does not stop the join")
+  void joinAgencyConsultants_ignoresInviteRejection() throws Exception {
+    var consultant = consultantWithAccount("c-1", "@c1:oriso.org");
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(consultant));
+    doThrow(new MatrixInviteUserException("already in room"))
+        .when(sessionRoomGateway)
+        .inviteUser(ROOM_ID, "@c1:oriso.org", AGENCY_TOKEN);
+    when(sessionRoomGateway.loginAsUser("@c1:oriso.org")).thenReturn("token-1");
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-1")).thenReturn(true);
+
+    assertEquals(1, underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN));
+  }
+
+  @Test
+  @DisplayName("one unusable consultant does not cost the remaining consultants their membership")
+  void joinAgencyConsultants_isBestEffortPerConsultant() throws Exception {
+    var broken = consultantWithAccount("c-broken", "@broken:oriso.org");
+    var healthy = consultantWithAccount("c-ok", "@ok:oriso.org");
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(broken, healthy));
+    when(sessionRoomGateway.loginAsUser("@broken:oriso.org"))
+        .thenThrow(new RuntimeException("synapse down for this user"));
+    when(sessionRoomGateway.loginAsUser("@ok:oriso.org")).thenReturn("token-ok");
+    when(sessionRoomGateway.joinRoom(ROOM_ID, "token-ok")).thenReturn(true);
+
+    assertEquals(1, underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN));
+    verify(sessionRoomGateway).joinRoom(ROOM_ID, "token-ok");
+  }
+
+  @Test
+  @DisplayName("a consultant whose Matrix account cannot be provisioned is skipped, not joined")
+  void joinAgencyConsultants_skipsConsultantWithoutResolvableAccount() throws Exception {
+    var fresh = consultantWithAccount("c-new", null);
+    when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
+        .thenReturn(List.of(fresh));
+    when(usernameTranscoder.decodeUsername("c-new")).thenReturn("c-new");
+    when(sessionRoomGateway.createUser(eq("c-new"), anyString(), anyString())).thenReturn(null);
+
+    assertEquals(0, underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, AGENCY_TOKEN));
+    verify(consultantRepository, never()).save(any());
+    verify(sessionRoomGateway, never()).joinRoom(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("missing agency, room or agency token short-circuits without touching Matrix")
+  void joinAgencyConsultants_shortCircuitsOnMissingInput() {
+    assertEquals(0, underTest.joinAgencyConsultants(null, ROOM_ID, AGENCY_TOKEN));
+    assertEquals(0, underTest.joinAgencyConsultants(AGENCY_ID, "", AGENCY_TOKEN));
+    assertEquals(0, underTest.joinAgencyConsultants(AGENCY_ID, ROOM_ID, ""));
+
+    verifyNoInteractions(sessionRoomGateway);
+    verifyNoInteractions(consultantRepository);
+  }
+}


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-Frontend#811 (P0). Implements ADR-002 §1 "real members from room creation". Companion FE PR: retry failed decryptions after a history-key import (`fix/enquiry-history-key-retry-811`) — **merge both**; each alone is insufficient.

## Problem

A counsellor reviewing an initial request saw an **empty conversation** — no messages, no files, no error. Root cause: the enquiry holding room was created with only the agency service account and the advice seeker as members; counsellors were invited at **accept** time. A non-member's Matrix `/sync` never contains the room, so the client had literally nothing to render.

## Change

- New `AgencySilentMembershipService`: invites + joins every active counsellor of the enquiry's agency into the holding room **at room creation, before the first message can be sent**. Ordering is load-bearing: a Megolm session only reaches devices present at encrypt time; anyone joined later cannot decrypt earlier content.
- Called from `AgencyPreAssignmentRoomService.ensureHoldingRoom` (both the registration and the enquiry-message path).
- Directly addressed enquiries (`isConsultantDirectlySet`) are excluded — the advice seeker chose one counsellor; the case must not fan out to the department.
- Best-effort per counsellor: an unresolvable Matrix account never costs the other counsellors their membership and never fails the advice seeker's enquiry.
- Provisions missing counsellor Matrix accounts (same create-or-resolve probe as `AssignEnquiryFacade`).

## Tests

- `AgencySilentMembershipServiceTest` (7 new): full-join, account provisioning, login-probe resolution, invite-rejection tolerance, per-consultant best effort, skip-on-unresolvable, input short-circuit.
- `AgencyPreAssignmentRoomServiceTest` (+2): join happens between room creation and persist; direct enquiries skip the fan-out.
- `CreateEnquiryMessageFacadeMatrixRoomProvisioningTest` (+1): counsellor is a member **before** the enquiry message is sent (in-order verification).
- Full unit suite: **3437 tests, 0 failures**.

## Live proof (Pre-Dev, run `_e2e-artifacts/e2e-20260728-fe811`)

| Check | Before | After (session 103532, with FE companion) |
|---|---|---|
| Room members at enquiry creation | 3 (agency svc, asker, matrixadm) | 8 (+ all 5 counsellors of agency 241) |
| Counsellor opens enquiry before accept | empty pane | full plaintext content |
| Same counsellor, fresh late-login device | empty pane | plaintext via history-key transfer |
| After accept | — | content still readable |

Evidence (screenshots, Synapse admin membership dumps, key-transfer diagnostics) recorded in the run folder. Pre-Dev was restored to the CI images after the proof; deploy this via the normal pipeline after merge.

## Consequences to be aware of

- Every enquiry room now syncs to every counsellor of the agency (fan-out grows with department size — fine at current sizes, worth measuring for very large agencies).
- ADR-002's curtain (visibility rules, reveal gate, audit) remains the confidentiality boundary between counsellors of the same agency; this PR implements the membership half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)