### PR TITLE
[TEN-INV] Public tenant-admin onboarding endpoints and anonymous invite-link access

### DIFF
--- a/services/tenantadminservice.yaml
+++ b/services/tenantadminservice.yaml
@@ -1176,6 +1176,13 @@ components:
           type: string
         updateDate:
           type: string
+        tenantIdReservationToken:
+          type: string
+          maxLength: 36
+          description: Token of an open tenant ID reservation. When creating a tenant with
+            a reserved ID, the matching token proves ownership of the reservation, which is
+            then consumed atomically with the creation. Without a matching token a reserved
+            ID is rejected with a conflict.
         licensing:
           $ref: '#/components/schemas/Licensing'
         theming:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -168,7 +168,10 @@ public class AccountInviteController {
    * idempotent 200s carrying {@code phase = PENDING_2FA_ACTIVATION}; once the gate is satisfied the
    * link is terminally consumed (410 {@code reason=CONSUMED}).
    */
-  @PostMapping("/users/account-invites/{token}/accept")
+  @PostMapping({
+    "/users/account-invites/{token}/accept",
+    "/service/users/account-invites/{token}/accept"
+  })
   public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
       @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
     String acceptedByUserId = request == null ? null : request.acceptedByUserId;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TenantAdminOnboardingController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/TenantAdminOnboardingController.java
@@ -1,0 +1,201 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.OnboardingInviteState;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.RegisterTenantAdminCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.TenantAdminRegistrationResult;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * PUBLIC tenant-admin onboarding endpoints (#569 chain fix; UserService side of the Admin panel's
+ * TEN-INV-U8 flow). All three endpoints are anonymous by design — the invitee has no account yet;
+ * the raw invite token in the path is the only credential. Mapped with and without the {@code
+ * /service} prefix because the API gateway forwards the prefix unchanged (same convention as the
+ * other public endpoints). Response/request shapes are pinned to the Admin panel client ({@code
+ * src/api/tenantOnboarding/tenantOnboarding.ts}); link-death answers are 410 with a
+ * machine-readable {@code reason} body (unknown tokens 404), which the client maps body-first.
+ */
+@RestController
+@RequiredArgsConstructor
+public class TenantAdminOnboardingController {
+
+  /** Onboarding phase of a consumed-but-resumable link (#569 resume contract). */
+  static final String PHASE_PENDING_2FA_ACTIVATION = "PENDING_2FA_ACTIVATION";
+
+  private final @NonNull TenantAdminOnboardingService onboardingService;
+
+  @GetMapping({
+    "/users/account-invites/{token}/onboarding",
+    "/service/users/account-invites/{token}/onboarding"
+  })
+  public ResponseEntity<TenantAdminOnboardingInviteResponseDTO> resolveOnboardingInvite(
+      @PathVariable String token) {
+    OnboardingInviteState state = onboardingService.resolveOnboardingInvite(token);
+    return ResponseEntity.ok(TenantAdminOnboardingInviteResponseDTO.from(state));
+  }
+
+  @PostMapping({
+    "/users/account-invites/{token}/onboarding/register",
+    "/service/users/account-invites/{token}/onboarding/register"
+  })
+  public ResponseEntity<TenantAdminRegistrationResponseDTO> registerTenantAdmin(
+      @PathVariable String token,
+      @RequestBody(required = false) TenantAdminRegistrationRequestDTO request) {
+    TenantAdminRegistrationResult result =
+        onboardingService.registerTenantAdmin(token, toCommand(request));
+    return ResponseEntity.ok(TenantAdminRegistrationResponseDTO.from(result));
+  }
+
+  @PostMapping({
+    "/users/account-invites/{token}/onboarding/two-factor",
+    "/service/users/account-invites/{token}/onboarding/two-factor"
+  })
+  public ResponseEntity<Void> activateTwoFactor(
+      @PathVariable String token,
+      @RequestBody(required = false) TwoFactorActivationRequestDTO request) {
+    onboardingService.activateTwoFactor(token, request == null ? null : request.otp);
+    return ResponseEntity.ok().build();
+  }
+
+  private static RegisterTenantAdminCommand toCommand(TenantAdminRegistrationRequestDTO request) {
+    TenantAdminRegistrationRequestDTO safe =
+        request == null ? new TenantAdminRegistrationRequestDTO() : request;
+    OrganisationDataDTO organisation =
+        safe.organisation == null ? new OrganisationDataDTO() : safe.organisation;
+    DpaAcceptanceDataDTO dpa = safe.dpa == null ? new DpaAcceptanceDataDTO() : safe.dpa;
+    AccountDataDTO account = safe.account == null ? new AccountDataDTO() : safe.account;
+    return new RegisterTenantAdminCommand(
+        organisation.name,
+        organisation.subdomain,
+        organisation.address,
+        Boolean.TRUE.equals(dpa.accepted),
+        dpa.signerName,
+        dpa.signerPosition,
+        dpa.signerEmail,
+        dpa.signerOrganisation,
+        account.password,
+        safe.reservedTenantId,
+        safe.tenantIdReservationToken);
+  }
+
+  public static class OrganisationDataDTO {
+    public String name;
+    public String subdomain;
+    public String address;
+  }
+
+  public static class DpaAcceptanceDataDTO {
+    public Boolean accepted;
+    public String signerName;
+    public String signerPosition;
+    public String signerEmail;
+    public String signerOrganisation;
+  }
+
+  public static class AccountDataDTO {
+    public String password;
+  }
+
+  public static class TenantAdminRegistrationRequestDTO {
+    public OrganisationDataDTO organisation;
+    public DpaAcceptanceDataDTO dpa;
+    public AccountDataDTO account;
+
+    /** Echoed reservation pair proving ownership of the invite's tenant-ID reservation. */
+    public Long reservedTenantId;
+
+    public String tenantIdReservationToken;
+  }
+
+  public static class TwoFactorActivationRequestDTO {
+    public String otp;
+  }
+
+  public static class TwoFactorSetupDTO {
+    /** Base32 TOTP secret to show/link in the authenticator app. */
+    public String secret;
+
+    /** QR code PNG (base64) when Keycloak provides one; the client renders text-only when null. */
+    public String qrCodeBase64;
+
+    static TwoFactorSetupDTO of(String secret, String qrCodeBase64) {
+      TwoFactorSetupDTO dto = new TwoFactorSetupDTO();
+      dto.secret = secret;
+      dto.qrCodeBase64 = qrCodeBase64;
+      return dto;
+    }
+  }
+
+  public static class TenantAdminOnboardingInviteResponseDTO {
+    public String recipientEmail;
+    public String firstName;
+    public String lastName;
+
+    /**
+     * The tenant ID the invite reserved (TenantService {@code TenantIdReservationDTO.tenantId}).
+     */
+    public Long reservedTenantId;
+
+    /** Reservation token echoed back on registration to consume the reservation atomically. */
+    public String tenantIdReservationToken;
+
+    public LocalDateTime expiresAt;
+
+    /**
+     * Published DPA/AVV text (JSON language -> HTML map). Not yet sourced server-side — the
+     * operator-DPA lookup is the U9 follow-up; the Admin panel renders the step without the preview
+     * text when null.
+     */
+    public String dpaContent;
+
+    /** {@code PENDING_2FA_ACTIVATION} when the flow re-enters at the 2FA step; null otherwise. */
+    public String phase;
+
+    /** Re-issued TOTP setup material for a resumable link; null renders the verify-only variant. */
+    public TwoFactorSetupDTO twoFactor;
+
+    static TenantAdminOnboardingInviteResponseDTO from(OnboardingInviteState state) {
+      AccountInvite invite = state.invite();
+      TenantAdminOnboardingInviteResponseDTO dto = new TenantAdminOnboardingInviteResponseDTO();
+      dto.recipientEmail = invite.getRecipientEmail();
+      dto.firstName = invite.getFirstName();
+      dto.lastName = invite.getLastName();
+      dto.reservedTenantId = invite.getTenantId();
+      dto.tenantIdReservationToken = invite.getTenantIdReservationToken();
+      dto.expiresAt = invite.getExpiresAt();
+      dto.dpaContent = null;
+      if (state.pendingTwoFactorResume()) {
+        dto.phase = PHASE_PENDING_2FA_ACTIVATION;
+        if (invite.getTotpPendingSecret() != null) {
+          // The raw token is the only credential, so re-showing the secret to the token holder
+          // exposes nothing new; the QR code is not re-issued (secret-only re-entry).
+          dto.twoFactor = TwoFactorSetupDTO.of(invite.getTotpPendingSecret(), null);
+        }
+      }
+      return dto;
+    }
+  }
+
+  public static class TenantAdminRegistrationResponseDTO {
+    /** The created (inactive) tenant — equals the reserved ID. */
+    public Long tenantId;
+
+    public TwoFactorSetupDTO twoFactor;
+
+    static TenantAdminRegistrationResponseDTO from(TenantAdminRegistrationResult result) {
+      TenantAdminRegistrationResponseDTO dto = new TenantAdminRegistrationResponseDTO();
+      dto.tenantId = result.tenantId();
+      dto.twoFactor = TwoFactorSetupDTO.of(result.totpSecret(), result.totpQrCodeBase64());
+      return dto;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -156,6 +156,23 @@ public class SecurityConfig {
                     RegexRequestMatcher.regexMatcher(
                         HttpMethod.POST, ".*/users/magic-link/(request|consume)$"))
                 .permitAll()
+                // PUBLIC account-invite endpoints (#569 chain fix): the invitee has no account
+                // yet, the raw invite token in the path is the only credential. Both prefix
+                // variants because the API gateway forwards /service unchanged.
+                .requestMatchers(
+                    HttpMethod.GET,
+                    "/users/account-invites/{token}/onboarding",
+                    "/service/users/account-invites/{token}/onboarding")
+                .permitAll()
+                .requestMatchers(
+                    HttpMethod.POST,
+                    "/users/account-invites/{token}/accept",
+                    "/service/users/account-invites/{token}/accept",
+                    "/users/account-invites/{token}/onboarding/register",
+                    "/service/users/account-invites/{token}/onboarding/register",
+                    "/users/account-invites/{token}/onboarding/two-factor",
+                    "/service/users/account-invites/{token}/onboarding/two-factor")
+                .permitAll()
                 // Password-reset request/confirm are already permitted by the exact requestMatchers
                 // above (with and without the /service prefix); no broad regex needed.
                 .requestMatchers(HttpMethod.GET, "/conversations/anonymous/{sessionId:[0-9]+}")

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -34,7 +34,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString(exclude = {"tokenHash", "tenantIdReservationToken"})
+@ToString(exclude = {"tokenHash", "tenantIdReservationToken", "totpPendingSecret"})
 public class AccountInvite {
 
   @Id
@@ -113,6 +113,15 @@ public class AccountInvite {
 
   @Column(name = "superseded_by_invite_id")
   private Long supersededByInviteId;
+
+  /**
+   * TOTP secret issued to the invitee during the public tenant-admin onboarding (#569 chain fix).
+   * The public two-factor endpoint only receives the one-time password, so the secret shown at
+   * registration must be kept server-side until the activation succeeds; it is cleared once the OTP
+   * credential exists. Only ever set for invites onboarded through the public onboarding endpoints.
+   */
+  @Column(name = "totp_pending_secret", length = 64)
+  private String totpPendingSecret;
 
   @Column(name = "two_factor_waived_by", length = 36)
   private String twoFactorWaivedBy;

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -582,7 +582,8 @@ public class AccountInviteService {
         || status == EmailVerificationStatus.VERIFIED;
   }
 
-  private static boolean isTwoFactorGateSatisfied(TwoFactorGateStatus status) {
+  /** Public because the tenant-admin onboarding flow shares the resume-window semantics. */
+  public static boolean isTwoFactorGateSatisfied(TwoFactorGateStatus status) {
     return status == TwoFactorGateStatus.NOT_REQUIRED
         || status == TwoFactorGateStatus.ACTIVE
         || status == TwoFactorGateStatus.WAIVED

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
@@ -1,0 +1,319 @@
+package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
+import de.caritas.cob.userservice.api.admin.service.admin.create.CreateAdminService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkException;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.MultilingualTenantDTO;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Public tenant-admin onboarding behind an invite link (#569 chain fix, UserService side of the
+ * Admin panel's TEN-INV-U8 flow, ORISO-Admin#571).
+ *
+ * <p>Contract pinned by the Admin panel client ({@code src/api/tenantOnboarding/tenantOnboarding
+ * .ts}): resolve returns the invite state keyed by the raw link token; register creates the
+ * still-inactive tenant (consuming the invite's TenantService tenant-ID reservation atomically via
+ * {@code MultilingualTenantDTO.tenantIdReservationToken}) plus the tenant-admin account and returns
+ * TOTP setup material; two-factor confirms the TOTP setup with a first one-time password. Links are
+ * strictly single-use, but stay resumable at the 2FA step while the mandatory activation is pending
+ * and the link is unexpired (resume contract shared with the public accept endpoint).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TenantAdminOnboardingService {
+
+  private static final int MIN_PASSWORD_LENGTH = 8;
+
+  private final @NonNull AccountInviteRepository accountInviteRepository;
+  private final @NonNull AccountInviteService accountInviteService;
+  private final @NonNull CreateAdminService createAdminService;
+  private final @NonNull IdentityClient identityClient;
+  private final @NonNull TenantCreationClient tenantCreationClient;
+  private final @NonNull UsernameTranscoder usernameTranscoder;
+
+  /**
+   * Resolves the invite state for a raw link token. Mirrors the accept endpoint's state machine: a
+   * deliverable ({@code EMAIL_SENT}) unexpired invite resolves plainly; a consumed invite whose
+   * mandatory 2FA activation is still open and whose link is unexpired resolves with a pending
+   * two-factor resume; every other state maps to the distinct link-death reasons (410 body {@code
+   * reason}, unknown tokens 404).
+   */
+  @Transactional
+  public OnboardingInviteState resolveOnboardingInvite(String rawToken) {
+    AccountInvite invite = findTenantAdminInvite(rawToken);
+    LocalDateTime now = LocalDateTime.now();
+
+    if (invite.getStatus() == AccountInviteStatus.EMAIL_SENT) {
+      expireIfPastExpiry(invite, now);
+      return new OnboardingInviteState(invite, false);
+    }
+    if (isResumableAtTwoFactorStep(invite, now)) {
+      return new OnboardingInviteState(invite, true);
+    }
+    throw linkDeathException(invite);
+  }
+
+  /**
+   * Creates the inactive tenant plus the tenant-admin account and consumes the tenant-ID
+   * reservation atomically; strictly single-use (atomic claim). Ordering keeps the external side
+   * effects compensable: the invite is claimed first (rolls back with the transaction), then the
+   * Keycloak account is created (compensated via {@code rollBackUser} on any later failure), and
+   * the TenantService creation — the irreversible reservation consumption — runs last.
+   */
+  @Transactional
+  public TenantAdminRegistrationResult registerTenantAdmin(
+      String rawToken, RegisterTenantAdminCommand command) {
+    validateRegistration(command);
+    AccountInvite invite = findTenantAdminInvite(rawToken);
+    LocalDateTime now = LocalDateTime.now();
+
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT) {
+      throw linkDeathException(invite);
+    }
+    expireIfPastExpiry(invite, now);
+    if (invite.getTenantId() == null || isBlank(invite.getTenantIdReservationToken())) {
+      // Legacy invite created while TenantService lacked the TEN-INV-U1 allocation endpoints —
+      // a reservation-consuming creation is impossible without the authoritative ledger.
+      throw new InternalServerErrorException(
+          "Invite holds no authoritative tenant-ID reservation — re-issue the invite after"
+              + " deploying the TenantService allocation endpoints (TEN-INV-U1)");
+    }
+    if (!invite.getTenantId().equals(command.reservedTenantId())
+        || !invite.getTenantIdReservationToken().equals(command.tenantIdReservationToken())) {
+      // The echoed reservation pair must prove ownership; a mismatch is an unusable link (404).
+      throw new NotFoundException("Reservation does not match this invite");
+    }
+
+    int claimed = accountInviteRepository.claimForAcceptance(invite.getId(), null, now);
+    if (claimed == 0) {
+      // Lost the single-use race — report the winner's committed state.
+      AccountInvite current =
+          accountInviteRepository
+              .findById(invite.getId())
+              .orElseThrow(() -> new NotFoundException("Account invite not found"));
+      throw linkDeathException(current);
+    }
+
+    var admin = createAdminService.createNewTenantAdmin(buildAdminDto(invite, command));
+    try {
+      OtpInfoDTO otpInfo =
+          identityClient.getOtpCredential(usernameTranscoder.encodeUsername(admin.getUsername()));
+      if (otpInfo == null || isBlank(otpInfo.getOtpSecret())) {
+        throw new InternalServerErrorException(
+            "Keycloak issued no TOTP setup material for the onboarding account");
+      }
+
+      AccountInvite claimedInvite =
+          accountInviteRepository
+              .findById(invite.getId())
+              .orElseThrow(() -> new NotFoundException("Account invite not found"));
+      claimedInvite.setAcceptedByUserId(admin.getId());
+      claimedInvite.setTotpPendingSecret(otpInfo.getOtpSecret());
+      claimedInvite.setUpdateDate(now);
+      accountInviteRepository.save(claimedInvite);
+
+      // DPA acceptance snapshot: the wording is rendered read-only by the Admin panel; full
+      // signature persistence in TenantService is the U9 follow-up. Log for the audit trail.
+      log.info(
+          "Tenant-admin onboarding registration accepted the DPA (invite {}, signer '{}')",
+          invite.getId(),
+          command.dpaSignerName());
+
+      MultilingualTenantDTO created =
+          tenantCreationClient.createTenant(buildTenantDto(invite, command));
+      Long tenantId =
+          created != null && created.getId() != null ? created.getId() : invite.getTenantId();
+      return new TenantAdminRegistrationResult(
+          tenantId, otpInfo.getOtpSecret(), otpInfo.getOtpSecretQrCode());
+    } catch (RuntimeException exception) {
+      // Every database change rolls back with the exception; the Keycloak account is external
+      // state and must be compensated explicitly so a failed registration stays retryable.
+      identityClient.rollBackUser(admin.getId());
+      throw exception;
+    }
+  }
+
+  /**
+   * Confirms the pending TOTP setup with a first one-time password. An invalid or rejected code
+   * answers 400 (the Admin panel maps 400/422 to its invalid-code state); once the gate is
+   * satisfied the link is terminally consumed.
+   */
+  @Transactional
+  public void activateTwoFactor(String rawToken, String oneTimePassword) {
+    if (isBlank(oneTimePassword)) {
+      throw new BadRequestException("otp is required");
+    }
+    AccountInvite invite = findTenantAdminInvite(rawToken);
+    LocalDateTime now = LocalDateTime.now();
+
+    if (invite.getStatus() == AccountInviteStatus.EMAIL_SENT) {
+      throw new BadRequestException("Registration has not happened yet for this invite");
+    }
+    if (invite.getStatus() != AccountInviteStatus.ACCEPTED) {
+      throw linkDeathException(invite);
+    }
+    if (!isResumableAtTwoFactorStep(invite, now)) {
+      // Gate already satisfied or resume window expired — terminally consumed.
+      throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
+    }
+    if (isBlank(invite.getTotpPendingSecret()) || isBlank(invite.getAcceptedByUserId())) {
+      throw new BadRequestException("No pending TOTP setup exists for this invite");
+    }
+
+    var keycloakUser = identityClient.getById(invite.getAcceptedByUserId());
+    boolean valid =
+        identityClient.setUpOtpCredential(
+            keycloakUser.getUsername(), oneTimePassword.trim(), invite.getTotpPendingSecret());
+    if (!valid) {
+      throw new BadRequestException("Invalid one-time password");
+    }
+
+    accountInviteService.markTwoFactorActive(invite.getAcceptedByUserId());
+    invite.setTotpPendingSecret(null);
+    invite.setUpdateDate(now);
+    accountInviteRepository.save(invite);
+  }
+
+  private AccountInvite findTenantAdminInvite(String rawToken) {
+    if (isBlank(rawToken)) {
+      throw new BadRequestException("Invite token is required");
+    }
+    AccountInvite invite =
+        accountInviteRepository
+            .findByTokenHash(AccountInviteService.hash(rawToken))
+            .orElseThrow(() -> new NotFoundException("Account invite not found"));
+    if (invite.getTargetRole() != AccountInviteTargetRole.TENANT_ADMIN) {
+      // Tokens of other roles must not resolve on the tenant-admin onboarding endpoints.
+      throw new NotFoundException("Account invite not found");
+    }
+    return invite;
+  }
+
+  private void expireIfPastExpiry(AccountInvite invite, LocalDateTime now) {
+    if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
+      invite.setStatus(AccountInviteStatus.EXPIRED);
+      invite.setUpdateDate(now);
+      accountInviteRepository.save(invite);
+      throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
+    }
+  }
+
+  private static boolean isResumableAtTwoFactorStep(AccountInvite invite, LocalDateTime now) {
+    boolean twoFactorStillPending =
+        !AccountInviteService.isTwoFactorGateSatisfied(invite.getTwoFactorStatus());
+    boolean withinExpiryWindow =
+        invite.getExpiresAt() == null || !invite.getExpiresAt().isBefore(now);
+    return invite.getStatus() == AccountInviteStatus.ACCEPTED
+        && twoFactorStillPending
+        && withinExpiryWindow;
+  }
+
+  private static AccountInviteLinkException linkDeathException(AccountInvite invite) {
+    return switch (invite.getStatus()) {
+      case ACCEPTED -> new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
+      case REVOKED -> new AccountInviteLinkException(AccountInviteLinkException.Reason.REVOKED);
+      case SUPERSEDED ->
+          new AccountInviteLinkException(AccountInviteLinkException.Reason.SUPERSEDED);
+      case EXPIRED -> new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
+      default -> new AccountInviteLinkException(AccountInviteLinkException.Reason.NOT_ACTIVE);
+    };
+  }
+
+  private static void validateRegistration(RegisterTenantAdminCommand command) {
+    if (command == null) {
+      throw new BadRequestException("Request body is required");
+    }
+    if (isBlank(command.organisationName())) {
+      throw new BadRequestException("organisation.name is required");
+    }
+    if (isBlank(command.password()) || command.password().length() < MIN_PASSWORD_LENGTH) {
+      throw new BadRequestException(
+          "account.password must be at least " + MIN_PASSWORD_LENGTH + " characters long");
+    }
+    if (!command.dpaAccepted()) {
+      throw new BadRequestException("The data processing agreement must be accepted");
+    }
+  }
+
+  private CreateAdminDTO buildAdminDto(AccountInvite invite, RegisterTenantAdminCommand command) {
+    CreateAdminDTO adminDto = new CreateAdminDTO();
+    adminDto.setUsername(invite.getRecipientEmail());
+    adminDto.setEmail(invite.getRecipientEmail());
+    // The Admin entity requires non-null names, but invite names are optional — fall back to the
+    // email local part so nameless invites still onboard (the admin can correct the name later).
+    adminDto.setFirstname(
+        isBlank(invite.getFirstName())
+            ? emailLocalPart(invite.getRecipientEmail())
+            : invite.getFirstName());
+    adminDto.setLastname(isBlank(invite.getLastName()) ? "Admin" : invite.getLastName());
+    adminDto.setPassword(command.password());
+    adminDto.setTenantId(invite.getTenantId().intValue());
+    return adminDto;
+  }
+
+  private static String emailLocalPart(String email) {
+    int atIndex = email.indexOf('@');
+    return atIndex > 0 ? email.substring(0, atIndex) : email;
+  }
+
+  private static MultilingualTenantDTO buildTenantDto(
+      AccountInvite invite, RegisterTenantAdminCommand command) {
+    return new MultilingualTenantDTO()
+        .id(invite.getTenantId())
+        .name(command.organisationName().trim())
+        .subdomain(trimToNull(command.subdomain()))
+        .address(trimToNull(command.address()))
+        .adminEmails(List.of(invite.getRecipientEmail()))
+        .tenantIdReservationToken(invite.getTenantIdReservationToken());
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  private static String trimToNull(String value) {
+    return isBlank(value) ? null : value.trim();
+  }
+
+  /**
+   * Resolved onboarding state: the invite plus whether the flow re-enters at the 2FA step (#569
+   * resume contract) instead of the registration step.
+   */
+  public record OnboardingInviteState(AccountInvite invite, boolean pendingTwoFactorResume) {}
+
+  /** Input for the reservation-consuming registration; mirrors the Admin panel request shape. */
+  public record RegisterTenantAdminCommand(
+      String organisationName,
+      String subdomain,
+      String address,
+      boolean dpaAccepted,
+      String dpaSignerName,
+      String dpaSignerPosition,
+      String dpaSignerEmail,
+      String dpaSignerOrganisation,
+      String password,
+      Long reservedTenantId,
+      String tenantIdReservationToken) {}
+
+  /** The created (inactive) tenant plus the TOTP setup material for the 2FA step. */
+  public record TenantAdminRegistrationResult(
+      Long tenantId, String totpSecret, String totpQrCodeBase64) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantCreationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantCreationClient.java
@@ -1,0 +1,68 @@
+package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
+
+import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.TenantControllerApi;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.MultilingualTenantDTO;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Server-to-server tenant creation for the PUBLIC tenant-admin onboarding (#569 chain fix). The
+ * invitee has no account while onboarding, so the call authenticates as the configured Keycloak
+ * technical user — that user must carry the {@code tenant-admin} realm role, because TenantService
+ * guards {@code createTenant} with {@code AUTHORIZATION_CREATE_TENANT}.
+ *
+ * <p>Reservation consumption is atomic on the TenantService side: the tenant is created with the
+ * invite's reserved ID plus the matching {@code tenantIdReservationToken}; a reserved ID without
+ * the matching token is rejected with 409.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantCreationClient {
+
+  private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
+  private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityClientConfig identityClientConfig;
+
+  private final @NonNull TenantAdminServiceApiControllerFactory
+      tenantAdminServiceApiControllerFactory;
+
+  /**
+   * Creates the tenant and consumes the invite's tenant-ID reservation atomically.
+   *
+   * @throws ConflictException when TenantService rejects the creation with 409 — the reserved ID
+   *     was consumed, released or taken in the meantime (single-use link semantics upstream)
+   */
+  public MultilingualTenantDTO createTenant(MultilingualTenantDTO tenant) {
+    try {
+      return createControllerApi().createTenant(tenant);
+    } catch (HttpClientErrorException.Conflict exception) {
+      throw new ConflictException(
+          "Tenant creation conflicted — the reserved tenant ID is no longer consumable");
+    }
+  }
+
+  private TenantControllerApi createControllerApi() {
+    var controllerApi = tenantAdminServiceApiControllerFactory.createControllerApi();
+    addTechnicalUserHeaders(controllerApi.getApiClient());
+    return controllerApi;
+  }
+
+  private void addTechnicalUserHeaders(ApiClient apiClient) {
+    var techUser = identityClientConfig.getTechnicalUser();
+    var keycloakLogin = identityClient.loginUser(techUser.getUsername(), techUser.getPassword());
+    HttpHeaders headers =
+        securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders(keycloakLogin.getAccessToken());
+    headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
+  }
+}

--- a/src/main/resources/db/changelog/changeset/0077_account_invite_totp_pending_secret/0077_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0077_account_invite_totp_pending_secret/0077_changeSet.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <!-- #569 chain fix: the public tenant-admin onboarding two-factor endpoint receives only the
+       one-time password, so the TOTP secret issued at registration must be kept with the invite
+       until the activation succeeds (cleared afterwards). -->
+  <changeSet id="0077-account-invite-totp-pending-secret" author="oriso">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="account_invite" columnName="totp_pending_secret"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="account_invite">
+      <column name="totp_pending_secret" type="varchar(64)"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="account_invite" columnName="totp_pending_secret"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -128,6 +128,8 @@
     file="db/changelog/changeset/0075_remove_rocket_chat_feedback_room_id/0075_changeSet.xml" />
   <include
     file="db/changelog/changeset/0076_account_invite_reservation_token/0076_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0077_account_invite_totp_pending_secret/0077_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TenantAdminOnboardingControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TenantAdminOnboardingControllerTest.java
@@ -1,0 +1,223 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.OnboardingInviteState;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.RegisterTenantAdminCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.TenantAdminRegistrationResult;
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@ExtendWith(MockitoExtension.class)
+class TenantAdminOnboardingControllerTest {
+
+  @Mock private TenantAdminOnboardingService onboardingService;
+
+  private TenantAdminOnboardingController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new TenantAdminOnboardingController(onboardingService);
+  }
+
+  private static AccountInvite invite() {
+    return AccountInvite.builder()
+        .id(7L)
+        .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+        .tenantId(21L)
+        .tenantIdReservationToken("reservation-token")
+        .recipientEmail("tenant.admin@example.org")
+        .firstName("Erika")
+        .lastName("Beispiel")
+        .status(AccountInviteStatus.EMAIL_SENT)
+        .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+        .expiresAt(LocalDateTime.of(2026, 8, 30, 12, 0))
+        .build();
+  }
+
+  @Test
+  void resolveOnboardingInvite_plainState_mapsInviteFieldsWithoutPhase() {
+    when(onboardingService.resolveOnboardingInvite("tok"))
+        .thenReturn(new OnboardingInviteState(invite(), false));
+
+    var response = controller.resolveOnboardingInvite("tok");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    var body = response.getBody();
+    assertNotNull(body);
+    assertEquals("tenant.admin@example.org", body.recipientEmail);
+    assertEquals("Erika", body.firstName);
+    assertEquals("Beispiel", body.lastName);
+    assertEquals(21L, body.reservedTenantId);
+    assertEquals("reservation-token", body.tenantIdReservationToken);
+    assertEquals(LocalDateTime.of(2026, 8, 30, 12, 0), body.expiresAt);
+    assertNull(body.phase);
+    assertNull(body.twoFactor);
+  }
+
+  @Test
+  void resolveOnboardingInvite_resumableState_mapsPhaseAndStoredSecret() {
+    AccountInvite resumable = invite();
+    resumable.setStatus(AccountInviteStatus.ACCEPTED);
+    resumable.setTotpPendingSecret("STOREDSECRET");
+    when(onboardingService.resolveOnboardingInvite("tok"))
+        .thenReturn(new OnboardingInviteState(resumable, true));
+
+    var body = controller.resolveOnboardingInvite("tok").getBody();
+
+    assertNotNull(body);
+    assertEquals("PENDING_2FA_ACTIVATION", body.phase);
+    assertNotNull(body.twoFactor);
+    assertEquals("STOREDSECRET", body.twoFactor.secret);
+    assertNull(body.twoFactor.qrCodeBase64);
+  }
+
+  @Test
+  void resolveOnboardingInvite_resumableWithoutStoredSecret_omitsTwoFactorMaterial() {
+    AccountInvite resumable = invite();
+    resumable.setStatus(AccountInviteStatus.ACCEPTED);
+    when(onboardingService.resolveOnboardingInvite("tok"))
+        .thenReturn(new OnboardingInviteState(resumable, true));
+
+    var body = controller.resolveOnboardingInvite("tok").getBody();
+
+    assertNotNull(body);
+    assertEquals("PENDING_2FA_ACTIVATION", body.phase);
+    assertNull(body.twoFactor);
+  }
+
+  @Test
+  void registerTenantAdmin_mapsRequestToCommandAndResultToResponse() {
+    when(onboardingService.registerTenantAdmin(eq("tok"), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(new TenantAdminRegistrationResult(21L, "TOTPSECRET", "QRBASE64"));
+
+    var request = new TenantAdminOnboardingController.TenantAdminRegistrationRequestDTO();
+    request.organisation = new TenantAdminOnboardingController.OrganisationDataDTO();
+    request.organisation.name = "Beispiel gGmbH";
+    request.organisation.subdomain = "beispiel";
+    request.organisation.address = "Musterstrasse 1";
+    request.dpa = new TenantAdminOnboardingController.DpaAcceptanceDataDTO();
+    request.dpa.accepted = true;
+    request.dpa.signerName = "Erika Beispiel";
+    request.account = new TenantAdminOnboardingController.AccountDataDTO();
+    request.account.password = "s3cretPassword";
+    request.reservedTenantId = 21L;
+    request.tenantIdReservationToken = "reservation-token";
+
+    var response = controller.registerTenantAdmin("tok", request);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    var body = response.getBody();
+    assertNotNull(body);
+    assertEquals(21L, body.tenantId);
+    assertNotNull(body.twoFactor);
+    assertEquals("TOTPSECRET", body.twoFactor.secret);
+    assertEquals("QRBASE64", body.twoFactor.qrCodeBase64);
+
+    ArgumentCaptor<RegisterTenantAdminCommand> captor =
+        ArgumentCaptor.forClass(RegisterTenantAdminCommand.class);
+    verify(onboardingService).registerTenantAdmin(eq("tok"), captor.capture());
+    RegisterTenantAdminCommand command = captor.getValue();
+    assertEquals("Beispiel gGmbH", command.organisationName());
+    assertEquals("beispiel", command.subdomain());
+    assertEquals("Musterstrasse 1", command.address());
+    assertTrue(command.dpaAccepted());
+    assertEquals("Erika Beispiel", command.dpaSignerName());
+    assertEquals("s3cretPassword", command.password());
+    assertEquals(21L, command.reservedTenantId());
+    assertEquals("reservation-token", command.tenantIdReservationToken());
+  }
+
+  @Test
+  void registerTenantAdmin_nullBody_mapsToEmptyCommandInsteadOfNpe() {
+    when(onboardingService.registerTenantAdmin(eq("tok"), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(new TenantAdminRegistrationResult(21L, "TOTPSECRET", null));
+
+    controller.registerTenantAdmin("tok", null);
+
+    ArgumentCaptor<RegisterTenantAdminCommand> captor =
+        ArgumentCaptor.forClass(RegisterTenantAdminCommand.class);
+    verify(onboardingService).registerTenantAdmin(eq("tok"), captor.capture());
+    assertNull(captor.getValue().organisationName());
+    assertNull(captor.getValue().password());
+  }
+
+  @Test
+  void activateTwoFactor_delegatesOtp() {
+    var request = new TenantAdminOnboardingController.TwoFactorActivationRequestDTO();
+    request.otp = "123456";
+
+    var response = controller.activateTwoFactor("tok", request);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    verify(onboardingService).activateTwoFactor("tok", "123456");
+  }
+
+  @Test
+  void activateTwoFactor_nullBody_delegatesNullOtp() {
+    controller.activateTwoFactor("tok", null);
+
+    verify(onboardingService).activateTwoFactor("tok", null);
+  }
+
+  @Test
+  void publicOnboardingEndpoints_haveNoPreAuthorizeAndMapBothPrefixVariants() throws Exception {
+    Method resolve =
+        TenantAdminOnboardingController.class.getMethod("resolveOnboardingInvite", String.class);
+    Method register =
+        TenantAdminOnboardingController.class.getMethod(
+            "registerTenantAdmin",
+            String.class,
+            TenantAdminOnboardingController.TenantAdminRegistrationRequestDTO.class);
+    Method twoFactor =
+        TenantAdminOnboardingController.class.getMethod(
+            "activateTwoFactor",
+            String.class,
+            TenantAdminOnboardingController.TwoFactorActivationRequestDTO.class);
+
+    assertNull(resolve.getAnnotation(PreAuthorize.class));
+    assertNull(register.getAnnotation(PreAuthorize.class));
+    assertNull(twoFactor.getAnnotation(PreAuthorize.class));
+
+    assertTrue(
+        Arrays.asList(resolve.getAnnotation(GetMapping.class).value())
+            .containsAll(
+                Arrays.asList(
+                    "/users/account-invites/{token}/onboarding",
+                    "/service/users/account-invites/{token}/onboarding")));
+    assertTrue(
+        Arrays.asList(register.getAnnotation(PostMapping.class).value())
+            .containsAll(
+                Arrays.asList(
+                    "/users/account-invites/{token}/onboarding/register",
+                    "/service/users/account-invites/{token}/onboarding/register")));
+    assertTrue(
+        Arrays.asList(twoFactor.getAnnotation(PostMapping.class).value())
+            .containsAll(
+                Arrays.asList(
+                    "/users/account-invites/{token}/onboarding/two-factor",
+                    "/service/users/account-invites/{token}/onboarding/two-factor")));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
@@ -1,0 +1,481 @@
+package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
+import de.caritas.cob.userservice.api.admin.service.admin.create.CreateAdminService;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.model.OtpInfoDTO;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityClient;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkException;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.RegisterTenantAdminCommand;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.MultilingualTenantDTO;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantAdminOnboardingServiceTest {
+
+  private static final String RAW_TOKEN = "raw-invite-token";
+  private static final String TOKEN_HASH = AccountInviteService.hash(RAW_TOKEN);
+  private static final String RESERVATION_TOKEN = "3f2c6d1e-8b1a-4b8e-9f47-1234567890ab";
+  private static final Long RESERVED_TENANT_ID = 21L;
+
+  @Mock private AccountInviteRepository accountInviteRepository;
+  @Mock private AccountInviteService accountInviteService;
+  @Mock private CreateAdminService createAdminService;
+  @Mock private IdentityClient identityClient;
+  @Mock private TenantCreationClient tenantCreationClient;
+
+  private TenantAdminOnboardingService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new TenantAdminOnboardingService(
+            accountInviteRepository,
+            accountInviteService,
+            createAdminService,
+            identityClient,
+            tenantCreationClient,
+            new UsernameTranscoder());
+  }
+
+  private static AccountInvite tenantAdminInvite(AccountInviteStatus status) {
+    return AccountInvite.builder()
+        .id(7L)
+        .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+        .tenantId(RESERVED_TENANT_ID)
+        .tenantIdReservationToken(RESERVATION_TOKEN)
+        .recipientEmail("tenant.admin@example.org")
+        .firstName("Erika")
+        .lastName("Beispiel")
+        .status(status)
+        .emailVerificationStatus(EmailVerificationStatus.PENDING)
+        .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+        .expiresAt(LocalDateTime.now().plusDays(10))
+        .createDate(LocalDateTime.now().minusDays(1))
+        .build();
+  }
+
+  private static RegisterTenantAdminCommand validCommand() {
+    return new RegisterTenantAdminCommand(
+        "Beispiel gGmbH",
+        "beispiel",
+        "Musterstrasse 1, 12345 Musterstadt",
+        true,
+        "Erika Beispiel",
+        "CEO",
+        "tenant.admin@example.org",
+        "Beispiel gGmbH",
+        "s3cretPassword",
+        RESERVED_TENANT_ID,
+        RESERVATION_TOKEN);
+  }
+
+  // --- resolve ---
+
+  @Test
+  void resolveOnboardingInvite_blankToken_throwsBadRequest() {
+    assertThrows(BadRequestException.class, () -> service.resolveOnboardingInvite(" "));
+  }
+
+  @Test
+  void resolveOnboardingInvite_unknownToken_throwsNotFound() {
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.empty());
+
+    assertThrows(NotFoundException.class, () -> service.resolveOnboardingInvite(RAW_TOKEN));
+  }
+
+  @Test
+  void resolveOnboardingInvite_nonTenantAdminInvite_throwsNotFound() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    invite.setTargetRole(AccountInviteTargetRole.COUNSELLOR);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    assertThrows(NotFoundException.class, () -> service.resolveOnboardingInvite(RAW_TOKEN));
+  }
+
+  @Test
+  void resolveOnboardingInvite_deliverableInvite_returnsPlainState() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var state = service.resolveOnboardingInvite(RAW_TOKEN);
+
+    assertEquals(invite, state.invite());
+    assertFalse(state.pendingTwoFactorResume());
+  }
+
+  @Test
+  void resolveOnboardingInvite_expiredDeliverableInvite_marksExpiredAndThrows() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    invite.setExpiresAt(LocalDateTime.now().minusMinutes(5));
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class, () -> service.resolveOnboardingInvite(RAW_TOKEN));
+
+    assertEquals(AccountInviteLinkException.Reason.EXPIRED, exception.getReason());
+    assertEquals(AccountInviteStatus.EXPIRED, invite.getStatus());
+    verify(accountInviteRepository).save(invite);
+  }
+
+  @Test
+  void resolveOnboardingInvite_consumedWithPendingTwoFactor_returnsResumeState() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setTotpPendingSecret("STOREDSECRET");
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var state = service.resolveOnboardingInvite(RAW_TOKEN);
+
+    assertTrue(state.pendingTwoFactorResume());
+    assertEquals("STOREDSECRET", state.invite().getTotpPendingSecret());
+  }
+
+  @Test
+  void resolveOnboardingInvite_consumedWithSatisfiedGate_throwsConsumed() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setTwoFactorStatus(TwoFactorGateStatus.ACTIVE);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class, () -> service.resolveOnboardingInvite(RAW_TOKEN));
+
+    assertEquals(AccountInviteLinkException.Reason.CONSUMED, exception.getReason());
+  }
+
+  @Test
+  void resolveOnboardingInvite_revokedInvite_throwsRevoked() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.REVOKED);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class, () -> service.resolveOnboardingInvite(RAW_TOKEN));
+
+    assertEquals(AccountInviteLinkException.Reason.REVOKED, exception.getReason());
+  }
+
+  // --- register ---
+
+  @Test
+  void registerTenantAdmin_happyPath_createsAdminAndTenantAndReturnsTotpMaterial() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    Admin admin =
+        Admin.builder()
+            .id("kc-user-1")
+            .username("tenant.admin@example.org")
+            .email("tenant.admin@example.org")
+            .firstName("Erika")
+            .lastName("Beispiel")
+            .build();
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(admin);
+    when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new OtpInfoDTO().otpSecret("TOTPSECRET").otpSecretQrCode("QRBASE64"));
+    when(tenantCreationClient.createTenant(any()))
+        .thenReturn(new MultilingualTenantDTO().id(RESERVED_TENANT_ID));
+
+    var result = service.registerTenantAdmin(RAW_TOKEN, validCommand());
+
+    assertEquals(RESERVED_TENANT_ID, result.tenantId());
+    assertEquals("TOTPSECRET", result.totpSecret());
+    assertEquals("QRBASE64", result.totpQrCodeBase64());
+
+    ArgumentCaptor<CreateAdminDTO> adminCaptor = ArgumentCaptor.forClass(CreateAdminDTO.class);
+    verify(createAdminService).createNewTenantAdmin(adminCaptor.capture());
+    assertEquals("tenant.admin@example.org", adminCaptor.getValue().getUsername());
+    assertEquals("tenant.admin@example.org", adminCaptor.getValue().getEmail());
+    assertEquals("s3cretPassword", adminCaptor.getValue().getPassword());
+    assertEquals(21, adminCaptor.getValue().getTenantId());
+
+    ArgumentCaptor<MultilingualTenantDTO> tenantCaptor =
+        ArgumentCaptor.forClass(MultilingualTenantDTO.class);
+    verify(tenantCreationClient).createTenant(tenantCaptor.capture());
+    assertEquals(RESERVED_TENANT_ID, tenantCaptor.getValue().getId());
+    assertEquals("Beispiel gGmbH", tenantCaptor.getValue().getName());
+    assertEquals("beispiel", tenantCaptor.getValue().getSubdomain());
+    assertEquals(RESERVATION_TOKEN, tenantCaptor.getValue().getTenantIdReservationToken());
+    assertTrue(tenantCaptor.getValue().getAdminEmails().contains("tenant.admin@example.org"));
+
+    assertEquals("kc-user-1", invite.getAcceptedByUserId());
+    assertEquals("TOTPSECRET", invite.getTotpPendingSecret());
+    verify(accountInviteRepository).save(invite);
+  }
+
+  @Test
+  void registerTenantAdmin_dpaNotAccepted_throwsBadRequest() {
+    var command =
+        new RegisterTenantAdminCommand(
+            "Beispiel gGmbH",
+            "beispiel",
+            null,
+            false,
+            null,
+            null,
+            null,
+            null,
+            "s3cretPassword",
+            RESERVED_TENANT_ID,
+            RESERVATION_TOKEN);
+
+    assertThrows(BadRequestException.class, () -> service.registerTenantAdmin(RAW_TOKEN, command));
+  }
+
+  @Test
+  void registerTenantAdmin_shortPassword_throwsBadRequest() {
+    var command =
+        new RegisterTenantAdminCommand(
+            "Beispiel gGmbH",
+            "beispiel",
+            null,
+            true,
+            null,
+            null,
+            null,
+            null,
+            "short",
+            RESERVED_TENANT_ID,
+            RESERVATION_TOKEN);
+
+    assertThrows(BadRequestException.class, () -> service.registerTenantAdmin(RAW_TOKEN, command));
+  }
+
+  @Test
+  void registerTenantAdmin_reservationMismatch_throwsNotFound() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    var command =
+        new RegisterTenantAdminCommand(
+            "Beispiel gGmbH",
+            "beispiel",
+            null,
+            true,
+            null,
+            null,
+            null,
+            null,
+            "s3cretPassword",
+            RESERVED_TENANT_ID,
+            "some-other-token");
+
+    assertThrows(NotFoundException.class, () -> service.registerTenantAdmin(RAW_TOKEN, command));
+    verify(accountInviteRepository, never()).claimForAcceptance(anyLong(), any(), any());
+  }
+
+  @Test
+  void registerTenantAdmin_missingReservation_throwsInternalServerError() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    invite.setTenantIdReservationToken(null);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+  }
+
+  @Test
+  void registerTenantAdmin_alreadyConsumedInvite_throwsConsumed() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class,
+            () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+
+    assertEquals(AccountInviteLinkException.Reason.CONSUMED, exception.getReason());
+    verify(createAdminService, never()).createNewTenantAdmin(any());
+  }
+
+  @Test
+  void registerTenantAdmin_lostClaimRace_reportsWinnersState() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(0);
+    AccountInvite winner = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(winner));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class,
+            () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+
+    assertEquals(AccountInviteLinkException.Reason.CONSUMED, exception.getReason());
+    verify(createAdminService, never()).createNewTenantAdmin(any());
+  }
+
+  @Test
+  void registerTenantAdmin_tenantCreationFails_rollsBackKeycloakUserAndRethrows() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    Admin admin =
+        Admin.builder()
+            .id("kc-user-1")
+            .username("tenant.admin@example.org")
+            .email("tenant.admin@example.org")
+            .firstName("Erika")
+            .lastName("Beispiel")
+            .build();
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(admin);
+    when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new OtpInfoDTO().otpSecret("TOTPSECRET"));
+    when(tenantCreationClient.createTenant(any()))
+        .thenThrow(new ConflictException("reservation no longer consumable"));
+
+    assertThrows(
+        ConflictException.class, () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+
+    verify(identityClient).rollBackUser("kc-user-1");
+  }
+
+  @Test
+  void registerTenantAdmin_missingTotpMaterial_rollsBackKeycloakUser() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    Admin admin =
+        Admin.builder()
+            .id("kc-user-1")
+            .username("tenant.admin@example.org")
+            .email("tenant.admin@example.org")
+            .firstName("Erika")
+            .lastName("Beispiel")
+            .build();
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(admin);
+    when(identityClient.getOtpCredential(anyString())).thenReturn(new OtpInfoDTO());
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+
+    verify(identityClient).rollBackUser("kc-user-1");
+    verify(tenantCreationClient, never()).createTenant(any());
+  }
+
+  // --- two-factor ---
+
+  @Test
+  void activateTwoFactor_happyPath_activatesGateAndClearsSecret() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setAcceptedByUserId("kc-user-1");
+    invite.setTotpPendingSecret("TOTPSECRET");
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    UserRepresentation keycloakUser = new UserRepresentation();
+    keycloakUser.setUsername("enc.keycloak-username");
+    when(identityClient.getById("kc-user-1")).thenReturn(keycloakUser);
+    when(identityClient.setUpOtpCredential("enc.keycloak-username", "123456", "TOTPSECRET"))
+        .thenReturn(true);
+
+    service.activateTwoFactor(RAW_TOKEN, "123456");
+
+    verify(accountInviteService).markTwoFactorActive("kc-user-1");
+    assertNull(invite.getTotpPendingSecret());
+    verify(accountInviteRepository).save(invite);
+  }
+
+  @Test
+  void activateTwoFactor_invalidCode_throwsBadRequestWithoutActivation() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setAcceptedByUserId("kc-user-1");
+    invite.setTotpPendingSecret("TOTPSECRET");
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    UserRepresentation keycloakUser = new UserRepresentation();
+    keycloakUser.setUsername("enc.keycloak-username");
+    when(identityClient.getById("kc-user-1")).thenReturn(keycloakUser);
+    when(identityClient.setUpOtpCredential(anyString(), anyString(), anyString()))
+        .thenReturn(false);
+
+    assertThrows(BadRequestException.class, () -> service.activateTwoFactor(RAW_TOKEN, "000000"));
+
+    verify(accountInviteService, never()).markTwoFactorActive(anyString());
+    assertEquals("TOTPSECRET", invite.getTotpPendingSecret());
+  }
+
+  @Test
+  void activateTwoFactor_blankOtp_throwsBadRequest() {
+    assertThrows(BadRequestException.class, () -> service.activateTwoFactor(RAW_TOKEN, " "));
+  }
+
+  @Test
+  void activateTwoFactor_registrationNotDoneYet_throwsBadRequest() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    assertThrows(BadRequestException.class, () -> service.activateTwoFactor(RAW_TOKEN, "123456"));
+  }
+
+  @Test
+  void activateTwoFactor_gateAlreadySatisfied_throwsConsumed() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setTwoFactorStatus(TwoFactorGateStatus.ACTIVE);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class, () -> service.activateTwoFactor(RAW_TOKEN, "123456"));
+
+    assertEquals(AccountInviteLinkException.Reason.CONSUMED, exception.getReason());
+  }
+
+  @Test
+  void activateTwoFactor_expiredResumeWindow_throwsConsumed() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setExpiresAt(LocalDateTime.now().minusMinutes(5));
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    var exception =
+        assertThrows(
+            AccountInviteLinkException.class, () -> service.activateTwoFactor(RAW_TOKEN, "123456"));
+
+    assertEquals(AccountInviteLinkException.Reason.CONSUMED, exception.getReason());
+  }
+
+  @Test
+  void activateTwoFactor_noPendingSecret_throwsBadRequest() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
+    invite.setAcceptedByUserId("kc-user-1");
+    invite.setTotpPendingSecret(null);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+
+    assertThrows(BadRequestException.class, () -> service.activateTwoFactor(RAW_TOKEN, "123456"));
+  }
+}


### PR DESCRIPTION
**Stack position: 4 of 6. Base: `fix/ten-inv-hardening-us` (PR 3). Review only the top commit.**

First of three chain-test fix PRs: defects found only once the whole onboarding chain was run
end to end on a clean-slate local stack. `Refs`, not `Closes` — these repair the chunks below.

## Problem

Two defects that between them made the entire tenant-admin onboarding flow unreachable:

1. **The public tenant-admin onboarding endpoints did not exist.** The Admin panel's public flow
   (ORISO-Admin, TEN-INV-U8) calls `GET /users/account-invites/{token}/onboarding`,
   `POST .../onboarding/register` and `POST .../onboarding/two-factor`. UserService implemented
   only `/{token}/accept`. Scenarios S1, S5 and S6 dead-ended at the first request.
2. **Even the endpoint that did exist was unreachable anonymously.** `SecurityConfig` had no
   permit rule for `/users/account-invites/**` and ends with `anyRequest().denyAll()`, so an
   invitee — who by definition has no account yet — always got `401`.

## What changed

**New `TenantAdminOnboardingController` + `TenantAdminOnboardingService`** implementing the
pinned contract:

- **resolve** — invite state keyed by the raw link token, including the
  `PENDING_2FA_ACTIVATION` resume phase and the re-issued TOTP secret; distinct `410 {reason}`
  link-death answers; `404` for unknown tokens.
- **register** — atomic single-use claim, then the tenant-admin Keycloak account and admin row
  (`CreateAdminService`), TOTP setup material, and the reservation-consuming tenant creation
  last. TenantService consumes the reserved ID against
  `MultilingualTenantDTO.tenantIdReservationToken` atomically (`TenantCreationClient`,
  technical-user auth). The Keycloak user is compensated via `rollBackUser` on any later failure,
  so a half-created onboarding does not leave an orphan identity behind.
- **two-factor** — confirms the pending TOTP setup (`400` on an invalid code), marks the invite
  gate `ACTIVE` and clears the stored secret.

**`SecurityConfig`** — permit rules for the accept endpoint and the three onboarding endpoints,
with and without the `/service` gateway prefix. The accept endpoint is now also mapped under
`/service`, consistent with the other public endpoints.

**Support changes**

- `account_invite.totp_pending_secret` (changeset `0077`): the public two-factor endpoint only
  receives the OTP, so the secret issued at registration is held server-side until activation and
  cleared afterwards.
- `services/tenantadminservice.yaml` synced with the TenantService contract
  (`MultilingualTenantDTO.tenantIdReservationToken`).

**Deployment note for the reviewer:** the Keycloak technical user must carry the tenant-admin
realm role — TenantService guards `createTenant` with `AUTHORIZATION_CREATE_TENANT`.

## Testing

Re-run locally on 2026-07-29 with JDK 21 on the tip of this stack:

| Suite | Result |
| --- | --- |
| `TenantAdminOnboardingServiceTest` | 29 tests, 0 failures |
| `TenantAdminOnboardingControllerTest` | 9 tests, 0 failures |
| `AccountInviteServiceTest` | 83 tests, 0 failures |

Both onboarding suites are new in this commit and cover resolve/register/two-factor including the
resume phase, the distinct link-death reasons, the unknown-token `404`, and the Keycloak
compensation path.

The real proof is the chain run itself — these endpoints are what made it complete at all:

- **S1** — invite → mail → local `/admin/tenant-onboarding/{token}` link → organisation data and
  DPA → account → TOTP → login, anonymously end to end.
- **S5** — revoked link shows its distinct error, a 2FA-pending link resumes, a completed link
  shows `CONSUMED`.
- **S6** — mobile 390x844 scrolling through the whole flow.
- **C1** — the onboarded admin subsequently logs in unblocked.

**Honest note:** `UserControllerE2EIT` fails on this machine with `RedisConnectionFailureException`
(`Connection refused: localhost/127.0.0.1:6379`) — no local Redis, identical on the untouched
baseline, not a regression. No green full IT suite is being claimed.

Refs OpenResilienceInitiative/ORISO-UserService#890

Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
