### PR TITLE
[TEN-INV-U6] Correct invite link targets and SENT only after confirmed delivery

### DIFF
--- a/.github/workflows/openapi-contracts.yml
+++ b/.github/workflows/openapi-contracts.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: OpenResilienceInitiative/ORISO-TenantService
-        ref: ${{ github.event_name == 'pull_request' && 'a213d5546e2cdbcbd1f641291661f11cbbca2cfc' || 'pre-dev' }}
+        ref: ${{ github.event_name == 'pull_request' && '1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e' || 'pre-dev' }}
         path: .providers/tenant
         persist-credentials: false
 

--- a/.github/workflows/openapi-contracts.yml
+++ b/.github/workflows/openapi-contracts.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: OpenResilienceInitiative/ORISO-AgencyService
-        ref: ${{ github.event_name == 'pull_request' && '299d4792820747ff8c5b387e421a6e971fb760d3' || 'pre-dev' }}
+        ref: ${{ github.event_name == 'pull_request' && '11d1e2426593ffa0a550a64042ce97ca6e0a80cf' || 'pre-dev' }}
         path: .providers/agency
         persist-credentials: false
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -72,8 +72,7 @@ public class AccountInviteController {
 
     if (safe.templateId != null) {
       InviteSendResult result =
-          accountInviteService.sendInvite(
-              new SendInviteCommand(invite.getId(), safe.templateId, safe.acceptBaseUrl));
+          accountInviteService.sendInvite(new SendInviteCommand(invite.getId(), safe.templateId));
       return new ResponseEntity<>(AccountInviteResponseDTO.from(result), HttpStatus.CREATED);
     }
 
@@ -122,8 +121,7 @@ public class AccountInviteController {
       @PathVariable Long inviteId, @RequestBody SendInviteRequestDTO request) {
     SendInviteRequestDTO safe = request == null ? new SendInviteRequestDTO() : request;
     InviteSendResult result =
-        accountInviteService.sendInvite(
-            new SendInviteCommand(inviteId, safe.templateId, safe.acceptBaseUrl));
+        accountInviteService.sendInvite(new SendInviteCommand(inviteId, safe.templateId));
     return ResponseEntity.ok(AccountInviteResponseDTO.from(result));
   }
 
@@ -133,8 +131,7 @@ public class AccountInviteController {
       @PathVariable Long inviteId, @RequestBody SendInviteRequestDTO request) {
     SendInviteRequestDTO safe = request == null ? new SendInviteRequestDTO() : request;
     InviteSendResult result =
-        accountInviteService.resendInvite(
-            new SendInviteCommand(inviteId, safe.templateId, safe.acceptBaseUrl));
+        accountInviteService.resendInvite(new SendInviteCommand(inviteId, safe.templateId));
     return ResponseEntity.ok(AccountInviteResponseDTO.from(result));
   }
 
@@ -256,6 +253,11 @@ public class AccountInviteController {
     public Long departmentId;
     public Long expiresInDays;
     public Long templateId;
+
+    /**
+     * Ignored since TEN-INV-U6 (#890): the accept link target is decided server-side from the
+     * invite's role and configuration. Kept only for wire compatibility with older clients.
+     */
     public String acceptBaseUrl;
 
     /**
@@ -269,6 +271,11 @@ public class AccountInviteController {
 
   public static class SendInviteRequestDTO {
     public Long templateId;
+
+    /**
+     * Ignored since TEN-INV-U6 (#890): the accept link target is decided server-side from the
+     * invite's role and configuration. Kept only for wire compatibility with older clients.
+     */
     public String acceptBaseUrl;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryS
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService.TemplateCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -161,16 +162,25 @@ public class AccountInviteController {
             accountInviteService.calculateAccessGate(invite)));
   }
 
+  /**
+   * Public accept endpoint. Resume contract (ORISO-Admin#569 hardening): while the accepted
+   * invite's mandatory 2FA activation is pending and the link is unexpired, repeated calls stay
+   * idempotent 200s carrying {@code phase = PENDING_2FA_ACTIVATION}; once the gate is satisfied the
+   * link is terminally consumed (410 {@code reason=CONSUMED}).
+   */
   @PostMapping("/users/account-invites/{token}/accept")
   public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
       @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
     String acceptedByUserId = request == null ? null : request.acceptedByUserId;
     AccountInvite invite = accountInviteService.acceptInvite(token, acceptedByUserId);
-    return ResponseEntity.ok(
+    AccountInviteResponseDTO response =
         AccountInviteResponseDTO.from(
-            invite,
-            latestDeliveryStatus(invite),
-            accountInviteService.calculateAccessGate(invite)));
+            invite, latestDeliveryStatus(invite), accountInviteService.calculateAccessGate(invite));
+    response.phase =
+        invite.getTwoFactorStatus() == TwoFactorGateStatus.PENDING_SETUP
+            ? AcceptPhase.PENDING_2FA_ACTIVATION.name()
+            : AcceptPhase.COMPLETED.name();
+    return ResponseEntity.ok(response);
   }
 
   @PreAuthorize(ADMIN_AUTH)
@@ -287,6 +297,14 @@ public class AccountInviteController {
     public String acceptedByUserId;
   }
 
+  /** Onboarding phase reported by the public accept endpoint (ORISO-Admin#569 resume contract). */
+  public enum AcceptPhase {
+    /** Invite consumed, but the mandatory 2FA activation is still open — the link is resumable. */
+    PENDING_2FA_ACTIVATION,
+    /** All account gates of the invite are satisfied. */
+    COMPLETED
+  }
+
   public static class TemplateRequestDTO {
     public String kind;
     public String name;
@@ -321,6 +339,13 @@ public class AccountInviteController {
     public LocalDateTime createDate;
     public String rawToken;
     public String acceptUrl;
+
+    /**
+     * Only set by the public accept endpoint (ORISO-Admin#569 resume contract): {@code
+     * PENDING_2FA_ACTIVATION} while the mandatory 2FA activation is open (link resumable), {@code
+     * COMPLETED} once every account gate is satisfied. {@code null} on admin-facing endpoints.
+     */
+    public String phase;
 
     static AccountInviteResponseDTO from(InviteSendResult result) {
       AccountInviteResponseDTO dto =

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
 
 import de.caritas.cob.userservice.api.exception.CustomCryptoException;
 import de.caritas.cob.userservice.api.exception.NoMasterKeyException;
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.CreateEnquiryMessageException;
@@ -15,6 +16,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.customheader.Custo
 import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
 import de.caritas.cob.userservice.api.exception.keycloak.KeycloakException;
 import de.caritas.cob.userservice.api.service.LogService;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkException;
 import jakarta.validation.ConstraintViolationException;
 import java.net.UnknownHostException;
 import java.util.Map;
@@ -219,6 +221,42 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
 
   private Map<String, String> messageBody(String message) {
     return Map.of("message", Optional.ofNullable(message).orElse(HttpStatus.BAD_REQUEST.name()));
+  }
+
+  /**
+   * 502 - Bad Gateway: the SMTP server did not accept an outgoing mail (TEN-INV-U6, #890). The
+   * caller must treat this as a failed delivery — no SENT state exists.
+   *
+   * @param request the invoking request
+   * @param ex the thrown exception
+   */
+  @ExceptionHandler({SmtpSendException.class})
+  public ResponseEntity<Object> handleSmtpSendFailure(
+      final SmtpSendException ex, final WebRequest request) {
+    log.error("SMTP send failed", ex);
+
+    return handleExceptionInternal(
+        ex,
+        Map.of("reason", "SMTP_SEND_FAILED"),
+        new HttpHeaders(),
+        HttpStatus.BAD_GATEWAY,
+        request);
+  }
+
+  /**
+   * 410 - Gone: an invite link exists but is consumed, revoked, superseded or expired (TEN-INV-U6,
+   * #890). The body carries the machine-readable reason for the public frontends.
+   *
+   * @param request the invoking request
+   * @param ex the thrown exception
+   */
+  @ExceptionHandler({AccountInviteLinkException.class})
+  public ResponseEntity<Object> handleAccountInviteLinkGone(
+      final AccountInviteLinkException ex, final WebRequest request) {
+    log.warn("Account invite link rejected: {}", ex.getReason());
+
+    return handleExceptionInternal(
+        ex, reasonBody(ex.getReason().name()), new HttpHeaders(), HttpStatus.GONE, request);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
@@ -1,0 +1,20 @@
+package de.caritas.cob.userservice.api.exception;
+
+/**
+ * Signals that an email could not be handed over to the SMTP server (or that the global SMTP
+ * configuration required to do so is unavailable). Mirrors the strict contract established in
+ * ConsultingTypeService (TEN-INV-U5): callers must never report success — and never persist a SENT
+ * state — when this is thrown. Mapped to 502 Bad Gateway.
+ */
+public class SmtpSendException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SmtpSendException(String message) {
+    super(message);
+  }
+
+  public SmtpSendException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,6 +21,32 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   Optional<AccountInvite> findByTokenHash(String tokenHash);
+
+  /**
+   * Atomic single-use claim of an invite (hardening for ORISO-Admin#569): flips {@code EMAIL_SENT
+   * -> ACCEPTED} as one guarded UPDATE, so of two concurrent accepts exactly one sees an affected
+   * row — independent of whether the database honored the pessimistic lock hint on the token
+   * lookup. Also stamps the email gate: an accept via the mailed link IS the verification.
+   *
+   * @return 1 when this call claimed the invite, 0 when another transaction already changed the
+   *     status away from {@code EMAIL_SENT}
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE AccountInvite i"
+          + " SET i.status ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.ACCEPTED,"
+          + " i.acceptedAt = :now,"
+          + " i.acceptedByUserId = :acceptedByUserId,"
+          + " i.emailVerificationStatus ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus.VERIFIED,"
+          + " i.updateDate = :now"
+          + " WHERE i.id = :id AND i.status ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.EMAIL_SENT")
+  int claimForAcceptance(
+      @Param("id") Long id,
+      @Param("acceptedByUserId") String acceptedByUserId,
+      @Param("now") LocalDateTime now);
 
   boolean existsByTenantIdAndTargetRoleAndStatusIn(
       Long tenantId, AccountInviteTargetRole targetRole, Collection<AccountInviteStatus> statuses);

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
@@ -1,0 +1,36 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+/**
+ * An invite link exists but is no longer usable (TEN-INV-U6, #890). Carries a distinct,
+ * machine-readable reason so public frontends can render dedicated terminal states; mapped to 410
+ * Gone with body {@code {"reason": "<REASON>"}}. Unknown tokens stay 404.
+ */
+public class AccountInviteLinkException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Why the link cannot (or can no longer) be used. */
+  public enum Reason {
+    /** The invite was already accepted — links are strictly single-use. */
+    CONSUMED,
+    /** An admin revoked the invite. */
+    REVOKED,
+    /** The invite was replaced by a resend; only the newest link is valid. */
+    SUPERSEDED,
+    /** The invite passed its expiry date. */
+    EXPIRED,
+    /** The invite is not in a deliverable state (e.g. draft that was never sent). */
+    NOT_ACTIVE
+  }
+
+  private final Reason reason;
+
+  public AccountInviteLinkException(Reason reason) {
+    super("Account invite link is not usable: " + reason);
+    this.reason = reason;
+  }
+
+  public Reason getReason() {
+    return reason;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
@@ -11,7 +11,13 @@ public class AccountInviteLinkException extends RuntimeException {
 
   /** Why the link cannot (or can no longer) be used. */
   public enum Reason {
-    /** The invite was already accepted — links are strictly single-use. */
+    /**
+     * The invite was already accepted and is terminally consumed — links are strictly single-use.
+     * Exception (ORISO-Admin#569 resume contract): while the invite's mandatory two-factor
+     * activation is still pending and the link is not expired, the accept endpoint answers 200 with
+     * {@code phase=PENDING_2FA_ACTIVATION} instead of this reason, so an interrupted onboarding can
+     * be resumed.
+     */
     CONSUMED,
     /** An admin revoked the invite. */
     REVOKED,

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -86,12 +87,16 @@ public class AccountInviteService {
     TenantIdReservation tenantReservation = null;
     Long reservedAgencyId = null;
     if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN) {
-      tenantReservation = tenantIdAllocationClient.reserve(command.tenantId());
+      tenantReservation = reserveTenantIdOrDegrade(command);
     }
     try {
       if (command.agencyIdAllocationMode() != null) {
+        // Long.valueOf: the reservation record carries a primitive long — a bare ternary would
+        // unbox command.tenantId() and NPE on invites without a tenant ID.
         Long tenantIdForAgency =
-            tenantReservation != null ? tenantReservation.tenantId() : command.tenantId();
+            tenantReservation != null
+                ? Long.valueOf(tenantReservation.tenantId())
+                : command.tenantId();
         reservedAgencyId = agencyIdAllocationClient.reserve(command.agencyId(), tenantIdForAgency);
       }
       revalidateReservations(tenantReservation, reservedAgencyId);
@@ -101,7 +106,9 @@ public class AccountInviteService {
           AccountInvite.builder()
               .targetRole(command.targetRole())
               .tenantId(
-                  tenantReservation != null ? tenantReservation.tenantId() : command.tenantId())
+                  tenantReservation != null
+                      ? Long.valueOf(tenantReservation.tenantId())
+                      : command.tenantId())
               .tenantIdReservationToken(
                   tenantReservation != null ? tenantReservation.token() : null)
               .recipientEmail(command.recipientEmail().trim())
@@ -128,6 +135,31 @@ public class AccountInviteService {
         tenantIdAllocationClient.release(tenantReservation.tenantId());
       }
       throw exception;
+    }
+  }
+
+  /**
+   * Reserves the tenant ID with graceful degradation for the deployment-order gap (ORISO-Admin#569
+   * hardening, U3 verify finding): a TenantService that does not yet expose the TEN-INV-U1
+   * allocation endpoints answers 404. Legacy requests (no explicit allocation mode) then fall back
+   * to the pre-U3 duplicate checks — already performed by {@code isTenantIdTaken} — instead of
+   * failing with an unmapped 500. Requests that explicitly demand AUTO/MANUAL allocation cannot be
+   * honored without the authoritative ledger and fail loudly.
+   */
+  private TenantIdReservation reserveTenantIdOrDegrade(CreateAccountInviteCommand command) {
+    try {
+      return tenantIdAllocationClient.reserve(command.tenantId());
+    } catch (HttpClientErrorException.NotFound exception) {
+      if (command.tenantIdAllocationMode() == null) {
+        log.warn(
+            "TenantService does not expose the tenant-ID allocation endpoints yet (deploy"
+                + " TEN-INV-U1 before U3) — creating a legacy invite without an authoritative"
+                + " reservation");
+        return null;
+      }
+      throw new InternalServerErrorException(
+          "Tenant-ID allocation was requested but TenantService does not expose the allocation"
+              + " endpoints (deployment-order gap: deploy TEN-INV-U1 before U3)");
     }
   }
 
@@ -266,23 +298,8 @@ public class AccountInviteService {
             .orElseThrow(() -> new NotFoundException("Account invite not found"));
 
     LocalDateTime now = LocalDateTime.now();
-    // Distinct, machine-readable reasons (TEN-INV-U6, #890): terminal states win over the date
-    // check so an already consumed/revoked link is reported as such, not as merely expired.
-    switch (invite.getStatus()) {
-      case ACCEPTED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
-      case REVOKED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
-      case SUPERSEDED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
-      case EXPIRED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
-      case EMAIL_SENT -> {
-        // eligible — continue below
-      }
-        // DRAFT (or any future state) has never been delivered to the recipient; accepting it
-        // would bypass the email verification step entirely.
-      default -> throw new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT) {
+      return resolveAlreadyProcessedInvite(invite, now);
     }
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
@@ -291,12 +308,72 @@ public class AccountInviteService {
       throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
     }
 
+    // Single-use enforcement as an atomic guarded UPDATE (hardening, ORISO-Admin#569): only the
+    // transaction whose UPDATE still matches EMAIL_SENT claims the invite. This does not depend
+    // on the database honoring the pessimistic lock hint of the token lookup above.
+    int claimed = accountInviteRepository.claimForAcceptance(invite.getId(), acceptedByUserId, now);
+    if (claimed == 0) {
+      // Lost the race between our read and the claim — re-read the winner's committed state
+      // (the persistence context was cleared by the modifying query) and map it as usual.
+      AccountInvite current =
+          accountInviteRepository
+              .findById(invite.getId())
+              .orElseThrow(() -> new NotFoundException("Account invite not found"));
+      return resolveAlreadyProcessedInvite(current, now);
+    }
+
+    // Mirror exactly the columns the guarded UPDATE wrote onto the (now detached) entity so the
+    // caller sees the persisted state without an extra round trip.
     invite.setStatus(AccountInviteStatus.ACCEPTED);
     invite.setAcceptedAt(now);
     invite.setAcceptedByUserId(acceptedByUserId);
     invite.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
     invite.setUpdateDate(now);
-    return accountInviteRepository.save(invite);
+    return invite;
+  }
+
+  /**
+   * Maps every non-{@code EMAIL_SENT} state to the wire contract. Distinct, machine-readable
+   * reasons (TEN-INV-U6, #890): terminal states win over the date check so an already
+   * consumed/revoked link is reported as such, not as merely expired. Consumed invites may still be
+   * resumable — see {@link #resumeConsumedInviteOrThrow(AccountInvite, LocalDateTime)}.
+   */
+  private AccountInvite resolveAlreadyProcessedInvite(AccountInvite invite, LocalDateTime now) {
+    switch (invite.getStatus()) {
+      case ACCEPTED -> {
+        return resumeConsumedInviteOrThrow(invite, now);
+      }
+      case REVOKED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
+      case SUPERSEDED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
+      case EXPIRED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
+        // DRAFT (or any future state) has never been delivered to the recipient; accepting it
+        // would bypass the email verification step entirely.
+      default -> throw new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    }
+  }
+
+  /**
+   * RESUME CONTRACT (hardening for ORISO-Admin#569): a consumed invite whose mandatory two-factor
+   * activation is still pending ({@code twoFactorStatus == PENDING_SETUP}) stays resumable — the
+   * accept call is then idempotent: it returns the invite unchanged (HTTP 200, same response shape
+   * and data as the original accept, nothing beyond it) so the client can pick the onboarding up at
+   * the 2FA step. The resume window stays token- and expiry-bound: after {@code expiresAt} the link
+   * is terminally CONSUMED. Once the gate is satisfied (ACTIVE via {@link
+   * #markTwoFactorActive(String)}, WAIVED, NOT_REQUIRED or DISABLED_BY_POLICY) the link is
+   * terminally consumed as well. The ACCEPTED audit state (acceptor, timestamps) is never rewritten
+   * by a resume attempt.
+   */
+  private AccountInvite resumeConsumedInviteOrThrow(AccountInvite invite, LocalDateTime now) {
+    boolean twoFactorStillPending = !isTwoFactorGateSatisfied(invite.getTwoFactorStatus());
+    boolean withinExpiryWindow =
+        invite.getExpiresAt() == null || !invite.getExpiresAt().isBefore(now);
+    if (twoFactorStillPending && withinExpiryWindow) {
+      return invite;
+    }
+    throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
   }
 
   public AccountAccessGateStatus calculateAccessGate(AccountInvite invite) {
@@ -487,8 +564,15 @@ public class AccountInviteService {
         .orElseThrow(() -> new NotFoundException("Invite e-mail template not found"));
   }
 
+  /**
+   * Counsellors and tenant admins carry a mandatory TOTP setup (ORISO-Admin#569: "account,
+   * password, 2FA" is one coherent onboarding flow). Their gate starts at {@code PENDING_SETUP},
+   * which also keeps the consumed invite link resumable until the OTP credential exists — see
+   * {@link #resumeConsumedInviteOrThrow(AccountInvite, LocalDateTime)}.
+   */
   private static TwoFactorGateStatus defaultTwoFactorStatus(AccountInviteTargetRole targetRole) {
     return targetRole == AccountInviteTargetRole.COUNSELLOR
+            || targetRole == AccountInviteTargetRole.TENANT_ADMIN
         ? TwoFactorGateStatus.PENDING_SETUP
         : TwoFactorGateStatus.NOT_REQUIRED;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.service.accountinvite;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
@@ -16,17 +17,21 @@ import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocat
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
+import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
+import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +39,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountInviteService {
@@ -51,6 +57,9 @@ public class AccountInviteService {
   private final @NonNull TenantService tenantService;
   private final @NonNull TenantIdAllocationClient tenantIdAllocationClient;
   private final @NonNull AgencyIdAllocationClient agencyIdAllocationClient;
+  private final @NonNull InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+  private final @NonNull InviteMailDispatchService inviteMailDispatchService;
+  private final @NonNull InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
 
   @Transactional
   public AccountInvite createInvite(CreateAccountInviteCommand command) {
@@ -178,7 +187,9 @@ public class AccountInviteService {
   public InviteSendResult sendInvite(SendInviteCommand command) {
     AccountInvite invite = findInvite(command.inviteId());
     InviteEmailTemplate template = findTemplate(command.templateId());
-    return sendInvite(invite, template, command.acceptBaseUrl());
+    // The invite was committed by an earlier createInvite transaction, so its id is a safe
+    // audit anchor for a FAILED delivery row written in an independent transaction.
+    return sendInvite(invite, template, invite.getId());
   }
 
   @Transactional
@@ -190,14 +201,9 @@ public class AccountInviteService {
     if (oldInvite.getStatus() == AccountInviteStatus.REVOKED) {
       throw new BadRequestException("Revoked invites cannot be resent");
     }
+    InviteEmailTemplate template = findTemplate(command.templateId());
 
     LocalDateTime now = LocalDateTime.now();
-    oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
-    oldInvite.setSupersededAt(now);
-    oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
-    oldInvite.setUpdateDate(now);
-    accountInviteRepository.save(oldInvite);
-
     AccountInvite replacement =
         AccountInvite.builder()
             .targetRole(oldInvite.getTargetRole())
@@ -219,12 +225,20 @@ public class AccountInviteService {
             .createDate(now)
             .updateDate(now)
             .build();
-    replacement = accountInviteRepository.save(replacement);
-    oldInvite.setSupersededByInviteId(replacement.getId());
-    accountInviteRepository.save(oldInvite);
 
-    InviteEmailTemplate template = findTemplate(command.templateId());
-    return sendInvite(replacement, template, command.acceptBaseUrl());
+    // Transport first (TEN-INV-U6): the old invite is only superseded and the replacement only
+    // persisted after the SMTP server accepted the replacement mail. A failed handover leaves
+    // the previous invite fully intact and resendable. The FAILED audit row anchors on the old
+    // invite because the replacement does not exist outside this transaction.
+    InviteSendResult result = sendInvite(replacement, template, oldInvite.getId());
+
+    oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
+    oldInvite.setSupersededAt(now);
+    oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
+    oldInvite.setSupersededByInviteId(result.invite().getId());
+    oldInvite.setUpdateDate(now);
+    accountInviteRepository.save(oldInvite);
+    return result;
   }
 
   @Transactional
@@ -252,17 +266,29 @@ public class AccountInviteService {
             .orElseThrow(() -> new NotFoundException("Account invite not found"));
 
     LocalDateTime now = LocalDateTime.now();
+    // Distinct, machine-readable reasons (TEN-INV-U6, #890): terminal states win over the date
+    // check so an already consumed/revoked link is reported as such, not as merely expired.
+    switch (invite.getStatus()) {
+      case ACCEPTED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
+      case REVOKED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
+      case SUPERSEDED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
+      case EXPIRED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
+      case EMAIL_SENT -> {
+        // eligible — continue below
+      }
+        // DRAFT (or any future state) has never been delivered to the recipient; accepting it
+        // would bypass the email verification step entirely.
+      default -> throw new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    }
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
       invite.setUpdateDate(now);
       accountInviteRepository.save(invite);
-      throw new BadRequestException("Account invite expired");
-    }
-    // Only EMAIL_SENT invites are eligible to be accepted: DRAFT invites have never been
-    // delivered to the recipient, so allowing them to be accepted would bypass the email
-    // verification step entirely.
-    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT) {
-      throw new BadRequestException("Account invite is not active");
+      throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
     }
 
     invite.setStatus(AccountInviteStatus.ACCEPTED);
@@ -337,8 +363,19 @@ public class AccountInviteService {
     accountInviteRepository.saveAll(invites);
   }
 
+  /**
+   * Renders and delivers the invite mail, then persists the send. SENT semantics (TEN-INV-U6,
+   * #890): the EMAIL_SENT status and the SENT delivery row are written only after the SMTP server
+   * confirmed acceptance of the message — a transport failure propagates as {@link
+   * SmtpSendException} (502), rolls back every pending state change and leaves at most a FAILED
+   * audit row behind.
+   *
+   * @param failureAuditInviteId id of an already-committed invite the FAILED audit row may
+   *     reference; for resends this is the old invite because the replacement only exists inside
+   *     the still-open transaction.
+   */
   private InviteSendResult sendInvite(
-      AccountInvite invite, InviteEmailTemplate template, String acceptBaseUrl) {
+      AccountInvite invite, InviteEmailTemplate template, Long failureAuditInviteId) {
     if (invite.getStatus() == AccountInviteStatus.ACCEPTED) {
       throw new BadRequestException("Accepted invites cannot be sent");
     }
@@ -349,7 +386,20 @@ public class AccountInviteService {
 
     LocalDateTime now = LocalDateTime.now();
     String rawToken = generateToken();
-    String acceptUrl = buildAcceptUrl(acceptBaseUrl, rawToken);
+    // The link target is decided server-side from the invite's role — tenant admins onboard on
+    // the public Admin route, everyone else accepts on the public App route.
+    String acceptUrl = inviteAcceptUrlBuilder.buildAcceptUrl(invite.getTargetRole(), rawToken);
+    String subject = render(template.getSubject(), invite, acceptUrl);
+    String body = render(template.getBody(), invite, acceptUrl);
+
+    InviteMailSendReceipt receipt;
+    try {
+      receipt = inviteMailDispatchService.send(invite.getRecipientEmail(), subject, body);
+    } catch (SmtpSendException exception) {
+      recordDeliveryFailureSafely(failureAuditInviteId, template, invite, subject, body, exception);
+      throw exception;
+    }
+
     invite.setTokenHash(hash(rawToken));
     if (invite.getExpiresAt() == null || invite.getExpiresAt().isBefore(now)) {
       invite.setExpiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS));
@@ -364,14 +414,40 @@ public class AccountInviteService {
             .templateId(template.getId())
             .templateKind(template.getKind())
             .recipientSnapshot(invite.getRecipientEmail())
-            .subjectSnapshot(render(template.getSubject(), invite, acceptUrl))
-            .bodySnapshot(render(template.getBody(), invite, acceptUrl))
+            .subjectSnapshot(subject)
+            .bodySnapshot(body)
             .status(InviteEmailDeliveryStatus.SENT)
-            .sentAt(now)
+            .sentAt(LocalDateTime.ofInstant(receipt.sentAt(), ZoneId.systemDefault()))
             .createDate(now)
             .build();
     delivery = deliveryRepository.save(delivery);
     return new InviteSendResult(invite, delivery, rawToken, acceptUrl);
+  }
+
+  /** Best-effort FAILED audit row in an independent transaction; never masks the send failure. */
+  private void recordDeliveryFailureSafely(
+      Long failureAuditInviteId,
+      InviteEmailTemplate template,
+      AccountInvite invite,
+      String subject,
+      String body,
+      SmtpSendException exception) {
+    if (failureAuditInviteId == null) {
+      return;
+    }
+    try {
+      deliveryFailureRecorder.recordFailure(
+          failureAuditInviteId,
+          template,
+          invite.getRecipientEmail(),
+          subject,
+          body,
+          exception.getMessage());
+    } catch (RuntimeException auditFailure) {
+      log.warn(
+          "Could not persist FAILED invite delivery audit row ({})",
+          auditFailure.getClass().getSimpleName());
+    }
   }
 
   private boolean isTenantIdTaken(Long tenantId) {
@@ -462,14 +538,6 @@ public class AccountInviteService {
     return rendered;
   }
 
-  private static String buildAcceptUrl(String acceptBaseUrl, String rawToken) {
-    String base = isBlank(acceptBaseUrl) ? "/account-invite" : acceptBaseUrl.trim();
-    while (base.endsWith("/")) {
-      base = base.substring(0, base.length() - 1);
-    }
-    return base + "/" + rawToken;
-  }
-
   public static String hash(String rawToken) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
@@ -533,7 +601,11 @@ public class AccountInviteService {
     }
   }
 
-  public record SendInviteCommand(Long inviteId, Long templateId, String acceptBaseUrl) {}
+  /**
+   * The accept link's base URL is server configuration, never caller input (TEN-INV-U6) — the
+   * former {@code acceptBaseUrl} member is gone on purpose.
+   */
+  public record SendInviteCommand(Long inviteId, Long templateId) {}
 
   public record InviteSendResult(
       AccountInvite invite, InviteEmailDelivery delivery, String rawToken, String acceptUrl) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteAcceptUrlBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteAcceptUrlBuilder.java
@@ -1,0 +1,56 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds the accept URL embedded in invite mails. The target layer is decided server-side from the
+ * invite's role and configuration — never by the calling client (TEN-INV-U6, #890):
+ *
+ * <ul>
+ *   <li>{@code TENANT_ADMIN} → the PUBLIC ADMIN onboarding route. The tenant is an organisation,
+ *       not an app user — the login belongs to the tenant admin and the flow completes on the Admin
+ *       panel's public page ({@code /admin/tenant-onboarding/{token}}, Admin U8, #571).
+ *   <li>all other roles (counsellors, advice seekers, …) → the public App accept route ({@code
+ *       /account-invite/{token}}).
+ * </ul>
+ */
+@Component
+public class InviteAcceptUrlBuilder {
+
+  /** Public Admin route serving the tenant-admin onboarding flow (ORISO-Admin U8, #571). */
+  static final String ADMIN_TENANT_ONBOARDING_PATH = "/admin/tenant-onboarding";
+
+  /** Public App route accepting non-admin invites. */
+  static final String APP_ACCEPT_PATH = "/account-invite";
+
+  private final String appFrontendBaseUrl;
+  private final String adminFrontendBaseUrl;
+
+  public InviteAcceptUrlBuilder(
+      @Value("${account.invite.app.frontend.base-url:https://app.oriso.org}")
+          String appFrontendBaseUrl,
+      @Value("${account.invite.admin.frontend.base-url:https://app.oriso.org}")
+          String adminFrontendBaseUrl) {
+    this.appFrontendBaseUrl = normalize(appFrontendBaseUrl, "https://app.oriso.org");
+    this.adminFrontendBaseUrl = normalize(adminFrontendBaseUrl, "https://app.oriso.org");
+  }
+
+  /** Builds the absolute accept URL for the given role's public frontend route. */
+  public String buildAcceptUrl(AccountInviteTargetRole targetRole, String rawToken) {
+    if (targetRole == AccountInviteTargetRole.TENANT_ADMIN) {
+      return adminFrontendBaseUrl + ADMIN_TENANT_ONBOARDING_PATH + "/" + rawToken;
+    }
+    return appFrontendBaseUrl + APP_ACCEPT_PATH + "/" + rawToken;
+  }
+
+  private static String normalize(String baseUrl, String fallback) {
+    String base = isBlank(baseUrl) ? fallback : baseUrl.trim();
+    while (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    return base;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailDeliveryFailureRecorder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailDeliveryFailureRecorder.java
@@ -1,0 +1,57 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists FAILED delivery audit rows in an independent transaction so they survive the rollback
+ * that a failed SMTP handover triggers in the surrounding send transaction (TEN-INV-U6, #890).
+ * Callers treat this as best-effort — auditing must never mask the original send failure.
+ */
+@Service
+@RequiredArgsConstructor
+public class InviteEmailDeliveryFailureRecorder {
+
+  private static final int MAX_FAILURE_REASON_LENGTH = 1024;
+
+  private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void recordFailure(
+      Long accountInviteId,
+      InviteEmailTemplate template,
+      String recipient,
+      String subject,
+      String body,
+      String failureReason) {
+    LocalDateTime now = LocalDateTime.now();
+    deliveryRepository.save(
+        InviteEmailDelivery.builder()
+            .accountInviteId(accountInviteId)
+            .templateId(template.getId())
+            .templateKind(template.getKind())
+            .recipientSnapshot(recipient)
+            .subjectSnapshot(subject == null ? "" : subject)
+            .bodySnapshot(body == null ? "" : body)
+            .status(InviteEmailDeliveryStatus.FAILED)
+            .failureReason(truncate(failureReason))
+            .createDate(now)
+            .build());
+  }
+
+  private static String truncate(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.length() <= MAX_FAILURE_REASON_LENGTH
+        ? value
+        : value.substring(0, MAX_FAILURE_REASON_LENGTH);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
@@ -1,0 +1,169 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
+import java.util.Map;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Sends account-invite mails via the platform's global SMTP settings with a strict
+ * receipt-after-send contract (TEN-INV-U6, #890): either the SMTP server accepted the message and
+ * an {@link InviteMailSendReceipt} is returned, or an {@link SmtpSendException} propagates. There
+ * is no silent-failure path — a caller that does not receive a receipt must never persist SENT.
+ *
+ * <p>Settings resolution mirrors {@link
+ * de.caritas.cob.userservice.api.service.auth.PasswordResetService}: connection settings come from
+ * the public ConsultingTypeService {@code /settings} payload (which deliberately omits credentials
+ * since CTS-C01), the credentials from the operator-provided {@code smtp.user}/{@code
+ * smtp.password} properties, falling back to the super-admin-guarded credentials endpoint when the
+ * request context allows it.
+ */
+@Slf4j
+@Service
+public class InviteMailDispatchService {
+
+  private final @NonNull RestTemplate restTemplate;
+  private final @NonNull ApplicationSettingsService applicationSettingsService;
+  private final @NonNull InviteMailTransport inviteMailTransport;
+  private final String consultingTypeServiceApiUrl;
+  private final String configuredSmtpUsername;
+  private final String configuredSmtpPassword;
+
+  public InviteMailDispatchService(
+      @NonNull RestTemplate restTemplate,
+      @NonNull ApplicationSettingsService applicationSettingsService,
+      @NonNull InviteMailTransport inviteMailTransport,
+      @Value("${consulting.type.service.api.url:}") String consultingTypeServiceApiUrl,
+      @Value("${smtp.user:}") String configuredSmtpUsername,
+      @Value("${smtp.password:}") String configuredSmtpPassword) {
+    this.restTemplate = restTemplate;
+    this.applicationSettingsService = applicationSettingsService;
+    this.inviteMailTransport = inviteMailTransport;
+    this.consultingTypeServiceApiUrl = consultingTypeServiceApiUrl;
+    this.configuredSmtpUsername = configuredSmtpUsername;
+    this.configuredSmtpPassword = configuredSmtpPassword;
+  }
+
+  /**
+   * Sends the given invite mail.
+   *
+   * @return a receipt confirming the SMTP server accepted the message
+   * @throws SmtpSendException if the global SMTP settings are unavailable/incomplete or the message
+   *     could not be handed over to the SMTP server
+   */
+  public InviteMailSendReceipt send(String recipient, String subject, String htmlBody) {
+    InviteSmtpSettings settings =
+        resolveGlobalSmtpSettings()
+            .orElseThrow(
+                () ->
+                    new SmtpSendException(
+                        "Global SMTP settings are unavailable or incomplete — invite mail not"
+                            + " sent"));
+    return inviteMailTransport.send(settings, recipient, subject, htmlBody);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Optional<InviteSmtpSettings> resolveGlobalSmtpSettings() {
+    if (isBlank(consultingTypeServiceApiUrl)) {
+      log.warn("Invite mail dispatch: 'consulting.type.service.api.url' is not configured");
+      return Optional.empty();
+    }
+    try {
+      String settingsUrl = normalizeBaseUrl(consultingTypeServiceApiUrl) + "/settings";
+      Map<String, Object> settingsResponse = restTemplate.getForObject(settingsUrl, Map.class);
+      if (settingsResponse == null || settingsResponse.isEmpty()) {
+        return Optional.empty();
+      }
+
+      boolean systemEmailsEnabled =
+          asBooleanSettingValue(
+              settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
+      boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
+      String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
+      Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
+      boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
+      String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
+
+      if (!systemEmailsEnabled || !smtpEnabled || isBlank(host) || port == null || isBlank(from)) {
+        log.warn("Invite mail dispatch: global SMTP settings are incomplete or disabled");
+        return Optional.empty();
+      }
+
+      // The public /settings payload deliberately omits the SMTP username and password since the
+      // CTS-C01 credential-leak fix, so they can never be read from there.
+      String username = configuredSmtpUsername;
+      String password = configuredSmtpPassword;
+      if (isBlank(username) || isBlank(password)) {
+        var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+        if (credentials.isEmpty()) {
+          log.warn(
+              "Invite mail not sent: no SMTP credentials available. Set SMTP_USER and"
+                  + " SMTP_PASSWORD on UserService or send with a super-admin token.");
+          return Optional.empty();
+        }
+        username = credentials.get().getGlobalSmtpUsername();
+        password = credentials.get().getGlobalSmtpPassword();
+      }
+
+      return Optional.of(new InviteSmtpSettings(host, port, secure, username, password, from));
+    } catch (Exception exception) {
+      log.warn(
+          "Invite mail dispatch: could not resolve global SMTP settings ({})",
+          exception.getClass().getSimpleName());
+      return Optional.empty();
+    }
+  }
+
+  private boolean asBooleanSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    if (value instanceof Boolean bool) {
+      return bool;
+    }
+    if (value instanceof String string) {
+      return "true".equalsIgnoreCase(string);
+    }
+    return false;
+  }
+
+  private String asStringSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    return nonNull(value) ? String.valueOf(value).trim() : null;
+  }
+
+  private Integer asIntSettingValue(Object raw) {
+    Object value = unwrapSettingValue(raw);
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    if (value instanceof String string && isNotBlank(string)) {
+      try {
+        return Integer.parseInt(string.trim());
+      } catch (NumberFormatException exception) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object unwrapSettingValue(Object raw) {
+    if (raw instanceof Map<?, ?> map) {
+      return ((Map<String, Object>) map).get("value");
+    }
+    return raw;
+  }
+
+  private static String normalizeBaseUrl(String value) {
+    String trimmed = value.trim();
+    return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailSendReceipt.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailSendReceipt.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import java.time.Instant;
+
+/**
+ * Confirmation that the SMTP server accepted an invite mail. Returned only after the transport
+ * completed without error, so callers may safely persist the delivery as SENT (TEN-INV-U6, mirrors
+ * ConsultingTypeService's DpaMailSendReceipt).
+ */
+public record InviteMailSendReceipt(String recipientEmail, Instant sentAt) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailTransport.java
@@ -1,0 +1,21 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
+
+/**
+ * Strict SMTP send contract for account-invite mails: implementations either return an {@link
+ * InviteMailSendReceipt} after the SMTP server accepted the message, or throw {@link
+ * SmtpSendException}. Silent success is not allowed (TEN-INV-U6, mirrors the ConsultingTypeService
+ * DpaMailTransport contract from U5).
+ */
+public interface InviteMailTransport {
+
+  /**
+   * Sends the given message via the provided SMTP settings.
+   *
+   * @return a receipt confirming the SMTP server accepted the message
+   * @throws SmtpSendException if the message could not be handed over to the SMTP server
+   */
+  InviteMailSendReceipt send(
+      InviteSmtpSettings settings, String recipient, String subject, String htmlBody);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteSmtpSettings.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteSmtpSettings.java
@@ -1,0 +1,5 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+/** Resolved global SMTP connection settings used to deliver account-invite mails. */
+public record InviteSmtpSettings(
+    String host, int port, boolean secure, String username, String password, String from) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
@@ -1,0 +1,59 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import jakarta.mail.Authenticator;
+import jakarta.mail.Message;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Instant;
+import java.util.Properties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Delivers invite mails synchronously via jakarta.mail. The receipt is created only after {@link
+ * Transport#send(Message)} returned, i.e. after the SMTP server accepted the message.
+ */
+@Component
+public class JakartaInviteMailTransport implements InviteMailTransport {
+
+  @Override
+  public InviteMailSendReceipt send(
+      InviteSmtpSettings settings, String recipient, String subject, String htmlBody) {
+    try {
+      Properties properties = new Properties();
+      properties.put("mail.smtp.auth", "true");
+      properties.put("mail.smtp.host", settings.host());
+      properties.put("mail.smtp.port", String.valueOf(settings.port()));
+      properties.put("mail.smtp.connectiontimeout", "10000");
+      properties.put("mail.smtp.timeout", "10000");
+      properties.put("mail.smtp.writetimeout", "10000");
+      if (settings.secure()) {
+        properties.put("mail.smtp.ssl.enable", "true");
+      } else {
+        properties.put("mail.smtp.starttls.enable", "true");
+      }
+
+      Session session =
+          Session.getInstance(
+              properties,
+              new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                  return new PasswordAuthentication(settings.username(), settings.password());
+                }
+              });
+      Message message = new MimeMessage(session);
+      message.setFrom(new InternetAddress(settings.from()));
+      message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(recipient, true));
+      message.setSubject(subject);
+      message.setContent(htmlBody, "text/html; charset=UTF-8");
+      Transport.send(message);
+      return new InviteMailSendReceipt(recipient, Instant.now());
+    } catch (Exception exception) {
+      throw new SmtpSendException("Account invite email could not be sent", exception);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
@@ -23,22 +23,9 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
   public InviteMailSendReceipt send(
       InviteSmtpSettings settings, String recipient, String subject, String htmlBody) {
     try {
-      Properties properties = new Properties();
-      properties.put("mail.smtp.auth", "true");
-      properties.put("mail.smtp.host", settings.host());
-      properties.put("mail.smtp.port", String.valueOf(settings.port()));
-      properties.put("mail.smtp.connectiontimeout", "10000");
-      properties.put("mail.smtp.timeout", "10000");
-      properties.put("mail.smtp.writetimeout", "10000");
-      if (settings.secure()) {
-        properties.put("mail.smtp.ssl.enable", "true");
-      } else {
-        properties.put("mail.smtp.starttls.enable", "true");
-      }
-
       Session session =
           Session.getInstance(
-              properties,
+              buildSessionProperties(settings),
               new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
@@ -55,5 +42,30 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
     } catch (Exception exception) {
       throw new SmtpSendException("Account invite email could not be sent", exception);
     }
+  }
+
+  /**
+   * Builds the jakarta.mail session properties for the configured security mode. Hardening
+   * (ORISO-Admin#569 follow-up): in STARTTLS mode ({@code secure() == false}) the upgrade is
+   * mandatory — {@code mail.smtp.starttls.required} refuses servers (or men-in-the-middle) that do
+   * not offer STARTTLS instead of silently sending credentials in plaintext. In both modes the
+   * server certificate must match the configured host ({@code mail.smtp.ssl.checkserveridentity}).
+   */
+  static Properties buildSessionProperties(InviteSmtpSettings settings) {
+    Properties properties = new Properties();
+    properties.put("mail.smtp.auth", "true");
+    properties.put("mail.smtp.host", settings.host());
+    properties.put("mail.smtp.port", String.valueOf(settings.port()));
+    properties.put("mail.smtp.connectiontimeout", "10000");
+    properties.put("mail.smtp.timeout", "10000");
+    properties.put("mail.smtp.writetimeout", "10000");
+    properties.put("mail.smtp.ssl.checkserveridentity", "true");
+    if (settings.secure()) {
+      properties.put("mail.smtp.ssl.enable", "true");
+    } else {
+      properties.put("mail.smtp.starttls.enable", "true");
+      properties.put("mail.smtp.starttls.required", "true");
+    }
+    return properties;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,13 @@ dpa.sign.frontend.base-url=${DPA_SIGN_FRONTEND_BASE_URL:https://app.oriso.org}
 # Self-service password reset link base URL. No default on purpose: when unset the feature is
 # disabled (fail closed) rather than emailing a hardcoded production URL. Set per environment.
 password.reset.frontend.base-url=${PASSWORD_RESET_FRONTEND_BASE_URL:}
+# Account-invite accept link targets (TEN-INV-U6, #890). The role decides the layer server-side:
+# tenant-admin invites onboard on the PUBLIC ADMIN route (<admin-base>/admin/tenant-onboarding/
+# {token}), all other invites accept on the public App route (<app-base>/account-invite/{token}).
+# The Admin panel is served under /admin on the App origin by default; override per environment
+# when it lives on a dedicated host.
+account.invite.app.frontend.base-url=${ACCOUNT_INVITE_APP_FRONTEND_BASE_URL:${system.notification.frontend.base-url}}
+account.invite.admin.frontend.base-url=${ACCOUNT_INVITE_ADMIN_FRONTEND_BASE_URL:${system.notification.frontend.base-url}}
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import java.util.Map;

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -100,4 +100,13 @@ class IdentityManagerTest {
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
   }
+
+  @Test
+  void isUsernameAvailableShouldDelegateToIdentityClient() {
+    when(identityClient.isUsernameAvailable(RAW_USERNAME)).thenReturn(true);
+
+    assertThat(identityManager.isUsernameAvailable(RAW_USERNAME)).isTrue();
+
+    verify(identityClient).isUsernameAvailable(RAW_USERNAME);
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetR
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
@@ -181,6 +182,29 @@ class AccountInviteControllerTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     verify(accountInviteService).acceptInvite("token-1", "user-1");
+    // No pending mandatory 2FA on this invite: the onboarding phase is terminal.
+    assertNotNull(response.getBody());
+    assertEquals("COMPLETED", response.getBody().phase);
+  }
+
+  @Test
+  void acceptInvite_pendingTwoFactor_reportsResumablePhase() {
+    // Resume contract (ORISO-Admin#569): while the mandatory 2FA activation is open, the accept
+    // response tells the client to continue at the 2FA step instead of a terminal state.
+    var invite = sampleInvite();
+    invite.setStatus(AccountInviteStatus.ACCEPTED);
+    invite.setTwoFactorStatus(TwoFactorGateStatus.PENDING_SETUP);
+    when(accountInviteService.acceptInvite("token-3", null)).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_TWO_FACTOR);
+
+    var response = controller.acceptInvite("token-3", null);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("PENDING_2FA_ACTIVATION", response.getBody().phase);
+    assertEquals(
+        AccountAccessGateStatus.BLOCKED_TWO_FACTOR.name(), response.getBody().accessGateStatus);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -59,6 +59,31 @@ class ApiResponseEntityExceptionHandlerTest {
   }
 
   @Test
+  void handleSmtpSendFailure_returnsBadGatewayWithMachineReadableReason() {
+    // TEN-INV-U6 (#890): a failed SMTP handover must never look like success to any client.
+    var ex = new de.caritas.cob.userservice.api.exception.SmtpSendException("handover failed");
+    var response = handler.handleSmtpSendFailure(ex, request);
+
+    assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("SMTP_SEND_FAILED", body.get("reason"));
+  }
+
+  @Test
+  void handleAccountInviteLinkGone_returnsGoneWithDistinctReason() {
+    // TEN-INV-U6 (#890): consumed/revoked/expired links surface a distinct machine-readable code.
+    var ex =
+        new de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkException(
+            de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkException.Reason
+                .CONSUMED);
+    var response = handler.handleAccountInviteLinkGone(ex, request);
+
+    assertEquals(HttpStatus.GONE, response.getStatusCode());
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("CONSUMED", body.get("reason"));
+  }
+
+  @Test
   void handleJPAConstraintViolationException_usernameConflict_returnsConflictReason() {
     // Business reason: duplicate usernames must return machine-readable conflict reasons.
     var ex = new ConstraintViolationException("duplicate username", null, null);

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
@@ -1,0 +1,184 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Hardening for bug ORISO-Admin#569: the accept link is strictly single-use — two concurrent
+ * accepts of the same token must never both claim the invite. The claim itself is a guarded UPDATE
+ * ({@code ... WHERE status = EMAIL_SENT}), so the guarantee holds even if the database does not
+ * honor the pessimistic lock hint on the token lookup.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(AccountInviteService.class)
+class AccountInviteAcceptRaceIT {
+
+  private static final String RAW_TOKEN = "race-raw-token";
+
+  @Autowired private AccountInviteService service;
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private TenantService tenantService;
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+  @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+
+  @MockitoBean
+  private de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService
+      inviteMailDispatchService;
+
+  @MockitoBean private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+
+  @AfterEach
+  void cleanUp() {
+    accountInviteRepository.deleteAll();
+  }
+
+  @Test
+  void concurrentAccepts_Should_LetExactlyOneClaimTheInvite_When_TwoFactorGateSatisfied()
+      throws Exception {
+    AccountInvite invite =
+        persistedEmailSentInvite(
+            AccountInviteTargetRole.PLATFORM_ADMIN, TwoFactorGateStatus.NOT_REQUIRED);
+
+    List<Object> outcomes =
+        runConcurrently(
+            () -> service.acceptInvite(RAW_TOKEN, "user-a"),
+            () -> service.acceptInvite(RAW_TOKEN, "user-b"));
+
+    List<AccountInvite> successes =
+        outcomes.stream()
+            .filter(AccountInvite.class::isInstance)
+            .map(AccountInvite.class::cast)
+            .toList();
+    List<AccountInviteLinkException> rejections =
+        outcomes.stream()
+            .filter(AccountInviteLinkException.class::isInstance)
+            .map(AccountInviteLinkException.class::cast)
+            .toList();
+
+    // Exactly one caller wins the single-use claim; the loser gets the distinct CONSUMED error.
+    assertThat(successes).hasSize(1);
+    assertThat(rejections).hasSize(1);
+    assertThat(rejections.get(0).getReason()).isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+
+    AccountInvite persisted = accountInviteRepository.findById(invite.getId()).orElseThrow();
+    assertThat(persisted.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    // The persisted claim belongs to the winner — no lost update, no mixed state.
+    assertThat(persisted.getAcceptedByUserId())
+        .isEqualTo(successes.get(0).getAcceptedByUserId())
+        .isIn("user-a", "user-b");
+    assertThat(persisted.getAcceptedAt()).isNotNull();
+    assertThat(persisted.getEmailVerificationStatus()).isEqualTo(EmailVerificationStatus.VERIFIED);
+  }
+
+  @Test
+  void concurrentAccepts_Should_PersistExactlyOneClaim_When_ResumeContractApplies()
+      throws Exception {
+    // Tenant-admin invites stay resumable while 2FA is pending (ORISO-Admin#569 resume
+    // contract): the racer that loses the claim receives the winner's committed state as an
+    // idempotent resume instead of an error — but the claim itself must still happen once.
+    AccountInvite invite =
+        persistedEmailSentInvite(
+            AccountInviteTargetRole.TENANT_ADMIN, TwoFactorGateStatus.PENDING_SETUP);
+
+    List<Object> outcomes =
+        runConcurrently(
+            () -> service.acceptInvite(RAW_TOKEN, "owner-a"),
+            () -> service.acceptInvite(RAW_TOKEN, "owner-b"));
+
+    List<AccountInvite> successes =
+        outcomes.stream()
+            .filter(AccountInvite.class::isInstance)
+            .map(AccountInvite.class::cast)
+            .toList();
+    assertThat(successes).hasSize(2);
+
+    AccountInvite persisted = accountInviteRepository.findById(invite.getId()).orElseThrow();
+    assertThat(persisted.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    // No lost update: exactly one contender's claim is persisted, and the resumed response of
+    // the loser mirrors that same committed state.
+    assertThat(persisted.getAcceptedByUserId()).isIn("owner-a", "owner-b");
+    assertThat(successes)
+        .extracting(AccountInvite::getAcceptedByUserId)
+        .containsOnly(persisted.getAcceptedByUserId());
+    assertThat(persisted.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+  }
+
+  private AccountInvite persistedEmailSentInvite(
+      AccountInviteTargetRole targetRole, TwoFactorGateStatus twoFactorStatus) {
+    LocalDateTime now = LocalDateTime.now();
+    return accountInviteRepository.save(
+        AccountInvite.builder()
+            .targetRole(targetRole)
+            .recipientEmail("race@example.org")
+            .tokenHash(AccountInviteService.hash(RAW_TOKEN))
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .emailVerificationStatus(EmailVerificationStatus.PENDING)
+            .twoFactorStatus(twoFactorStatus)
+            .expiresAt(now.plusDays(30))
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  /** Starts both calls on a shared latch and collects results and exceptions alike. */
+  private List<Object> runConcurrently(
+      Callable<AccountInvite> first, Callable<AccountInvite> second) throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    try {
+      List<Future<Object>> futures = new ArrayList<>();
+      for (Callable<AccountInvite> call : List.of(first, second)) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startLatch.await(5, TimeUnit.SECONDS);
+                  try {
+                    return (Object) call.call();
+                  } catch (Exception exception) {
+                    return exception;
+                  }
+                }));
+      }
+      startLatch.countDown();
+      List<Object> outcomes = new ArrayList<>();
+      for (Future<Object> future : futures) {
+        outcomes.add(future.get(30, TimeUnit.SECONDS));
+      }
+      return outcomes;
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -64,6 +64,15 @@ class AccountInviteReservationOrchestrationIT {
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
 
+  // TEN-INV-U6 collaborators of the send path — not exercised by these creation-focused tests.
+  @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+
+  @MockitoBean
+  private de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService
+      inviteMailDispatchService;
+
+  @MockitoBean private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+
   /** In-memory stand-in for the TenantService reservation ledger (U1). */
   private final Set<Long> tenantIdLedger = ConcurrentHashMap.newKeySet();
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -406,7 +407,31 @@ class AccountInviteServiceTest {
   }
 
   @Test
-  void createInvite_Should_defaultTwoFactorNotRequired_When_targetRoleNotCounsellor() {
+  void createInvite_Should_defaultTwoFactorNotRequired_When_targetRoleWithoutMandatory2fa() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.PLATFORM_ADMIN,
+                null,
+                "new@example.org",
+                null,
+                null,
+                null,
+                null,
+                null));
+
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.NOT_REQUIRED);
+    assertThat(invite.getFirstName()).isNull();
+  }
+
+  @Test
+  void createInvite_Should_defaultTwoFactorPendingSetup_When_targetRoleTenantAdmin() {
+    // Tenant-admin TOTP is mandatory (#569): the gate starts open and the invite stays
+    // resumable until markTwoFactorActive() flips it to ACTIVE.
     when(authenticatedUser.getUserId()).thenReturn("admin-1");
     when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -423,8 +448,7 @@ class AccountInviteServiceTest {
                 null,
                 null));
 
-    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.NOT_REQUIRED);
-    assertThat(invite.getFirstName()).isNull();
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
   }
 
   @Test
@@ -607,13 +631,156 @@ class AccountInviteServiceTest {
             .expiresAt(LocalDateTime.now().plusDays(1))
             .build();
     when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
-    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(accountInviteRepository.claimForAcceptance(eq(1L), eq("user-1"), any())).thenReturn(1);
 
     AccountInvite result = service.acceptInvite("raw-token", "user-1");
 
     assertThat(result.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
     assertThat(result.getAcceptedByUserId()).isEqualTo("user-1");
     assertThat(result.getEmailVerificationStatus()).isEqualTo(EmailVerificationStatus.VERIFIED);
+    assertThat(result.getAcceptedAt()).isNotNull();
+    // The claim is the single write — no additional save() that could race.
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_resolveAuthoritativeState_When_singleUseClaimIsLostToRacer() {
+    // Both callers read EMAIL_SENT, but the guarded UPDATE flips the row exactly once — the
+    // loser must re-read the winner's committed state and map it like any consumed link.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .expiresAt(LocalDateTime.now().plusDays(1))
+            .build();
+    AccountInvite claimedByWinner =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("winner")
+            .twoFactorStatus(TwoFactorGateStatus.NOT_REQUIRED)
+            .expiresAt(invite.getExpiresAt())
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(1L), eq("loser"), any())).thenReturn(0);
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(claimedByWinner));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", "loser"))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+  }
+
+  // --- resume contract (#569 hardening): consumed but 2FA still pending ---
+
+  @Test
+  void acceptInvite_Should_returnInviteForResume_When_consumedButTwoFactorPendingAndNotExpired() {
+    // A tenant admin who registered but closed the browser before activating mandatory TOTP
+    // must be able to reopen the link instead of hitting a terminal 410 CONSUMED.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .acceptedAt(LocalDateTime.now().minusHours(2))
+            .emailVerificationStatus(EmailVerificationStatus.VERIFIED)
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    AccountInvite result = service.acceptInvite("raw-token", "someone-else");
+
+    // Idempotent: same invite, no state change, the original acceptor is untouched.
+    assertThat(result).isSameAs(invite);
+    assertThat(result.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    assertThat(result.getAcceptedByUserId()).isEqualTo("owner-1");
+    assertThat(result.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+    verify(accountInviteRepository, never()).save(any());
+    verify(accountInviteRepository, never()).claimForAcceptance(any(), any(), any());
+  }
+
+  @Test
+  void acceptInvite_Should_stayIdempotent_When_resumedRepeatedly() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    AccountInvite first = service.acceptInvite("raw-token", null);
+    AccountInvite second = service.acceptInvite("raw-token", null);
+
+    assertThat(first).isSameAs(second);
+    assertThat(second.getAcceptedByUserId()).isEqualTo("owner-1");
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorPendingButExpired() {
+    // The resume window stays expiry-bound: after expiresAt the consumed link is terminal.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().minusMinutes(5))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+    // The ACCEPTED audit state must never be rewritten by the resume expiry check.
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorActive() {
+    // Once 2FA is activated the link is terminally consumed — resume closes for good.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .twoFactorStatus(TwoFactorGateStatus.ACTIVE)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorWaived() {
+    // A waiver satisfies the gate exactly like an activation: nothing is left to resume.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .twoFactorStatus(TwoFactorGateStatus.WAIVED)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
   }
 
   @Test
@@ -1147,6 +1314,64 @@ class AccountInviteServiceTest {
             AccountInviteTargetRole.TENANT_ADMIN,
             List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
         .thenReturn(false);
+  }
+
+  @Test
+  void createInvite_Should_FallBackToLegacyChecks_When_AllocationEndpointsMissingAndNoMode() {
+    // Deployment-order gap (#569, U3 verify): a TenantService without the U1 endpoints answers
+    // 404. Legacy requests (no allocation mode) must degrade to the pre-U3 duplicate checks
+    // instead of failing with an unmapped 500.
+    givenAdminAndPassthroughSave();
+    givenTenantIdFreeLocally(7L);
+    when(tenantIdAllocationClient.reserve(7L))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.TENANT_ADMIN,
+                7L,
+                "owner@example.org",
+                "New",
+                "Owner",
+                null,
+                null,
+                30L));
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getTenantId()).isEqualTo(7L);
+    assertThat(invite.getTenantIdReservationToken()).isNull();
+    // No reservation exists, so no availability re-validation and no release compensation.
+    verify(tenantIdAllocationClient, never()).getAvailability(anyLong());
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void createInvite_Should_FailLoudly_When_AllocationEndpointsMissingButModeExplicit() {
+    // An explicit AUTO/MANUAL allocation request cannot be honored without the U1 endpoints —
+    // pretending a reservation would reintroduce the collision risk the epic closes.
+    when(tenantIdAllocationClient.reserve(null))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            null,
+            "owner@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L,
+            IdAllocationMode.AUTO,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("TEN-INV-U1");
+    verify(accountInviteRepository, never()).save(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
@@ -30,7 +31,10 @@ import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocat
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
+import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
+import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -55,8 +59,23 @@ class AccountInviteServiceTest {
   @Mock private TenantService tenantService;
   @Mock private TenantIdAllocationClient tenantIdAllocationClient;
   @Mock private AgencyIdAllocationClient agencyIdAllocationClient;
+  @Mock private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+  @Mock private InviteMailDispatchService inviteMailDispatchService;
+  @Mock private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
 
   @InjectMocks private AccountInviteService service;
+
+  /** Stubs the strict-send collaborators for tests exercising a successful delivery. */
+  private void givenSuccessfulDispatch() {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenAnswer(
+            invocation -> "https://app.oriso.org/account-invite/" + invocation.getArgument(1));
+    when(inviteMailDispatchService.send(any(), any(), any()))
+        .thenAnswer(
+            invocation ->
+                new InviteMailSendReceipt(
+                    invocation.getArgument(0), Instant.parse("2026-07-28T10:15:30Z")));
+  }
 
   @Test
   void sendInvite_Should_SetEmailSentAndPersistSnapshot_When_TemplateExists() {
@@ -81,9 +100,9 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
 
-    var result =
-        service.sendInvite(new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+    var result = service.sendInvite(new SendInviteCommand(10L, 20L));
 
     assertThat(result.invite().getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
     assertThat(result.rawToken()).isNotBlank();
@@ -120,16 +139,164 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
 
-    var result =
-        service.resendInvite(
-            new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+    var result = service.resendInvite(new SendInviteCommand(10L, 20L));
 
     assertThat(oldInvite.getStatus()).isEqualTo(AccountInviteStatus.SUPERSEDED);
     assertThat(result.invite()).isNotSameAs(oldInvite);
     assertThat(result.invite().getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
     assertThat(result.invite().getSupersededByInviteId()).isNull();
     assertThat(result.invite().getRecipientEmail()).isEqualTo(oldInvite.getRecipientEmail());
+  }
+
+  // --- TEN-INV-U6 (#890): SENT only after the transport confirmed the handover ---
+
+  @Test
+  void sendInvite_Should_NotPersistSentState_When_TransportFails() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.TENANT_INVITE)
+            .subject("s")
+            .body("{{inviteLink}}")
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://app.oriso.org/admin/tenant-onboarding/x");
+    when(inviteMailDispatchService.send(any(), any(), any()))
+        .thenThrow(new SmtpSendException("SMTP refused the message"));
+
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(10L, 20L)))
+        .isInstanceOf(SmtpSendException.class);
+
+    // No false success anywhere: neither EMAIL_SENT nor a SENT delivery row nor a token hash.
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getTokenHash()).isNull();
+    verify(accountInviteRepository, never()).save(any());
+    verify(deliveryRepository, never()).save(any());
+    verify(deliveryFailureRecorder)
+        .recordFailure(eq(10L), eq(template), eq("owner@example.org"), any(), any(), any());
+  }
+
+  @Test
+  void sendInvite_Should_PropagateTransportFailure_When_AuditRecordingAlsoFails() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder().id(20L).subject("s").body("b").build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any())).thenReturn("https://x/y");
+    when(inviteMailDispatchService.send(any(), any(), any()))
+        .thenThrow(new SmtpSendException("SMTP refused the message"));
+    org.mockito.Mockito.doThrow(new IllegalStateException("audit down"))
+        .when(deliveryFailureRecorder)
+        .recordFailure(any(), any(), any(), any(), any(), any());
+
+    // Auditing is best-effort — it must never mask the original send failure.
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(10L, 20L)))
+        .isInstanceOf(SmtpSendException.class);
+  }
+
+  @Test
+  void sendInvite_Should_DispatchBeforePersistingAnything() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder().id(20L).subject("s").body("{{inviteLink}}").build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
+
+    service.sendInvite(new SendInviteCommand(10L, 20L));
+
+    var inOrder =
+        org.mockito.Mockito.inOrder(
+            inviteMailDispatchService, accountInviteRepository, deliveryRepository);
+    inOrder.verify(inviteMailDispatchService).send(eq("owner@example.org"), any(), any());
+    inOrder.verify(accountInviteRepository).save(invite);
+    inOrder.verify(deliveryRepository).save(any());
+  }
+
+  @Test
+  void sendInvite_Should_TakeSentAtFromTransportReceipt() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder().id(20L).subject("s").body("b").build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
+
+    var result = service.sendInvite(new SendInviteCommand(10L, 20L));
+
+    assertThat(result.delivery().getSentAt())
+        .isEqualTo(
+            LocalDateTime.ofInstant(
+                Instant.parse("2026-07-28T10:15:30Z"), java.time.ZoneId.systemDefault()));
+  }
+
+  @Test
+  void resendInvite_Should_LeaveOldInviteIntact_When_TransportFails() {
+    AccountInvite oldInvite =
+        AccountInvite.builder()
+            .id(10L)
+            .recipientEmail("owner@example.org")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .kind(InviteEmailTemplateKind.TENANT_INVITE)
+            .subject("s")
+            .body("{{inviteLink}}")
+            .build();
+    when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any())).thenReturn("https://x/y");
+    when(inviteMailDispatchService.send(any(), any(), any()))
+        .thenThrow(new SmtpSendException("SMTP refused the message"));
+
+    assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(10L, 20L)))
+        .isInstanceOf(SmtpSendException.class);
+
+    // The previous invite must stay valid and resendable — no supersede, no replacement.
+    assertThat(oldInvite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+    assertThat(oldInvite.getSupersededByInviteId()).isNull();
+    verify(accountInviteRepository, never()).save(any());
+    verify(deliveryRepository, never()).save(any());
+    // The FAILED audit row anchors on the committed old invite.
+    verify(deliveryFailureRecorder)
+        .recordFailure(eq(10L), eq(template), any(), any(), any(), any());
   }
 
   @Test
@@ -154,7 +321,8 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-    service.sendInvite(new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+    givenSuccessfulDispatch();
+    service.sendInvite(new SendInviteCommand(10L, 20L));
     template.setSubject("Changed");
     template.setBody("Changed");
 
@@ -358,7 +526,7 @@ class AccountInviteServiceTest {
   }
 
   @Test
-  void acceptInvite_Should_expireAndThrow_When_pastExpiry() {
+  void acceptInvite_Should_expireAndThrowDistinctExpiredError_When_pastExpiry() {
     AccountInvite invite =
         AccountInvite.builder()
             .id(1L)
@@ -369,18 +537,65 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
-        .isInstanceOf(BadRequestException.class);
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.EXPIRED);
     assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EXPIRED);
   }
 
   @Test
-  void acceptInvite_Should_throwBadRequest_When_statusNotActive() {
+  void acceptInvite_Should_throwDistinctRevokedError_When_statusRevoked() {
     AccountInvite invite =
         AccountInvite.builder().id(1L).status(AccountInviteStatus.REVOKED).build();
     when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
 
     assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
-        .isInstanceOf(BadRequestException.class);
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.REVOKED);
+  }
+
+  @Test
+  void acceptInvite_Should_throwDistinctConsumedError_When_alreadyAccepted() {
+    // Links are strictly single-use: a second accept must be distinguishable from expiry.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.ACCEPTED)
+            .expiresAt(LocalDateTime.now().minusDays(1))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+    // The terminal state must not be overwritten by the expiry check.
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+  }
+
+  @Test
+  void acceptInvite_Should_throwDistinctSupersededError_When_replacedByResend() {
+    AccountInvite invite =
+        AccountInvite.builder().id(1L).status(AccountInviteStatus.SUPERSEDED).build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.SUPERSEDED);
+  }
+
+  @Test
+  void acceptInvite_Should_throwDistinctExpiredError_When_statusAlreadyExpired() {
+    AccountInvite invite =
+        AccountInvite.builder().id(1L).status(AccountInviteStatus.EXPIRED).build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.EXPIRED);
   }
 
   @Test
@@ -402,7 +617,7 @@ class AccountInviteServiceTest {
   }
 
   @Test
-  void acceptInvite_Should_throwBadRequest_When_statusDraftAndNoExpiry() {
+  void acceptInvite_Should_throwNotActiveError_When_statusDraftAndNoExpiry() {
     // DRAFT invites have never been delivered to the recipient, so accepting one would
     // bypass email verification. acceptInvite() must reject any status other than EMAIL_SENT.
     AccountInvite invite =
@@ -410,7 +625,9 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
 
     assertThatThrownBy(() -> service.acceptInvite("raw-token", "user-1"))
-        .isInstanceOf(BadRequestException.class);
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.NOT_ACTIVE);
   }
 
   // --- resendInvite guards ---
@@ -421,7 +638,7 @@ class AccountInviteServiceTest {
         AccountInvite.builder().id(1L).status(AccountInviteStatus.ACCEPTED).build();
     when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
 
-    assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(1L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(1L, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -431,7 +648,7 @@ class AccountInviteServiceTest {
         AccountInvite.builder().id(1L).status(AccountInviteStatus.REVOKED).build();
     when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
 
-    assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(1L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(1L, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -445,7 +662,7 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L))
         .thenReturn(Optional.of(InviteEmailTemplate.builder().id(20L).build()));
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -457,7 +674,7 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L))
         .thenReturn(Optional.of(InviteEmailTemplate.builder().id(20L).build()));
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -470,7 +687,7 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L))
         .thenReturn(Optional.of(InviteEmailTemplate.builder().id(20L).build()));
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -491,7 +708,8 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-    service.sendInvite(new SendInviteCommand(1L, 20L, "https://x"));
+    givenSuccessfulDispatch();
+    service.sendInvite(new SendInviteCommand(1L, 20L));
 
     assertThat(invite.getExpiresAt()).isEqualTo(future);
   }
@@ -500,7 +718,7 @@ class AccountInviteServiceTest {
 
   @Test
   void sendInvite_Should_throwBadRequest_When_inviteIdNull() {
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(null, 20L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(null, 20L)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -508,7 +726,7 @@ class AccountInviteServiceTest {
   void sendInvite_Should_throwNotFound_When_inviteMissing() {
     when(accountInviteRepository.findById(99L)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(99L, 20L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(99L, 20L)))
         .isInstanceOf(NotFoundException.class);
   }
 
@@ -517,7 +735,7 @@ class AccountInviteServiceTest {
     AccountInvite invite = AccountInvite.builder().id(1L).status(AccountInviteStatus.DRAFT).build();
     when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, null, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, null)))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -527,7 +745,7 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
     when(templateRepository.findById(99L)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 99L, "https://x")))
+    assertThatThrownBy(() -> service.sendInvite(new SendInviteCommand(1L, 99L)))
         .isInstanceOf(NotFoundException.class);
   }
 
@@ -682,7 +900,7 @@ class AccountInviteServiceTest {
   // --- render / buildAcceptUrl via sendInvite ---
 
   @Test
-  void sendInvite_Should_renderAllPlaceholders_And_stripTrailingSlashes() {
+  void sendInvite_Should_renderAllPlaceholders_FromRoleBasedAcceptUrl() {
     AccountInvite invite =
         AccountInvite.builder()
             .id(1L)
@@ -690,6 +908,7 @@ class AccountInviteServiceTest {
             .recipientEmail("a@example.org")
             .firstName("Ada")
             .lastName("Lovelace")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
             .status(AccountInviteStatus.DRAFT)
             .build();
     InviteEmailTemplate template =
@@ -703,18 +922,25 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-    var result = service.sendInvite(new SendInviteCommand(1L, 20L, "https://app.oriso.org///"));
+    givenSuccessfulDispatch();
+    var result = service.sendInvite(new SendInviteCommand(1L, 20L));
 
     assertThat(result.delivery().getSubjectSnapshot()).isEqualTo("Ada Lovelace a@example.org 9");
-    assertThat(result.acceptUrl()).startsWith("https://app.oriso.org/").doesNotContain("///");
+    // The accept URL comes from the role-aware server-side builder, never from the caller.
+    verify(inviteAcceptUrlBuilder)
+        .buildAcceptUrl(AccountInviteTargetRole.COUNSELLOR, result.rawToken());
+    assertThat(result.acceptUrl())
+        .isEqualTo("https://app.oriso.org/account-invite/" + result.rawToken());
+    assertThat(result.delivery().getBodySnapshot()).isEqualTo("Link: " + result.acceptUrl());
   }
 
   @Test
-  void sendInvite_Should_useDefaultAcceptUrl_When_baseUrlBlank() {
+  void sendInvite_Should_requestTenantAdminAcceptUrlForTenantAdminRole() {
     AccountInvite invite =
         AccountInvite.builder()
             .id(1L)
             .recipientEmail("a@example.org")
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
             .status(AccountInviteStatus.DRAFT)
             .build();
     InviteEmailTemplate template =
@@ -723,10 +949,18 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(eq(AccountInviteTargetRole.TENANT_ADMIN), any()))
+        .thenAnswer(
+            invocation ->
+                "https://app.oriso.org/admin/tenant-onboarding/" + invocation.getArgument(1));
+    when(inviteMailDispatchService.send(any(), any(), any()))
+        .thenReturn(new InviteMailSendReceipt("a@example.org", Instant.now()));
 
-    var result = service.sendInvite(new SendInviteCommand(1L, 20L, "   "));
+    var result = service.sendInvite(new SendInviteCommand(1L, 20L));
 
-    assertThat(result.acceptUrl()).startsWith("/account-invite/");
+    assertThat(result.acceptUrl())
+        .isEqualTo("https://app.oriso.org/admin/tenant-onboarding/" + result.rawToken());
+    assertThat(result.delivery().getBodySnapshot()).contains("/admin/tenant-onboarding/");
   }
 
   @Test
@@ -744,7 +978,8 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-    var result = service.sendInvite(new SendInviteCommand(1L, 20L, "https://x"));
+    givenSuccessfulDispatch();
+    var result = service.sendInvite(new SendInviteCommand(1L, 20L));
 
     assertThat(result.delivery().getSubjectSnapshot()).isEmpty();
     assertThat(result.delivery().getBodySnapshot()).isEmpty();
@@ -1181,9 +1416,8 @@ class AccountInviteServiceTest {
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-    var result =
-        service.resendInvite(
-            new SendInviteCommand(10L, 20L, "https://app.oriso.org/account-invite"));
+    givenSuccessfulDispatch();
+    var result = service.resendInvite(new SendInviteCommand(10L, 20L));
 
     assertThat(result.invite().getTenantIdReservationToken()).isEqualTo("res-token-21");
     assertThat(result.invite().getTenantId()).isEqualTo(21L);

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/InviteAcceptUrlBuilderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/InviteAcceptUrlBuilderTest.java
@@ -1,0 +1,60 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Link-target contract (TEN-INV-U6, #890): tenant-admin invites must land on the PUBLIC ADMIN
+ * onboarding route, counsellor (and other app-level) invites on the public App accept route.
+ */
+class InviteAcceptUrlBuilderTest {
+
+  private final InviteAcceptUrlBuilder builder =
+      new InviteAcceptUrlBuilder("https://app.example.org", "https://admin.example.org");
+
+  @Test
+  void buildAcceptUrl_Should_targetPublicAdminOnboardingRoute_ForTenantAdmin() {
+    String url = builder.buildAcceptUrl(AccountInviteTargetRole.TENANT_ADMIN, "tok-1");
+
+    assertThat(url).isEqualTo("https://admin.example.org/admin/tenant-onboarding/tok-1");
+  }
+
+  @Test
+  void buildAcceptUrl_Should_targetPublicAppRoute_ForCounsellor() {
+    String url = builder.buildAcceptUrl(AccountInviteTargetRole.COUNSELLOR, "tok-2");
+
+    assertThat(url).isEqualTo("https://app.example.org/account-invite/tok-2");
+  }
+
+  @Test
+  void buildAcceptUrl_Should_targetPublicAppRoute_ForOtherRoles() {
+    assertThat(builder.buildAcceptUrl(AccountInviteTargetRole.AGENCY_ADMIN, "t"))
+        .isEqualTo("https://app.example.org/account-invite/t");
+    assertThat(builder.buildAcceptUrl(AccountInviteTargetRole.PLATFORM_ADMIN, "t"))
+        .isEqualTo("https://app.example.org/account-invite/t");
+    assertThat(builder.buildAcceptUrl(AccountInviteTargetRole.ADVICE_SEEKER, "t"))
+        .isEqualTo("https://app.example.org/account-invite/t");
+  }
+
+  @Test
+  void buildAcceptUrl_Should_stripTrailingSlashesFromConfiguredBaseUrls() {
+    var slashy =
+        new InviteAcceptUrlBuilder("https://app.example.org///", "https://admin.example.org/");
+
+    assertThat(slashy.buildAcceptUrl(AccountInviteTargetRole.COUNSELLOR, "tok"))
+        .isEqualTo("https://app.example.org/account-invite/tok");
+    assertThat(slashy.buildAcceptUrl(AccountInviteTargetRole.TENANT_ADMIN, "tok"))
+        .isEqualTo("https://admin.example.org/admin/tenant-onboarding/tok");
+  }
+
+  @Test
+  void buildAcceptUrl_Should_fallBackToDefaultOrigin_When_ConfigurationBlank() {
+    var blank = new InviteAcceptUrlBuilder("  ", null);
+
+    assertThat(blank.buildAcceptUrl(AccountInviteTargetRole.COUNSELLOR, "tok"))
+        .isEqualTo("https://app.oriso.org/account-invite/tok");
+    assertThat(blank.buildAcceptUrl(AccountInviteTargetRole.TENANT_ADMIN, "tok"))
+        .isEqualTo("https://app.oriso.org/admin/tenant-onboarding/tok");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
@@ -1,0 +1,143 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
+import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model.ApplicationSettingsSmtpCredentialsDTO;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Strict-send contract (TEN-INV-U6, #890): either the transport confirms the handover and a receipt
+ * is returned, or an {@link SmtpSendException} propagates — including when the global SMTP
+ * configuration is unavailable. There is no silent-failure path.
+ */
+@ExtendWith(MockitoExtension.class)
+class InviteMailDispatchServiceTest {
+
+  @Mock private RestTemplate restTemplate;
+  @Mock private ApplicationSettingsService applicationSettingsService;
+  @Mock private InviteMailTransport inviteMailTransport;
+
+  private InviteMailDispatchService service(String smtpUser, String smtpPassword) {
+    return new InviteMailDispatchService(
+        restTemplate,
+        applicationSettingsService,
+        inviteMailTransport,
+        "http://consultingtypeservice:8080/service",
+        smtpUser,
+        smtpPassword);
+  }
+
+  private Map<String, Object> completeSettingsPayload() {
+    return Map.of(
+        "globalFeatureSystemNotificationEmailsEnabled", Map.of("value", true),
+        "globalSmtpEnabled", Map.of("value", true),
+        "globalSmtpHost", Map.of("value", "smtp.example.org"),
+        "globalSmtpPort", Map.of("value", "587"),
+        "globalSmtpSecure", Map.of("value", false),
+        "globalSmtpFrom", Map.of("value", "noreply@example.org"));
+  }
+
+  @Test
+  void send_Should_returnTransportReceipt_When_SettingsCompleteAndTransportConfirms() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    InviteMailSendReceipt receipt = new InviteMailSendReceipt("to@example.org", Instant.now());
+    when(inviteMailTransport.send(any(), any(), any(), any())).thenReturn(receipt);
+
+    var result = service("smtp-user", "smtp-pass").send("to@example.org", "subject", "<p>body</p>");
+
+    assertThat(result).isSameAs(receipt);
+    verify(inviteMailTransport)
+        .send(
+            new InviteSmtpSettings(
+                "smtp.example.org", 587, false, "smtp-user", "smtp-pass", "noreply@example.org"),
+            "to@example.org",
+            "subject",
+            "<p>body</p>");
+  }
+
+  @Test
+  void send_Should_throwSmtpSendException_When_SmtpDisabled() {
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenReturn(
+            Map.of(
+                "globalFeatureSystemNotificationEmailsEnabled", Map.of("value", true),
+                "globalSmtpEnabled", Map.of("value", false)));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class);
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  @Test
+  void send_Should_throwSmtpSendException_When_SettingsEndpointUnreachable() {
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenThrow(new org.springframework.web.client.ResourceAccessException("down"));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class);
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  @Test
+  void send_Should_fallBackToCredentialEndpoint_When_NoOperatorCredentialsConfigured() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    var credentials = new ApplicationSettingsSmtpCredentialsDTO();
+    credentials.setGlobalSmtpUsername("endpoint-user");
+    credentials.setGlobalSmtpPassword("endpoint-pass");
+    when(applicationSettingsService.getGlobalSmtpCredentials())
+        .thenReturn(Optional.of(credentials));
+    when(inviteMailTransport.send(any(), any(), any(), any()))
+        .thenReturn(new InviteMailSendReceipt("to@example.org", Instant.now()));
+
+    service("", "").send("to@example.org", "s", "b");
+
+    verify(inviteMailTransport)
+        .send(
+            new InviteSmtpSettings(
+                "smtp.example.org",
+                587,
+                false,
+                "endpoint-user",
+                "endpoint-pass",
+                "noreply@example.org"),
+            "to@example.org",
+            "s",
+            "b");
+  }
+
+  @Test
+  void send_Should_throwSmtpSendException_When_NoCredentialsAnywhere() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    when(applicationSettingsService.getGlobalSmtpCredentials()).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service("", "").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class);
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  @Test
+  void send_Should_propagateSmtpSendException_When_TransportFails() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    when(inviteMailTransport.send(any(), any(), any(), any()))
+        .thenThrow(new SmtpSendException("handover failed", new RuntimeException("io")));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("handover failed");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class JakartaInviteMailTransportTest {
+
+  /**
+   * Hardening (bug ORISO-Admin#569 follow-up): without {@code mail.smtp.starttls.required} a
+   * malicious or misconfigured SMTP server that does not offer STARTTLS silently downgrades the
+   * session to plaintext — including the AUTH exchange, i.e. the operator SMTP credentials.
+   */
+  @Test
+  void buildSessionProperties_Should_requireStartTls_When_settingsNotSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.starttls.enable")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.starttls.required")).isEqualTo("true");
+  }
+
+  /** The negotiated TLS certificate must match the configured host (MITM defense in depth). */
+  @Test
+  void buildSessionProperties_Should_checkServerIdentity_When_settingsNotSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.ssl.checkserveridentity")).isEqualTo("true");
+  }
+
+  @Test
+  void buildSessionProperties_Should_enableImplicitTlsAndCheckServerIdentity_When_settingsSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(secureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.ssl.enable")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.ssl.checkserveridentity")).isEqualTo("true");
+    // Implicit TLS sessions must not also announce STARTTLS.
+    assertThat(properties.getProperty("mail.smtp.starttls.enable")).isNull();
+  }
+
+  @Test
+  void buildSessionProperties_Should_keepConnectionBasicsAndTimeouts() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.auth")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.host")).isEqualTo("mail.example.org");
+    assertThat(properties.getProperty("mail.smtp.port")).isEqualTo("587");
+    assertThat(properties.getProperty("mail.smtp.connectiontimeout")).isEqualTo("10000");
+    assertThat(properties.getProperty("mail.smtp.timeout")).isEqualTo("10000");
+    assertThat(properties.getProperty("mail.smtp.writetimeout")).isEqualTo("10000");
+  }
+
+  private static InviteSmtpSettings insecureSettings() {
+    return new InviteSmtpSettings(
+        "mail.example.org", 587, false, "user", "secret", "noreply@example.org");
+  }
+
+  private static InviteSmtpSettings secureSettings() {
+    return new InviteSmtpSettings(
+        "mail.example.org", 465, true, "user", "secret", "noreply@example.org");
+  }
+}

--- a/tests/contracts/test_openapi_contract_gate.py
+++ b/tests/contracts/test_openapi_contract_gate.py
@@ -131,7 +131,7 @@ class OpenApiContractGateTest(unittest.TestCase):
             workflow,
             re.compile(
                 r"repository: OpenResilienceInitiative/ORISO-AgencyService.*"
-                r"299d4792820747ff8c5b387e421a6e971fb760d3",
+                r"11d1e2426593ffa0a550a64042ce97ca6e0a80cf",
                 re.DOTALL,
             ),
         )
@@ -147,7 +147,7 @@ class OpenApiContractGateTest(unittest.TestCase):
             workflow,
             re.compile(
                 r"repository: OpenResilienceInitiative/ORISO-TenantService.*"
-                r"a213d5546e2cdbcbd1f641291661f11cbbca2cfc",
+                r"1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e",
                 re.DOTALL,
             ),
         )


### PR DESCRIPTION
**Stack position: 2 of 6. Base: `fix/ten-inv-u3-invite-reservation-orchestration` (PR 1). Review only the top commit.**

## Problem

Three defects confirmed by the PreDev QA run of 2026-07-28, all recorded on
OpenResilienceInitiative/ORISO-UserService#890:

1. **No mail was ever dispatched.** `AccountInviteService.sendInvite()` rendered subject and
   body into an `invite_email_delivery` row with `status = SENT` hard-coded. There was no
   MailService call anywhere in the account-invite package and no consumer of
   `InviteEmailDeliveryRepository` — the `FAILED` path was unreachable code. The API
   answered `201` with `EMAIL_SENT`/`SENT` while nothing left the building.
2. **`acceptBaseUrl` was trusted verbatim from the client.** Any authorized API caller could
   mint invite links pointing at an arbitrary domain — a phishing vector the moment mail
   actually started sending.
3. **Link targets were dead ends.** Tenant-admin links pointed at the App layer, which has no
   `account-invite` route, so an anonymous open silently redirected to the advice-seeker login.
   Consumed, revoked and expired links were also indistinguishable to the client.

## What changed

**SENT only after confirmed delivery**

- New `InviteMailDispatchService` + `InviteMailTransport` with a strict
  receipt-after-send contract (mirroring CTS TEN-INV-U5): either the SMTP server accepted the
  message and a receipt comes back, or `SmtpSendException` propagates as
  `502 SMTP_SEND_FAILED`. Connection settings come from the public CTS `/settings` payload;
  credentials from `smtp.user`/`smtp.password` or the super-admin credentials endpoint.
- `sendInvite()` now dispatches **before** persisting. `EMAIL_SENT` and the `SENT` delivery
  row are written only after the transport receipt; a failure rolls the send back and leaves
  at most a `FAILED` audit row (`InviteEmailDeliveryFailureRecorder`, `REQUIRES_NEW`).
- Resend supersedes the old invite only after the replacement mail was accepted — a failed
  handover leaves the old invite intact and usable.

**Server-side link targets**

- New `InviteAcceptUrlBuilder` derives the accept URL from role plus configuration:
  `TENANT_ADMIN` → `<admin-base>/admin/tenant-onboarding/{token}` (the Admin U8 public route),
  every other role → `<app-base>/account-invite/{token}`.
- `SendInviteCommand` no longer carries `acceptBaseUrl`. The DTO field is kept but ignored,
  for wire compatibility with clients that still send it.

**Distinct machine-readable link errors**

- `acceptInvite()` maps consumed / revoked / superseded / expired / not-active links to
  `AccountInviteLinkException` → `410 Gone` with `{"reason": "<CODE>"}`. Terminal states win
  over the expiry check, so a revoked link never masquerades as merely expired.

New configuration: `account.invite.app.frontend.base-url` and
`account.invite.admin.frontend.base-url`, both defaulting to
`system.notification.frontend.base-url`.

## Testing

Re-run locally on 2026-07-29 with JDK 21 on the tip of this stack:

| Suite | Result |
| --- | --- |
| `AccountInviteServiceTest` | 83 tests, 0 failures |
| `InviteMailDispatchServiceTest` | 6 tests, 0 failures |
| `InviteAcceptUrlBuilderTest` | 5 tests, 0 failures |
| `ApiResponseEntityExceptionHandlerTest` | 13 tests, 0 failures |
| `AccountInviteReservationOrchestrationIT` | 3 tests, 0 failures |

End-to-end evidence from the clean-slate local chain run, which is what actually retires the
three acceptance boxes on #890:

- **S1** — a real mail was delivered through a STARTTLS catcher and contained the local
  `/admin/tenant-onboarding/{token}` Admin link (not an App link); following it led through
  organisation data, DPA, account creation, TOTP and a working login.
- **S2** — with SMTP down the API answered `502`, the invite stayed `DRAFT`/`FAILED`, and no
  success toast appeared.
- **S5** — a revoked link showed its own distinct error, a 2FA-pending link resumed, and a
  completed link reported `CONSUMED`.

**Honest note on the wider suite:** `UserControllerE2EIT` fails on this machine with
`RedisConnectionFailureException` / `Connection refused: localhost/127.0.0.1:6379` — no local
Redis. That is an environment gap present identically on the untouched baseline, not a
regression from this stack, and I am not claiming a green full IT suite.

Closes OpenResilienceInitiative/ORISO-UserService#890

Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
