### PR TITLE
Fix Liquibase SnakeYAML runtime compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,8 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>2.0</version>
+			<!-- Liquibase 4.8 uses the SnakeYAML 1.x constructor API at runtime. -->
+			<version>1.33</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Summary

- pins SnakeYAML to 1.33 for compatibility with Liquibase 4.8 runtime APIs
- fixes the dev deployment crash where Liquibase fails with `NoSuchMethodError: org.yaml.snakeyaml.constructor.SafeConstructor.<init>()` before applying migrations

## Validation

- inspected the UserService crash log from dev deployment showing Liquibase failing on SnakeYAML `SafeConstructor` API mismatch
- attempted `mvn dependency:tree -Dincludes=org.yaml:snakeyaml,org.liquibase:liquibase-core`, but Maven is not installed in the local Codex shell

## Deployment note

After merge, rebuild/publish `ghcr.io/openresilienceinitiative/oriso-userservice:dev`, then redeploy ORISO-Helm so Liquibase can create the schema from a fresh MariaDB volume.
