### PR TITLE
Align Liquibase with SnakeYAML 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
 		<log4j.version>2.25.4</log4j.version> <!-- force safe version due to https://logging.apache.org/log4j/2.x/security.html -->
 		<commons-text.version>1.10.0</commons-text.version>
 		<commons-validator.version>1.10.1</commons-validator.version>
-		<liquibase-maven-plugin.version>4.8.0</liquibase-maven-plugin.version>
+		<liquibase-maven-plugin.version>4.23.2</liquibase-maven-plugin.version>
+		<liquibase-core.version>4.23.2</liquibase-core.version>
 		<jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
 		<javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
 		<json-smart.version>2.6.0</json-smart.version>
@@ -283,6 +284,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
+			<version>${liquibase-core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -473,8 +475,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<!-- Liquibase 4.8 uses the SnakeYAML 1.x constructor API at runtime. -->
-			<version>1.33</version>
+			<version>2.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 		<log4j.version>2.25.4</log4j.version> <!-- force safe version due to https://logging.apache.org/log4j/2.x/security.html -->
 		<commons-text.version>1.10.0</commons-text.version>
 		<commons-validator.version>1.10.1</commons-validator.version>
-		<liquibase-maven-plugin.version>4.23.2</liquibase-maven-plugin.version>
-		<liquibase-core.version>4.23.2</liquibase-core.version>
+		<liquibase.version>4.27.0</liquibase.version>
+		<snakeyaml.version>2.0</snakeyaml.version>
 		<jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
 		<javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
 		<json-smart.version>2.6.0</json-smart.version>
@@ -284,7 +284,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>${liquibase-core.version}</version>
+			<version>${liquibase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -475,7 +475,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>2.0</version>
+			<version>${snakeyaml.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -1069,7 +1069,7 @@
 			<plugin>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-maven-plugin</artifactId>
-				<version>${liquibase-maven-plugin.version}</version>
+				<version>${liquibase.version}</version>
 				<configuration>
 					<propertyFile>src/main/resources/liquibase.properties</propertyFile>
 				</configuration>


### PR DESCRIPTION
## Summary
- upgrade Liquibase core and Maven plugin alignment from 4.8.0 to 4.23.2
- move the explicit SnakeYAML runtime dependency from 1.33 to 2.0 so the Trivy CVE gate no longer flags CVE-2022-1471
- keep Liquibase compatible with SnakeYAML 2.x instead of reverting to the vulnerable 1.x constructor API

## Validation
- ./mvnw dependency:tree -Dincludes=org.liquibase:liquibase-core,org.yaml:snakeyaml -Dverbose -DskipTests
- ./mvnw -q -Dskip.integration-tests=true package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration tooling to version 4.23.2.
  * Upgraded YAML processing support to version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->