### PR TITLE
Fix PreDev identity mock contract regression

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -39,6 +39,7 @@ import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.consultingtypeservice.generated.ApiClient;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.ConsultingTypeControllerApi;
@@ -120,7 +121,12 @@ class UserAdminControllerE2EIT {
 
   @MockitoBean private Keycloak keycloak;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -22,6 +22,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -63,7 +64,12 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -76,6 +76,7 @@ import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.ChatService;
@@ -158,7 +159,12 @@ class UserControllerAuthorizationIT {
   @MockitoBean private ConsultantImportService consultantImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private IdentityManager identityManager;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -53,6 +53,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
@@ -277,7 +278,12 @@ class UserControllerIT {
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -24,6 +24,7 @@ import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -51,7 +52,12 @@ class CreateAdminServiceIT {
 
   @Autowired private CreateAdminService createAdminService;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -31,7 +32,12 @@ public class UpdateAdminServiceIT {
 
   @Autowired private UpdateAdminService updateAdminService;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @Autowired private RetrieveAdminService retrieveAdminService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -28,6 +28,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -76,7 +77,12 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private ConsultingTypeManager consultingTypeManager;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,7 +30,12 @@ public class ConsultantUpdateServiceBase {
 
   @Autowired protected ConsultantUpdateService consultantUpdateService;
 
-  @MockitoBean(extraInterfaces = {IdentityAuthentication.class, IdentityEmailOwnerLookup.class})
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   protected IdentityClient identityClient;
 
   @MockitoBean protected AgencyService agencyService;


### PR DESCRIPTION
## Summary

- restore `IdentityUsernameAvailability` on all eight shared `IdentityClient` Spring mocks
- preserve the `IdentityAuthentication` and `IdentityEmailOwnerLookup` interfaces added by the later identity-port merges
- repair test wiring only; production behavior is unchanged

## Root cause

The merged username-availability boundary (#881) and later authentication boundary (#880) both changed the same `@MockitoBean` declarations. The later conflict resolution retained authentication and email-owner lookup but dropped username availability. `IdentityManager` then received a bean named `keycloakService` that could not satisfy `IdentityUsernameAvailability`, causing 193 integration errors while loading Spring contexts on current `pre-dev`.

## Verification

- red evidence: PreDev run 30431743046 — 858 tests, 193 context errors
- targeted regression: `UserAdminControllerE2EIT` — 30/30 green
- required integration contract: 85 reports, 858 tests, 0 failures, 0 errors, 9 expected environment skips
- unit suite: 3,543 tests, 0 failures, 0 errors
- CI and architecture contracts: 54 tests green
- Java 21 formatter and package build green

## Release truth

This PR only restores the currently broken PreDev test contract. It does not merge or deploy the larger refactor in #888. The Matrix-only target remains ORISO-owned frontend plus an ORISO-controlled Element Call/MatrixRTC fork and LiveKit; Rocket.Chat and Jitsi remain complete removal targets, never fallbacks.

Fixes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)