### PR TITLE
fix(session-data): keep session managed while updating session data (#938)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/SessionDataService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/SessionDataService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Service for session data. */
 @Service
@@ -24,9 +25,16 @@ public class SessionDataService {
   /**
    * Saves additional registration information in session data for the given session ID.
    *
+   * <p>Runs in a transaction so the loaded {@link Session} stays managed while {@link
+   * SessionDataProvider} reads its lazily fetched {@code sessionData} collection. Without it the
+   * session is detached as soon as {@link SessionService#getSession(Long)} returns and the lazy
+   * access fails with a {@code LazyInitializationException} (the service runs with {@code
+   * spring.jpa.open-in-view=false}).
+   *
    * @param sessionId the session ID
    * @param sessionData {@link SessionData}
    */
+  @Transactional
   public void saveSessionData(Long sessionId, SessionDataDTO sessionData) {
     Session session =
         sessionService

--- a/src/test/java/de/caritas/cob/userservice/api/service/SessionDataServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/SessionDataServiceIT.java
@@ -74,6 +74,9 @@ class SessionDataServiceIT {
   @Test
   void saveSessionData_Should_UpdateExistingSessionData_When_CalledTwice() {
     sessionDataService.saveSessionData(SESSION_ID, new SessionDataDTO().age("25").state("8"));
+    assertThat(sessionDataRepository.findBySessionId(SESSION_ID))
+        .extracting(SessionData::getKey, SessionData::getValue)
+        .containsExactlyInAnyOrder(tuple("age", "25"), tuple("state", "8"));
 
     assertThatCode(
             () ->

--- a/src/test/java/de/caritas/cob/userservice/api/service/SessionDataServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/SessionDataServiceIT.java
@@ -1,0 +1,90 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDataDTO;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.SessionData;
+import de.caritas.cob.userservice.api.port.out.SessionDataRepository;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.SessionDataInitializingDTO;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Integration test for {@link SessionDataService} covering the {@code PUT} session-data update
+ * path.
+ *
+ * <p>The test methods are intentionally <b>not</b> annotated with {@code @Transactional}: they must
+ * reproduce the production call, where the controller invokes the service without an ambient
+ * transaction and {@code spring.jpa.open-in-view=false} leaves no open persistence context. Under
+ * those conditions reading the lazily fetched {@code Session.sessionData} collection used to fail
+ * with a {@code LazyInitializationException}.
+ */
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+class SessionDataServiceIT {
+
+  private static final Long SESSION_ID = 1216L;
+
+  @Autowired private SessionDataService sessionDataService;
+
+  @Autowired private SessionDataRepository sessionDataRepository;
+
+  @MockitoBean private ConsultingTypeManager consultingTypeManager;
+
+  @BeforeEach
+  void setUp() {
+    when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
+        .thenReturn(
+            new ExtendedConsultingTypeResponseDTO()
+                .sessionDataInitializing(new SessionDataInitializingDTO().age(true).state(true)));
+  }
+
+  @AfterEach
+  void tearDown() {
+    sessionDataRepository.deleteAll(sessionDataRepository.findBySessionId(SESSION_ID));
+  }
+
+  @Test
+  void saveSessionData_Should_PersistSessionData_When_CalledWithoutAmbientTransaction() {
+    var sessionData = new SessionDataDTO().age("25").state("8");
+
+    assertThatCode(() -> sessionDataService.saveSessionData(SESSION_ID, sessionData))
+        .doesNotThrowAnyException();
+
+    List<SessionData> persisted = sessionDataRepository.findBySessionId(SESSION_ID);
+    assertThat(persisted).hasSize(2);
+    assertThat(persisted)
+        .extracting(SessionData::getKey, SessionData::getValue)
+        .containsExactlyInAnyOrder(tuple("age", "25"), tuple("state", "8"));
+  }
+
+  @Test
+  void saveSessionData_Should_UpdateExistingSessionData_When_CalledTwice() {
+    sessionDataService.saveSessionData(SESSION_ID, new SessionDataDTO().age("25").state("8"));
+
+    assertThatCode(
+            () ->
+                sessionDataService.saveSessionData(
+                    SESSION_ID, new SessionDataDTO().age("42").state("9")))
+        .doesNotThrowAnyException();
+
+    List<SessionData> persisted = sessionDataRepository.findBySessionId(SESSION_ID);
+    assertThat(persisted).hasSize(2);
+    assertThat(persisted)
+        .extracting(SessionData::getKey, SessionData::getValue)
+        .containsExactlyInAnyOrder(tuple("age", "42"), tuple("state", "9"));
+  }
+}


### PR DESCRIPTION
Closes #938

## Problem

`PUT` session-data updates returned a 500 with:

```
org.hibernate.LazyInitializationException: Cannot lazily initialize collection of role
'de.caritas.cob.userservice.api.model.Session.sessionData' with key '...' (no session)
  at ...SessionDataProvider.obtainUpdatedOrInitialSessionData(SessionDataProvider.java:94)
  at ...SessionDataService.saveSessionData(SessionDataService.java:46)
  at ...UserSupportControllerDelegate.updateSessionData(UserSupportControllerDelegate.java:46)
```

`SessionDataService.saveSessionData(Long, SessionDataDTO)` had no `@Transactional`. It loads the
session through `SessionService.getSession(...)`, which runs in its own transaction and closes it
before returning — so the `Session` is **detached** by the time `SessionDataProvider` reads the
lazily fetched `Session.sessionData` collection.

`spring.jpa.open-in-view=false` (`application.properties:5`, intentional) means there is no
request-scoped persistence context to fall back on, so this fails for **every** session, not just
the one in the report. Boot's `open-in-view=true` default would have masked it.

## Fix

Annotate `saveSessionData(Long, SessionDataDTO)` with `@Transactional`. The lookup and the
subsequent lazy read then share one persistence context, so the session stays managed for the whole
save.

The `saveSessionData(Session, SessionDataDTO)` overload is deliberately left alone: its callers
(`CreateSessionFacade`, `AskerImportService`) pass freshly initialised sessions whose `sessionData`
is still `null`, so they take the initial-data path and never touch the lazy collection. Wrapping
that overload would not re-attach an already-detached entity anyway.

## Verification

New `SessionDataServiceIT` calls the service **without** an ambient transaction — exactly like the
controller does — against the H2 test database with `open-in-view=false`.

Reverting only the `@Transactional` line and re-running reproduces the reported failure at the very
same frame:

```
Tests run: 2, Failures: 1, Errors: 1
org.hibernate.LazyInitializationException: Cannot lazily initialize collection of role
'de.caritas.cob.userservice.api.model.Session.sessionData' with key '1216' (no session)
  at ...SessionDataProvider.obtainUpdatedOrInitialSessionData(SessionDataProvider.java:94)
```

With the fix in place:

```
SessionDataServiceIT      Tests run: 2, Failures: 0, Errors: 0
SessionDataServiceTest    Tests run: 3, Failures: 0, Errors: 0
SessionDataProviderTest   Tests run: 9, Failures: 0, Errors: 0
SessionServiceIT          Tests run: 5, Failures: 0, Errors: 0
```

The IT covers both the insert path and the update path (called twice, values updated in place rather
than duplicated). `mvn spotless:apply` reports no formatting changes. The full CI contract runs on
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session data saving to reliably load and persist lazy session details when no surrounding transaction is available.
  * Fixed repeated session data updates to correctly retain the latest values.

* **Tests**
  * Added integration coverage for creating and updating session data under production-like transaction settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->