### PR TITLE
[TEN-INV] Invite hardening: strict STARTTLS, atomic accept claim, resumable 2FA onboarding

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryS
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService.TemplateCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -161,16 +162,25 @@ public class AccountInviteController {
             accountInviteService.calculateAccessGate(invite)));
   }
 
+  /**
+   * Public accept endpoint. Resume contract (ORISO-Admin#569 hardening): while the accepted
+   * invite's mandatory 2FA activation is pending and the link is unexpired, repeated calls stay
+   * idempotent 200s carrying {@code phase = PENDING_2FA_ACTIVATION}; once the gate is satisfied the
+   * link is terminally consumed (410 {@code reason=CONSUMED}).
+   */
   @PostMapping("/users/account-invites/{token}/accept")
   public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
       @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
     String acceptedByUserId = request == null ? null : request.acceptedByUserId;
     AccountInvite invite = accountInviteService.acceptInvite(token, acceptedByUserId);
-    return ResponseEntity.ok(
+    AccountInviteResponseDTO response =
         AccountInviteResponseDTO.from(
-            invite,
-            latestDeliveryStatus(invite),
-            accountInviteService.calculateAccessGate(invite)));
+            invite, latestDeliveryStatus(invite), accountInviteService.calculateAccessGate(invite));
+    response.phase =
+        invite.getTwoFactorStatus() == TwoFactorGateStatus.PENDING_SETUP
+            ? AcceptPhase.PENDING_2FA_ACTIVATION.name()
+            : AcceptPhase.COMPLETED.name();
+    return ResponseEntity.ok(response);
   }
 
   @PreAuthorize(ADMIN_AUTH)
@@ -287,6 +297,14 @@ public class AccountInviteController {
     public String acceptedByUserId;
   }
 
+  /** Onboarding phase reported by the public accept endpoint (ORISO-Admin#569 resume contract). */
+  public enum AcceptPhase {
+    /** Invite consumed, but the mandatory 2FA activation is still open — the link is resumable. */
+    PENDING_2FA_ACTIVATION,
+    /** All account gates of the invite are satisfied. */
+    COMPLETED
+  }
+
   public static class TemplateRequestDTO {
     public String kind;
     public String name;
@@ -321,6 +339,13 @@ public class AccountInviteController {
     public LocalDateTime createDate;
     public String rawToken;
     public String acceptUrl;
+
+    /**
+     * Only set by the public accept endpoint (ORISO-Admin#569 resume contract): {@code
+     * PENDING_2FA_ACTIVATION} while the mandatory 2FA activation is open (link resumable), {@code
+     * COMPLETED} once every account gate is satisfied. {@code null} on admin-facing endpoints.
+     */
+    public String phase;
 
     static AccountInviteResponseDTO from(InviteSendResult result) {
       AccountInviteResponseDTO dto =

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,6 +21,32 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   Optional<AccountInvite> findByTokenHash(String tokenHash);
+
+  /**
+   * Atomic single-use claim of an invite (hardening for ORISO-Admin#569): flips {@code EMAIL_SENT
+   * -> ACCEPTED} as one guarded UPDATE, so of two concurrent accepts exactly one sees an affected
+   * row — independent of whether the database honored the pessimistic lock hint on the token
+   * lookup. Also stamps the email gate: an accept via the mailed link IS the verification.
+   *
+   * @return 1 when this call claimed the invite, 0 when another transaction already changed the
+   *     status away from {@code EMAIL_SENT}
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE AccountInvite i"
+          + " SET i.status ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.ACCEPTED,"
+          + " i.acceptedAt = :now,"
+          + " i.acceptedByUserId = :acceptedByUserId,"
+          + " i.emailVerificationStatus ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus.VERIFIED,"
+          + " i.updateDate = :now"
+          + " WHERE i.id = :id AND i.status ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.EMAIL_SENT")
+  int claimForAcceptance(
+      @Param("id") Long id,
+      @Param("acceptedByUserId") String acceptedByUserId,
+      @Param("now") LocalDateTime now);
 
   boolean existsByTenantIdAndTargetRoleAndStatusIn(
       Long tenantId, AccountInviteTargetRole targetRole, Collection<AccountInviteStatus> statuses);

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteLinkException.java
@@ -11,7 +11,13 @@ public class AccountInviteLinkException extends RuntimeException {
 
   /** Why the link cannot (or can no longer) be used. */
   public enum Reason {
-    /** The invite was already accepted — links are strictly single-use. */
+    /**
+     * The invite was already accepted and is terminally consumed — links are strictly single-use.
+     * Exception (ORISO-Admin#569 resume contract): while the invite's mandatory two-factor
+     * activation is still pending and the link is not expired, the accept endpoint answers 200 with
+     * {@code phase=PENDING_2FA_ACTIVATION} instead of this reason, so an interrupted onboarding can
+     * be resumed.
+     */
     CONSUMED,
     /** An admin revoked the invite. */
     REVOKED,

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -86,12 +87,16 @@ public class AccountInviteService {
     TenantIdReservation tenantReservation = null;
     Long reservedAgencyId = null;
     if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN) {
-      tenantReservation = tenantIdAllocationClient.reserve(command.tenantId());
+      tenantReservation = reserveTenantIdOrDegrade(command);
     }
     try {
       if (command.agencyIdAllocationMode() != null) {
+        // Long.valueOf: the reservation record carries a primitive long — a bare ternary would
+        // unbox command.tenantId() and NPE on invites without a tenant ID.
         Long tenantIdForAgency =
-            tenantReservation != null ? tenantReservation.tenantId() : command.tenantId();
+            tenantReservation != null
+                ? Long.valueOf(tenantReservation.tenantId())
+                : command.tenantId();
         reservedAgencyId = agencyIdAllocationClient.reserve(command.agencyId(), tenantIdForAgency);
       }
       revalidateReservations(tenantReservation, reservedAgencyId);
@@ -101,7 +106,9 @@ public class AccountInviteService {
           AccountInvite.builder()
               .targetRole(command.targetRole())
               .tenantId(
-                  tenantReservation != null ? tenantReservation.tenantId() : command.tenantId())
+                  tenantReservation != null
+                      ? Long.valueOf(tenantReservation.tenantId())
+                      : command.tenantId())
               .tenantIdReservationToken(
                   tenantReservation != null ? tenantReservation.token() : null)
               .recipientEmail(command.recipientEmail().trim())
@@ -128,6 +135,31 @@ public class AccountInviteService {
         tenantIdAllocationClient.release(tenantReservation.tenantId());
       }
       throw exception;
+    }
+  }
+
+  /**
+   * Reserves the tenant ID with graceful degradation for the deployment-order gap (ORISO-Admin#569
+   * hardening, U3 verify finding): a TenantService that does not yet expose the TEN-INV-U1
+   * allocation endpoints answers 404. Legacy requests (no explicit allocation mode) then fall back
+   * to the pre-U3 duplicate checks — already performed by {@code isTenantIdTaken} — instead of
+   * failing with an unmapped 500. Requests that explicitly demand AUTO/MANUAL allocation cannot be
+   * honored without the authoritative ledger and fail loudly.
+   */
+  private TenantIdReservation reserveTenantIdOrDegrade(CreateAccountInviteCommand command) {
+    try {
+      return tenantIdAllocationClient.reserve(command.tenantId());
+    } catch (HttpClientErrorException.NotFound exception) {
+      if (command.tenantIdAllocationMode() == null) {
+        log.warn(
+            "TenantService does not expose the tenant-ID allocation endpoints yet (deploy"
+                + " TEN-INV-U1 before U3) — creating a legacy invite without an authoritative"
+                + " reservation");
+        return null;
+      }
+      throw new InternalServerErrorException(
+          "Tenant-ID allocation was requested but TenantService does not expose the allocation"
+              + " endpoints (deployment-order gap: deploy TEN-INV-U1 before U3)");
     }
   }
 
@@ -266,23 +298,8 @@ public class AccountInviteService {
             .orElseThrow(() -> new NotFoundException("Account invite not found"));
 
     LocalDateTime now = LocalDateTime.now();
-    // Distinct, machine-readable reasons (TEN-INV-U6, #890): terminal states win over the date
-    // check so an already consumed/revoked link is reported as such, not as merely expired.
-    switch (invite.getStatus()) {
-      case ACCEPTED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
-      case REVOKED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
-      case SUPERSEDED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
-      case EXPIRED ->
-          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
-      case EMAIL_SENT -> {
-        // eligible — continue below
-      }
-        // DRAFT (or any future state) has never been delivered to the recipient; accepting it
-        // would bypass the email verification step entirely.
-      default -> throw new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT) {
+      return resolveAlreadyProcessedInvite(invite, now);
     }
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
@@ -291,12 +308,72 @@ public class AccountInviteService {
       throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
     }
 
+    // Single-use enforcement as an atomic guarded UPDATE (hardening, ORISO-Admin#569): only the
+    // transaction whose UPDATE still matches EMAIL_SENT claims the invite. This does not depend
+    // on the database honoring the pessimistic lock hint of the token lookup above.
+    int claimed = accountInviteRepository.claimForAcceptance(invite.getId(), acceptedByUserId, now);
+    if (claimed == 0) {
+      // Lost the race between our read and the claim — re-read the winner's committed state
+      // (the persistence context was cleared by the modifying query) and map it as usual.
+      AccountInvite current =
+          accountInviteRepository
+              .findById(invite.getId())
+              .orElseThrow(() -> new NotFoundException("Account invite not found"));
+      return resolveAlreadyProcessedInvite(current, now);
+    }
+
+    // Mirror exactly the columns the guarded UPDATE wrote onto the (now detached) entity so the
+    // caller sees the persisted state without an extra round trip.
     invite.setStatus(AccountInviteStatus.ACCEPTED);
     invite.setAcceptedAt(now);
     invite.setAcceptedByUserId(acceptedByUserId);
     invite.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
     invite.setUpdateDate(now);
-    return accountInviteRepository.save(invite);
+    return invite;
+  }
+
+  /**
+   * Maps every non-{@code EMAIL_SENT} state to the wire contract. Distinct, machine-readable
+   * reasons (TEN-INV-U6, #890): terminal states win over the date check so an already
+   * consumed/revoked link is reported as such, not as merely expired. Consumed invites may still be
+   * resumable — see {@link #resumeConsumedInviteOrThrow(AccountInvite, LocalDateTime)}.
+   */
+  private AccountInvite resolveAlreadyProcessedInvite(AccountInvite invite, LocalDateTime now) {
+    switch (invite.getStatus()) {
+      case ACCEPTED -> {
+        return resumeConsumedInviteOrThrow(invite, now);
+      }
+      case REVOKED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
+      case SUPERSEDED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
+      case EXPIRED ->
+          throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
+        // DRAFT (or any future state) has never been delivered to the recipient; accepting it
+        // would bypass the email verification step entirely.
+      default -> throw new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    }
+  }
+
+  /**
+   * RESUME CONTRACT (hardening for ORISO-Admin#569): a consumed invite whose mandatory two-factor
+   * activation is still pending ({@code twoFactorStatus == PENDING_SETUP}) stays resumable — the
+   * accept call is then idempotent: it returns the invite unchanged (HTTP 200, same response shape
+   * and data as the original accept, nothing beyond it) so the client can pick the onboarding up at
+   * the 2FA step. The resume window stays token- and expiry-bound: after {@code expiresAt} the link
+   * is terminally CONSUMED. Once the gate is satisfied (ACTIVE via {@link
+   * #markTwoFactorActive(String)}, WAIVED, NOT_REQUIRED or DISABLED_BY_POLICY) the link is
+   * terminally consumed as well. The ACCEPTED audit state (acceptor, timestamps) is never rewritten
+   * by a resume attempt.
+   */
+  private AccountInvite resumeConsumedInviteOrThrow(AccountInvite invite, LocalDateTime now) {
+    boolean twoFactorStillPending = !isTwoFactorGateSatisfied(invite.getTwoFactorStatus());
+    boolean withinExpiryWindow =
+        invite.getExpiresAt() == null || !invite.getExpiresAt().isBefore(now);
+    if (twoFactorStillPending && withinExpiryWindow) {
+      return invite;
+    }
+    throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
   }
 
   public AccountAccessGateStatus calculateAccessGate(AccountInvite invite) {
@@ -487,8 +564,15 @@ public class AccountInviteService {
         .orElseThrow(() -> new NotFoundException("Invite e-mail template not found"));
   }
 
+  /**
+   * Counsellors and tenant admins carry a mandatory TOTP setup (ORISO-Admin#569: "account,
+   * password, 2FA" is one coherent onboarding flow). Their gate starts at {@code PENDING_SETUP},
+   * which also keeps the consumed invite link resumable until the OTP credential exists — see
+   * {@link #resumeConsumedInviteOrThrow(AccountInvite, LocalDateTime)}.
+   */
   private static TwoFactorGateStatus defaultTwoFactorStatus(AccountInviteTargetRole targetRole) {
     return targetRole == AccountInviteTargetRole.COUNSELLOR
+            || targetRole == AccountInviteTargetRole.TENANT_ADMIN
         ? TwoFactorGateStatus.PENDING_SETUP
         : TwoFactorGateStatus.NOT_REQUIRED;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
@@ -23,22 +23,9 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
   public InviteMailSendReceipt send(
       InviteSmtpSettings settings, String recipient, String subject, String htmlBody) {
     try {
-      Properties properties = new Properties();
-      properties.put("mail.smtp.auth", "true");
-      properties.put("mail.smtp.host", settings.host());
-      properties.put("mail.smtp.port", String.valueOf(settings.port()));
-      properties.put("mail.smtp.connectiontimeout", "10000");
-      properties.put("mail.smtp.timeout", "10000");
-      properties.put("mail.smtp.writetimeout", "10000");
-      if (settings.secure()) {
-        properties.put("mail.smtp.ssl.enable", "true");
-      } else {
-        properties.put("mail.smtp.starttls.enable", "true");
-      }
-
       Session session =
           Session.getInstance(
-              properties,
+              buildSessionProperties(settings),
               new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
@@ -55,5 +42,30 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
     } catch (Exception exception) {
       throw new SmtpSendException("Account invite email could not be sent", exception);
     }
+  }
+
+  /**
+   * Builds the jakarta.mail session properties for the configured security mode. Hardening
+   * (ORISO-Admin#569 follow-up): in STARTTLS mode ({@code secure() == false}) the upgrade is
+   * mandatory — {@code mail.smtp.starttls.required} refuses servers (or men-in-the-middle) that do
+   * not offer STARTTLS instead of silently sending credentials in plaintext. In both modes the
+   * server certificate must match the configured host ({@code mail.smtp.ssl.checkserveridentity}).
+   */
+  static Properties buildSessionProperties(InviteSmtpSettings settings) {
+    Properties properties = new Properties();
+    properties.put("mail.smtp.auth", "true");
+    properties.put("mail.smtp.host", settings.host());
+    properties.put("mail.smtp.port", String.valueOf(settings.port()));
+    properties.put("mail.smtp.connectiontimeout", "10000");
+    properties.put("mail.smtp.timeout", "10000");
+    properties.put("mail.smtp.writetimeout", "10000");
+    properties.put("mail.smtp.ssl.checkserveridentity", "true");
+    if (settings.secure()) {
+      properties.put("mail.smtp.ssl.enable", "true");
+    } else {
+      properties.put("mail.smtp.starttls.enable", "true");
+      properties.put("mail.smtp.starttls.required", "true");
+    }
+    return properties;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetR
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateService;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
@@ -181,6 +182,29 @@ class AccountInviteControllerTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     verify(accountInviteService).acceptInvite("token-1", "user-1");
+    // No pending mandatory 2FA on this invite: the onboarding phase is terminal.
+    assertNotNull(response.getBody());
+    assertEquals("COMPLETED", response.getBody().phase);
+  }
+
+  @Test
+  void acceptInvite_pendingTwoFactor_reportsResumablePhase() {
+    // Resume contract (ORISO-Admin#569): while the mandatory 2FA activation is open, the accept
+    // response tells the client to continue at the 2FA step instead of a terminal state.
+    var invite = sampleInvite();
+    invite.setStatus(AccountInviteStatus.ACCEPTED);
+    invite.setTwoFactorStatus(TwoFactorGateStatus.PENDING_SETUP);
+    when(accountInviteService.acceptInvite("token-3", null)).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_TWO_FACTOR);
+
+    var response = controller.acceptInvite("token-3", null);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals("PENDING_2FA_ACTIVATION", response.getBody().phase);
+    assertEquals(
+        AccountAccessGateStatus.BLOCKED_TWO_FACTOR.name(), response.getBody().accessGateStatus);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
@@ -1,0 +1,184 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Hardening for bug ORISO-Admin#569: the accept link is strictly single-use — two concurrent
+ * accepts of the same token must never both claim the invite. The claim itself is a guarded UPDATE
+ * ({@code ... WHERE status = EMAIL_SENT}), so the guarantee holds even if the database does not
+ * honor the pessimistic lock hint on the token lookup.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(AccountInviteService.class)
+class AccountInviteAcceptRaceIT {
+
+  private static final String RAW_TOKEN = "race-raw-token";
+
+  @Autowired private AccountInviteService service;
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private TenantService tenantService;
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+  @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+
+  @MockitoBean
+  private de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService
+      inviteMailDispatchService;
+
+  @MockitoBean private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+
+  @AfterEach
+  void cleanUp() {
+    accountInviteRepository.deleteAll();
+  }
+
+  @Test
+  void concurrentAccepts_Should_LetExactlyOneClaimTheInvite_When_TwoFactorGateSatisfied()
+      throws Exception {
+    AccountInvite invite =
+        persistedEmailSentInvite(
+            AccountInviteTargetRole.PLATFORM_ADMIN, TwoFactorGateStatus.NOT_REQUIRED);
+
+    List<Object> outcomes =
+        runConcurrently(
+            () -> service.acceptInvite(RAW_TOKEN, "user-a"),
+            () -> service.acceptInvite(RAW_TOKEN, "user-b"));
+
+    List<AccountInvite> successes =
+        outcomes.stream()
+            .filter(AccountInvite.class::isInstance)
+            .map(AccountInvite.class::cast)
+            .toList();
+    List<AccountInviteLinkException> rejections =
+        outcomes.stream()
+            .filter(AccountInviteLinkException.class::isInstance)
+            .map(AccountInviteLinkException.class::cast)
+            .toList();
+
+    // Exactly one caller wins the single-use claim; the loser gets the distinct CONSUMED error.
+    assertThat(successes).hasSize(1);
+    assertThat(rejections).hasSize(1);
+    assertThat(rejections.get(0).getReason()).isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+
+    AccountInvite persisted = accountInviteRepository.findById(invite.getId()).orElseThrow();
+    assertThat(persisted.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    // The persisted claim belongs to the winner — no lost update, no mixed state.
+    assertThat(persisted.getAcceptedByUserId())
+        .isEqualTo(successes.get(0).getAcceptedByUserId())
+        .isIn("user-a", "user-b");
+    assertThat(persisted.getAcceptedAt()).isNotNull();
+    assertThat(persisted.getEmailVerificationStatus()).isEqualTo(EmailVerificationStatus.VERIFIED);
+  }
+
+  @Test
+  void concurrentAccepts_Should_PersistExactlyOneClaim_When_ResumeContractApplies()
+      throws Exception {
+    // Tenant-admin invites stay resumable while 2FA is pending (ORISO-Admin#569 resume
+    // contract): the racer that loses the claim receives the winner's committed state as an
+    // idempotent resume instead of an error — but the claim itself must still happen once.
+    AccountInvite invite =
+        persistedEmailSentInvite(
+            AccountInviteTargetRole.TENANT_ADMIN, TwoFactorGateStatus.PENDING_SETUP);
+
+    List<Object> outcomes =
+        runConcurrently(
+            () -> service.acceptInvite(RAW_TOKEN, "owner-a"),
+            () -> service.acceptInvite(RAW_TOKEN, "owner-b"));
+
+    List<AccountInvite> successes =
+        outcomes.stream()
+            .filter(AccountInvite.class::isInstance)
+            .map(AccountInvite.class::cast)
+            .toList();
+    assertThat(successes).hasSize(2);
+
+    AccountInvite persisted = accountInviteRepository.findById(invite.getId()).orElseThrow();
+    assertThat(persisted.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    // No lost update: exactly one contender's claim is persisted, and the resumed response of
+    // the loser mirrors that same committed state.
+    assertThat(persisted.getAcceptedByUserId()).isIn("owner-a", "owner-b");
+    assertThat(successes)
+        .extracting(AccountInvite::getAcceptedByUserId)
+        .containsOnly(persisted.getAcceptedByUserId());
+    assertThat(persisted.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+  }
+
+  private AccountInvite persistedEmailSentInvite(
+      AccountInviteTargetRole targetRole, TwoFactorGateStatus twoFactorStatus) {
+    LocalDateTime now = LocalDateTime.now();
+    return accountInviteRepository.save(
+        AccountInvite.builder()
+            .targetRole(targetRole)
+            .recipientEmail("race@example.org")
+            .tokenHash(AccountInviteService.hash(RAW_TOKEN))
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .emailVerificationStatus(EmailVerificationStatus.PENDING)
+            .twoFactorStatus(twoFactorStatus)
+            .expiresAt(now.plusDays(30))
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  /** Starts both calls on a shared latch and collects results and exceptions alike. */
+  private List<Object> runConcurrently(
+      Callable<AccountInvite> first, Callable<AccountInvite> second) throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    try {
+      List<Future<Object>> futures = new ArrayList<>();
+      for (Callable<AccountInvite> call : List.of(first, second)) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startLatch.await(5, TimeUnit.SECONDS);
+                  try {
+                    return (Object) call.call();
+                  } catch (Exception exception) {
+                    return exception;
+                  }
+                }));
+      }
+      startLatch.countDown();
+      List<Object> outcomes = new ArrayList<>();
+      for (Future<Object> future : futures) {
+        outcomes.add(future.get(30, TimeUnit.SECONDS));
+      }
+      return outcomes;
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
@@ -406,7 +407,31 @@ class AccountInviteServiceTest {
   }
 
   @Test
-  void createInvite_Should_defaultTwoFactorNotRequired_When_targetRoleNotCounsellor() {
+  void createInvite_Should_defaultTwoFactorNotRequired_When_targetRoleWithoutMandatory2fa() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.PLATFORM_ADMIN,
+                null,
+                "new@example.org",
+                null,
+                null,
+                null,
+                null,
+                null));
+
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.NOT_REQUIRED);
+    assertThat(invite.getFirstName()).isNull();
+  }
+
+  @Test
+  void createInvite_Should_defaultTwoFactorPendingSetup_When_targetRoleTenantAdmin() {
+    // Tenant-admin TOTP is mandatory (#569): the gate starts open and the invite stays
+    // resumable until markTwoFactorActive() flips it to ACTIVE.
     when(authenticatedUser.getUserId()).thenReturn("admin-1");
     when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -423,8 +448,7 @@ class AccountInviteServiceTest {
                 null,
                 null));
 
-    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.NOT_REQUIRED);
-    assertThat(invite.getFirstName()).isNull();
+    assertThat(invite.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
   }
 
   @Test
@@ -607,13 +631,156 @@ class AccountInviteServiceTest {
             .expiresAt(LocalDateTime.now().plusDays(1))
             .build();
     when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
-    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(accountInviteRepository.claimForAcceptance(eq(1L), eq("user-1"), any())).thenReturn(1);
 
     AccountInvite result = service.acceptInvite("raw-token", "user-1");
 
     assertThat(result.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
     assertThat(result.getAcceptedByUserId()).isEqualTo("user-1");
     assertThat(result.getEmailVerificationStatus()).isEqualTo(EmailVerificationStatus.VERIFIED);
+    assertThat(result.getAcceptedAt()).isNotNull();
+    // The claim is the single write — no additional save() that could race.
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_resolveAuthoritativeState_When_singleUseClaimIsLostToRacer() {
+    // Both callers read EMAIL_SENT, but the guarded UPDATE flips the row exactly once — the
+    // loser must re-read the winner's committed state and map it like any consumed link.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .expiresAt(LocalDateTime.now().plusDays(1))
+            .build();
+    AccountInvite claimedByWinner =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("winner")
+            .twoFactorStatus(TwoFactorGateStatus.NOT_REQUIRED)
+            .expiresAt(invite.getExpiresAt())
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(1L), eq("loser"), any())).thenReturn(0);
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(claimedByWinner));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", "loser"))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+  }
+
+  // --- resume contract (#569 hardening): consumed but 2FA still pending ---
+
+  @Test
+  void acceptInvite_Should_returnInviteForResume_When_consumedButTwoFactorPendingAndNotExpired() {
+    // A tenant admin who registered but closed the browser before activating mandatory TOTP
+    // must be able to reopen the link instead of hitting a terminal 410 CONSUMED.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .acceptedAt(LocalDateTime.now().minusHours(2))
+            .emailVerificationStatus(EmailVerificationStatus.VERIFIED)
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    AccountInvite result = service.acceptInvite("raw-token", "someone-else");
+
+    // Idempotent: same invite, no state change, the original acceptor is untouched.
+    assertThat(result).isSameAs(invite);
+    assertThat(result.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    assertThat(result.getAcceptedByUserId()).isEqualTo("owner-1");
+    assertThat(result.getTwoFactorStatus()).isEqualTo(TwoFactorGateStatus.PENDING_SETUP);
+    verify(accountInviteRepository, never()).save(any());
+    verify(accountInviteRepository, never()).claimForAcceptance(any(), any(), any());
+  }
+
+  @Test
+  void acceptInvite_Should_stayIdempotent_When_resumedRepeatedly() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    AccountInvite first = service.acceptInvite("raw-token", null);
+    AccountInvite second = service.acceptInvite("raw-token", null);
+
+    assertThat(first).isSameAs(second);
+    assertThat(second.getAcceptedByUserId()).isEqualTo("owner-1");
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorPendingButExpired() {
+    // The resume window stays expiry-bound: after expiresAt the consumed link is terminal.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .acceptedByUserId("owner-1")
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .expiresAt(LocalDateTime.now().minusMinutes(5))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+    // The ACCEPTED audit state must never be rewritten by the resume expiry check.
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.ACCEPTED);
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorActive() {
+    // Once 2FA is activated the link is terminally consumed — resume closes for good.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .twoFactorStatus(TwoFactorGateStatus.ACTIVE)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
+  }
+
+  @Test
+  void acceptInvite_Should_throwConsumed_When_consumedAndTwoFactorWaived() {
+    // A waiver satisfies the gate exactly like an activation: nothing is left to resume.
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+            .status(AccountInviteStatus.ACCEPTED)
+            .twoFactorStatus(TwoFactorGateStatus.WAIVED)
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .build();
+    when(accountInviteRepository.findByTokenHash(any())).thenReturn(Optional.of(invite));
+
+    assertThatThrownBy(() -> service.acceptInvite("raw-token", null))
+        .isInstanceOf(AccountInviteLinkException.class)
+        .extracting("reason")
+        .isEqualTo(AccountInviteLinkException.Reason.CONSUMED);
   }
 
   @Test
@@ -1147,6 +1314,64 @@ class AccountInviteServiceTest {
             AccountInviteTargetRole.TENANT_ADMIN,
             List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)))
         .thenReturn(false);
+  }
+
+  @Test
+  void createInvite_Should_FallBackToLegacyChecks_When_AllocationEndpointsMissingAndNoMode() {
+    // Deployment-order gap (#569, U3 verify): a TenantService without the U1 endpoints answers
+    // 404. Legacy requests (no allocation mode) must degrade to the pre-U3 duplicate checks
+    // instead of failing with an unmapped 500.
+    givenAdminAndPassthroughSave();
+    givenTenantIdFreeLocally(7L);
+    when(tenantIdAllocationClient.reserve(7L))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    AccountInvite invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.TENANT_ADMIN,
+                7L,
+                "owner@example.org",
+                "New",
+                "Owner",
+                null,
+                null,
+                30L));
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+    assertThat(invite.getTenantId()).isEqualTo(7L);
+    assertThat(invite.getTenantIdReservationToken()).isNull();
+    // No reservation exists, so no availability re-validation and no release compensation.
+    verify(tenantIdAllocationClient, never()).getAvailability(anyLong());
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void createInvite_Should_FailLoudly_When_AllocationEndpointsMissingButModeExplicit() {
+    // An explicit AUTO/MANUAL allocation request cannot be honored without the U1 endpoints —
+    // pretending a reservation would reintroduce the collision risk the epic closes.
+    when(tenantIdAllocationClient.reserve(null))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            null,
+            "owner@example.org",
+            "New",
+            "Owner",
+            null,
+            null,
+            30L,
+            IdAllocationMode.AUTO,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("TEN-INV-U1");
+    verify(accountInviteRepository, never()).save(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.service.accountinvite.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class JakartaInviteMailTransportTest {
+
+  /**
+   * Hardening (bug ORISO-Admin#569 follow-up): without {@code mail.smtp.starttls.required} a
+   * malicious or misconfigured SMTP server that does not offer STARTTLS silently downgrades the
+   * session to plaintext — including the AUTH exchange, i.e. the operator SMTP credentials.
+   */
+  @Test
+  void buildSessionProperties_Should_requireStartTls_When_settingsNotSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.starttls.enable")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.starttls.required")).isEqualTo("true");
+  }
+
+  /** The negotiated TLS certificate must match the configured host (MITM defense in depth). */
+  @Test
+  void buildSessionProperties_Should_checkServerIdentity_When_settingsNotSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.ssl.checkserveridentity")).isEqualTo("true");
+  }
+
+  @Test
+  void buildSessionProperties_Should_enableImplicitTlsAndCheckServerIdentity_When_settingsSecure() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(secureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.ssl.enable")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.ssl.checkserveridentity")).isEqualTo("true");
+    // Implicit TLS sessions must not also announce STARTTLS.
+    assertThat(properties.getProperty("mail.smtp.starttls.enable")).isNull();
+  }
+
+  @Test
+  void buildSessionProperties_Should_keepConnectionBasicsAndTimeouts() {
+    Properties properties = JakartaInviteMailTransport.buildSessionProperties(insecureSettings());
+
+    assertThat(properties.getProperty("mail.smtp.auth")).isEqualTo("true");
+    assertThat(properties.getProperty("mail.smtp.host")).isEqualTo("mail.example.org");
+    assertThat(properties.getProperty("mail.smtp.port")).isEqualTo("587");
+    assertThat(properties.getProperty("mail.smtp.connectiontimeout")).isEqualTo("10000");
+    assertThat(properties.getProperty("mail.smtp.timeout")).isEqualTo("10000");
+    assertThat(properties.getProperty("mail.smtp.writetimeout")).isEqualTo("10000");
+  }
+
+  private static InviteSmtpSettings insecureSettings() {
+    return new InviteSmtpSettings(
+        "mail.example.org", 587, false, "user", "secret", "noreply@example.org");
+  }
+
+  private static InviteSmtpSettings secureSettings() {
+    return new InviteSmtpSettings(
+        "mail.example.org", 465, true, "user", "secret", "noreply@example.org");
+  }
+}


### PR DESCRIPTION
**Stack position: 3 of 6. Base: `fix/ten-inv-u6-invite-links-and-sent-status` (PR 2). Review only the top commit.**

This is the review-hardening PR for the two chunks below it. It closes findings raised in the
U3/U6 verify pass rather than delivering a sub-issue of its own, so it uses `Refs`, not `Closes`.

## Problem

Findings from the U3/U6 verify pass, plus one latent crash:

- **Credentials could go out in plaintext.** The SMTP transport enabled STARTTLS but did not
  *require* it. A server — or a MITM — that simply does not advertise STARTTLS caused a silent
  fallback to an unencrypted session carrying the operator's SMTP credentials. Server identity
  was also not checked against the certificate.
- **Single-use accept depended on a lock hint.** The accept path relied on a
  `PESSIMISTIC_WRITE` hint on the token lookup to serialize two concurrent accepts. That hint
  happens to be honoured by H2, but it is not an invariant to build single-use semantics on.
- **Tenant admins could get stranded mid-onboarding.** A tenant admin who completed account
  creation but dropped out before activating TOTP came back to a terminal `410 CONSUMED` — the
  link was spent and the account unusable, with no way forward.
- **Deployment order produced an unmapped 500.** `createInvite` for `TENANT_ADMIN` crashed with
  an unmapped 500 when TenantService did not yet expose the TEN-INV-U1 allocation endpoints (404).
- **Latent NPE:** creating any invite without a `tenantId` unboxed `command.tenantId()` through
  the reservation ternary (`TenantIdReservation` holds a primitive `long`) and crashed 500.

## What changed

**SMTP transport (`JakartaInviteMailTransport`)**

- `mail.smtp.starttls.required=true` in STARTTLS mode — a server that does not offer STARTTLS
  is refused instead of silently receiving the credentials in the clear.
- `mail.smtp.ssl.checkserveridentity=true` in both modes; the certificate must match the
  configured host.

**Atomic single-use accept**

- `AccountInviteRepository.claimForAcceptance()` flips `EMAIL_SENT → ACCEPTED` as one guarded
  `UPDATE`. Of two concurrent accepts exactly one sees an affected row, independent of whether
  the pessimistic lock hint is honoured. The loser re-reads the winner's committed state and
  runs through the normal terminal/resume logic.

**Resume contract for stranded tenant-admin onboarding**

- `TENANT_ADMIN` invites now default to `twoFactorStatus=PENDING_SETUP` (tenant-admin TOTP is
  mandatory per ORISO-Admin#569).
- A consumed invite whose 2FA gate is still `PENDING_SETUP` stays resumable inside the original
  expiry window: `POST /users/account-invites/{token}/accept` answers an idempotent `200` with
  `phase=PENDING_2FA_ACTIVATION` — same response shape and data as the original accept, the
  `ACCEPTED` audit state untouched — instead of a terminal `410 CONSUMED`. Once the gate is
  satisfied (`ACTIVE` via the OTP lifecycle, `WAIVED`, `NOT_REQUIRED`) or the link expires, the
  link is terminally consumed (`410 reason=CONSUMED`).
- New `AcceptPhase` enum and `phase` field on the accept response; `null` on admin-facing endpoints.

**Deployment-order degradation**

- Legacy requests without an allocation mode fall back to the pre-U3 duplicate checks with a
  warning when TenantService lacks the U1 endpoints. Explicit `AUTO`/`MANUAL` requests still fail
  loudly, now with a clear deployment-order message instead of an unmapped 500.

## Testing

Re-run locally on 2026-07-29 with JDK 21 on the tip of this stack:

| Suite | Result |
| --- | --- |
| `AccountInviteServiceTest` | 83 tests, 0 failures |
| `AccountInviteControllerTest` | 27 tests, 0 failures |
| `JakartaInviteMailTransportTest` | 4 tests, 0 failures |
| `AccountInviteAcceptRaceIT` | 2 tests, 0 failures |

`AccountInviteAcceptRaceIT` is new and proves the single-use invariant with two latched threads
against the real JPA layer. Worth knowing while reviewing: the pre-existing `PESSIMISTIC_WRITE`
hint already serialized this race on H2 — the guarded `UPDATE` removes the *dependency* on that
hint, it does not fix an observed H2 failure. That is exactly why it is worth having on MariaDB.

Chain-run evidence from the clean-slate local stack:

- **S5** — a 2FA-pending link resumed rather than dead-ending; a completed link reported `CONSUMED`.
- **S1** — the STARTTLS catcher accepted the invite mail with the required-STARTTLS transport.

**Honest note:** `UserControllerE2EIT` fails on this machine with `RedisConnectionFailureException`
(`Connection refused: localhost/127.0.0.1:6379`) — no local Redis, identical on the untouched
baseline, not a regression from this stack. No green full IT suite is being claimed.

Refs OpenResilienceInitiative/ORISO-UserService#889
Refs OpenResilienceInitiative/ORISO-UserService#890

Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
