### PR TITLE
[TEN-INV-U3] Coordinate tenant/agency ID reservations during invite creation

### DIFF
--- a/.github/workflows/openapi-contracts.yml
+++ b/.github/workflows/openapi-contracts.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: OpenResilienceInitiative/ORISO-TenantService
-        ref: ${{ github.event_name == 'pull_request' && 'a213d5546e2cdbcbd1f641291661f11cbbca2cfc' || 'pre-dev' }}
+        ref: ${{ github.event_name == 'pull_request' && '1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e' || 'pre-dev' }}
         path: .providers/tenant
         persist-credentials: false
 

--- a/.github/workflows/openapi-contracts.yml
+++ b/.github/workflows/openapi-contracts.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: OpenResilienceInitiative/ORISO-AgencyService
-        ref: ${{ github.event_name == 'pull_request' && '299d4792820747ff8c5b387e421a6e971fb760d3' || 'pre-dev' }}
+        ref: ${{ github.event_name == 'pull_request' && '11d1e2426593ffa0a550a64042ce97ca6e0a80cf' || 'pre-dev' }}
         path: .providers/agency
         persist-credentials: false
 

--- a/services/agencyadminservice.yaml
+++ b/services/agencyadminservice.yaml
@@ -4,6 +4,127 @@ info:
   description: This information will be replaced by the SpringFox config information
   version: 0.0.1
 paths:
+  /agencyadmin/agencyids/{agencyId}/availability:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: 'Returns the authoritative allocation state of one agency ID: FREE, RESERVED by an open invite, or ASSIGNED to a real agency. [Authorization: Role: agency-admin]'
+      operationId: getAgencyIdAvailability
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency ID to check
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: OK - successfull operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgencyIdAvailabilityResponseDTO'
+        '401':
+          description: UNAUTHORIZED - no/invalid role/authorization
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /agencyadmin/agencyids/next-free:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: 'Returns the next free agency ID from the given value in the given direction, skipping assigned and reserved IDs. [Authorization: Role: agency-admin]'
+      operationId: getNextFreeAgencyId
+      parameters:
+        - name: fromId
+          in: query
+          description: The agency ID to start stepping from (exclusive)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: direction
+          in: query
+          description: Stepping direction
+          required: true
+          schema:
+            type: string
+            enum:
+              - UP
+              - DOWN
+      responses:
+        '200':
+          description: OK - successfull operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgencyIdResponseDTO'
+        '400':
+          description: BAD REQUEST - invalid/incomplete request
+        '401':
+          description: UNAUTHORIZED - no/invalid role/authorization
+        '404':
+          description: NOT FOUND - no free agency ID exists in that direction
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /agencyadmin/agencyids/reservations:
+    post:
+      tags:
+        - admin-agency-controller
+      summary: 'Reserves an agency ID for an open invite. Without an agencyId in the body (AUTO mode) the smallest currently free ID is reserved atomically; with one, exactly that ID is reserved or the request fails with a conflict. Reserves agency IDs only; a supplied tenantId is validated against TenantService but never reserved here. [Authorization: Role: agency-admin]'
+      operationId: reserveAgencyId
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgencyIdReservationRequestDTO'
+        required: true
+      responses:
+        '201':
+          description: CREATED - agency ID was reserved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgencyIdResponseDTO'
+        '400':
+          description: BAD REQUEST - invalid request or non-existing tenant
+        '401':
+          description: UNAUTHORIZED - no/invalid role/authorization
+        '409':
+          description: CONFLICT - agency ID is already assigned or reserved
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /agencyadmin/agencyids/reservations/{agencyId}:
+    delete:
+      tags:
+        - admin-agency-controller
+      summary: 'Releases an open agency ID reservation (e.g. when an unconsumed invite is revoked or deleted), making the ID assignable again. [Authorization: Role: agency-admin]'
+      operationId: releaseAgencyIdReservation
+      parameters:
+        - name: agencyId
+          in: path
+          description: The reserved agency ID to release
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: NO CONTENT - reservation was released
+        '401':
+          description: UNAUTHORIZED - no/invalid role/authorization
+        '404':
+          description: NOT FOUND - no open reservation for this agency ID
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
   /agencyadmin:
     get:
       tags:
@@ -1769,6 +1890,45 @@ components:
           example: false
         agencyAdminControls:
           $ref: '#/components/schemas/AgencyAdminControls'
+    AgencyIdAvailabilityResponseDTO:
+      type: object
+      required:
+        - agencyId
+        - status
+      properties:
+        agencyId:
+          type: integer
+          format: int64
+          example: 21
+        status:
+          type: string
+          enum:
+            - FREE
+            - RESERVED
+            - ASSIGNED
+          example: FREE
+    AgencyIdResponseDTO:
+      type: object
+      required:
+        - agencyId
+      properties:
+        agencyId:
+          type: integer
+          format: int64
+          example: 21
+    AgencyIdReservationRequestDTO:
+      type: object
+      properties:
+        agencyId:
+          type: integer
+          format: int64
+          description: 'The manually picked agency ID to reserve. Omit for AUTO mode (smallest free ID).'
+          example: 21
+        tenantId:
+          type: integer
+          format: int64
+          description: 'Tenant the pending agency belongs to. Validated only - never reserved here.'
+          example: 1
   securitySchemes:
     Bearer:
       type: apiKey

--- a/services/tenantadminservice.yaml
+++ b/services/tenantadminservice.yaml
@@ -4,6 +4,139 @@ info:
   description: This information will be replaced by the SpringFox config information
   version: 0.0.1
 paths:
+  /tenantadmin/tenant-ids/{id}/availability:
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Returns the allocation status of a single tenant ID [Authorization: platform admin]'
+      operationId: getTenantIdAvailability
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID to check
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '200':
+          description: OK - successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantIdAvailabilityDTO'
+        '400':
+          description: BAD REQUEST - invalid/incomplete request
+        '401':
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        '403':
+          description: FORBIDDEN - no platform admin authority
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /tenantadmin/tenant-ids/next-free:
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Returns the next free tenant ID from a value in a direction, skipping assigned and reserved IDs [Authorization: platform admin]'
+      operationId: getNextFreeTenantId
+      parameters:
+        - name: from
+          in: query
+          description: Value to navigate from (exclusive)
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+        - name: direction
+          in: query
+          description: Navigation direction
+          required: true
+          schema:
+            type: string
+            enum:
+              - UP
+              - DOWN
+      responses:
+        '200':
+          description: OK - successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NextFreeTenantIdDTO'
+        '400':
+          description: BAD REQUEST - invalid/incomplete request
+        '401':
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        '403':
+          description: FORBIDDEN - no platform admin authority
+        '404':
+          description: NOT FOUND - no free tenant ID exists in the given direction
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /tenantadmin/tenant-ids/reservations:
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Reserves a tenant ID for an open invite. Without a tenantId in the body (AUTO mode) the smallest currently free ID is reserved atomically [Authorization: platform admin]'
+      operationId: reserveTenantId
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantIdReservationRequestDTO'
+      responses:
+        '201':
+          description: CREATED - the ID was reserved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantIdReservationDTO'
+        '400':
+          description: BAD REQUEST - invalid/incomplete request
+        '401':
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        '403':
+          description: FORBIDDEN - no platform admin authority
+        '409':
+          description: CONFLICT - the requested ID is already assigned or reserved
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
+  /tenantadmin/tenant-ids/reservations/{id}:
+    delete:
+      tags:
+        - tenant-controller
+      summary: 'Releases an unconsumed tenant ID reservation so the ID becomes assignable again [Authorization: platform admin]'
+      operationId: releaseTenantIdReservation
+      parameters:
+        - name: id
+          in: path
+          description: Reserved tenant ID to release
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '204':
+          description: NO CONTENT - reservation released
+        '401':
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        '403':
+          description: FORBIDDEN - no platform admin authority
+        '404':
+          description: NOT FOUND - no open reservation exists for this ID
+        '500':
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: []
   /tenantadmin:
     post:
       tags:
@@ -1723,3 +1856,51 @@ components:
         welcomeMessage:
           allOf:
             - $ref: '#/components/schemas/WelcomeMessageDTO'
+    TenantIdAvailabilityDTO:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 21
+        status:
+          type: string
+          description: FREE = assignable, RESERVED = held by an open invite, ASSIGNED = consumed by an existing tenant
+          enum:
+            - FREE
+            - RESERVED
+            - ASSIGNED
+    NextFreeTenantIdDTO:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 36
+    TenantIdReservationRequestDTO:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Specific tenant ID to reserve. Omit for AUTO mode, which reserves the smallest currently free ID atomically.
+    TenantIdReservationDTO:
+      type: object
+      required:
+        - tenantId
+        - token
+      properties:
+        tenantId:
+          type: integer
+          format: int64
+          example: 21
+        token:
+          type: string
+          maxLength: 36
+          description: Reservation token. Required to consume the reserved ID when the tenant is created.

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryS
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService.TemplateCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.NonNull;
@@ -61,7 +62,13 @@ public class AccountInviteController {
                 safe.lastName,
                 safe.agencyId,
                 safe.departmentId,
-                safe.expiresInDays));
+                safe.expiresInDays,
+                parseOptionalEnum(
+                    IdAllocationMode.class, safe.tenantIdAllocationMode, "tenantIdAllocationMode"),
+                parseOptionalEnum(
+                    IdAllocationMode.class,
+                    safe.agencyIdAllocationMode,
+                    "agencyIdAllocationMode")));
 
     if (safe.templateId != null) {
       InviteSendResult result =
@@ -250,6 +257,14 @@ public class AccountInviteController {
     public Long expiresInDays;
     public Long templateId;
     public String acceptBaseUrl;
+
+    /**
+     * TEN-INV-U3: AUTO = the owning service assigns the smallest free ID (the matching ID field
+     * must be omitted); MANUAL = the pinned ID is reserved or rejected with 409.
+     */
+    public String tenantIdAllocationMode;
+
+    public String agencyIdAllocationMode;
   }
 
   public static class SendInviteRequestDTO {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/IdAllocationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/IdAllocationController.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import java.util.function.LongFunction;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Aggregated live validation of tenant and agency IDs for the Admin invite composer (TEN-INV-U3,
+ * ORISO-UserService#889).
+ *
+ * <p>Proxies the authoritative allocation state from TenantService ({@code
+ * /tenantadmin/tenant-ids/**}) and AgencyService ({@code /agencyadmin/agencyids/**}) in one call.
+ * The response is advisory for the UI only — reservation happens server-side on invite creation, so
+ * a stale green state here never produces a duplicate ID.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class IdAllocationController {
+
+  private static final String ADMIN_AUTH =
+      "hasAnyAuthority('AUTHORIZATION_TENANT_ADMIN', 'AUTHORIZATION_USER_ADMIN',"
+          + " 'AUTHORIZATION_RESTRICTED_AGENCY_ADMIN')";
+
+  private final @NonNull TenantIdAllocationClient tenantIdAllocationClient;
+  private final @NonNull AgencyIdAllocationClient agencyIdAllocationClient;
+
+  /**
+   * Returns the allocation state of the requested IDs. At least one of {@code tenantId} and {@code
+   * agencyId} is required; each entry is independent, so a failing upstream service degrades only
+   * its own entry to {@code SERVICE_ERROR} (with the upstream HTTP status passed through) instead
+   * of failing the whole validation.
+   */
+  @PreAuthorize(ADMIN_AUTH)
+  @GetMapping("/useradmin/id-allocation")
+  public ResponseEntity<IdAllocationValidationResponseDTO> validateIds(
+      @RequestParam(value = "tenantId", required = false) Long tenantId,
+      @RequestParam(value = "agencyId", required = false) Long agencyId) {
+    if (tenantId == null && agencyId == null) {
+      throw new BadRequestException("At least one of tenantId and agencyId is required");
+    }
+    var response = new IdAllocationValidationResponseDTO();
+    if (tenantId != null) {
+      response.tenant = resolve(tenantId, tenantIdAllocationClient::getAvailability, "tenant");
+    }
+    if (agencyId != null) {
+      response.agency = resolve(agencyId, agencyIdAllocationClient::getAvailability, "agency");
+    }
+    return ResponseEntity.ok(response);
+  }
+
+  private static IdAllocationEntryDTO resolve(
+      long id, LongFunction<IdAllocationStatus> availability, String kind) {
+    var entry = new IdAllocationEntryDTO();
+    entry.id = id;
+    try {
+      entry.status = availability.apply(id).name();
+    } catch (RestClientResponseException exception) {
+      log.warn(
+          "ID allocation lookup for {} ID {} failed upstream with status {}",
+          kind,
+          id,
+          exception.getStatusCode().value());
+      entry.status = IdAllocationEntryDTO.SERVICE_ERROR;
+      entry.upstreamStatus = exception.getStatusCode().value();
+    } catch (RuntimeException exception) {
+      log.warn("ID allocation lookup for {} ID {} failed: {}", kind, id, exception.getMessage());
+      entry.status = IdAllocationEntryDTO.SERVICE_ERROR;
+    }
+    return entry;
+  }
+
+  /** One validated ID: FREE / RESERVED / ASSIGNED, or SERVICE_ERROR when the lookup failed. */
+  public static class IdAllocationEntryDTO {
+    public static final String SERVICE_ERROR = "SERVICE_ERROR";
+
+    public Long id;
+    public String status;
+
+    /** Upstream HTTP status, only set when {@link #status} is {@code SERVICE_ERROR}. */
+    public Integer upstreamStatus;
+  }
+
+  public static class IdAllocationValidationResponseDTO {
+    public IdAllocationEntryDTO tenant;
+    public IdAllocationEntryDTO agency;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -34,7 +34,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString(exclude = "tokenHash")
+@ToString(exclude = {"tokenHash", "tenantIdReservationToken"})
 public class AccountInvite {
 
   @Id
@@ -60,6 +60,14 @@ public class AccountInvite {
 
   @Column(name = "agency_id")
   private Long agencyId;
+
+  /**
+   * Token of the TenantService tenant-ID reservation held by this invite (TEN-INV-U3). Tenant
+   * creation consumes the reserved ID only against this token; it stays with the invite until the
+   * reservation is consumed or released.
+   */
+  @Column(name = "tenant_id_reservation_token", length = 36)
+  private String tenantIdReservationToken;
 
   @Column(name = "department_id")
   private Long departmentId;

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -11,6 +11,11 @@ import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -44,6 +49,8 @@ public class AccountInviteService {
   private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull TenantService tenantService;
+  private final @NonNull TenantIdAllocationClient tenantIdAllocationClient;
+  private final @NonNull AgencyIdAllocationClient agencyIdAllocationClient;
 
   @Transactional
   public AccountInvite createInvite(CreateAccountInviteCommand command) {
@@ -56,6 +63,7 @@ public class AccountInviteService {
     if (isBlank(command.recipientEmail())) {
       throw new BadRequestException("recipientEmail is required");
     }
+    validateAllocationModes(command);
     if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN
         && command.tenantId() != null
         && isTenantIdTaken(command.tenantId())) {
@@ -63,26 +71,96 @@ public class AccountInviteService {
       throw new ConflictException("tenantId " + command.tenantId() + " is already taken");
     }
 
-    LocalDateTime now = LocalDateTime.now();
-    AccountInvite invite =
-        AccountInvite.builder()
-            .targetRole(command.targetRole())
-            .tenantId(command.tenantId())
-            .recipientEmail(command.recipientEmail().trim())
-            .firstName(trimToNull(command.firstName()))
-            .lastName(trimToNull(command.lastName()))
-            .agencyId(command.agencyId())
-            .departmentId(command.departmentId())
-            .expiresAt(resolveExpiry(now, command.expiresInDays()))
-            .status(AccountInviteStatus.DRAFT)
-            .emailVerificationStatus(EmailVerificationStatus.PENDING)
-            .twoFactorStatus(defaultTwoFactorStatus(command.targetRole()))
-            .createdByUserId(authenticatedUser.getUserId())
-            .createdByUsername(authenticatedUser.getUsername())
-            .createDate(now)
-            .updateDate(now)
-            .build();
-    return accountInviteRepository.save(invite);
+    // TEN-INV-U3 (#889): tenant-admin invites hold an authoritative TenantService reservation;
+    // agency IDs are reserved in AgencyService's own ID space (U2 decision, AS#214). The green
+    // UI state alone grants nothing — the reservation plus the re-validation below decide.
+    TenantIdReservation tenantReservation = null;
+    Long reservedAgencyId = null;
+    if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN) {
+      tenantReservation = tenantIdAllocationClient.reserve(command.tenantId());
+    }
+    try {
+      if (command.agencyIdAllocationMode() != null) {
+        Long tenantIdForAgency =
+            tenantReservation != null ? tenantReservation.tenantId() : command.tenantId();
+        reservedAgencyId = agencyIdAllocationClient.reserve(command.agencyId(), tenantIdForAgency);
+      }
+      revalidateReservations(tenantReservation, reservedAgencyId);
+
+      LocalDateTime now = LocalDateTime.now();
+      AccountInvite invite =
+          AccountInvite.builder()
+              .targetRole(command.targetRole())
+              .tenantId(
+                  tenantReservation != null ? tenantReservation.tenantId() : command.tenantId())
+              .tenantIdReservationToken(
+                  tenantReservation != null ? tenantReservation.token() : null)
+              .recipientEmail(command.recipientEmail().trim())
+              .firstName(trimToNull(command.firstName()))
+              .lastName(trimToNull(command.lastName()))
+              .agencyId(reservedAgencyId != null ? reservedAgencyId : command.agencyId())
+              .departmentId(command.departmentId())
+              .expiresAt(resolveExpiry(now, command.expiresInDays()))
+              .status(AccountInviteStatus.DRAFT)
+              .emailVerificationStatus(EmailVerificationStatus.PENDING)
+              .twoFactorStatus(defaultTwoFactorStatus(command.targetRole()))
+              .createdByUserId(authenticatedUser.getUserId())
+              .createdByUsername(authenticatedUser.getUsername())
+              .createDate(now)
+              .updateDate(now)
+              .build();
+      return accountInviteRepository.save(invite);
+    } catch (RuntimeException exception) {
+      // Compensation: a failed creation must not leave orphaned reservations behind.
+      if (reservedAgencyId != null) {
+        agencyIdAllocationClient.release(reservedAgencyId);
+      }
+      if (tenantReservation != null) {
+        tenantIdAllocationClient.release(tenantReservation.tenantId());
+      }
+      throw exception;
+    }
+  }
+
+  private static void validateAllocationModes(CreateAccountInviteCommand command) {
+    if (command.tenantIdAllocationMode() == IdAllocationMode.MANUAL && command.tenantId() == null) {
+      throw new BadRequestException("tenantId is required in MANUAL tenant allocation mode");
+    }
+    if (command.tenantIdAllocationMode() == IdAllocationMode.AUTO && command.tenantId() != null) {
+      throw new BadRequestException("tenantId must be omitted in AUTO tenant allocation mode");
+    }
+    if (command.tenantIdAllocationMode() != null
+        && command.targetRole() != AccountInviteTargetRole.TENANT_ADMIN) {
+      throw new BadRequestException(
+          "tenantIdAllocationMode is only supported for TENANT_ADMIN invites");
+    }
+    if (command.agencyIdAllocationMode() == IdAllocationMode.MANUAL && command.agencyId() == null) {
+      throw new BadRequestException("agencyId is required in MANUAL agency allocation mode");
+    }
+    if (command.agencyIdAllocationMode() == IdAllocationMode.AUTO && command.agencyId() != null) {
+      throw new BadRequestException("agencyId must be omitted in AUTO agency allocation mode");
+    }
+  }
+
+  /**
+   * Re-validates the reservations immediately before saving: the owning services must still report
+   * RESERVED for the held IDs. The server-side check is authoritative — a stale UI state or a lost
+   * reservation never produces a duplicate ID.
+   */
+  private void revalidateReservations(
+      TenantIdReservation tenantReservation, Long reservedAgencyId) {
+    if (tenantReservation != null
+        && tenantIdAllocationClient.getAvailability(tenantReservation.tenantId())
+            != IdAllocationStatus.RESERVED) {
+      throw new ConflictException(
+          "tenantId " + tenantReservation.tenantId() + " is no longer reserved for this invite");
+    }
+    if (reservedAgencyId != null
+        && agencyIdAllocationClient.getAvailability(reservedAgencyId)
+            != IdAllocationStatus.RESERVED) {
+      throw new ConflictException(
+          "agencyId " + reservedAgencyId + " is no longer reserved for this invite");
+    }
   }
 
   @Transactional(readOnly = true)
@@ -124,6 +202,9 @@ public class AccountInviteService {
         AccountInvite.builder()
             .targetRole(oldInvite.getTargetRole())
             .tenantId(oldInvite.getTenantId())
+            // The reservation follows the invite chain: the replacement keeps the reserved
+            // tenant ID, so it must also keep the token that consumes the reservation.
+            .tenantIdReservationToken(oldInvite.getTenantIdReservationToken())
             .recipientEmail(oldInvite.getRecipientEmail())
             .firstName(oldInvite.getFirstName())
             .lastName(oldInvite.getLastName())
@@ -424,7 +505,33 @@ public class AccountInviteService {
       String lastName,
       Long agencyId,
       Long departmentId,
-      Long expiresInDays) {}
+      Long expiresInDays,
+      IdAllocationMode tenantIdAllocationMode,
+      IdAllocationMode agencyIdAllocationMode) {
+
+    /** Convenience for callers without ID-allocation semantics (no reservation modes). */
+    public CreateAccountInviteCommand(
+        AccountInviteTargetRole targetRole,
+        Long tenantId,
+        String recipientEmail,
+        String firstName,
+        String lastName,
+        Long agencyId,
+        Long departmentId,
+        Long expiresInDays) {
+      this(
+          targetRole,
+          tenantId,
+          recipientEmail,
+          firstName,
+          lastName,
+          agencyId,
+          departmentId,
+          expiresInDays,
+          null,
+          null);
+    }
+  }
 
   public record SendInviteCommand(Long inviteId, Long templateId, String acceptBaseUrl) {}
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/AgencyIdAllocationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/AgencyIdAllocationClient.java
@@ -1,0 +1,89 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import de.caritas.cob.userservice.agencyadminserivce.generated.ApiClient;
+import de.caritas.cob.userservice.agencyadminserivce.generated.web.AdminAgencyControllerApi;
+import de.caritas.cob.userservice.agencyadminserivce.generated.web.model.AgencyIdReservationRequestDTO;
+import de.caritas.cob.userservice.api.config.apiclient.AgencyAdminServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.service.httpheader.TenantHeaderSupplier;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Client-boundary wrapper for the authoritative agency-ID allocation endpoints of AgencyService
+ * (TEN-INV-U2, {@code /agencyadmin/agencyids/**}).
+ *
+ * <p>Per the U2 decision (ORISO-AgencyService#214) agency IDs live in AgencyService's own ID space;
+ * a supplied tenantId is validated by AgencyService but never reserved there.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AgencyIdAllocationClient {
+
+  private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
+  private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
+
+  private final @NonNull AgencyAdminServiceApiControllerFactory
+      agencyAdminServiceApiControllerFactory;
+
+  /**
+   * Reserves an agency ID. {@code requestedAgencyId == null} is AUTO mode: AgencyService assigns
+   * the smallest currently free ID atomically.
+   *
+   * @throws ConflictException when the requested ID is already assigned or reserved (upstream 409)
+   */
+  public long reserve(Long requestedAgencyId, Long tenantId) {
+    var request =
+        new AgencyIdReservationRequestDTO().agencyId(requestedAgencyId).tenantId(tenantId);
+    try {
+      return createControllerApi().reserveAgencyId(request).getAgencyId();
+    } catch (HttpClientErrorException.Conflict exception) {
+      throw new ConflictException(
+          "agencyId " + requestedAgencyId + " is already assigned or reserved");
+    }
+  }
+
+  /** Returns the authoritative allocation status of one agency ID. */
+  public IdAllocationStatus getAvailability(long agencyId) {
+    var availability = createControllerApi().getAgencyIdAvailability(agencyId);
+    return IdAllocationStatus.valueOf(availability.getStatus().getValue());
+  }
+
+  /**
+   * Best-effort compensation: releases an unconsumed reservation so the ID becomes assignable
+   * again. Never throws — a failed release must not mask the original creation failure; the
+   * upstream reservation ledger stays the single source of truth for manual cleanup.
+   */
+  public void release(long agencyId) {
+    try {
+      createControllerApi().releaseAgencyIdReservation(agencyId);
+    } catch (HttpClientErrorException.NotFound exception) {
+      log.info("Agency ID reservation {} was already released", agencyId);
+    } catch (RestClientException exception) {
+      log.error(
+          "Failed to release agency ID reservation {} — possible orphaned reservation in"
+              + " AgencyService",
+          agencyId,
+          exception);
+    }
+  }
+
+  private AdminAgencyControllerApi createControllerApi() {
+    var controllerApi = agencyAdminServiceApiControllerFactory.createControllerApi();
+    addDefaultHeaders(controllerApi.getApiClient());
+    return controllerApi;
+  }
+
+  private void addDefaultHeaders(ApiClient apiClient) {
+    HttpHeaders headers = this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+    tenantHeaderSupplier.addTenantHeader(headers);
+    headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdAllocationMode.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdAllocationMode.java
@@ -1,0 +1,13 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+/**
+ * How an ID field of the invite composer is allocated (TEN-INV, ORISO-Admin#569).
+ *
+ * <p>{@code AUTO} — the owning service assigns the smallest currently free ID atomically; the
+ * request must not pin an ID. {@code MANUAL} — the admin pinned a specific ID which is reserved or
+ * rejected with a conflict.
+ */
+public enum IdAllocationMode {
+  AUTO,
+  MANUAL
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdAllocationStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdAllocationStatus.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+/**
+ * Authoritative allocation state of a tenant or agency ID as reported by the owning service
+ * (TenantService U1 / AgencyService U2, ORISO-Admin#569).
+ */
+public enum IdAllocationStatus {
+  /** Assignable — no tenant/agency and no open reservation uses this ID. */
+  FREE,
+  /** Held by an open invite reservation. */
+  RESERVED,
+  /** Consumed by an existing tenant/agency. */
+  ASSIGNED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdAllocationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdAllocationClient.java
@@ -1,0 +1,83 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.TenantControllerApi;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantIdReservationRequestDTO;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Client-boundary wrapper for the authoritative tenant-ID allocation endpoints of TenantService
+ * (TEN-INV-U1, {@code /tenantadmin/tenant-ids/**}).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantIdAllocationClient {
+
+  private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
+
+  private final @NonNull TenantAdminServiceApiControllerFactory
+      tenantAdminServiceApiControllerFactory;
+
+  /**
+   * Reserves a tenant ID. {@code requestedTenantId == null} is AUTO mode: TenantService assigns the
+   * smallest currently free ID atomically.
+   *
+   * @throws ConflictException when the requested ID is already assigned or reserved (upstream 409)
+   */
+  public TenantIdReservation reserve(Long requestedTenantId) {
+    var request = new TenantIdReservationRequestDTO().tenantId(requestedTenantId);
+    try {
+      var reservation = createControllerApi().reserveTenantId(request);
+      return new TenantIdReservation(reservation.getTenantId(), reservation.getToken());
+    } catch (HttpClientErrorException.Conflict exception) {
+      throw new ConflictException(
+          "tenantId " + requestedTenantId + " is already assigned or reserved");
+    }
+  }
+
+  /** Returns the authoritative allocation status of one tenant ID. */
+  public IdAllocationStatus getAvailability(long tenantId) {
+    var availability = createControllerApi().getTenantIdAvailability(tenantId);
+    return IdAllocationStatus.valueOf(availability.getStatus().getValue());
+  }
+
+  /**
+   * Best-effort compensation: releases an unconsumed reservation so the ID becomes assignable
+   * again. Never throws — a failed release must not mask the original creation failure; the
+   * upstream reservation ledger stays the single source of truth for manual cleanup.
+   */
+  public void release(long tenantId) {
+    try {
+      createControllerApi().releaseTenantIdReservation(tenantId);
+    } catch (HttpClientErrorException.NotFound exception) {
+      log.info("Tenant ID reservation {} was already released", tenantId);
+    } catch (RestClientException exception) {
+      log.error(
+          "Failed to release tenant ID reservation {} — possible orphaned reservation in"
+              + " TenantService",
+          tenantId,
+          exception);
+    }
+  }
+
+  private TenantControllerApi createControllerApi() {
+    var controllerApi = tenantAdminServiceApiControllerFactory.createControllerApi();
+    addDefaultHeaders(controllerApi.getApiClient());
+    return controllerApi;
+  }
+
+  private void addDefaultHeaders(ApiClient apiClient) {
+    HttpHeaders headers = this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+    headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdReservation.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdReservation.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+/**
+ * A successful tenant-ID reservation issued by TenantService (TEN-INV-U1).
+ *
+ * @param tenantId the reserved tenant ID (AUTO mode: assigned by TenantService)
+ * @param token reservation token; must be kept with the invite because tenant creation consumes the
+ *     reserved ID only against this token ({@code MultilingualTenantDTO.tenantIdReservationToken})
+ */
+public record TenantIdReservation(long tenantId, String token) {}

--- a/src/main/resources/db/changelog/changeset/0076_account_invite_reservation_token/0076_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0076_account_invite_reservation_token/0076_changeSet.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <!-- TEN-INV-U3 (ORISO-UserService#889): tenant-admin invites hold the TenantService
+       tenant-ID reservation token so tenant creation can consume the reserved ID and a
+       failed/abandoned invite can release it (no orphaned reservations). -->
+  <changeSet id="0076-account-invite-tenant-id-reservation-token" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="account_invite" columnName="tenant_id_reservation_token"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="account_invite">
+      <column name="tenant_id_reservation_token" type="varchar(36)"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="account_invite" columnName="tenant_id_reservation_token"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -126,6 +126,8 @@
     file="db/changelog/changeset/0074_remove_rocket_chat_room_ids/0074_changeSet.xml" />
   <include
     file="db/changelog/changeset/0075_remove_rocket_chat_feedback_room_id/0075_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0076_account_invite_reservation_token/0076_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetR
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -76,6 +77,40 @@ class AccountInviteControllerTest {
     verify(accountInviteService).createInvite(commandCaptor.capture());
     assertEquals(AccountInviteTargetRole.COUNSELLOR, commandCaptor.getValue().targetRole());
     assertEquals("invitee@example.org", commandCaptor.getValue().recipientEmail());
+  }
+
+  @Test
+  void createInvite_allocationModes_areParsedAndPassedToTheCommand() {
+    // TEN-INV-U3: the composer's AUTO/MANUAL allocation modes reach the orchestration untouched.
+    var request = new AccountInviteController.CreateAccountInviteRequestDTO();
+    request.targetRole = AccountInviteTargetRole.TENANT_ADMIN.name();
+    request.recipientEmail = "owner@example.org";
+    request.tenantIdAllocationMode = "AUTO";
+    request.agencyIdAllocationMode = "MANUAL";
+    request.agencyId = 9L;
+
+    var invite = sampleInvite();
+    when(accountInviteService.createInvite(any())).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_INVITE);
+
+    controller.createInvite(request);
+
+    var commandCaptor =
+        ArgumentCaptor.forClass(AccountInviteService.CreateAccountInviteCommand.class);
+    verify(accountInviteService).createInvite(commandCaptor.capture());
+    assertEquals(IdAllocationMode.AUTO, commandCaptor.getValue().tenantIdAllocationMode());
+    assertEquals(IdAllocationMode.MANUAL, commandCaptor.getValue().agencyIdAllocationMode());
+  }
+
+  @Test
+  void createInvite_unknownAllocationMode_throwsBadRequest() {
+    var request = new AccountInviteController.CreateAccountInviteRequestDTO();
+    request.targetRole = AccountInviteTargetRole.TENANT_ADMIN.name();
+    request.recipientEmail = "owner@example.org";
+    request.tenantIdAllocationMode = "SOMETIMES";
+
+    assertThrows(BadRequestException.class, () -> controller.createInvite(request));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/IdAllocationControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/IdAllocationControllerTest.java
@@ -1,0 +1,88 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+@ExtendWith(MockitoExtension.class)
+class IdAllocationControllerTest {
+
+  @Mock private TenantIdAllocationClient tenantIdAllocationClient;
+  @Mock private AgencyIdAllocationClient agencyIdAllocationClient;
+
+  @InjectMocks private IdAllocationController controller;
+
+  @Test
+  void validateIds_Should_ReturnBothStates_When_TenantAndAgencyIdGiven() {
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.FREE);
+    when(agencyIdAllocationClient.getAvailability(3L)).thenReturn(IdAllocationStatus.RESERVED);
+
+    var response = controller.validateIds(21L, 3L).getBody();
+
+    assertThat(response.tenant.id).isEqualTo(21L);
+    assertThat(response.tenant.status).isEqualTo("FREE");
+    assertThat(response.agency.id).isEqualTo(3L);
+    assertThat(response.agency.status).isEqualTo("RESERVED");
+  }
+
+  @Test
+  void validateIds_Should_OmitAgencyEntry_When_OnlyTenantIdGiven() {
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.ASSIGNED);
+
+    var response = controller.validateIds(21L, null).getBody();
+
+    assertThat(response.tenant.status).isEqualTo("ASSIGNED");
+    assertThat(response.agency).isNull();
+  }
+
+  @Test
+  void validateIds_Should_PassUpstreamStatusThrough_When_OneServiceFails() {
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.FREE);
+    when(agencyIdAllocationClient.getAvailability(3L))
+        .thenThrow(
+            HttpServerErrorException.create(
+                HttpStatus.BAD_GATEWAY,
+                "bad gateway",
+                new HttpHeaders(),
+                new byte[0],
+                StandardCharsets.UTF_8));
+
+    var response = controller.validateIds(21L, 3L).getBody();
+
+    assertThat(response.tenant.status).isEqualTo("FREE");
+    assertThat(response.agency.status).isEqualTo("SERVICE_ERROR");
+    assertThat(response.agency.upstreamStatus).isEqualTo(502);
+  }
+
+  @Test
+  void validateIds_Should_MarkServiceError_When_ServiceUnreachable() {
+    when(tenantIdAllocationClient.getAvailability(21L))
+        .thenThrow(new ResourceAccessException("connection refused"));
+
+    var response = controller.validateIds(21L, null).getBody();
+
+    assertThat(response.tenant.status).isEqualTo("SERVICE_ERROR");
+    assertThat(response.tenant.upstreamStatus).isNull();
+  }
+
+  @Test
+  void validateIds_Should_ThrowBadRequest_When_NoIdGiven() {
+    assertThatThrownBy(() -> controller.validateIds(null, null))
+        .isInstanceOf(BadRequestException.class);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -1,0 +1,228 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * TEN-INV-U3 (#889): invite creation orchestrates the authoritative tenant-ID reservations.
+ *
+ * <p>TenantService/AgencyService are mocked at the client boundary with a realistic in-memory
+ * reservation ledger (first reservation of an ID wins and returns 201-equivalent data, the loser
+ * gets the 409-mapped {@link ConflictException}), while the invite persistence and the service
+ * transaction run for real against the JPA layer.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(AccountInviteService.class)
+class AccountInviteReservationOrchestrationIT {
+
+  @Autowired private AccountInviteService service;
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private TenantService tenantService;
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+  @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+
+  /** In-memory stand-in for the TenantService reservation ledger (U1). */
+  private final Set<Long> tenantIdLedger = ConcurrentHashMap.newKeySet();
+
+  @BeforeEach
+  void setUpRealisticTenantIdLedger() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+
+    // AUTO mode: the smallest currently free ID is reserved atomically (ledger insert wins).
+    when(tenantIdAllocationClient.reserve(isNull()))
+        .thenAnswer(
+            invocation -> {
+              for (long candidate = 1; ; candidate++) {
+                if (tenantIdLedger.add(candidate)) {
+                  return new TenantIdReservation(candidate, "token-" + candidate);
+                }
+              }
+            });
+    // MANUAL mode: exactly the requested ID is reserved, or the loser gets the mapped 409.
+    when(tenantIdAllocationClient.reserve(anyLong()))
+        .thenAnswer(
+            invocation -> {
+              long requested = invocation.getArgument(0);
+              if (!tenantIdLedger.add(requested)) {
+                throw new ConflictException(
+                    "tenantId " + requested + " is already assigned or reserved");
+              }
+              return new TenantIdReservation(requested, "token-" + requested);
+            });
+    when(tenantIdAllocationClient.getAvailability(anyLong()))
+        .thenAnswer(
+            invocation ->
+                tenantIdLedger.contains((long) invocation.getArgument(0))
+                    ? IdAllocationStatus.RESERVED
+                    : IdAllocationStatus.FREE);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              tenantIdLedger.remove((long) invocation.getArgument(0));
+              return null;
+            })
+        .when(tenantIdAllocationClient)
+        .release(anyLong());
+  }
+
+  @AfterEach
+  void cleanUp() {
+    accountInviteRepository.deleteAll();
+    tenantIdLedger.clear();
+  }
+
+  @Test
+  void parallelAutoInvites_Should_ReceiveDifferentTenantIds() throws Exception {
+    List<AccountInvite> invites =
+        runConcurrently(
+            () -> createTenantAdminInvite(null, IdAllocationMode.AUTO, "auto-a@example.org"),
+            () -> createTenantAdminInvite(null, IdAllocationMode.AUTO, "auto-b@example.org"));
+
+    assertThat(invites).hasSize(2);
+    assertThat(invites.get(0).getTenantId()).isNotEqualTo(invites.get(1).getTenantId());
+    assertThat(invites.get(0).getTenantIdReservationToken())
+        .isNotEqualTo(invites.get(1).getTenantIdReservationToken());
+    assertThat(accountInviteRepository.count()).isEqualTo(2);
+    assertThat(tenantIdLedger).contains(invites.get(0).getTenantId(), invites.get(1).getTenantId());
+  }
+
+  @Test
+  void parallelManualInvitesForSameId_Should_LetExactlyOneSucceed() throws Exception {
+    List<Object> outcomes =
+        runConcurrentlyCollectingErrors(
+            () -> createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "manual-a@example.org"),
+            () -> createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "manual-b@example.org"));
+
+    List<AccountInvite> successes =
+        outcomes.stream()
+            .filter(AccountInvite.class::isInstance)
+            .map(AccountInvite.class::cast)
+            .toList();
+    List<Object> conflicts = outcomes.stream().filter(ConflictException.class::isInstance).toList();
+
+    assertThat(successes).hasSize(1);
+    assertThat(conflicts).hasSize(1);
+    assertThat(successes.get(0).getTenantId()).isEqualTo(21L);
+    assertThat(accountInviteRepository.count()).isEqualTo(1);
+    // The winner's reservation is still held — the loser's conflict released nothing.
+    assertThat(tenantIdLedger).containsExactly(21L);
+  }
+
+  @Test
+  void failedCreation_Should_LeaveNoReservationBehind() {
+    // The re-validation directly before saving loses the race: the ID is meanwhile ASSIGNED.
+    when(tenantIdAllocationClient.getAvailability(anyLong()))
+        .thenReturn(IdAllocationStatus.ASSIGNED);
+
+    assertThatThrownBy(
+            () -> createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "owner@example.org"))
+        .isInstanceOf(ConflictException.class);
+
+    verify(tenantIdAllocationClient).release(21L);
+    assertThat(accountInviteRepository.count()).isZero();
+    assertThat(tenantIdLedger).isEmpty();
+  }
+
+  private AccountInvite createTenantAdminInvite(
+      Long tenantId, IdAllocationMode mode, String email) {
+    return service.createInvite(
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            tenantId,
+            email,
+            null,
+            null,
+            null,
+            null,
+            null,
+            mode,
+            null));
+  }
+
+  private List<AccountInvite> runConcurrently(
+      Callable<AccountInvite> first, Callable<AccountInvite> second) throws Exception {
+    List<Object> outcomes = runConcurrentlyCollectingErrors(first, second);
+    List<AccountInvite> invites = new ArrayList<>();
+    for (Object outcome : outcomes) {
+      if (outcome instanceof Exception exception) {
+        throw exception;
+      }
+      invites.add((AccountInvite) outcome);
+    }
+    return invites;
+  }
+
+  private List<Object> runConcurrentlyCollectingErrors(
+      Callable<AccountInvite> first, Callable<AccountInvite> second) throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      CountDownLatch startTogether = new CountDownLatch(1);
+      List<Future<Object>> futures =
+          List.of(first, second).stream()
+              .map(
+                  callable ->
+                      executor.submit(
+                          (Callable<Object>)
+                              () -> {
+                                startTogether.await(5, TimeUnit.SECONDS);
+                                try {
+                                  return callable.call();
+                                } catch (Exception exception) {
+                                  return exception;
+                                }
+                              }))
+              .toList();
+      startTogether.countDown();
+      List<Object> outcomes = new ArrayList<>();
+      for (Future<Object> future : futures) {
+        outcomes.add(future.get(30, TimeUnit.SECONDS));
+      }
+      return outcomes;
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -3,10 +3,12 @@ package de.caritas.cob.userservice.api.service.accountinvite;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
@@ -23,6 +25,11 @@ import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.SendInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,6 +53,8 @@ class AccountInviteServiceTest {
   @Mock private InviteEmailDeliveryRepository deliveryRepository;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private TenantService tenantService;
+  @Mock private TenantIdAllocationClient tenantIdAllocationClient;
+  @Mock private AgencyIdAllocationClient agencyIdAllocationClient;
 
   @InjectMocks private AccountInviteService service;
 
@@ -883,5 +892,300 @@ class AccountInviteServiceTest {
 
     assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
     assertThat(invite.getTenantId()).isEqualTo(9L);
+  }
+
+  // ---------------------------------------------------------------------------
+  // TEN-INV-U3 — tenant/agency ID reservation orchestration (#889)
+  // ---------------------------------------------------------------------------
+
+  private void givenAdminAndPassthroughSave() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  private void givenTenantIdFreeLocally(long tenantId) {
+    when(tenantService.getRestrictedTenantData(tenantId))
+        .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    when(accountInviteRepository.existsByTenantIdAndTargetRoleAndStatusIn(
+            tenantId,
+            AccountInviteTargetRole.TENANT_ADMIN,
+            List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
+        .thenReturn(false);
+  }
+
+  @Test
+  void createInvite_Should_ReserveTenantIdAndKeepToken_When_TenantAdminManualId() {
+    givenAdminAndPassthroughSave();
+    givenTenantIdFreeLocally(21L);
+    when(tenantIdAllocationClient.reserve(21L))
+        .thenReturn(new TenantIdReservation(21L, "res-token-21"));
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.RESERVED);
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.TENANT_ADMIN,
+                21L,
+                "owner@example.org",
+                "New",
+                "Owner",
+                null,
+                null,
+                30L,
+                IdAllocationMode.MANUAL,
+                null));
+
+    assertThat(invite.getTenantId()).isEqualTo(21L);
+    assertThat(invite.getTenantIdReservationToken()).isEqualTo("res-token-21");
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void createInvite_Should_AutoReserveSmallestFreeTenantId_When_TenantAdminWithoutTenantId() {
+    givenAdminAndPassthroughSave();
+    when(tenantIdAllocationClient.reserve(null))
+        .thenReturn(new TenantIdReservation(36L, "res-token-36"));
+    when(tenantIdAllocationClient.getAvailability(36L)).thenReturn(IdAllocationStatus.RESERVED);
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.TENANT_ADMIN,
+                null,
+                "owner@example.org",
+                "New",
+                "Owner",
+                null,
+                null,
+                30L,
+                IdAllocationMode.AUTO,
+                null));
+
+    assertThat(invite.getTenantId()).isEqualTo(36L);
+    assertThat(invite.getTenantIdReservationToken()).isEqualTo("res-token-36");
+  }
+
+  @Test
+  void createInvite_Should_PropagateConflictWithoutSaving_When_TenantIdReservationConflicts() {
+    givenTenantIdFreeLocally(21L);
+    when(tenantIdAllocationClient.reserve(21L))
+        .thenThrow(new ConflictException("tenantId 21 is already assigned or reserved"));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            21L,
+            "owner@example.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            IdAllocationMode.MANUAL,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(ConflictException.class);
+    verify(accountInviteRepository, never()).save(any());
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void createInvite_Should_ReleaseReservation_When_RevalidationBeforeSaveFindsIdNotReserved() {
+    givenTenantIdFreeLocally(21L);
+    when(tenantIdAllocationClient.reserve(21L))
+        .thenReturn(new TenantIdReservation(21L, "res-token-21"));
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.ASSIGNED);
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            21L,
+            "owner@example.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            IdAllocationMode.MANUAL,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(ConflictException.class);
+    verify(accountInviteRepository, never()).save(any());
+    verify(tenantIdAllocationClient).release(21L);
+  }
+
+  @Test
+  void createInvite_Should_ReleaseReservation_When_SavingTheInviteFails() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    givenTenantIdFreeLocally(21L);
+    when(tenantIdAllocationClient.reserve(21L))
+        .thenReturn(new TenantIdReservation(21L, "res-token-21"));
+    when(tenantIdAllocationClient.getAvailability(21L)).thenReturn(IdAllocationStatus.RESERVED);
+    when(accountInviteRepository.save(any())).thenThrow(new IllegalStateException("db down"));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            21L,
+            "owner@example.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            IdAllocationMode.MANUAL,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(IllegalStateException.class);
+    verify(tenantIdAllocationClient).release(21L);
+  }
+
+  @Test
+  void createInvite_Should_ReserveAgencyIdInAgencyServiceIdSpace_When_AgencyAllocationRequested() {
+    givenAdminAndPassthroughSave();
+    when(tenantIdAllocationClient.reserve(null))
+        .thenReturn(new TenantIdReservation(36L, "res-token-36"));
+    when(tenantIdAllocationClient.getAvailability(36L)).thenReturn(IdAllocationStatus.RESERVED);
+    when(agencyIdAllocationClient.reserve(null, 36L)).thenReturn(5L);
+    when(agencyIdAllocationClient.getAvailability(5L)).thenReturn(IdAllocationStatus.RESERVED);
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.TENANT_ADMIN,
+                null,
+                "owner@example.org",
+                null,
+                null,
+                null,
+                null,
+                null,
+                IdAllocationMode.AUTO,
+                IdAllocationMode.AUTO));
+
+    assertThat(invite.getTenantId()).isEqualTo(36L);
+    assertThat(invite.getAgencyId()).isEqualTo(5L);
+    verify(agencyIdAllocationClient).reserve(null, 36L);
+  }
+
+  @Test
+  void createInvite_Should_ReleaseTenantReservation_When_AgencyReservationConflicts() {
+    givenTenantIdFreeLocally(21L);
+    when(tenantIdAllocationClient.reserve(21L))
+        .thenReturn(new TenantIdReservation(21L, "res-token-21"));
+    when(agencyIdAllocationClient.reserve(9L, 21L))
+        .thenThrow(new ConflictException("agencyId 9 is already assigned or reserved"));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            21L,
+            "owner@example.org",
+            null,
+            null,
+            9L,
+            null,
+            null,
+            IdAllocationMode.MANUAL,
+            IdAllocationMode.MANUAL);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(ConflictException.class);
+    verify(tenantIdAllocationClient).release(21L);
+    verify(agencyIdAllocationClient, never()).release(anyLong());
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void createInvite_Should_ThrowBadRequest_When_ManualTenantModeWithoutTenantId() {
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            null,
+            "owner@example.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            IdAllocationMode.MANUAL,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    verify(tenantIdAllocationClient, never()).reserve(any());
+  }
+
+  @Test
+  void createInvite_Should_ThrowBadRequest_When_AutoTenantModeWithPinnedTenantId() {
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            21L,
+            "owner@example.org",
+            null,
+            null,
+            null,
+            null,
+            null,
+            IdAllocationMode.AUTO,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+    verify(tenantIdAllocationClient, never()).reserve(any());
+  }
+
+  @Test
+  void createInvite_Should_NotTouchAllocationServices_When_NonTenantAdminWithoutAgencyMode() {
+    givenAdminAndPassthroughSave();
+
+    service.createInvite(
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "counsellor@example.org",
+            null,
+            null,
+            3L,
+            null,
+            null,
+            null,
+            null));
+
+    verifyNoInteractions(tenantIdAllocationClient);
+    verifyNoInteractions(agencyIdAllocationClient);
+  }
+
+  @Test
+  void resendInvite_Should_CarryReservationTokenToReplacementInvite() {
+    AccountInvite oldInvite =
+        AccountInvite.builder()
+            .id(10L)
+            .tenantId(21L)
+            .tenantIdReservationToken("res-token-21")
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.TENANT_INVITE)
+            .subject("Again")
+            .body("Use {{inviteLink}}")
+            .active(true)
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.resendInvite(
+            new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+
+    assertThat(result.invite().getTenantIdReservationToken()).isEqualTo("res-token-21");
+    assertThat(result.invite().getTenantId()).isEqualTo(21L);
   }
 }

--- a/tests/contracts/test_openapi_contract_gate.py
+++ b/tests/contracts/test_openapi_contract_gate.py
@@ -131,7 +131,7 @@ class OpenApiContractGateTest(unittest.TestCase):
             workflow,
             re.compile(
                 r"repository: OpenResilienceInitiative/ORISO-AgencyService.*"
-                r"299d4792820747ff8c5b387e421a6e971fb760d3",
+                r"11d1e2426593ffa0a550a64042ce97ca6e0a80cf",
                 re.DOTALL,
             ),
         )
@@ -147,7 +147,7 @@ class OpenApiContractGateTest(unittest.TestCase):
             workflow,
             re.compile(
                 r"repository: OpenResilienceInitiative/ORISO-TenantService.*"
-                r"a213d5546e2cdbcbd1f641291661f11cbbca2cfc",
+                r"1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e",
                 re.DOTALL,
             ),
         )


### PR DESCRIPTION
**Stack position: 1 of 6 — bottom of the chain. Base: `pre-dev`.**

## Problem

Tenant-admin invite creation allocated no ID authoritatively. Two invites created in
parallel could end up pointing at the same tenant ID, a failed creation left the ID
half-claimed, and the Admin UI had no server-backed way to tell an operator whether a
tenant or agency ID was actually free before submitting. The "green" client-side state
was the only signal, and it granted nothing.

## What changed

- **Authoritative tenant-ID reservation.** Invite creation reserves the tenant ID in
  TenantService (`POST /tenantadmin/tenant-ids/reservations`, `AUTO` or a pinned ID) and
  stores the reservation token on the invite (new column
  `account_invite.tenant_id_reservation_token`, changeset `0076`), so tenant creation can
  later consume exactly the reserved ID.
- **Agency IDs** are reserved in AgencyService's own ID space (per the U2 decision,
  ORISO-AgencyService#214) when the composer sends an agency allocation mode; tenant IDs
  are only validated there, never minted.
- **Re-validation before save.** The `RESERVED` state is re-checked immediately before the
  invite row is written; a lost race maps to `409` and releases the reservation.
- **Compensation.** Any creation failure after reservation releases both the tenant and the
  agency reservation, so no orphans accumulate. Release is best-effort and never masks the
  original failure.
- **Concurrent conflicts.** A second manual invite for the same ID gets `409` from the
  upstream ledger, passed through as `ConflictException`.
- **Resend** carries the reservation token over to the replacement invite.
- **New live-validation endpoint for the Admin UI:**
  `GET /useradmin/id-allocation?tenantId=&agencyId=` returning per-ID
  `FREE` / `RESERVED` / `ASSIGNED`, or `SERVICE_ERROR` with upstream status passthrough.
- `services/tenantadminservice.yaml` and `services/agencyadminservice.yaml` extended with
  the real U1/U2 endpoint contracts so the generated clients pick them up.

The submit-time server check stays authoritative: the aggregated endpoint is advisory UI
sugar, it does not reserve anything.

## Testing

Re-run locally on 2026-07-29 with JDK 21 (`./mvnw test` / `surefire:test@integration-tests`,
targeted classes) on the tip of this stack — all six branches applied:

| Suite | Result |
| --- | --- |
| `AccountInviteServiceTest` | 83 tests, 0 failures |
| `AccountInviteControllerTest` | 27 tests, 0 failures |
| `IdAllocationControllerTest` | 5 tests, 0 failures |
| `AccountInviteReservationOrchestrationIT` | 3 tests, 0 failures |

`AccountInviteReservationOrchestrationIT` mocks TenantService/AgencyService at the client
boundary with a realistic reservation ledger and proves the three acceptance criteria
directly: parallel `AUTO` invites receive different IDs, a same-ID race lets exactly one
request succeed, and a failed creation leaves no reservation behind.

End-to-end evidence from the clean-slate local chain run (all services rebuilt from these
branches) covering this chunk:

- **S1** — invite with `AUTO` ID reserved and consumed through to a working tenant-admin login.
- **S3** — `AUTO` takes the smallest free ID; a manual ID that is already taken blocks
  sending; rapid successive invites get distinct IDs.

**Honest note on the wider suite:** `UserControllerE2EIT` fails on this machine
(`RedisConnectionFailureException: Unable to connect to Redis` / `Connection refused:
localhost/127.0.0.1:6379` on every one of its 22 failing cases). There is no Redis running
locally; this is an environment gap, identical on the untouched baseline, and this stack
touches none of the classes that suite exercises. I am **not** claiming a green full IT
suite — only the targeted suites listed above were observed green.

Closes OpenResilienceInitiative/ORISO-UserService#889

Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
