### PR TITLE
fix(test): let shared identity mocks stand in for every KeycloakService port

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -19,8 +19,11 @@ import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControlle
 import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.session.SessionTopicEnrichmentService;
 import de.caritas.cob.userservice.api.tenant.TenantResolverService;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -62,7 +65,13 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
 
   @MockitoBean AgencyServiceApiControllerFactory agencyServiceApiControllerFactory;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   IdentityClient identityClient;
 
   @MockitoBean TenantService tenantService;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -73,8 +73,11 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.ChatService;
@@ -157,7 +160,13 @@ class UserControllerAuthorizationIT {
   @MockitoBean private ConsultantImportService consultantImportService;
   @MockitoBean private ConsultantAgencyService consultantAgencyService;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private IdentityManager identityManager;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -49,9 +49,12 @@ import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.service.*;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import de.caritas.cob.userservice.api.service.archive.SessionArchiveService;
@@ -276,7 +279,13 @@ class UserControllerIT {
   @MockitoBean private AssignSessionFacade assignSessionFacade;
   @MockitoBean private AssignEnquiryFacade assignEnquiryFacade;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private DecryptionService encryptionService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -21,8 +21,11 @@ import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHt
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
@@ -50,7 +53,13 @@ class CreateAdminServiceIT {
 
   @Autowired private CreateAdminService createAdminService;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -11,8 +11,11 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAgencyAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminService;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -30,7 +33,13 @@ public class UpdateAdminServiceIT {
 
   @Autowired private UpdateAdminService updateAdminService;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @Autowired private RetrieveAdminService retrieveAdminService;

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -25,8 +25,11 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
@@ -75,7 +78,13 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
   @MockitoBean private AgencyService agencyService;
 
-  @MockitoBean(extraInterfaces = IdentityDummyEmailUpdater.class)
+  @MockitoBean(
+      extraInterfaces = {
+        IdentityAuthentication.class,
+        IdentityDummyEmailUpdater.class,
+        IdentityEmailOwnerLookup.class,
+        IdentityUsernameAvailability.class
+      })
   private IdentityClient identityClient;
 
   @MockitoBean private ConsultingTypeManager consultingTypeManager;


### PR DESCRIPTION
## Problem

`pre-dev` is red after #900 merged. `CI - Main` run [30542537111](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/30542537111) fails with **157 integration-test errors** across five classes:

```
Bean named 'keycloakService' is expected to be of type
'...port.out.IdentityAuthentication' but was actually of type
'...port.out.IdentityClient$MockitoMock$...'
```

The #900 merge narrowed `extraInterfaces` on six shared `@MockitoBean IdentityClient` mocks to `IdentityDummyEmailUpdater` alone, dropping `IdentityAuthentication`, `IdentityEmailOwnerLookup` and `IdentityUsernameAvailability`.

`KeycloakService` implements all four ports, so a mock replacing the `keycloakService` bean that implements only two cannot satisfy injection points expecting the others — `AppointmentService` wants `IdentityAuthentication`, which cascades through `AccountManager` and fails context startup.

## Fix

All eight shared identity mocks now declare the full port set, so the mock stays type-compatible with every consumer of `KeycloakService`.

`UserControllerIT` is included even though its context did not fail, so the eight declarations are identical rather than dependent on which beans each context happens to load.

## Failing classes addressed

- `UpdateAdminServiceIT` (2)
- `CreateAdminServiceIT` (8)
- `UserControllerAuthorizationIT` (143)
- `UserAdminControllerMultiTenancyTrueE2EIT` (2)
- `ConsultantAgencyRelationCreatorServiceTenantAwareIT` (2)

## Verification

Static checks before pushing — all 8 mocks declare all 4 ports, every port imported, no unused imports, and the `test_module_boundaries` dummy-email assertion still holds.

Not built locally; CI is the confirmation.