### PR TITLE
chore(ci): generate suite counts instead of writing them into the record

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -38,6 +38,19 @@ runs:
           sys.exit(1)
       PY
 
+  # Also guards against a vacuously green run: the failure check above passes
+  # when no report exists at all, --require does not.
+  - name: Report unit inventory
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      set -o pipefail
+      {
+        echo "### Unit test inventory"
+        echo
+        python3 scripts/ci/suite-inventory.py --require unit
+      } | tee -a "$GITHUB_STEP_SUMMARY"
+
   - name: Verify CI and load-test contracts
     shell: bash
     run: python3 -m unittest discover -s tests/ci -p 'test_*.py'

--- a/.github/actions/maven-verify-required/action.yml
+++ b/.github/actions/maven-verify-required/action.yml
@@ -18,6 +18,17 @@ runs:
     shell: bash
     run: scripts/ci/run-required-integration-tests.sh
 
+  - name: Report integration inventory
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      set -o pipefail
+      {
+        echo "### Integration test inventory"
+        echo
+        python3 scripts/ci/suite-inventory.py --require integration
+      } | tee -a "$GITHUB_STEP_SUMMARY"
+
   - name: Upload required integration reports
     if: ${{ always() }}
     uses: actions/upload-artifact@v4

--- a/documentation/USER_SERVICE_STABILITY.md
+++ b/documentation/USER_SERVICE_STABILITY.md
@@ -1,7 +1,11 @@
 # UserService stability, dependency measurements and module decision
 
-Last verified: 2026-07-29
 Target branch: `pre-dev`
+
+Suite counts in this record are generated, not written down — see
+[Reproducible stability result](#reproducible-stability-result). A date stamp
+here would have the same problem, so freshness comes from the CI run that
+produced the numbers.
 
 ## Reproducible stability result
 
@@ -23,50 +27,59 @@ and 45 initial Spring context-threshold cascades. The artifact preserves the
 15-suite breakdown behind those 45 errors and does not invent a more specific
 original exception where the retained report did not contain one.
 
-After repairing those clusters:
+After repairing those clusters the suite is green.
 
-| Suite | Tests | Failures | Errors | Skipped | Command |
-| --- | ---: | ---: | ---: | ---: | --- |
-| Unit | 3,456 | 0 | 0 | 0 | `./mvnw -Dskip.integration-tests=true test` |
-| Integration + contract + E2E | 856 | 0 | 0 | 9 | `scripts/ci/run-required-integration-tests.sh` |
-| MariaDB schema contracts | 2 | 0 | 0 | 0 | required fresh MariaDB job |
-| Redis availability contract | 1 | 0 | 0 | 0 | required Redis job |
+The current execution counts are deliberately not recorded here. They are a
+measurement, not a decision, and every branch that adds a test changes them —
+which made this file conflict on each merge and forced a hand reconciliation
+that is easy to get wrong. `scripts/ci/suite-inventory.py` derives them from
+the Surefire and Failsafe reports instead, and both test jobs publish the
+result to their CI run summary. For the combined view locally:
 
-The rows are not one additive total: the MariaDB and Redis rows are dedicated
-environment proofs for cases that belong to the integration inventory. The
-comparable primary current inventory is therefore 3,456 unit plus 856
-integration executions, or 4,312.
+```
+./mvnw verify
+python3 scripts/ci/suite-inventory.py
+```
+
+What is enforced rather than described:
+
+- `scripts/ci/run-required-integration-tests.sh` owns the complete `*IT` suite,
+  requires at least 75 reports and 830 executed tests, and fails on any failure
+  or error;
+- a required CI guard rejects newly disabled or ignored tests;
+- the MariaDB schema and statistics contracts and the Redis availability
+  contract run as their own required jobs, so they are dedicated environment
+  proofs rather than part of the primary inventory.
 
 The historical 4,707 figure is the raw failing discovery run, not the same test
 inventory with failures simply subtracted. After the original repair work, the
 last pre-cutover inventory recorded 3,782 unit and 940 integration executions,
-or 4,722. The Matrix-only cutover then changed the executable product and test
-inventory to the current 4,312: 326 fewer unit and 84 fewer integration
-executions. The source diff for that same pre-cutover-to-current interval
-deletes 40 obsolete test classes and adds 29 Matrix-only contract classes.
-Thirty-three of the 40 deleted classes cover the removed Rocket.Chat, legacy
+or 4,722. Those figures are frozen reference points and do not move.
+
+The Matrix-only cutover then reduced both the executable product and its test
+inventory. The source diff for that pre-cutover-to-current interval deletes 40
+obsolete test classes and adds 29 Matrix-only contract classes. Thirty-three of
+the 40 deleted classes cover the removed Rocket.Chat, legacy
 chat/import/message, or obsolete session/conversation E2E paths. Because JUnit
 execution counts include parameterized and dynamic cases, class counts do not
-map one-to-one to the 410-execution net reduction. This is intentional scope
-removal plus replacement coverage, not unexplained test quarantine.
+map one-to-one to the execution delta. This is intentional scope removal plus
+replacement coverage, not unexplained test quarantine.
 
 Nineteen stale security tests were removed. They asserted that safe `GET`
 requests or the explicitly CSRF-exempt public registration endpoint require a
 CSRF token, which contradicts the service's security contract. No failing test
 is skipped or quarantined.
 
-`scripts/ci/run-required-integration-tests.sh` now owns the complete `*IT`
-suite, starts from a clean build, requires at least 830 executed tests and
-checks for critical E2E reports.
-The previous three-test required subset and the non-blocking legacy quarantine
-were removed. On the current Matrix-only `pre-dev` baseline, the four remaining
-`NewEnquiryEmailSupplierTest` log assertions run normally. The Matrix cutover
-deleted `NewMessageEmailSupplierTest`; this replay deliberately does not restore
-that legacy path. The current Matrix-only floor is 830 tests; the older 900-test
-floor included deleted Rocket.Chat-only tests. A required CI guard rejects newly
-disabled or ignored tests. The two environment-gated cases are not quarantined:
-Redis and MariaDB have their own required service-container/fresh-database jobs
-on branch, pull-request and publish workflows.
+The integration contract starts from a clean build and additionally checks that
+the critical E2E reports are present, so a green run cannot mean a silently
+shrunken suite. The previous three-test required subset and the non-blocking
+legacy quarantine were removed. On the current Matrix-only `pre-dev` baseline,
+the four remaining `NewEnquiryEmailSupplierTest` log assertions run normally.
+The Matrix cutover deleted `NewMessageEmailSupplierTest`; this replay
+deliberately does not restore that legacy path. The 830-test floor is the
+Matrix-only figure; the older 900-test floor included deleted Rocket.Chat-only
+tests. The environment-gated Redis and MariaDB jobs run on the branch,
+pull-request and publish workflows.
 
 The first clean Ubuntu run exposed three portability defects that a warmed local
 workspace had hidden. Each Spring test context now owns a unique H2 database so
@@ -238,10 +251,8 @@ workflow identifiers instead of escaping the transaction. The technical mail
 context also no longer performs the TenantService lookup that caused the
 observed notification failure, which removes the most frequent trigger.
 
-Measured on this branch after merging `pre-dev`: 3,456 unit executions with
-zero failures, zero errors and no skips, and 856 required integration
-executions across 84 reports with zero failures, zero errors and nine skips.
-The focused supplier test and formatting gate also pass.
+Both suites, the focused supplier test and the formatting gate pass; the
+per-run counts are in the CI summary rather than repeated here.
 
 #### Measured limit of this repair
 

--- a/scripts/ci/suite-inventory.py
+++ b/scripts/ci/suite-inventory.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""Derives the current test inventory from Surefire/Failsafe reports.
+
+The stability record used to carry these counts as prose. Every branch that
+adds a test changed them, so `documentation/USER_SERVICE_STABILITY.md`
+conflicted on every merge and had to be reconciled by hand. The numbers are a
+measurement, not a decision, so they are produced here instead of stored.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT_DIRECTORY = REPOSITORY_ROOT / "target" / "surefire-reports"
+
+
+class Suite:
+    def __init__(self, label: str):
+        self.label = label
+        self.reports = 0
+        self.tests = 0
+        self.failures = 0
+        self.errors = 0
+        self.skipped = 0
+
+    def add(self, root: ET.Element) -> None:
+        self.reports += 1
+        self.tests += int(root.attrib.get("tests", 0))
+        self.failures += int(root.attrib.get("failures", 0))
+        self.errors += int(root.attrib.get("errors", 0))
+        self.skipped += int(root.attrib.get("skipped", 0))
+
+    @property
+    def clean(self) -> bool:
+        return self.failures == 0 and self.errors == 0
+
+
+def simple_class_name(root: ET.Element) -> str:
+    return root.attrib.get("name", "").rsplit(".", 1)[-1]
+
+
+def collect(report_directory: Path) -> tuple[Suite, Suite]:
+    unit = Suite("Unit")
+    integration = Suite("Integration + contract + E2E")
+
+    for report in sorted(report_directory.glob("TEST-*.xml")):
+        root = ET.parse(report).getroot()
+        target = integration if simple_class_name(root).endswith("IT") else unit
+        target.add(root)
+
+    return unit, integration
+
+
+def render_markdown(unit: Suite, integration: Suite) -> str:
+    """Renders only the halves that are actually present.
+
+    CI runs unit tests and the integration contract in separate jobs, so each
+    job sees one half of the reports. A locally run `./mvnw verify` produces
+    both and therefore also the combined total.
+    """
+    present = [
+        (suite, command)
+        for suite, command in (
+            (unit, "`./mvnw -Dskip.integration-tests=true test`"),
+            (integration, "`scripts/ci/run-required-integration-tests.sh`"),
+        )
+        if suite.reports
+    ]
+    if not present:
+        return "No Surefire or Failsafe reports found."
+
+    lines = [
+        "| Suite | Tests | Failures | Errors | Skipped | Command |",
+        "| --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for suite, command in present:
+        lines.append(
+            f"| {suite.label} | {suite.tests:,} | {suite.failures} | "
+            f"{suite.errors} | {suite.skipped} | {command} |"
+        )
+
+    lines.append("")
+    if len(present) == 2:
+        lines.append(
+            f"Primary inventory: {unit.tests:,} unit plus {integration.tests:,} "
+            f"integration executions, or {unit.tests + integration.tests:,}, "
+            f"across {unit.reports + integration.reports:,} reports."
+        )
+    else:
+        suite = present[0][0]
+        lines.append(
+            f"{suite.label} inventory: {suite.tests:,} executions across "
+            f"{suite.reports:,} reports. The other half runs in its own job."
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report-directory",
+        type=Path,
+        default=DEFAULT_REPORT_DIRECTORY,
+        help="Surefire/Failsafe report directory (default: target/surefire-reports)",
+    )
+    parser.add_argument(
+        "--require",
+        choices=["unit", "integration", "both"],
+        help="Fail when the named part of the inventory is empty or not clean",
+    )
+    arguments = parser.parse_args()
+
+    if not arguments.report_directory.is_dir():
+        print(f"No report directory at {arguments.report_directory}.", file=sys.stderr)
+        return 1
+
+    unit, integration = collect(arguments.report_directory)
+    print(render_markdown(unit, integration))
+
+    if arguments.require is None:
+        return 0
+
+    required = {
+        "unit": [unit],
+        "integration": [integration],
+        "both": [unit, integration],
+    }[arguments.require]
+
+    for suite in required:
+        if suite.tests == 0:
+            print(f"{suite.label} inventory is empty.", file=sys.stderr)
+            return 1
+        if not suite.clean:
+            print(f"{suite.label} inventory contains failures or errors.", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_suite_inventory.py
+++ b/tests/ci/test_suite_inventory.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "scripts/ci/suite-inventory.py"
+STABILITY_DOCUMENT = ROOT / "documentation/USER_SERVICE_STABILITY.md"
+
+
+def report(name: str, tests: int, failures: int = 0, errors: int = 0, skipped: int = 0) -> str:
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<testsuite name="{name}" tests="{tests}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}"/>'
+    )
+
+
+class SuiteInventoryContractTest(unittest.TestCase):
+    def run_inventory(self, reports: dict[str, str], *arguments: str):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_directory = Path(temp_dir)
+            for file_name, content in reports.items():
+                (report_directory / file_name).write_text(content)
+
+            return subprocess.run(
+                [
+                    sys.executable,
+                    INVENTORY,
+                    "--report-directory",
+                    report_directory,
+                    *arguments,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_separates_integration_reports_from_unit_reports(self):
+        result = self.run_inventory(
+            {
+                "TEST-de.example.FooTest.xml": report("de.example.FooTest", tests=7),
+                "TEST-de.example.BarIT.xml": report("de.example.BarIT", tests=3, skipped=1),
+            },
+            "--require",
+            "both",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Unit | 7 | 0 | 0 | 0 |", result.stdout)
+        self.assertIn("| Integration + contract + E2E | 3 | 0 | 0 | 1 |", result.stdout)
+        self.assertIn("7 unit plus 3 integration executions, or 10", result.stdout)
+
+    def test_reports_one_half_when_only_one_job_has_run(self):
+        result = self.run_inventory(
+            {"TEST-de.example.FooTest.xml": report("de.example.FooTest", tests=7)},
+            "--require",
+            "unit",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Integration + contract + E2E", result.stdout)
+        self.assertIn("The other half runs in its own job.", result.stdout)
+
+    def test_rejects_an_empty_inventory(self):
+        result = self.run_inventory({}, "--require", "unit")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("empty", result.stderr)
+
+    def test_rejects_reports_containing_failures(self):
+        result = self.run_inventory(
+            {"TEST-de.example.FooTest.xml": report("de.example.FooTest", tests=7, failures=1)},
+            "--require",
+            "unit",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("failures or errors", result.stderr)
+
+    def test_reports_without_requiring_anything_by_default(self):
+        result = self.run_inventory(
+            {"TEST-de.example.FooTest.xml": report("de.example.FooTest", tests=7, failures=1)}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_stability_document_does_not_hardcode_current_counts(self):
+        """The counts moved on every branch and made this file conflict on each merge."""
+        document = STABILITY_DOCUMENT.read_text()
+
+        self.assertIn("scripts/ci/suite-inventory.py", document)
+        for frozen_reference in ("4,707", "3,782", "4,722"):
+            self.assertIn(
+                frozen_reference,
+                document,
+                "frozen historical reference points must stay in the record",
+            )
+        self.assertNotIn(
+            "| Unit |",
+            document,
+            "current suite counts belong in the generated inventory, not in prose",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`documentation/USER_SERVICE_STABILITY.md` carried the current unit and integration execution counts — plus a chain of totals and deltas derived from them — as prose. Every branch that adds a test changed those numbers, so the file conflicted on every merge.

That is not hypothetical: it was the only conflicting file in three consecutive merges over the last two days, and one hand resolution silently dropped a test helper that only the compiler caught afterwards.

## The change

The counts are a measurement, not a decision, so they are produced rather than stored.

- **`scripts/ci/suite-inventory.py`** derives them from the Surefire and Failsafe reports, classifying by the `*IT` suffix, and renders the table.
- It reports whichever half is present, because CI runs unit tests and the integration contract in **separate jobs** and each sees only its own reports. After a local `./mvnw verify` both are present and it also prints the combined total.
- Both composite build actions publish the result to the CI run summary, so the numbers stay visible per run.
- `--require` additionally fails an empty inventory. The existing unit check scans the reports that exist for failures, so it passed vacuously when no report existed at all. That gap is now closed.

## What the record keeps

The frozen reference points stay, because they do not move: the 4,707 discovery run, the 3,782 / 940 pre-cutover inventory, the Matrix-cutover narrative and the class-level diff. What replaced the moving numbers is a statement of what is *enforced* — the 75-report / 830-test floor, the critical-E2E check, the quarantine guard, and the separate MariaDB and Redis jobs.

`tests/ci/test_suite_inventory.py` pins both halves: the frozen figures must stay in the record, and a current-count table must not come back.

## Verification

- 62 CI contract tests pass, including six new ones and the existing stability-document contract
- The integration counts the generator produces match `run-required-integration-tests.sh` exactly on the current baseline (856 tests across 84 reports, 9 skipped)
- Both composite actions parse; the new steps are `always()` so the inventory is reported even on a failing run

## Note

The generator uses `xml.etree.ElementTree`, matching `run-required-integration-tests.sh` and the existing `maven-build` action. The input is build output from the same workspace, not untrusted XML. Switching to `defusedxml` would mean a new CI dependency and would leave the two neighbouring parsers inconsistent — worth doing as a separate sweep if wanted, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
