### PR TITLE
fix(logs): scope the admin audit logs to the agencies an admin owns

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/AdminAuditAgencyScope.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/AdminAuditAgencyScope.java
@@ -1,0 +1,49 @@
+package de.caritas.cob.userservice.api.service;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AdminAgency;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves how far an admin may read the session-bound audit logs (supervision, case handover).
+ *
+ * <p>Tenant-wide admins (platform admin, Träger admin) keep the tenant scope they always had.
+ * Beratungsstellen-Admins — {@code restricted-agency-admin}, which is always paired with {@code
+ * user-admin} and therefore already passes the endpoint's authority check — are narrowed to the
+ * agencies they are actually assigned to, so surfacing these logs in the Admin menu
+ * (ORISO-Admin#84) cannot turn into a cross-agency read.
+ *
+ * <p>Fail closed: an assigned-to-nothing agency admin gets an empty scope, never the tenant.
+ */
+@Component
+@RequiredArgsConstructor
+public class AdminAuditAgencyScope {
+
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull AdminAgencyRepository adminAgencyRepository;
+
+  /**
+   * @return the agency ids the current admin may read, or {@link Optional#empty()} when the admin
+   *     reads the whole tenant and must not be narrowed.
+   */
+  public Optional<Set<Long>> resolveAgencyIds() {
+    if (authenticatedUser.isTenantSuperAdmin() || authenticatedUser.isSingleTenantAdmin()) {
+      return Optional.empty();
+    }
+    if (!authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        adminAgencyRepository.findByAdminId(authenticatedUser.getUserId()).stream()
+            .map(AdminAgency::getAgencyId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet()));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverLogsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverLogsService.java
@@ -10,6 +10,8 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
@@ -25,6 +27,7 @@ public class CaseHandoverLogsService {
 
   private final @NonNull NamedParameterJdbcTemplate namedParameterJdbcTemplate;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull AdminAuditAgencyScope adminAuditAgencyScope;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   public CaseHandoverLogsResult listCaseHandoverLogs(int page, int perPage) {
@@ -32,19 +35,37 @@ public class CaseHandoverLogsService {
     int safePage = Math.max(page, 1);
     int offset = (safePage - 1) * safePerPage;
     Long tenantId = resolveEffectiveTenantId();
+    Optional<Set<Long>> agencyIds = adminAuditAgencyScope.resolveAgencyIds();
+
+    // Fail closed: a Beratungsstellen-Admin without a single agency assignment reads nothing —
+    // never the whole tenant, and never an `IN ()` that the database would reject.
+    if (agencyIds.isPresent() && agencyIds.get().isEmpty()) {
+      return CaseHandoverLogsResult.builder()
+          .data(List.of())
+          .total(0L)
+          .page(safePage)
+          .perPage(safePerPage)
+          .build();
+    }
+
+    // Empty for tenant-wide admins, an agency filter for Beratungsstellen-Admins. Appended rather
+    // than parameterised because a NULL collection cannot be expanded into an `IN` list.
+    String agencyFilter = agencyIds.isPresent() ? "\nAND s.agency_id IN (:agencyIds)" : "";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("tenantId", tenantId)
             .addValue("limit", safePerPage)
             .addValue("offset", offset);
+    agencyIds.ifPresent(ids -> params.addValue("agencyIds", ids));
 
     Long total =
         namedParameterJdbcTemplate.queryForObject(
             "SELECT COUNT(*)\n"
                 + "FROM case_handover_request chr\n"
                 + "JOIN session s ON s.id = chr.session_id\n"
-                + "WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))",
+                + "WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter,
             params,
             Long.class);
 
@@ -72,8 +93,9 @@ public class CaseHandoverLogsService {
                 + "JOIN session s ON s.id = chr.session_id\n"
                 + "JOIN consultant req ON req.consultant_id = chr.requester_consultant_id\n"
                 + "LEFT JOIN consultant prev ON prev.consultant_id = chr.previous_consultant_id\n"
-                + "WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))\n"
-                + "ORDER BY chr.created_at DESC\n"
+                + "WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter
+                + "\nORDER BY chr.created_at DESC\n"
                 + "LIMIT :limit OFFSET :offset",
             params,
             new CaseHandoverLogEntryRowMapper());

--- a/src/main/java/de/caritas/cob/userservice/api/service/SupervisorLogsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/SupervisorLogsService.java
@@ -11,6 +11,8 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
@@ -26,6 +28,7 @@ public class SupervisorLogsService {
 
   private final @NonNull NamedParameterJdbcTemplate namedParameterJdbcTemplate;
   private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull AdminAuditAgencyScope adminAuditAgencyScope;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   public SupervisorLogsResult listSupervisorLogs(int page, int perPage) {
@@ -34,12 +37,29 @@ public class SupervisorLogsService {
     final int offset = (safePage - 1) * safePerPage;
 
     final Long tenantId = resolveEffectiveTenantId();
+    final Optional<Set<Long>> agencyIds = adminAuditAgencyScope.resolveAgencyIds();
+
+    // Fail closed: a Beratungsstellen-Admin without a single agency assignment reads nothing —
+    // never the whole tenant, and never an `IN ()` that the database would reject.
+    if (agencyIds.isPresent() && agencyIds.get().isEmpty()) {
+      return SupervisorLogsResult.builder()
+          .data(List.of())
+          .total(0L)
+          .page(safePage)
+          .perPage(safePerPage)
+          .build();
+    }
+
+    // Empty for tenant-wide admins, an agency filter for Beratungsstellen-Admins. Appended rather
+    // than parameterised because a NULL collection cannot be expanded into an `IN` list.
+    final String agencyFilter = agencyIds.isPresent() ? "\n  AND s.agency_id IN (:agencyIds)" : "";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("tenantId", tenantId)
             .addValue("limit", safePerPage)
             .addValue("offset", offset);
+    agencyIds.ifPresent(ids -> params.addValue("agencyIds", ids));
 
     // Total count for pagination: added events + removed events (only where removed_date exists).
     Long total =
@@ -49,16 +69,18 @@ public class SupervisorLogsService {
                 + "    SELECT COUNT(*)\n"
                 + "    FROM session_supervisor ss\n"
                 + "    JOIN session s ON s.id = ss.session_id\n"
-                + "    WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))\n"
-                + "  )\n"
+                + "    WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter
+                + "\n  )\n"
                 + "  +\n"
                 + "  (\n"
                 + "    SELECT COUNT(*)\n"
                 + "    FROM session_supervisor ss\n"
                 + "    JOIN session s ON s.id = ss.session_id\n"
                 + "    WHERE ss.removed_date IS NOT NULL\n"
-                + "      AND (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))\n"
-                + "  ) AS total",
+                + "      AND (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter
+                + "\n  ) AS total",
             params,
             Long.class);
 
@@ -82,7 +104,9 @@ public class SupervisorLogsService {
                 + "  JOIN session s ON s.id = ss.session_id\n"
                 + "  JOIN consultant sup ON sup.consultant_id = ss.supervisor_consultant_id\n"
                 + "  JOIN consultant act ON act.consultant_id = ss.added_by_consultant_id\n"
-                + "  WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))\n"
+                + "  WHERE (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter
+                + "\n"
                 + "\n"
                 + "  UNION ALL\n"
                 + "\n"
@@ -103,8 +127,9 @@ public class SupervisorLogsService {
                 + "  JOIN consultant sup ON sup.consultant_id = ss.supervisor_consultant_id\n"
                 + "  JOIN consultant act ON act.consultant_id = ss.added_by_consultant_id\n"
                 + "  WHERE ss.removed_date IS NOT NULL\n"
-                + "    AND (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))\n"
-                + ") e\n"
+                + "    AND (:tenantId IS NULL OR s.tenant_id = :tenantId OR (:tenantId = 1 AND s.tenant_id IS NULL))"
+                + agencyFilter
+                + "\n) e\n"
                 + "ORDER BY e.eventDate DESC\n"
                 + "LIMIT :limit OFFSET :offset",
             params,

--- a/src/test/java/de/caritas/cob/userservice/api/service/AdminAuditAgencyScopeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/AdminAuditAgencyScopeTest.java
@@ -1,0 +1,86 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AdminAgency;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminAuditAgencyScopeTest {
+
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private AdminAgencyRepository adminAgencyRepository;
+
+  @InjectMocks private AdminAuditAgencyScope scope;
+
+  @Test
+  void resolveAgencyIds_Should_ReturnEmpty_When_UserIsTenantSuperAdmin() {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+
+    assertThat(scope.resolveAgencyIds()).isEmpty();
+  }
+
+  @Test
+  void resolveAgencyIds_Should_ReturnEmpty_When_UserIsSingleTenantAdmin() {
+    when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
+
+    assertThat(scope.resolveAgencyIds()).isEmpty();
+  }
+
+  @Test
+  void resolveAgencyIds_Should_ReturnEmpty_When_UserIsFullAgencyAdmin() {
+    // `agency-admin` lifts the restriction — hasRestrictedAgencyPriviliges() is then false.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+
+    assertThat(scope.resolveAgencyIds()).isEmpty();
+  }
+
+  @Test
+  void resolveAgencyIds_Should_ReturnAssignedAgencies_When_UserIsBeratungsstellenAdmin() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(adminAgencyRepository.findByAdminId("admin-1"))
+        .thenReturn(
+            List.of(
+                AdminAgency.builder().agencyId(3L).build(),
+                AdminAgency.builder().agencyId(8L).build()));
+
+    assertThat(scope.resolveAgencyIds()).contains(Set.of(3L, 8L));
+  }
+
+  @Test
+  void resolveAgencyIds_Should_SkipNullAgencyIds() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(adminAgencyRepository.findByAdminId("admin-1"))
+        .thenReturn(
+            List.of(
+                AdminAgency.builder().agencyId(null).build(),
+                AdminAgency.builder().agencyId(4L).build()));
+
+    assertThat(scope.resolveAgencyIds()).contains(Set.of(4L));
+  }
+
+  @Test
+  void resolveAgencyIds_Should_ReturnEmptySet_When_AdminHasNoAgencyAssignment() {
+    // Fail closed: an empty set is a scope of nothing, not the absence of a scope.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(adminAgencyRepository.findByAdminId("admin-1")).thenReturn(List.of());
+
+    assertThat(scope.resolveAgencyIds()).isPresent();
+    assertThat(scope.resolveAgencyIds()).contains(Set.of());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverLogsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverLogsServiceTest.java
@@ -1,0 +1,115 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.service.CaseHandoverLogsService.CaseHandoverLogsResult;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CaseHandoverLogsServiceTest {
+
+  @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private AdminAuditAgencyScope adminAuditAgencyScope;
+
+  @InjectMocks private CaseHandoverLogsService service;
+
+  @BeforeEach
+  void tenantWideByDefault() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.empty());
+    TenantContext.setCurrentTenant(5L);
+  }
+
+  @AfterEach
+  void cleanTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void listCaseHandoverLogs_Should_NotFilterByAgency_When_AdminIsTenantWide() {
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            sqlCaptor.capture(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(2L);
+    when(namedParameterJdbcTemplate.query(
+            sqlCaptor.capture(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    CaseHandoverLogsResult result = service.listCaseHandoverLogs(1, 10);
+
+    assertThat(result.getTotal()).isEqualTo(2L);
+    assertThat(sqlCaptor.getAllValues())
+        .allSatisfy(sql -> assertThat(sql).doesNotContain("agencyIds"));
+  }
+
+  @Test
+  void listCaseHandoverLogs_Should_FilterByAgency_When_AdminIsAgencyScoped() {
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.of(Set.of(11L)));
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<SqlParameterSource> paramsCaptor =
+        ArgumentCaptor.forClass(SqlParameterSource.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            sqlCaptor.capture(), paramsCaptor.capture(), eq(Long.class)))
+        .thenReturn(0L);
+    when(namedParameterJdbcTemplate.query(
+            sqlCaptor.capture(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    service.listCaseHandoverLogs(1, 10);
+
+    assertThat(sqlCaptor.getAllValues())
+        .allSatisfy(sql -> assertThat(sql).contains("s.agency_id IN (:agencyIds)"));
+    assertThat(paramsCaptor.getValue().getValue("agencyIds")).isEqualTo(Set.of(11L));
+  }
+
+  @Test
+  void listCaseHandoverLogs_Should_ReturnNothing_When_AgencyScopeIsEmpty() {
+    // Fail closed: an agency admin assigned to no agency must not fall back to the tenant.
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.of(Set.of()));
+
+    CaseHandoverLogsResult result = service.listCaseHandoverLogs(1, 10);
+
+    assertThat(result.getTotal()).isZero();
+    assertThat(result.getData()).isEmpty();
+    verifyNoInteractions(namedParameterJdbcTemplate);
+  }
+
+  @Test
+  void listCaseHandoverLogs_Should_ClampPaginationBounds() {
+    when(namedParameterJdbcTemplate.queryForObject(
+            anyString(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(0L);
+    when(namedParameterJdbcTemplate.query(
+            anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    CaseHandoverLogsResult result = service.listCaseHandoverLogs(-3, 5000);
+
+    assertThat(result.getPage()).isEqualTo(1);
+    assertThat(result.getPerPage()).isEqualTo(200);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/SupervisorLogsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/SupervisorLogsServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -13,7 +14,10 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -32,8 +36,14 @@ class SupervisorLogsServiceTest {
 
   @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
   @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private AdminAuditAgencyScope adminAuditAgencyScope;
 
   @InjectMocks private SupervisorLogsService service;
+
+  @BeforeEach
+  void tenantWideByDefault() {
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.empty());
+  }
 
   @AfterEach
   void cleanTenantContext() {
@@ -266,6 +276,62 @@ class SupervisorLogsServiceTest {
     service.listSupervisorLogs(1, 10);
 
     assertThat(paramsCaptor.getValue().getValue("tenantId")).isEqualTo(77L);
+  }
+
+  // ─── agency scope (Beratungsstellen-Admins) ───────────────────────────────
+
+  @Test
+  void listSupervisorLogs_Should_FilterByAgency_When_AdminIsAgencyScoped() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(5L);
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.of(Set.of(7L, 9L)));
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<SqlParameterSource> paramsCaptor =
+        ArgumentCaptor.forClass(SqlParameterSource.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            sqlCaptor.capture(), paramsCaptor.capture(), eq(Long.class)))
+        .thenReturn(0L);
+    when(namedParameterJdbcTemplate.query(
+            sqlCaptor.capture(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    service.listSupervisorLogs(1, 10);
+
+    assertThat(sqlCaptor.getAllValues())
+        .allSatisfy(sql -> assertThat(sql).contains("s.agency_id IN (:agencyIds)"));
+    assertThat(paramsCaptor.getValue().getValue("agencyIds")).isEqualTo(Set.of(7L, 9L));
+  }
+
+  @Test
+  void listSupervisorLogs_Should_NotFilterByAgency_When_AdminIsTenantWide() {
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(5L);
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    when(namedParameterJdbcTemplate.queryForObject(
+            sqlCaptor.capture(), any(SqlParameterSource.class), eq(Long.class)))
+        .thenReturn(0L);
+    when(namedParameterJdbcTemplate.query(
+            sqlCaptor.capture(), any(SqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(List.of());
+
+    service.listSupervisorLogs(1, 10);
+
+    assertThat(sqlCaptor.getAllValues())
+        .allSatisfy(sql -> assertThat(sql).doesNotContain("agencyIds"));
+  }
+
+  @Test
+  void listSupervisorLogs_Should_ReturnNothing_When_AgencyScopeIsEmpty() {
+    // Fail closed: an agency admin assigned to no agency must not fall back to the tenant.
+    when(authenticatedUser.getAccessToken()).thenReturn(null);
+    TenantContext.setCurrentTenant(5L);
+    when(adminAuditAgencyScope.resolveAgencyIds()).thenReturn(Optional.of(Set.of()));
+
+    SupervisorLogsResult result = service.listSupervisorLogs(1, 10);
+
+    assertThat(result.getTotal()).isZero();
+    assertThat(result.getData()).isEmpty();
+    verifyNoInteractions(namedParameterJdbcTemplate);
   }
 
   // ─── helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`/users/supervisors/logs` and `/users/case-handover/logs` filter by tenant only. Beratungsstellen-Admins (`restricted-agency-admin`, always paired with `user-admin`) already pass the authority check on both endpoints, so they can read the whole Träger's audit trail. The Admin panel is about to surface these views for that role (OpenResilienceInitiative/ORISO-Admin#84), which turns a latent gap into a visible one.

## What changed

- new `AdminAuditAgencyScope` resolves how far an admin may read: empty `Optional` for tenant-wide admins (platform, Träger, full `agency-admin`), the assigned agency set for a Beratungsstellen-Admin
- `SupervisorLogsService` and `CaseHandoverLogsService` append `s.agency_id IN (:agencyIds)` when a scope is present; tenant-wide admins keep the exact query they had
- fail closed: an admin with no agency assignment reads nothing and the database is never queried, instead of falling back to the tenant
- no `SecurityConfig` change — the authority set is already correct, only the data scope was too wide

## Verification

- `./mvnw test -Dtest='SupervisorLogsServiceTest,CaseHandoverLogsServiceTest,AdminAuditAgencyScopeTest'` — 31 tests, green (run on JDK 21; Mockito cannot mock under JDK 25 locally, which also fails the pre-existing tests)
- `./mvnw spotless:apply` clean

Refs OpenResilienceInitiative/ORISO-Admin#84