### PR TITLE
Disable MariaDB Liquibase contract in CI

### DIFF
--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -43,6 +43,3 @@ jobs:
       uses: ./.github/actions/maven-verify-required
       with:
         java_version: '21'
-
-  mariadb-contract:
-    uses: ./.github/workflows/mariadb-contract.yml

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -13,9 +13,6 @@ env:
   ORG: openresilienceinitiative
 
 jobs:
-  mariadb-contract:
-    uses: ./.github/workflows/mariadb-contract.yml
-
   required-integration-tests:
     name: required integration tests
     runs-on: ubuntu-latest
@@ -41,7 +38,7 @@ jobs:
 
   publish:
     name: test, build and publish image
-    needs: [required-integration-tests, mariadb-contract]
+    needs: [required-integration-tests]
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -61,9 +61,6 @@ jobs:
         -Dtest=ConsultantActivityRegistryRedisIT,RedisOneTimeTokenStoreIT
         test
 
-  mariadb-contract:
-    uses: ./.github/workflows/mariadb-contract.yml
-
   required-integration-tests:
     name: required integration tests
     runs-on: ubuntu-latest
@@ -90,7 +87,7 @@ jobs:
   required-ci:
     name: required PreDev CI
     if: always()
-    needs: [validate, redis-contract, mariadb-contract, required-integration-tests]
+    needs: [validate, redis-contract, required-integration-tests]
     runs-on: ubuntu-latest
 
     steps:
@@ -98,15 +95,14 @@ jobs:
       env:
         VALIDATE_RESULT: ${{ needs.validate.result }}
         REDIS_RESULT: ${{ needs.redis-contract.result }}
-        MARIADB_RESULT: ${{ needs.mariadb-contract.result }}
         INTEGRATION_RESULT: ${{ needs.required-integration-tests.result }}
       run: |
         conclusion=success
-        if [[ "${VALIDATE_RESULT}" != success || "${REDIS_RESULT}" != success || "${MARIADB_RESULT}" != success || "${INTEGRATION_RESULT}" != success ]]; then
+        if [[ "${VALIDATE_RESULT}" != success || "${REDIS_RESULT}" != success || "${INTEGRATION_RESULT}" != success ]]; then
           conclusion=failure
         fi
         if [[ "${conclusion}" != success ]]; then
-          echo "::error::Required CI failed: validate=${VALIDATE_RESULT}, redis=${REDIS_RESULT}, mariadb=${MARIADB_RESULT}, integration=${INTEGRATION_RESULT}"
+          echo "::error::Required CI failed: validate=${VALIDATE_RESULT}, redis=${REDIS_RESULT}, integration=${INTEGRATION_RESULT}"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary
- stop invoking the reusable MariaDB/Liquibase contract from PR, feature-branch, and main CI
- keep the existing normal build, integration, Redis, image publish, and vulnerability gates
- leave runtime Liquibase behavior controlled by Helm/global `SPRING_LIQUIBASE_ENABLED`

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci-pull-request.yml .github/workflows/ci-feature-branch.yml .github/workflows/ci-main.yml`\n- `rg -n "mariadb-contract|MARIADB_RESULT|needs: .*mariadb" .github/workflows/ci-pull-request.yml .github/workflows/ci-feature-branch.yml .github/workflows/ci-main.yml || true`