### PR TITLE
[TEN-INV] Record the invitee's DPA acceptance as the tenant's signature

### DIFF
--- a/.github/workflows/openapi-contracts.yml
+++ b/.github/workflows/openapi-contracts.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: OpenResilienceInitiative/ORISO-TenantService
-        ref: ${{ github.event_name == 'pull_request' && '1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e' || 'pre-dev' }}
+        ref: ${{ github.event_name == 'pull_request' && 'f7f1d8878e9d52cb0106549a10894ca5944a968e' || 'pre-dev' }}
         path: .providers/tenant
         persist-credentials: false
 

--- a/services/tenantadminservice.yaml
+++ b/services/tenantadminservice.yaml
@@ -1191,6 +1191,46 @@ components:
           $ref: '#/components/schemas/MultilingualContent'
         settings:
           $ref: '#/components/schemas/Settings'
+        onboardingDpaAcceptance:
+          $ref: '#/components/schemas/OnboardingDpaAcceptanceDTO'
+    OnboardingDpaAcceptanceDTO:
+      type: object
+      description: 'Creation-only: the data processing agreement acceptance a tenant admin gave
+        while onboarding through a public invite link (TEN-INV-U9/#569). TenantService persists it
+        append-only as the tenant''s admin signature in the SAME unit of work as the tenant
+        creation, so a tenant never exists without the acceptance that created it.'
+      required:
+        - accepted
+        - signerUserId
+        - signerName
+      properties:
+        accepted:
+          type: boolean
+        signerUserId:
+          type: string
+          maxLength: 255
+        signerUsername:
+          type: string
+          maxLength: 255
+        signerName:
+          type: string
+          maxLength: 255
+        signerPosition:
+          type: string
+          maxLength: 255
+        signerEmail:
+          type: string
+          maxLength: 255
+        signerOrganisation:
+          type: string
+          maxLength: 255
+        language:
+          type: string
+          maxLength: 10
+        dpaVersion:
+          type: string
+          description: Activation timestamp of the operator DPA version that was actually shown
+            to the signer (as served by DpaVersionDTO.activationDate).
     BasicTenantLicensingDTO:
       type: object
       required:

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClient.java
@@ -72,26 +72,36 @@ public class OperatorDpaContentClient {
   }
 
   /**
-   * The operator's newest published DPA content — the stored language -&gt; HTML JSON map the Admin
-   * panel renders read-only — or {@code null} when nothing is published, the lookup is disabled or
-   * TenantService could not be read.
+   * The operator's newest published DPA: the stored language -&gt; HTML JSON map the Admin panel
+   * renders read-only PLUS the activation timestamp identifying that version. {@code null} when
+   * nothing is published, the lookup is disabled or TenantService could not be read.
+   *
+   * <p>The version travels with the content on purpose (#569): the acceptance the invitee gives is
+   * recorded as a signature against exactly the version that was rendered here, never against
+   * whatever happens to be current when the registration lands.
    */
-  public String fetchPublishedDpaContent() {
+  public OperatorDpa fetchPublishedDpa() {
     if (operatorTenantId <= 0) {
       return null;
     }
     CachedContent cached = cache.get();
     if (cached != null && !cached.isExpired()) {
-      return cached.content();
+      return cached.dpa();
     }
-    String content = readNewestPublishedContent();
-    if (content != null) {
-      cache.set(new CachedContent(content, System.nanoTime() + CACHE_TTL.toNanos()));
+    OperatorDpa dpa = readNewestPublished();
+    if (dpa != null) {
+      cache.set(new CachedContent(dpa, System.nanoTime() + CACHE_TTL.toNanos()));
     }
-    return content;
+    return dpa;
   }
 
-  private String readNewestPublishedContent() {
+  /** Content-only convenience for the resolve step, which renders but does not sign. */
+  public String fetchPublishedDpaContent() {
+    OperatorDpa dpa = fetchPublishedDpa();
+    return dpa == null ? null : dpa.content();
+  }
+
+  private OperatorDpa readNewestPublished() {
     List<DpaVersionDTO> versions;
     try {
       versions = createControllerApi().getDataProcessingAgreementVersions(operatorTenantId);
@@ -110,13 +120,31 @@ public class OperatorDpaContentClient {
           operatorTenantId);
       return null;
     }
-    // TenantService lists the versions newest first; skip empty snapshots defensively.
+    // TenantService lists the versions newest first; skip empty snapshots defensively. Content and
+    // version must come from the SAME entry, otherwise the recorded signature would name a version
+    // whose wording was never shown.
     return versions.stream()
-        .map(DpaVersionDTO::getContent)
-        .filter(content -> content != null && !content.trim().isEmpty())
+        .filter(version -> isNotBlank(version.getContent()))
         .findFirst()
+        .map(
+            version ->
+                new OperatorDpa(version.getContent(), trimToNull(version.getActivationDate())))
         .orElse(null);
   }
+
+  private static boolean isNotBlank(String value) {
+    return value != null && !value.trim().isEmpty();
+  }
+
+  private static String trimToNull(String value) {
+    return isNotBlank(value) ? value.trim() : null;
+  }
+
+  /**
+   * The governing operator DPA as shown to an invitee: the multilingual content snapshot and the
+   * activation timestamp identifying the version ({@code null} when TenantService served none).
+   */
+  public record OperatorDpa(String content, String version) {}
 
   private TenantControllerApi createControllerApi() {
     var controllerApi = tenantAdminServiceApiControllerFactory.createControllerApi();
@@ -132,7 +160,7 @@ public class OperatorDpaContentClient {
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }
 
-  private record CachedContent(String content, long expiresAtNanos) {
+  private record CachedContent(OperatorDpa dpa, long expiresAtNanos) {
     boolean isExpired() {
       return System.nanoTime() - expiresAtNanos >= 0;
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
@@ -14,7 +15,9 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteLinkExc
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.OperatorDpaContentClient.OperatorDpa;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.MultilingualTenantDTO;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.OnboardingDpaAcceptanceDTO;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.NonNull;
@@ -84,6 +87,19 @@ public class TenantAdminOnboardingService {
    * effects compensable: the invite is claimed first (rolls back with the transaction), then the
    * Keycloak account is created (compensated via {@code rollBackUser} on any later failure), and
    * the TenantService creation — the irreversible reservation consumption — runs last.
+   *
+   * <p>The DPA acceptance travels WITH that creation call (#569). There is exactly one data
+   * processing agreement relationship, platform operator &lt;-&gt; tenant, and the acceptance the
+   * invitee gives here IS the tenant's signature on the operator's current version — so it is
+   * recorded through the U9 admin-signature contract for the tenant being created, against the
+   * version that was actually shown. Handing it to TenantService inside the creation is what makes
+   * it consistent: tenant and signature are committed together or rolled back together (including
+   * the ID reservation), so the flow can neither report success for an unrecorded acceptance nor
+   * leave behind a tenant whose admin walks into a non-actionable DPA blocker on first login.
+   *
+   * <p>Consequence: without a published operator DPA there is nothing to accept, and the
+   * registration is refused up front — before the invite is claimed, so the link stays usable once
+   * the operator publishes.
    */
   @Transactional
   public TenantAdminRegistrationResult registerTenantAdmin(
@@ -107,6 +123,19 @@ public class TenantAdminOnboardingService {
         || !invite.getTenantIdReservationToken().equals(command.tenantIdReservationToken())) {
       // The echoed reservation pair must prove ownership; a mismatch is an unusable link (404).
       throw new NotFoundException("Reservation does not match this invite");
+    }
+
+    OperatorDpa operatorDpa = operatorDpaContentClient.fetchPublishedDpa();
+    if (operatorDpa == null) {
+      // Nothing to accept: the acceptance would be unrecordable and the tenant would be created
+      // straight into the non-actionable DPA blocker. Refuse before touching the invite.
+      log.error(
+          "Tenant-admin onboarding registration refused for invite {}: the platform operator has"
+              + " published no data processing agreement, so the acceptance cannot be recorded",
+          invite.getId());
+      throw new InternalServerErrorException(
+          "No data processing agreement is published by the platform operator — publish it before"
+              + " tenant admins can complete the onboarding");
     }
 
     int claimed = accountInviteRepository.claimForAcceptance(invite.getId(), null, now);
@@ -137,28 +166,14 @@ public class TenantAdminOnboardingService {
       claimedInvite.setUpdateDate(now);
       accountInviteRepository.save(claimedInvite);
 
-      // DPA acceptance snapshot: the wording is rendered read-only by the Admin panel from the
-      // operator's published DPA; the binding per-tenant signature is taken later against the
-      // tenant's own published version (TenantService U9/U10 blocker). Log for the audit trail,
-      // including whether a contract text existed to be shown — an acceptance recorded while the
-      // operator published no DPA is a configuration defect and must be visible as such.
-      boolean dpaTextPresentable = operatorDpaContentClient.fetchPublishedDpaContent() != null;
-      if (!dpaTextPresentable) {
-        log.warn(
-            "Tenant-admin onboarding registration accepted the DPA although the platform operator"
-                + " has published none (invite {}, signer '{}') — publish the operator DPA so the"
-                + " wording is shown before the acceptance box",
-            invite.getId(),
-            command.dpaSignerName());
-      } else {
-        log.info(
-            "Tenant-admin onboarding registration accepted the DPA (invite {}, signer '{}')",
-            invite.getId(),
-            command.dpaSignerName());
-      }
-
       MultilingualTenantDTO created =
-          tenantCreationClient.createTenant(buildTenantDto(invite, command));
+          tenantCreationClient.createTenant(
+              buildTenantDto(invite, command, buildDpaAcceptance(command, admin, operatorDpa)));
+      log.info(
+          "Tenant-admin onboarding recorded the DPA acceptance of invite {} against operator DPA"
+              + " version {}",
+          invite.getId(),
+          operatorDpa.version());
       Long tenantId =
           created != null && created.getId() != null ? created.getId() : invite.getTenantId();
       return new TenantAdminRegistrationResult(
@@ -295,14 +310,38 @@ public class TenantAdminOnboardingService {
   }
 
   private static MultilingualTenantDTO buildTenantDto(
-      AccountInvite invite, RegisterTenantAdminCommand command) {
+      AccountInvite invite,
+      RegisterTenantAdminCommand command,
+      OnboardingDpaAcceptanceDTO dpaAcceptance) {
     return new MultilingualTenantDTO()
         .id(invite.getTenantId())
         .name(command.organisationName().trim())
         .subdomain(trimToNull(command.subdomain()))
         .address(trimToNull(command.address()))
         .adminEmails(List.of(invite.getRecipientEmail()))
-        .tenantIdReservationToken(invite.getTenantIdReservationToken());
+        .tenantIdReservationToken(invite.getTenantIdReservationToken())
+        .onboardingDpaAcceptance(dpaAcceptance);
+  }
+
+  /**
+   * The invitee's acceptance in the shape TenantService persists as the tenant's append-only admin
+   * signature (U9). The signer is the tenant-admin account just created — not the technical user
+   * carrying the call — and the version is the operator DPA that was rendered to them.
+   */
+  private static OnboardingDpaAcceptanceDTO buildDpaAcceptance(
+      RegisterTenantAdminCommand command, Admin admin, OperatorDpa operatorDpa) {
+    return new OnboardingDpaAcceptanceDTO()
+        .accepted(true)
+        .signerUserId(admin.getId())
+        .signerUsername(admin.getUsername())
+        .signerName(
+            isBlank(command.dpaSignerName())
+                ? admin.getFirstName() + " " + admin.getLastName()
+                : command.dpaSignerName().trim())
+        .signerPosition(trimToNull(command.dpaSignerPosition()))
+        .signerEmail(trimToNull(command.dpaSignerEmail()))
+        .signerOrganisation(trimToNull(command.dpaSignerOrganisation()))
+        .dpaVersion(operatorDpa.version());
   }
 
   private static boolean isBlank(String value) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OperatorDpaContentClientTest.java
@@ -100,6 +100,59 @@ class OperatorDpaContentClientTest {
   }
 
   @Test
+  void fetchPublishedDpaReturnsContentAndVersionOfTheNewestPublishedEntry() {
+    when(tenantControllerApi.getDataProcessingAgreementVersions(OPERATOR_TENANT_ID))
+        .thenReturn(
+            List.of(
+                new DpaVersionDTO().activationDate("2026-07-20T10:00").content(DPA_JSON),
+                new DpaVersionDTO()
+                    .activationDate("2026-01-02T10:00")
+                    .content("{\"de\":\"old\"}")));
+
+    var dpa = clientFor(OPERATOR_TENANT_ID).fetchPublishedDpa();
+
+    assertEquals(DPA_JSON, dpa.content());
+    assertEquals("2026-07-20T10:00", dpa.version());
+  }
+
+  /**
+   * The recorded signature must name the version whose wording was shown, so content and version
+   * always come from the same entry — never the newest date paired with an older text.
+   */
+  @Test
+  void fetchPublishedDpaTakesContentAndVersionFromTheSameEntry() {
+    when(tenantControllerApi.getDataProcessingAgreementVersions(OPERATOR_TENANT_ID))
+        .thenReturn(
+            List.of(
+                new DpaVersionDTO().activationDate("2026-07-20T10:00").content("   "),
+                new DpaVersionDTO().activationDate("2026-01-02T10:00").content(DPA_JSON)));
+
+    var dpa = clientFor(OPERATOR_TENANT_ID).fetchPublishedDpa();
+
+    assertEquals(DPA_JSON, dpa.content());
+    assertEquals("2026-01-02T10:00", dpa.version());
+  }
+
+  @Test
+  void fetchPublishedDpaReturnsNullVersionWhenUpstreamServesNone() {
+    when(tenantControllerApi.getDataProcessingAgreementVersions(OPERATOR_TENANT_ID))
+        .thenReturn(List.of(new DpaVersionDTO().content(DPA_JSON)));
+
+    var dpa = clientFor(OPERATOR_TENANT_ID).fetchPublishedDpa();
+
+    assertEquals(DPA_JSON, dpa.content());
+    assertNull(dpa.version());
+  }
+
+  @Test
+  void fetchPublishedDpaReturnsNullWhenNothingIsPublished() {
+    when(tenantControllerApi.getDataProcessingAgreementVersions(OPERATOR_TENANT_ID))
+        .thenReturn(List.of());
+
+    assertNull(clientFor(OPERATOR_TENANT_ID).fetchPublishedDpa());
+  }
+
+  @Test
   void fetchPublishedDpaContentReturnsNullWhenTheOperatorTenantPublishedNothing() {
     when(tenantControllerApi.getDataProcessingAgreementVersions(OPERATOR_TENANT_ID))
         .thenReturn(List.of());

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,6 +33,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.onboarding.OperatorDpaContentClient.OperatorDpa;
 import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.RegisterTenantAdminCommand;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.MultilingualTenantDTO;
 import java.time.LocalDateTime;
@@ -91,6 +93,14 @@ class TenantAdminOnboardingServiceTest {
         .expiresAt(LocalDateTime.now().plusDays(10))
         .createDate(LocalDateTime.now().minusDays(1))
         .build();
+  }
+
+  private static final OperatorDpa OPERATOR_DPA =
+      new OperatorDpa(OPERATOR_DPA_JSON, "2026-07-20T10:00");
+
+  /** The governing operator DPA the invitee is shown and accepts (#569). */
+  private void givenPublishedOperatorDpa() {
+    when(operatorDpaContentClient.fetchPublishedDpa()).thenReturn(OPERATOR_DPA);
   }
 
   private static RegisterTenantAdminCommand validCommand() {
@@ -225,6 +235,7 @@ class TenantAdminOnboardingServiceTest {
   @Test
   void registerTenantAdmin_happyPath_createsAdminAndTenantAndReturnsTotpMaterial() {
     AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
     when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
     when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
     when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
@@ -267,6 +278,108 @@ class TenantAdminOnboardingServiceTest {
     assertEquals("kc-user-1", invite.getAcceptedByUserId());
     assertEquals("TOTPSECRET", invite.getTotpPendingSecret());
     verify(accountInviteRepository).save(invite);
+  }
+
+  /**
+   * #569 defect 2 (compliance): the acceptance must become an auditable U9 admin signature for the
+   * tenant being created — signer identity, the operator DPA version actually shown and the form
+   * data — instead of a log line. Defect 1 follows from it: with that signature the tenant's DPA
+   * status resolves to VALID, so the first login is not blocked.
+   */
+  @Test
+  void registerTenantAdmin_recordsTheDpaAcceptanceAsTheTenantsAdminSignature() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(onboardedAdmin());
+    when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new OtpInfoDTO().otpSecret("TOTPSECRET"));
+    when(tenantCreationClient.createTenant(any()))
+        .thenReturn(new MultilingualTenantDTO().id(RESERVED_TENANT_ID));
+
+    service.registerTenantAdmin(RAW_TOKEN, validCommand());
+
+    ArgumentCaptor<MultilingualTenantDTO> tenantCaptor =
+        ArgumentCaptor.forClass(MultilingualTenantDTO.class);
+    verify(tenantCreationClient).createTenant(tenantCaptor.capture());
+    var acceptance = tenantCaptor.getValue().getOnboardingDpaAcceptance();
+    assertNotNull(acceptance);
+    assertTrue(acceptance.getAccepted());
+    assertEquals("kc-user-1", acceptance.getSignerUserId());
+    assertEquals("tenant.admin@example.org", acceptance.getSignerUsername());
+    assertEquals("Erika Beispiel", acceptance.getSignerName());
+    assertEquals("CEO", acceptance.getSignerPosition());
+    assertEquals("tenant.admin@example.org", acceptance.getSignerEmail());
+    assertEquals("Beispiel gGmbH", acceptance.getSignerOrganisation());
+    assertEquals("2026-07-20T10:00", acceptance.getDpaVersion());
+  }
+
+  /**
+   * No governing DPA published means there is nothing the invitee could validly accept, and the
+   * tenant would be created straight into the non-actionable blocker. The registration is refused
+   * BEFORE the single-use link is claimed, so it stays usable once the operator publishes.
+   */
+  @Test
+  void registerTenantAdmin_noOperatorDpaPublished_refusesBeforeConsumingAnything() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(operatorDpaContentClient.fetchPublishedDpa()).thenReturn(null);
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> service.registerTenantAdmin(RAW_TOKEN, validCommand()));
+
+    verify(accountInviteRepository, never()).claimForAcceptance(anyLong(), any(), any());
+    verify(createAdminService, never()).createNewTenantAdmin(any());
+    verify(tenantCreationClient, never()).createTenant(any());
+  }
+
+  /** A signature the invitee left nameless still names a human: the invited admin. */
+  @Test
+  void registerTenantAdmin_blankSignerName_fallsBackToTheOnboardedAdminsName() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(onboardedAdmin());
+    when(identityClient.getOtpCredential(anyString()))
+        .thenReturn(new OtpInfoDTO().otpSecret("TOTPSECRET"));
+    when(tenantCreationClient.createTenant(any()))
+        .thenReturn(new MultilingualTenantDTO().id(RESERVED_TENANT_ID));
+    var command =
+        new RegisterTenantAdminCommand(
+            "Beispiel gGmbH",
+            "beispiel",
+            null,
+            true,
+            "  ",
+            null,
+            null,
+            null,
+            "s3cretPassword",
+            RESERVED_TENANT_ID,
+            RESERVATION_TOKEN);
+
+    service.registerTenantAdmin(RAW_TOKEN, command);
+
+    ArgumentCaptor<MultilingualTenantDTO> tenantCaptor =
+        ArgumentCaptor.forClass(MultilingualTenantDTO.class);
+    verify(tenantCreationClient).createTenant(tenantCaptor.capture());
+    assertEquals(
+        "Erika Beispiel", tenantCaptor.getValue().getOnboardingDpaAcceptance().getSignerName());
+  }
+
+  private static Admin onboardedAdmin() {
+    return Admin.builder()
+        .id("kc-user-1")
+        .username("tenant.admin@example.org")
+        .email("tenant.admin@example.org")
+        .firstName("Erika")
+        .lastName("Beispiel")
+        .build();
   }
 
   @Test
@@ -357,6 +470,7 @@ class TenantAdminOnboardingServiceTest {
   @Test
   void registerTenantAdmin_lostClaimRace_reportsWinnersState() {
     AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
     when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
     when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(0);
     AccountInvite winner = tenantAdminInvite(AccountInviteStatus.ACCEPTED);
@@ -374,6 +488,7 @@ class TenantAdminOnboardingServiceTest {
   @Test
   void registerTenantAdmin_tenantCreationFails_rollsBackKeycloakUserAndRethrows() {
     AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
     when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
     when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
     when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
@@ -400,6 +515,7 @@ class TenantAdminOnboardingServiceTest {
   @Test
   void registerTenantAdmin_missingTotpMaterial_rollsBackKeycloakUser() {
     AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
     when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
     when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
     Admin admin =

--- a/tests/contracts/test_openapi_contract_gate.py
+++ b/tests/contracts/test_openapi_contract_gate.py
@@ -147,7 +147,7 @@ class OpenApiContractGateTest(unittest.TestCase):
             workflow,
             re.compile(
                 r"repository: OpenResilienceInitiative/ORISO-TenantService.*"
-                r"1bf83a2a747c3c2a0ec3b30a35a3ab0c7b989a4e",
+                r"f7f1d8878e9d52cb0106549a10894ca5944a968e",
                 re.DOTALL,
             ),
         )


### PR DESCRIPTION
**Stack position: 6 of 6 — top of the chain. Base: `fix/ten-inv-chainfix2-userservice` (PR 5). Review only the top commit.**

Final chain-test fix PR. Its head equals the proven integration state for this repository.
`Refs`, not `Closes`.

## Problem

The public tenant-admin onboarding asked the invitee to confirm the data processing agreement on
behalf of their organisation — and then dropped the answer. The confirmation, together with signer
name, position, email and organisation, existed only as an application log line.

The created tenant therefore held no signature at all, its DPA status read `MISSING`, and the
invitee's very next login hit the non-bypassable DPA blocker with nothing to act on. The account
was created successfully and immediately locked out.

## What changed

There is exactly one data processing agreement relationship — platform operator ↔ tenant — and the
acceptance given during onboarding **is** the tenant's signature on the operator's current version.

- Registration now passes the acceptance into the tenant-creating call as
  `onboardingDpaAcceptance`, where TenantService persists it through the U9 append-only
  admin-signature contract for the new tenant: signer identity of the tenant-admin account just
  created, the operator DPA version that was actually shown, the timestamp, and the verbatim form
  snapshot.
- **Carrying it inside the creation is what keeps it consistent.** TenantService commits tenant and
  signature together and rolls both back — restoring the ID reservation — otherwise. So the flow
  can neither report a successful onboarding for an unrecorded acceptance, nor leave behind a
  tenant whose admin is locked out.
- `OperatorDpaContentClient` now serves content and version together, taken from the same published
  entry, so a recorded signature can never name a version whose wording was not the one rendered.
- With no operator DPA published there is nothing to accept: registration is refused *before* the
  single-use link is claimed, so the link stays usable once the operator publishes.

## Testing

Re-run locally on 2026-07-29 with JDK 21 on this branch, which is the tip of the stack:

| Suite | Result |
| --- | --- |
| `TenantAdminOnboardingServiceTest` | 29 tests, 0 failures |
| `OperatorDpaContentClientTest` | 13 tests, 0 failures |
| `TenantAdminOnboardingControllerTest` | 9 tests, 0 failures |
| `AccountInviteServiceTest` | 83 tests, 0 failures |
| `AccountInviteControllerTest` | 27 tests, 0 failures |
| `IdAllocationControllerTest` | 5 tests, 0 failures |
| `InviteAcceptUrlBuilderTest` | 5 tests, 0 failures |
| `InviteMailDispatchServiceTest` | 6 tests, 0 failures |
| `JakartaInviteMailTransportTest` | 4 tests, 0 failures |
| `ApiResponseEntityExceptionHandlerTest` | 13 tests, 0 failures |
| `AccountInviteReservationOrchestrationIT` | 3 tests, 0 failures |
| `AccountInviteAcceptRaceIT` | 2 tests, 0 failures |

That is the complete set of suites this stack adds or touches: 194 unit tests plus 5 integration
tests, all observed green in one run on this branch.

Continuity evidence from the clean-slate local chain run, which is exactly what this commit exists
to satisfy:

- **C1** — the onboarded admin logs in **unblocked**; before this change the same login hit the DPA
  blocker with `MISSING` status.
- **C2/C3** — the acceptance is persisted verbatim and append-only.
- **C4** — a directly created tenant (not via onboarding) can still read **and** sign the governing
  operator DPA — the U9/U10 path is unregressed by the new write.
- **C5/C6** — forwarding unregressed.

**Honest note:** `UserControllerE2EIT` fails on this machine — every one of its 22 failing cases is
`RedisConnectionFailureException: Unable to connect to Redis` / `Connection refused:
localhost/127.0.0.1:6379`. There is no Redis running locally. This is an environment gap, identical
on the untouched baseline, and this stack touches none of the classes that suite exercises. I am
explicitly **not** claiming a green full IT suite.

Refs OpenResilienceInitiative/ORISO-UserService#889
Refs OpenResilienceInitiative/ORISO-UserService#890

Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
