### PR TITLE
fix(admin): validate consultant topics against live agency coverage (#939)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacade.java
@@ -41,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Facade to encapsulate admin functions for consultants. */
 @Service
@@ -185,9 +186,16 @@ public class ConsultantAdminFacade {
    * are left untouched (idempotency). Validation failures (e.g. topic/agency mismatch) are
    * propagated to the caller instead of being swallowed, so the admin UI can surface them.
    *
+   * <p>Runs in a single transaction. A rejected deletion (e.g. the consultant is the last one of a
+   * still-active agency) aborts the whole call, so the consultant can never be left with a partly
+   * applied agency set — earlier deletions rolled back, later creations never reached. A consultant
+   * stuck in such a half-applied state fails the subsequent topic update, because the topics are
+   * then validated against agencies that are no longer the ones the admin selected.
+   *
    * @param consultantId the consultant to update
    * @param agencyList the desired complete set of agency relations
    */
+  @Transactional
   public void setConsultantAgencies(
       String consultantId, List<CreateConsultantAgencyDTO> agencyList) {
     var persistedAgencyIds =

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidator.java
@@ -104,9 +104,24 @@ public class ConsultantTopicAgencyCompatibilityValidator {
     if (!uncoveredTopicIds.isEmpty()) {
       throw new BadRequestException(
           String.format(
-              "Consultant topic ids %s are not covered by selected/assigned agencies %s",
-              uncoveredTopicIds, selectedAgencyIds));
+              "Consultant topic ids %s are not covered by selected/assigned agencies %s (coverage: %s)",
+              uncoveredTopicIds, selectedAgencyIds, describeCoverage(agencies)));
     }
+  }
+
+  /**
+   * Renders {@code agencyId=[coveredTopicIds]} pairs so a rejection tells the admin which agency
+   * was actually evaluated and what it covers, instead of only listing the agency ids.
+   */
+  private String describeCoverage(List<AgencyDTO> agencies) {
+    return agencies.stream()
+        .map(
+            agency ->
+                String.format(
+                    "%s=%s",
+                    agency.getId(),
+                    agency.getTopicIds() == null ? List.of() : agency.getTopicIds()))
+        .collect(Collectors.joining(", ", "{", "}"));
   }
 
   private List<Long> assignedAgencyIdsOf(String consultantId) {
@@ -124,8 +139,14 @@ public class ConsultantTopicAgencyCompatibilityValidator {
                     String.format("Consultant with id %s does not exist", consultantId)));
   }
 
+  /**
+   * Reads the agencies uncached on purpose. Topic coverage lives in the AgencyService and is edited
+   * there (add a topic to an existing agency), while the userservice caches agencies in {@code
+   * agencyCache} for three hours with no cross-service invalidation. Serving this validation from
+   * that cache rejects topics the agency already covers until the entry expires.
+   */
   private List<AgencyDTO> agenciesFor(List<Long> selectedAgencyIds) {
-    var agencies = agencyService.getAgencies(selectedAgencyIds);
+    var agencies = agencyService.getAgenciesWithoutCaching(selectedAgencyIds);
     if (agencies == null) {
       return Collections.emptyList();
     }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeTest.java
@@ -2,10 +2,12 @@ package de.caritas.cob.userservice.api.admin.facade;
 
 import static de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO.AgencyTypeEnum.DEFAULT_AGENCY;
 import static de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO.AgencyTypeEnum.TEAM_AGENCY;
+import static de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason.CONSULTANT_IS_THE_LAST_OF_AGENCY_AND_AGENCY_IS_STILL_ACTIVE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -34,6 +36,7 @@ import de.caritas.cob.userservice.api.admin.service.consultant.ConsultantAdminFi
 import de.caritas.cob.userservice.api.admin.service.consultant.ConsultantAdminService;
 import de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation.ConsultantAgencyRelationCreatorService;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
@@ -46,6 +49,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class ConsultantAdminFacadeTest {
@@ -478,6 +482,36 @@ class ConsultantAdminFacadeTest {
         () ->
             consultantAdminFacade.setConsultantAgencies(
                 "consultantId", Lists.newArrayList(new CreateConsultantAgencyDTO().agencyId(9L))));
+  }
+
+  @Test
+  void setConsultantAgencies_Should_notCreateAnything_When_ADeletionIsRejected() {
+    // Issue #939: the deletion leg runs first. When it is rejected (last consultant of a still
+    // active agency), no relation may be created either - a half-applied agency set makes the
+    // following consultant update validate topics against agencies the admin did not select.
+    when(consultantAgencyAdminService.findConsultantAgencyIds("consultantId"))
+        .thenReturn(Lists.newArrayList(1L, 2L));
+    doThrow(
+            new CustomValidationHttpStatusException(
+                CONSULTANT_IS_THE_LAST_OF_AGENCY_AND_AGENCY_IS_STILL_ACTIVE))
+        .when(consultantAgencyAdminService)
+        .markConsultantAgenciesForDeletion(eq("consultantId"), anyList());
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () ->
+            consultantAdminFacade.setConsultantAgencies(
+                "consultantId", Lists.newArrayList(new CreateConsultantAgencyDTO().agencyId(3L))));
+
+    verify(relationCreatorService, never()).createNewConsultantAgency(any(), any());
+  }
+
+  @Test
+  void setConsultantAgencies_Should_beTransactional_SoRejectedDeletionsRollBack() throws Exception {
+    var method =
+        ConsultantAdminFacade.class.getMethod("setConsultantAgencies", String.class, List.class);
+
+    assertThat(method.getAnnotation(Transactional.class), notNullValue());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -91,7 +91,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(0);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
 
@@ -129,7 +129,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setTeamAgency(true);
     agencyDTO.setConsultingType(0);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(extendedConsultingTypeResponseDTO);
 
@@ -164,7 +164,7 @@ class ConsultantAgencyRelationCreatorServiceIT {
     agencyDTO.setTeamAgency(false);
     agencyDTO.setConsultingType(consultingType);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     var consultant = createConsultantWithoutAgencyAndSession();
     when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -125,7 +125,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     agencyDTO.setConsultingType(0);
     agencyDTO.setTenantId(1L);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     Session enquirySessionWithoutConsultant =
         createSessionWithoutConsultant(agencyDTO.getId(), SessionStatus.NEW);
@@ -164,7 +164,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0).tenantId(83L);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
-    when(agencyService.getAgencies(List.of(15L))).thenReturn(List.of(agencyDTO));
+    when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
     when(consultingTypeManager.getConsultingTypeSettings(0))
         .thenReturn(new ExtendedConsultingTypeResponseDTO());
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -54,7 +54,7 @@ public class ConsultantUpdateServiceBase {
 
   @BeforeEach
   void stubAssignedAgencies() {
-    when(agencyService.getAgencies(anyList()))
+    when(agencyService.getAgenciesWithoutCaching(anyList()))
         .thenAnswer(
             invocation ->
                 invocation.<List<Long>>getArgument(0).stream()

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/validation/ConsultantTopicAgencyCompatibilityValidatorTest.java
@@ -3,12 +3,15 @@ package de.caritas.cob.userservice.api.admin.service.consultant.validation;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
@@ -33,7 +36,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredAcrossActiveAgencies() {
-    when(agencyService.getAgencies(List.of(10L, 20L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -45,7 +48,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_AllowsTopicsCoveredByOfflineAgency() {
-    when(agencyService.getAgencies(List.of(10L, 20L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, true, List.of(7L))));
 
@@ -57,7 +60,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsAgencyFromDifferentTenant() {
-    when(agencyService.getAgencies(List.of(10L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of(3L))));
 
     var exception =
@@ -72,7 +75,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
 
   @Test
   void validateGrantTopicsAgainstSelectedAgencies_RejectsForeignAgencyWithoutTopics() {
-    when(agencyService.getAgencies(List.of(10L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
         .thenReturn(List.of(agency(10L, 2L, false, List.of())));
 
     var exception =
@@ -90,7 +93,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(Optional.of(consultant("consultant-id", 1L)));
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgencies(List.of(10L, 20L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -107,7 +110,7 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
         .thenReturn(List.of());
     when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-id"))
         .thenReturn(List.of(3L, 7L));
-    when(agencyService.getAgencies(List.of(10L, 20L)))
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -118,8 +121,8 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
   }
 
   @Test
-  void validateGrantTopicsAgainstSelectedAgencies_UsesTenantScopedCachedBatchLookup() {
-    when(agencyService.getAgencies(List.of(10L, 20L)))
+  void validateGrantTopicsAgainstSelectedAgencies_ReadsAgenciesUncached() {
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L, 20L)))
         .thenReturn(
             List.of(agency(10L, 1L, false, List.of(3L)), agency(20L, 1L, false, List.of(7L))));
 
@@ -128,7 +131,49 @@ class ConsultantTopicAgencyCompatibilityValidatorTest {
             validator.validateGrantTopicsAgainstSelectedAgencies(
                 List.of(3L, 7L), List.of(10L, 20L), 1L));
 
-    verify(agencyService).getAgencies(List.of(10L, 20L));
+    verify(agencyService).getAgenciesWithoutCaching(List.of(10L, 20L));
+    verify(agencyService, never()).getAgencies(anyList());
+  }
+
+  @Test
+  void validateTopicUpdateAgainstAssignedAgencies_AcceptsTopicAddedToAssignedAgencyAfterCreation() {
+    // Issue #939: the agency was created without topics and topic 3 was added afterwards. Reading
+    // the assigned agency through the three-hour agencyCache kept serving the pre-topic snapshot,
+    // so assigning topic 3 to the consultant was rejected although the agency covers it.
+    when(consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull("consultant-id"))
+        .thenReturn(List.of(consultantAgency(10L)));
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+        .thenReturn(List.of(agency(10L, 1L, true, List.of(3L))));
+
+    assertDoesNotThrow(
+        () ->
+            validator.validateTopicUpdateAgainstAssignedAgencies("consultant-id", List.of(3L), 1L));
+
+    verify(agencyService, never()).getAgencies(anyList());
+  }
+
+  @Test
+  void validateTopicUpdateAgainstAssignedAgencies_NamesTheEvaluatedAgencyCoverageOnRejection() {
+    when(consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull("consultant-id"))
+        .thenReturn(List.of(consultantAgency(10L)));
+    when(agencyService.getAgenciesWithoutCaching(List.of(10L)))
+        .thenReturn(List.of(agency(10L, 1L, false, List.of(7L))));
+
+    var exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                validator.validateTopicUpdateAgainstAssignedAgencies(
+                    "consultant-id", List.of(3L), 1L));
+
+    assertTrue(exception.getMessage().contains("topic ids [3]"));
+    assertTrue(exception.getMessage().contains("coverage: {10=[7]}"));
+  }
+
+  private ConsultantAgency consultantAgency(Long agencyId) {
+    var consultantAgency = new ConsultantAgency();
+    consultantAgency.setAgencyId(agencyId);
+    return consultantAgency;
   }
 
   private AgencyDTO agency(Long agencyId, Long tenantId, boolean offline, List<Long> topicIds) {


### PR DESCRIPTION
Fixes #939

## Problem

Assigning a topic to a consultant failed with

```
BadRequestException: Consultant topic ids [3] are not covered by selected/assigned agencies [0]
```

even though the consultant's assigned agency covered topic 3.

## Root cause

`ConsultantTopicAgencyCompatibilityValidator.agenciesFor(...)` read the agencies through the **cached** `AgencyService.getAgencies(...)` — changed from the uncached read in 749594c4 (`perf(admin): collapse consultant agency reads`).

Topic coverage is owned by the ORISO-AgencyService and edited there (step 2 of the repro: add topic 3 to an existing agency), while the userservice keeps agencies in `agencyCache` with `timeToLiveSeconds=10800` and **no cross-service invalidation**. The validator therefore evaluated the agency's *pre-topic* snapshot and rejected a topic the agency already covered — for up to three hours after the edit.

That is exactly the reported sequence: create an agency without topics → add the topic afterwards → the agency's cached snapshot still has no topics → assigning the topic to a consultant of that agency is rejected.

The related `setConsultantAgencies` error compounds it: the method marks removed relations for deletion **before** creating the new ones, so a rejected deletion (`CONSULTANT_IS_THE_LAST_OF_AGENCY_AND_AGENCY_IS_STILL_ACTIVE`) left the consultant with a half-applied agency set — some relations already soft-deleted, the new ones never created. The subsequent `updateConsultant` then validated the topics against agencies the admin had not selected.

## Changes

- `ConsultantTopicAgencyCompatibilityValidator` reads agencies **uncached**. Admin-only write path, so the extra call is cheap; the cached read stays for the hot read paths that don't depend on topic coverage.
- `ConsultantAdminFacade.setConsultantAgencies` is `@Transactional`, so a rejected deletion rolls back instead of leaving a partly applied agency set.
- The rejection message now carries the per-agency coverage (`coverage: {10=[7]}`) so an admin can see which agency was evaluated and what it actually covers, rather than only the agency ids.

## Verification

`623 tests, 0 failures` — the full `api.admin.**` package plus every `UserAdminController*` suite (`UserAdminControllerIT`, `…E2EIT`, `…AuthorizationIT`, `…MultiTenancyTrueE2EIT`).

New regression tests:
- `validateTopicUpdateAgainstAssignedAgencies_AcceptsTopicAddedToAssignedAgencyAfterCreation` — the issue repro; also asserts the cached read is never used.
- `validateGrantTopicsAgainstSelectedAgencies_ReadsAgenciesUncached`
- `validateTopicUpdateAgainstAssignedAgencies_NamesTheEvaluatedAgencyCoverageOnRejection`
- `setConsultantAgencies_Should_notCreateAnything_When_ADeletionIsRejected`
- `setConsultantAgencies_Should_beTransactional_SoRejectedDeletionsRollBack`

Not verified against the dev environment — the fix is covered by unit/integration tests only.

## Note on `agencies [0]` — resolved: 0 is the real agency id

The `[0]` is not a placeholder and not a broken consultant→agency association. `sequence_agency` is created `START WITH 0 MINVALUE = 0` (ORISO-AgencyService, `0001_initsql/initTables.sql:30`) and `Agency.id` is `@GeneratedValue(SEQUENCE)` over it with `allocationSize=1`, so **the first agency created in an environment gets id 0**. No changeset ever alters that sequence — the demo baseline `SETVAL`s only `sequence_agency_postcode_range` and `sequence_agency_topic`, and inserts its own agency with an explicit id (246).

That is exactly step 1 of the repro ("Create a new agency"). Agency 0 is an ordinary row, so `findByIdIn([0])` returns it — which is why `assertAllSelectedAgenciesResolved` and the tenant check both passed and execution reached the coverage check at all. The association resolved correctly the whole time; the failure is the stale cache fixed here.

Worth a separate issue: agency id 0 is a latent defect, because the rest of the platform treats 0 as invalid or as a sentinel.

- `AgencyIdAllocationService.reserve()` rejects `agencyId < 1` with *"agencyId must be a positive number"* — the sequence issues an id the allocator considers invalid, and `AgencyIdReservationRepository`'s candidate queries are all `>= 1`.
- ORISO-Admin `pages/Agency/Edit/components/RegistrationSettings/index.tsx:51` computes `hasPersistedAgency` as `Number(id) > 0`, so agency 0 is treated as not persisted and its registration-settings panel is disabled.
- `TenantContext.TECHNICAL_TENANT_ID = 0L` — 0 is a sentinel elsewhere in the platform, and `agencyId: 0` is falsy in any JS truthiness check.

Not verified against the live dev schema: Liquibase is disabled and the applied DDL lives in ORISO-Database, so this reads the AgencyService changelogs as the source. `SELECT id FROM agency ORDER BY id LIMIT 1` on dev confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
