### PR TITLE
fix(case-handover): unblock handover on existing membership + pseudonymous counsellor identity (#925)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
 import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.facade.TeamDiscussionFacade;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.MatrixIds;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
@@ -52,6 +53,7 @@ public class AssignEnquiryFacade {
   private final @NonNull UserRepository userRepository;
   private final @NonNull UserHelper userHelper;
   private final @NonNull UsernameTranscoder usernameTranscoder;
+  private final @NonNull ConsultantDisplayNameResolver consultantDisplayNameResolver;
   private final @NonNull AgencyMatrixCredentialClient agencyMatrixCredentialClient;
   private final @NonNull EventNotificationService eventNotificationService;
 
@@ -446,7 +448,7 @@ public class AssignEnquiryFacade {
     }
 
     var matrixLocalpart = usernameTranscoder.decodeUsername(consultant.getUsername());
-    var displayName = consultant.getFirstName() + " " + consultant.getLastName();
+    var displayName = consultantDisplayNameResolver.resolveMatrixDisplayName(consultant);
     var matrixUserId = createOrResolveMatrixUserId(matrixLocalpart, displayName);
     if (!isBlank(matrixUserId)) {
       consultant.setMatrixUserId(matrixUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
  * member of the same room, so their own client can read every member's display name straight from
  * {@code /joined_members} — filtering the participant list in the UI does not hide anything.
  *
- * <p>The invariant this class enforces: a counsellor's Matrix display name never reveals more
- * than the room's member list already does. The Matrix ID itself carries the (transcoded)
- * username, and the app already shows the client {@link Consultant#getDisplayName()} where one is
- * set — so those two are the only permitted sources. The real name is never used.
+ * <p>The invariant this class enforces: a counsellor's Matrix display name never reveals more than
+ * the room's member list already does. The Matrix ID itself carries the (transcoded) username, and
+ * the app already shows the client {@link Consultant#getDisplayName()} where one is set — so those
+ * two are the only permitted sources. The real name is never used.
  */
 @Component
 public class ConsultantDisplayNameResolver {

--- a/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
@@ -1,0 +1,53 @@
+package de.caritas.cob.userservice.api.helper;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the Matrix {@code displayname} a counsellor's account is provisioned with.
+ *
+ * <p>ADR-002 §2: the whole department are real, permanent members of a conversation room, and
+ * silent members must be <em>pseudonymous</em> towards the advice seeker. The advice seeker is a
+ * member of the same room, so their own client can read every member's display name straight from
+ * {@code /joined_members} — filtering the participant list in the UI does not hide anything.
+ *
+ * <p>The invariant this class enforces: a counsellor's Matrix display name never reveals more
+ * than the room's member list already does. The Matrix ID itself carries the (transcoded)
+ * username, and the app already shows the client {@link Consultant#getDisplayName()} where one is
+ * set — so those two are the only permitted sources. The real name is never used.
+ */
+@Component
+public class ConsultantDisplayNameResolver {
+
+  private final UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
+
+  /**
+   * @param consultant the counsellor whose Matrix account is being provisioned
+   * @return the display name to register with Synapse, never the counsellor's real name
+   */
+  public String resolveMatrixDisplayName(Consultant consultant) {
+    if (consultant == null) {
+      return null;
+    }
+
+    var appDisplayName = consultant.getDisplayName();
+    if (isUsable(appDisplayName)) {
+      return appDisplayName;
+    }
+
+    // Falls back to what the Matrix ID already exposes, so provisioning adds no new information.
+    return usernameTranscoder.decodeUsername(consultant.getUsername());
+  }
+
+  /**
+   * An encoded value would render as noise rather than as a pseudonym, so it is treated as absent
+   * and the username is used instead. Mirrors the check the notification service applies before
+   * putting a counsellor's name in front of a client.
+   */
+  private boolean isUsable(String value) {
+    if (value == null || value.isBlank()) {
+      return false;
+    }
+    return !value.startsWith("enc.") && !value.matches("^[A-Za-z0-9+/=]{25,}$");
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -867,17 +867,19 @@ public class CaseHandoverService {
           "Failed to create previous consultant Matrix token for case handover");
     }
 
+    // Since #905 the department's counsellors are already members of the room (ADR-002 §1), so
+    // Synapse answers this invite with 403 "<user> is already in the room" — the normal case, not
+    // a failure. The join below is the actual assertion, so let it decide. Mirrors the same
+    // tolerance in AgencySilentMembershipService.joinSilently.
     try {
       matrixSynapseService.inviteUserToRoom(
           roomId, requester.getMatrixUserId(), previousConsultantToken);
     } catch (Exception exception) {
-      log.error(
-          "Failed to invite case handover requester {} to Matrix room {}: {}",
+      log.debug(
+          "Invite of case handover requester {} to Matrix room {} did not succeed: {}",
           requester.getUsername(),
           roomId,
           exception.getMessage());
-      throw new InternalServerErrorException(
-          "Failed to invite case handover requester to Matrix room");
     }
 
     String requesterToken =
@@ -893,16 +895,10 @@ public class CaseHandoverService {
           "Failed to join case handover requester to Matrix room");
     }
 
-    // A completed takeover transfers access; it must not leave the previous
-    // counsellor joined at the transport layer after the application curtain
-    // has hidden the conversation. Removing the old member only after the new
-    // member joined keeps the room reachable if the join itself fails.
-    boolean previousConsultantLeft =
-        matrixSynapseService.leaveRoom(roomId, previousConsultantToken);
-    if (!previousConsultantLeft) {
-      throw new InternalServerErrorException(
-          "Failed to remove previous consultant from Matrix room after case handover");
-    }
+    // The previous counsellor deliberately keeps their membership. ADR-002's reveal lifecycle has
+    // a takeover re-hide the original counsellor while they stay a member, so they can reclaim the
+    // case when they return — and under Megolm a counsellor removed here could never be given the
+    // history back. Hiding the conversation is the application curtain's job, not Matrix's.
   }
 
   private String resolveConsultantName(Consultant consultant) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.service.session;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -41,6 +42,7 @@ public class AgencySilentMembershipService {
   private final @NonNull SessionRoomGateway sessionRoomGateway;
   private final @NonNull UserHelper userHelper;
   private final @NonNull UsernameTranscoder usernameTranscoder;
+  private final @NonNull ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   /**
    * Invites and joins every active counsellor of the given agency into the room.
@@ -132,7 +134,7 @@ public class AgencySilentMembershipService {
     }
 
     var localpart = usernameTranscoder.decodeUsername(consultant.getUsername());
-    var displayName = consultant.getFirstName() + " " + consultant.getLastName();
+    var displayName = consultantDisplayNameResolver.resolveMatrixDisplayName(consultant);
 
     String matrixUserId;
     try {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomService.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.service.session;
 
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -25,6 +26,7 @@ public class DirectSessionMatrixRoomService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull SessionService sessionService;
   private final @NonNull UserHelper userHelper;
+  private final @NonNull ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   /**
    * Creates a Matrix room between {@code consultant} and the session's user, invites both parties,
@@ -154,7 +156,7 @@ public class DirectSessionMatrixRoomService {
           sessionRoomGateway.createUser(
               consultant.getUsername(),
               generatedMatrixPassword,
-              consultant.getFirstName() + " " + consultant.getLastName());
+              consultantDisplayNameResolver.resolveMatrixDisplayName(consultant));
       if (matrixUserId != null) {
         consultant.setMatrixUserId(matrixUserId);
         consultantRepository.save(consultant);

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
@@ -122,7 +122,11 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
             gateway,
             sessionService,
             new de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService(
-                consultantRepository, gateway, userHelper, usernameTranscoder));
+                consultantRepository,
+                gateway,
+                userHelper,
+                usernameTranscoder,
+                new de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver()));
     setField(createEnquiryMessageFacade, "agencyPreAssignmentRoomService", realRoomService);
 
     user = new User();

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -27,6 +27,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -78,6 +79,7 @@ class AssignEnquiryFacadeTest {
   @Mock EventNotificationService eventNotificationService;
   @Mock de.caritas.cob.userservice.api.facade.SessionSupervisorFacade sessionSupervisorFacade;
   @Mock de.caritas.cob.userservice.api.facade.TeamDiscussionFacade teamDiscussionFacade;
+  @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   private static final String USER_MATRIX_ID = "@user:matrix.example.com";
   private static final String CONSULTANT_MATRIX_ID = "@consultant:matrix.example.com";
@@ -86,6 +88,10 @@ class AssignEnquiryFacadeTest {
 
   @BeforeEach
   public void setup() throws MatrixCreateRoomException {
+    // ADR-002 §2: the display name comes from the resolver, never from the real name.
+    lenient()
+        .when(consultantDisplayNameResolver.resolveMatrixDisplayName(any(Consultant.class)))
+        .thenReturn("pseudonym");
     // dev's Matrix migration: assignEnquiry now provisions a Matrix room and reads
     // session.getUser().getMatrixUserId() / consultant.getMatrixUserId(). The shared
     // TestConstants do not set these, so populate them here (reset in tearDown) and stub the

--- a/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
@@ -1,0 +1,66 @@
+package de.caritas.cob.userservice.api.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-002 §2: silent members are pseudonymous towards the advice seeker, who is a member of the
+ * same room and can read every display name from {@code /joined_members}. These tests state that
+ * invariant so a later refactor cannot quietly put real names back on the wire.
+ */
+class ConsultantDisplayNameResolverTest {
+
+  private final ConsultantDisplayNameResolver resolver = new ConsultantDisplayNameResolver();
+
+  private Consultant consultantWith(String username, String displayName) {
+    var consultant = new Consultant();
+    consultant.setUsername(username);
+    consultant.setDisplayName(displayName);
+    consultant.setFirstName("Angela");
+    consultant.setLastName("Musterfrau");
+    return consultant;
+  }
+
+  @Test
+  @DisplayName("never exposes the counsellor's real name")
+  void resolveMatrixDisplayName_Should_NeverReturnTheRealName() {
+    var withDisplayName =
+        resolver.resolveMatrixDisplayName(consultantWith("beraterin1", "Frau M."));
+    var withoutDisplayName = resolver.resolveMatrixDisplayName(consultantWith("beraterin1", null));
+
+    assertThat(withDisplayName).doesNotContain("Angela").doesNotContain("Musterfrau");
+    assertThat(withoutDisplayName).doesNotContain("Angela").doesNotContain("Musterfrau");
+  }
+
+  @Test
+  @DisplayName("uses the app-level display name the client already sees")
+  void resolveMatrixDisplayName_Should_PreferTheAppDisplayName() {
+    assertThat(resolver.resolveMatrixDisplayName(consultantWith("beraterin1", "Frau M.")))
+        .isEqualTo("Frau M.");
+  }
+
+  @Test
+  @DisplayName("falls back to the username, which the Matrix ID already exposes")
+  void resolveMatrixDisplayName_Should_FallBackToTheUsername_When_NoDisplayNameIsSet() {
+    assertThat(resolver.resolveMatrixDisplayName(consultantWith("beraterin1", "  ")))
+        .isEqualTo("beraterin1");
+    assertThat(resolver.resolveMatrixDisplayName(consultantWith("beraterin1", null)))
+        .isEqualTo("beraterin1");
+  }
+
+  @Test
+  @DisplayName("treats an encoded display name as absent rather than rendering noise")
+  void resolveMatrixDisplayName_Should_IgnoreAnEncodedDisplayName() {
+    assertThat(resolver.resolveMatrixDisplayName(consultantWith("beraterin1", "enc.MFRGGZDF")))
+        .isEqualTo("beraterin1");
+  }
+
+  @Test
+  @DisplayName("tolerates a missing consultant")
+  void resolveMatrixDisplayName_Should_ReturnNull_When_ConsultantIsNull() {
+    assertThat(resolver.resolveMatrixDisplayName(null)).isNull();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.CaseHandoverReasonPolicy;
 import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
@@ -109,7 +110,6 @@ class CaseHandoverServiceTest {
         .thenReturn(List.of());
     when(caseHandoverRequestRepository.save(any(CaseHandoverRequest.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
-    when(matrixSynapseService.leaveRoom(anyString(), anyString())).thenReturn(true);
   }
 
   @Test
@@ -136,18 +136,24 @@ class CaseHandoverServiceTest {
     when(matrixSynapseService.loginAsUserAccessToken("@requester:matrix"))
         .thenReturn("requester-token");
     when(matrixSynapseService.joinRoom("!room:matrix", "requester-token")).thenReturn(true);
-    when(matrixSynapseService.leaveRoom("!room:matrix", "previous-token")).thenReturn(true);
 
     caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
 
     verify(matrixSynapseService)
         .inviteUserToRoom("!room:matrix", "@requester:matrix", "previous-token");
     verify(matrixSynapseService).joinRoom("!room:matrix", "requester-token");
-    verify(matrixSynapseService).leaveRoom("!room:matrix", "previous-token");
+    // ADR-002: a takeover re-hides the original counsellor but keeps their membership, so they
+    // can reclaim the case. Removing them here would make the history unrecoverable under Megolm.
+    verify(matrixSynapseService, never()).leaveRoom(anyString(), anyString());
   }
 
+  /**
+   * Reproduced on Pre-Dev 2026-07-30: since #905 the requester is already a member of the enquiry
+   * room, and Synapse rejects the invite with 403 "<user> is already in the room". Before this test
+   * the rejection was turned into a 500 and the handover failed outright.
+   */
   @Test
-  void requestAccess_doesNotActivateRequester_WhenPreviousConsultantCannotLeaveMatrixRoom()
+  void requestAccess_grantsAccess_WhenRequesterIsAlreadyAMemberAndTheInviteIsRejected()
       throws Exception {
     session.setMatrixRoomId("!room:matrix");
     requester.setMatrixUserId("@requester:matrix");
@@ -156,8 +162,30 @@ class CaseHandoverServiceTest {
         .thenReturn("previous-token");
     when(matrixSynapseService.loginAsUserAccessToken("@requester:matrix"))
         .thenReturn("requester-token");
+    when(matrixSynapseService.inviteUserToRoom(
+            "!room:matrix", "@requester:matrix", "previous-token"))
+        .thenThrow(new MatrixInviteUserException("@requester:matrix is already in the room."));
     when(matrixSynapseService.joinRoom("!room:matrix", "requester-token")).thenReturn(true);
-    when(matrixSynapseService.leaveRoom("!room:matrix", "previous-token")).thenReturn(false);
+
+    CaseHandoverStatus status =
+        caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
+
+    assertEquals("GRANTED", status.getStatus());
+    assertEquals(requester, session.getConsultant());
+    verify(matrixSynapseService).joinRoom("!room:matrix", "requester-token");
+    verify(sessionRepository).save(session);
+  }
+
+  @Test
+  void requestAccess_doesNotActivateRequester_WhenRequesterCannotJoinMatrixRoom() throws Exception {
+    session.setMatrixRoomId("!room:matrix");
+    requester.setMatrixUserId("@requester:matrix");
+    previous.setMatrixUserId("@previous:matrix");
+    when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
+        .thenReturn("previous-token");
+    when(matrixSynapseService.loginAsUserAccessToken("@requester:matrix"))
+        .thenReturn("requester-token");
+    when(matrixSynapseService.joinRoom("!room:matrix", "requester-token")).thenReturn(false);
 
     assertThrows(
         InternalServerErrorException.class,

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -45,6 +46,9 @@ class AgencySilentMembershipServiceTest {
   @Mock private SessionRoomGateway sessionRoomGateway;
   @Mock private UserHelper userHelper;
   @Mock private UsernameTranscoder usernameTranscoder;
+  // ADR-002 §2: provisioning must never register the counsellor's real name (see
+  // ConsultantDisplayNameResolverTest for the invariant itself).
+  @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   @InjectMocks private AgencySilentMembershipService underTest;
 
@@ -91,7 +95,9 @@ class AgencySilentMembershipServiceTest {
     when(consultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(AGENCY_ID))
         .thenReturn(List.of(fresh));
     when(usernameTranscoder.decodeUsername("c-new")).thenReturn("c-new");
-    when(sessionRoomGateway.createUser("c-new", "generated-password", "First Last"))
+    when(consultantDisplayNameResolver.resolveMatrixDisplayName(any(Consultant.class)))
+        .thenReturn("pseudonym");
+    when(sessionRoomGateway.createUser("c-new", "generated-password", "pseudonym"))
         .thenReturn("@c-new:oriso.org");
     when(sessionRoomGateway.loginAsUser("@c-new:oriso.org")).thenReturn("token-new");
     when(sessionRoomGateway.joinRoom(ROOM_ID, "token-new")).thenReturn(true);

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/DirectSessionMatrixRoomServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -39,6 +40,7 @@ class DirectSessionMatrixRoomServiceTest {
   @Mock private ConsultantRepository consultantRepository;
   @Mock private SessionService sessionService;
   @Mock private UserHelper userHelper;
+  @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   private Session session;
   private Consultant consultant;
@@ -122,7 +124,10 @@ class DirectSessionMatrixRoomServiceTest {
       throws Exception {
     consultant.setMatrixUserId(null);
     when(userHelper.getRandomPassword()).thenReturn("pw");
-    when(sessionRoomGateway.createUser("consultant", "pw", "First Last"))
+    // ADR-002 §2: provisioned with the pseudonym, never the real name.
+    when(consultantDisplayNameResolver.resolveMatrixDisplayName(consultant))
+        .thenReturn("pseudonym");
+    when(sessionRoomGateway.createUser("consultant", "pw", "pseudonym"))
         .thenReturn(CONSULTANT_MXID);
     when(sessionRoomGateway.createRoomAsUser(any(), any(), eq(CONSULTANT_MXID)))
         .thenReturn(ROOM_ID);


### PR DESCRIPTION
Closes the two parts of #925 that block case handover, so the major release does not ship a handover that fails.

## 1. Case handover failed outright on any normal enquiry

**Reproduced on Pre-Dev** (session 103538, room `!HDEZBMvJfPGczsaVPJ`), inviting a counsellor who is already in the room:

```
HTTP 403 {"errcode":"M_FORBIDDEN","error":"@councelor2:… is already in the room."}
```

Since #905 the department's counsellors are permanent members of every enquiry room (ADR-002 §1), so an already-joined requester is the normal state of a handover. `MatrixRoomClient` turns the 403 into a `MatrixInviteUserException`, and `CaseHandoverService` turned that into a 500 — the handover never completed.

The invite is now best-effort and the **join** is the assertion, mirroring the tolerance `AgencySilentMembershipService.joinSilently` already documents for exactly this case.

**The previous counsellor also keeps their membership.** ADR-002's reveal lifecycle has a takeover re-hide the original counsellor while they remain a member so they can reclaim the case when they return; removing them at the transport layer made that unrecoverable under Megolm, and a failing removal was a second hard-500 path. Hiding the conversation is the application curtain's job — the session list is database-driven and already drops an accepted case from every other counsellor's list.

## 2. Counsellors' real names were readable from the room member list

All three Matrix provisioning paths registered counsellors as `firstName + " " + lastName`. The advice seeker is a member of the same room, so their own client could read every counsellor's real name from `/joined_members` — filtering the participant list in the UI does not help against that. ADR-002 requires silent members to be pseudonymous towards the client.

The three paths now share `ConsultantDisplayNameResolver`: the app-level display name the client already sees, otherwise the transcoded username the Matrix ID already exposes. Never the real name.

## Verification

- 3599 unit tests green on JDK 21 (the CI JDK), `spotless:apply` clean.
- The 403 case is reproduced as a test, so the handover cannot silently regress to the invite-join-kick model.
- Pre-Dev probe scripts left at `/root/repro-handover-invite.sh` and `/root/repro-list-rooms.sh` on `46.224.170.69`; they read secrets from the pod env and never print them.

## Deliberately not in this PR

- **Client participant view** (#204) — frontend, follows separately.
- **Client opt-out consent switch** (#313) — this is the control that turns the technical property into an informed decision by the advice seeker, and it needs the expanded policy model (#201). Not a same-day change.
- **Department scope** (#199/#203) — needs the Department entity first; membership stays agency-scoped for now.
- **Directly addressed enquiries** still create their holding room through the shared helper. Routing them past it entirely breaks the advice seeker's first message, because `CreateEnquiryMessageFacade.ensureMatrixRoomForEnquiry` throws when no room exists. They already bypass the pre-selection queue in every other respect (single assigned consultant, single-recipient notification, no department membership), so this is naming rather than behaviour and should be a separate change.

Refs ADR-002 §1 and §2, epic #205, ORISO-Frontend#811.
