### PR TITLE
fix(notifications): dedup dual-path message events + millisecond ordering (#942)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.NotificationRoomLevel;
 import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.notification.TeamDiscussionNotificationService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -85,6 +86,17 @@ public class EventNotificationController {
       return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    // #942: the Matrix event id (when the client sends it) keys deduplication,
+    // so this producer and the server-side Matrix listener collapse into one
+    // row per recipient for the same message.
+    PrivacyEnvelope envelope =
+        request.getMatrixEventId() != null && !request.getMatrixEventId().isBlank()
+            ? PrivacyEnvelope.builder()
+                .messageId(request.getMatrixEventId())
+                .roomId(request.getRoomId())
+                .senderId(authenticatedUser.getUserId())
+                .build()
+            : null;
     if (request.getThreadRootId() != null && !request.getThreadRootId().isBlank()) {
       eventNotificationService.createThreadReplyNotificationFromRoom(
           request.getRoomId(),
@@ -93,14 +105,16 @@ public class EventNotificationController {
           request.getThreadRootId(),
           request.getSupervisorMessage() != null && request.getSupervisorMessage(),
           request.getSenderDisplayName(),
-          request.getThreadParentPreview());
+          request.getThreadParentPreview(),
+          envelope);
     } else {
       eventNotificationService.createMessageNotificationFromRoom(
           request.getRoomId(),
           authenticatedUser.getUserId(),
           request.getMessagePreview(),
           request.getSupervisorMessage() != null && request.getSupervisorMessage(),
-          request.getSenderDisplayName());
+          request.getSenderDisplayName(),
+          envelope);
     }
 
     // Debug-only mirror to Redis for Redis Commander verification of outgoing preview flow.
@@ -182,8 +196,19 @@ public class EventNotificationController {
     private Boolean teamDiscussion;
     private java.util.List<String> mentionedUserIds;
 
+    /** Matrix event id of the message this event mirrors (#942, dedup key). */
+    private String matrixEventId;
+
     public Boolean getTeamDiscussion() {
       return teamDiscussion;
+    }
+
+    public String getMatrixEventId() {
+      return matrixEventId;
+    }
+
+    public void setMatrixEventId(String matrixEventId) {
+      this.matrixEventId = matrixEventId;
     }
 
     public void setTeamDiscussion(Boolean teamDiscussion) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationController.java
@@ -6,9 +6,13 @@ import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.notification.TeamDiscussionNotificationService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -71,7 +75,7 @@ public class EventNotificationController {
 
   @PostMapping("/message-events")
   public ResponseEntity<Void> createMessageEventNotification(
-      @RequestBody MessageEventRequestDTO request) {
+      @Valid @RequestBody MessageEventRequestDTO request) {
     if (request == null || request.getRoomId() == null || request.getRoomId().isBlank()) {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
@@ -95,6 +99,11 @@ public class EventNotificationController {
                 .messageId(request.getMatrixEventId())
                 .roomId(request.getRoomId())
                 .senderId(authenticatedUser.getUserId())
+                // Mirror MatrixEventListenerService#buildPrivacyEnvelope so the
+                // persisted row keeps the correct content class no matter which
+                // producer wins the dedup race.
+                .contentClass(normaliseContentClass(request.getContentClass()))
+                .hasAttachment(request.getHasAttachment() != null && request.getHasAttachment())
                 .build()
             : null;
     if (request.getThreadRootId() != null && !request.getThreadRootId().isBlank()) {
@@ -130,6 +139,23 @@ public class EventNotificationController {
                 null));
 
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  /** Vocabulary of {@code MatrixEventListenerService#classifyContent}. */
+  private static final Set<String> KNOWN_CONTENT_CLASSES =
+      Set.of("TEXT", "IMAGE", "FILE", "AUDIO", "VIDEO", "NOTICE", "EMOTE", "OTHER", "UNKNOWN");
+
+  /**
+   * Keep the client-supplied content class inside the classification vocabulary of {@code
+   * MatrixEventListenerService#classifyContent} — it feeds notification fallback text and the
+   * structured params rendered for other users.
+   */
+  private static String normaliseContentClass(String contentClass) {
+    if (contentClass == null || contentClass.isBlank()) {
+      return null;
+    }
+    String normalised = contentClass.trim().toUpperCase(Locale.ROOT);
+    return KNOWN_CONTENT_CLASSES.contains(normalised) ? normalised : "OTHER";
   }
 
   /**
@@ -196,8 +222,21 @@ public class EventNotificationController {
     private Boolean teamDiscussion;
     private java.util.List<String> mentionedUserIds;
 
-    /** Matrix event id of the message this event mirrors (#942, dedup key). */
+    /**
+     * Matrix event id of the message this event mirrors (#942, dedup key). Matrix event ids are at
+     * most 255 chars; the bound keeps oversized values away from the 191-char dedup column.
+     */
+    @Size(max = 255)
     private String matrixEventId;
+
+    /**
+     * Optional content class of the mirrored message, from the client's {@code msgtype} — mirrors
+     * {@code MatrixEventListenerService#classifyContent} (TEXT, IMAGE, FILE, AUDIO, VIDEO, ...).
+     */
+    private String contentClass;
+
+    /** Optional: whether the mirrored message carries an attachment. */
+    private Boolean hasAttachment;
 
     public Boolean getTeamDiscussion() {
       return teamDiscussion;
@@ -209,6 +248,22 @@ public class EventNotificationController {
 
     public void setMatrixEventId(String matrixEventId) {
       this.matrixEventId = matrixEventId;
+    }
+
+    public String getContentClass() {
+      return contentClass;
+    }
+
+    public void setContentClass(String contentClass) {
+      this.contentClass = contentClass;
+    }
+
+    public Boolean getHasAttachment() {
+      return hasAttachment;
+    }
+
+    public void setHasAttachment(Boolean hasAttachment) {
+      this.hasAttachment = hasAttachment;
     }
 
     public void setTeamDiscussion(Boolean teamDiscussion) {

--- a/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/EventNotification.java
@@ -84,10 +84,10 @@ public class EventNotification implements TenantAware {
   @Column(name = "deduplication_key", length = 191)
   private String deduplicationKey;
 
-  @Column(name = "read_date", columnDefinition = "datetime")
+  @Column(name = "read_date", columnDefinition = "datetime(3)")
   private LocalDateTime readDate;
 
-  @Column(name = "create_date", nullable = false, columnDefinition = "datetime")
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime(3)")
   private LocalDateTime createDate;
 
   @Column(name = "tenant_id")

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventNotificationRepository extends JpaRepository<EventNotification, Long> {
 
-  List<EventNotification> findByRecipientUserIdOrderByCreateDateDesc(
+  List<EventNotification> findByRecipientUserIdOrderByCreateDateDescIdDesc(
       String recipientUserId, Pageable pageable);
 
   long countByRecipientUserIdAndReadDateIsNull(String recipientUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -42,6 +42,9 @@ public class EventNotificationService {
   public static final String CATEGORY_SYSTEM = "system";
   public static final String CATEGORY_MESSAGE = "message";
 
+  /** Matches the {@code deduplication_key} column length (VARCHAR(191), changeset 0063). */
+  static final int MAX_DEDUPLICATION_KEY_LENGTH = 191;
+
   private static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
   private static final String REDACTED_PREVIEW = "[content hidden]";
   private static final long ACTIVE_VIEW_TTL_NANOS = Duration.ofSeconds(30).toNanos();
@@ -613,18 +616,27 @@ public class EventNotificationService {
       Long sourceSessionId,
       Long tenantId) {
     if (matrixEventId != null && !matrixEventId.isBlank()) {
-      createEventOnce(
-          eventType + ":" + matrixEventId,
-          recipientUserId,
+      String deduplicationKey = eventType + ":" + matrixEventId;
+      if (deduplicationKey.length() <= MAX_DEDUPLICATION_KEY_LENGTH) {
+        createEventOnce(
+            deduplicationKey,
+            recipientUserId,
+            eventType,
+            CATEGORY_MESSAGE,
+            title,
+            text,
+            params,
+            actionPath,
+            sourceSessionId,
+            tenantId);
+        return;
+      }
+      // An oversized key would fail the insert with a truncation error that the
+      // dedup path misreads as "already persisted" — persist unconditionally instead.
+      log.warn(
+          "Deduplication key for event type {} exceeds {} chars; persisting without deduplication",
           eventType,
-          CATEGORY_MESSAGE,
-          title,
-          text,
-          params,
-          actionPath,
-          sourceSessionId,
-          tenantId);
-      return;
+          MAX_DEDUPLICATION_KEY_LENGTH);
     }
     createEvent(
         recipientUserId,

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -370,10 +370,10 @@ public class EventNotificationService {
         && session.getUser().getUserId() != null
         && !session.getUser().getUserId().equals(senderUserId)
         && !shouldSuppressNotification(session.getUser().getUserId(), roomId, null)) {
-      createEvent(
-          session.getUser().getUserId(),
+      createMessageEventDeduplicated(
           "message.new",
-          CATEGORY_MESSAGE,
+          envelope != null ? envelope.getMessageId() : null,
+          session.getUser().getUserId(),
           "New message",
           text,
           buildMessageParams(session, senderLabel, contentClass, "user"),
@@ -386,10 +386,10 @@ public class EventNotificationService {
         && session.getConsultant().getId() != null
         && !session.getConsultant().getId().equals(senderUserId)
         && !shouldSuppressNotification(session.getConsultant().getId(), roomId, null)) {
-      createEvent(
-          session.getConsultant().getId(),
+      createMessageEventDeduplicated(
           "message.new",
-          CATEGORY_MESSAGE,
+          envelope != null ? envelope.getMessageId() : null,
+          session.getConsultant().getId(),
           "New message",
           text,
           buildMessageParams(session, senderLabel, contentClass, "consultant"),
@@ -467,10 +467,10 @@ public class EventNotificationService {
         && session.getUser().getUserId() != null
         && !session.getUser().getUserId().equals(senderUserId)
         && !shouldSuppressNotification(session.getUser().getUserId(), roomId, threadRootId)) {
-      createEvent(
-          session.getUser().getUserId(),
+      createMessageEventDeduplicated(
           "thread.reply.new",
-          CATEGORY_MESSAGE,
+          envelope != null ? envelope.getMessageId() : null,
+          session.getUser().getUserId(),
           "New thread reply",
           text,
           buildThreadReplyParams(session, senderLabel, contentClass, threadRootId, "user"),
@@ -483,10 +483,10 @@ public class EventNotificationService {
         && session.getConsultant().getId() != null
         && !session.getConsultant().getId().equals(senderUserId)
         && !shouldSuppressNotification(session.getConsultant().getId(), roomId, threadRootId)) {
-      createEvent(
-          session.getConsultant().getId(),
+      createMessageEventDeduplicated(
           "thread.reply.new",
-          CATEGORY_MESSAGE,
+          envelope != null ? envelope.getMessageId() : null,
+          session.getConsultant().getId(),
           "New thread reply",
           text,
           buildThreadReplyParams(session, senderLabel, contentClass, threadRootId, "consultant"),
@@ -505,7 +505,7 @@ public class EventNotificationService {
     var pageable = PageRequest.of(safePage, safePerPage);
     List<NotificationItem> items =
         eventNotificationRepository
-            .findByRecipientUserIdOrderByCreateDateDesc(recipientUserId, pageable)
+            .findByRecipientUserIdOrderByCreateDateDescIdDesc(recipientUserId, pageable)
             .stream()
             .map(this::toItem)
             .collect(Collectors.toList());
@@ -582,6 +582,48 @@ public class EventNotificationService {
         title,
         text,
         null,
+        actionPath,
+        sourceSessionId,
+        tenantId);
+  }
+
+  /**
+   * #942: message-type events carry a deterministic deduplication key derived from the Matrix event
+   * id, so the Matrix sync listener and the frontend's {@code POST /message-events} for the same
+   * message collapse into one row per recipient. Without an event id (legacy callers) the event
+   * persists unconditionally, as before.
+   */
+  private void createMessageEventDeduplicated(
+      String eventType,
+      String matrixEventId,
+      String recipientUserId,
+      String title,
+      String text,
+      String params,
+      String actionPath,
+      Long sourceSessionId,
+      Long tenantId) {
+    if (matrixEventId != null && !matrixEventId.isBlank()) {
+      createEventOnce(
+          eventType + ":" + matrixEventId,
+          recipientUserId,
+          eventType,
+          CATEGORY_MESSAGE,
+          title,
+          text,
+          params,
+          actionPath,
+          sourceSessionId,
+          tenantId);
+      return;
+    }
+    createEvent(
+        recipientUserId,
+        eventType,
+        CATEGORY_MESSAGE,
+        title,
+        text,
+        params,
         actionPath,
         sourceSessionId,
         tenantId);

--- a/src/main/resources/db/changelog/changeset/0080_event_notification_millis/0080_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0080_event_notification_millis/0080_changeSet.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <changeSet id="0080-event-notification-millis" author="frank">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="event_notification" schemaName="userservice"/>
+    </preConditions>
+    <sqlFile
+      path="db/changelog/changeset/0080_event_notification_millis/migrate.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <rollback>
+      <sql>
+        ALTER TABLE userservice.event_notification
+          MODIFY create_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          MODIFY read_date DATETIME NULL;
+      </sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0080_event_notification_millis/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0080_event_notification_millis/migrate.sql
@@ -1,0 +1,7 @@
+-- #942: create_date had second precision only — fan-out bursts write many
+-- rows in the same second and the feed order flipped between two polls.
+-- Millisecond precision plus the id tiebreaker in the repository query
+-- make the ordering deterministic. Existing rows keep their timestamps.
+ALTER TABLE userservice.event_notification
+  MODIFY create_date DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  MODIFY read_date DATETIME(3) NULL;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -134,6 +134,8 @@
     file="db/changelog/changeset/0078_handshake/0078_changeSet.xml" />
   <include
     file="db/changelog/changeset/0079_support_room/0079_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0080_event_notification_millis/0080_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
@@ -237,4 +237,102 @@ class EventNotificationControllerTest {
             envelopeCaptor.capture());
     assertEquals("$evt-42", envelopeCaptor.getValue().getMessageId());
   }
+
+  @Test
+  void createMessageEventNotification_withContentMetadata_populatesEnvelope() {
+    // #942 review: the REST producer must carry contentClass/hasAttachment like the
+    // Matrix listener, or the persisted row loses them when this path wins the dedup race.
+    when(authenticatedUser.getUserId()).thenReturn("u-6");
+    var request = new EventNotificationController.MessageEventRequestDTO();
+    request.setRoomId("room-7");
+    request.setMessagePreview("preview");
+    request.setMatrixEventId("$evt-43");
+    request.setContentClass("image");
+    request.setHasAttachment(true);
+
+    var response = controllerWithoutMirror.createMessageEventNotification(request);
+
+    assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    var envelopeCaptor = org.mockito.ArgumentCaptor.forClass(PrivacyEnvelope.class);
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            org.mockito.ArgumentMatchers.eq("room-7"),
+            org.mockito.ArgumentMatchers.eq("u-6"),
+            org.mockito.ArgumentMatchers.eq("preview"),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.isNull(),
+            envelopeCaptor.capture());
+    assertEquals("IMAGE", envelopeCaptor.getValue().getContentClass());
+    assertEquals(true, envelopeCaptor.getValue().isHasAttachment());
+  }
+
+  @Test
+  void createMessageEventNotification_unknownContentClass_normalisedToOther() {
+    // contentClass feeds text rendered for other users — arbitrary client strings
+    // must collapse into the classifyContent vocabulary.
+    when(authenticatedUser.getUserId()).thenReturn("u-6");
+    var request = new EventNotificationController.MessageEventRequestDTO();
+    request.setRoomId("room-7");
+    request.setMatrixEventId("$evt-43");
+    request.setContentClass("<script>alert(1)</script>");
+
+    controllerWithoutMirror.createMessageEventNotification(request);
+
+    var envelopeCaptor = org.mockito.ArgumentCaptor.forClass(PrivacyEnvelope.class);
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            org.mockito.ArgumentMatchers.eq("room-7"),
+            org.mockito.ArgumentMatchers.eq("u-6"),
+            org.mockito.ArgumentMatchers.isNull(),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.isNull(),
+            envelopeCaptor.capture());
+    assertEquals("OTHER", envelopeCaptor.getValue().getContentClass());
+  }
+
+  @Test
+  void createThreadReplyEventNotification_withMatrixEventId_passesDedupEnvelope() {
+    // #942 review: the thread-reply branch shares the envelope construction and
+    // must dedup by Matrix event id too.
+    when(authenticatedUser.getUserId()).thenReturn("u-7");
+    var request = new EventNotificationController.MessageEventRequestDTO();
+    request.setRoomId("room-8");
+    request.setMessagePreview("reply");
+    request.setThreadRootId("$root-1");
+    request.setMatrixEventId("$evt-44");
+
+    var response = controllerWithoutMirror.createMessageEventNotification(request);
+
+    assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    var envelopeCaptor = org.mockito.ArgumentCaptor.forClass(PrivacyEnvelope.class);
+    verify(eventNotificationService)
+        .createThreadReplyNotificationFromRoom(
+            org.mockito.ArgumentMatchers.eq("room-8"),
+            org.mockito.ArgumentMatchers.eq("u-7"),
+            org.mockito.ArgumentMatchers.eq("reply"),
+            org.mockito.ArgumentMatchers.eq("$root-1"),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.isNull(),
+            org.mockito.ArgumentMatchers.isNull(),
+            envelopeCaptor.capture());
+    assertEquals("$evt-44", envelopeCaptor.getValue().getMessageId());
+  }
+
+  @Test
+  void createMessageEventNotification_matrixEventIdBoundedAndBodyValidated() throws Exception {
+    // #942 review: oversized event ids must be rejected at the API boundary before
+    // they can poison the 191-char dedup column.
+    java.lang.reflect.Field field =
+        EventNotificationController.MessageEventRequestDTO.class.getDeclaredField("matrixEventId");
+    jakarta.validation.constraints.Size size =
+        field.getAnnotation(jakarta.validation.constraints.Size.class);
+    assertEquals(255, size.max());
+
+    Method endpoint =
+        EventNotificationController.class.getMethod(
+            "createMessageEventNotification",
+            EventNotificationController.MessageEventRequestDTO.class);
+    assertEquals(
+        true, endpoint.getParameters()[0].isAnnotationPresent(jakarta.validation.Valid.class));
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/EventNotificationControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.service.matrix.RedisMessageMirrorService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.notification.PrivacyEnvelope;
 import de.caritas.cob.userservice.api.service.notification.TeamDiscussionNotificationService;
 import jakarta.validation.constraints.Min;
 import java.lang.reflect.Method;
@@ -155,7 +156,7 @@ class EventNotificationControllerTest {
 
     assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     verify(eventNotificationService)
-        .createMessageNotificationFromRoom("room-2", "u-1", "hello", false, "Sender");
+        .createMessageNotificationFromRoom("room-2", "u-1", "hello", false, "Sender", null);
   }
 
   @Test
@@ -178,7 +179,7 @@ class EventNotificationControllerTest {
     assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     verify(eventNotificationService)
         .createThreadReplyNotificationFromRoom(
-            "room-3", "u-2", "reply", "thread-3", true, "Sender-3", "parent");
+            "room-3", "u-2", "reply", "thread-3", true, "Sender-3", "parent", null);
   }
 
   @Test
@@ -210,6 +211,30 @@ class EventNotificationControllerTest {
 
     assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
     verify(eventNotificationService)
-        .createMessageNotificationFromRoom("room-5", "u-4", "preview", false, null);
+        .createMessageNotificationFromRoom("room-5", "u-4", "preview", false, null, null);
+  }
+
+  @Test
+  void createMessageEventNotification_withMatrixEventId_passesDedupEnvelope() {
+    // #942: the Matrix event id keys deduplication against the sync listener.
+    when(authenticatedUser.getUserId()).thenReturn("u-5");
+    var request = new EventNotificationController.MessageEventRequestDTO();
+    request.setRoomId("room-6");
+    request.setMessagePreview("preview");
+    request.setMatrixEventId("$evt-42");
+
+    var response = controllerWithoutMirror.createMessageEventNotification(request);
+
+    assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    var envelopeCaptor = org.mockito.ArgumentCaptor.forClass(PrivacyEnvelope.class);
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            org.mockito.ArgumentMatchers.eq("room-6"),
+            org.mockito.ArgumentMatchers.eq("u-5"),
+            org.mockito.ArgumentMatchers.eq("preview"),
+            org.mockito.ArgumentMatchers.eq(false),
+            org.mockito.ArgumentMatchers.isNull(),
+            envelopeCaptor.capture());
+    assertEquals("$evt-42", envelopeCaptor.getValue().getMessageId());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceReplicaIT.java
@@ -37,7 +37,7 @@ class EventNotificationServiceReplicaIT {
   @AfterEach
   void deleteReplicaProofNotification() {
     var notifications =
-        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(
+        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(
             RECIPIENT, Pageable.unpaged());
     eventNotificationRepository.deleteAll(notifications);
   }
@@ -63,7 +63,7 @@ class EventNotificationServiceReplicaIT {
     }
 
     var notifications =
-        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(
+        eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(
             RECIPIENT, Pageable.unpaged());
     assertThat(notifications)
         .singleElement()

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -571,7 +571,7 @@ class EventNotificationServiceTest {
 
   @Test
   void getFeed_clampsNegativePageToZeroAndOverLimitPerPageToHundred() {
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(any(), any()))
         .thenReturn(List.of());
     when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
 
@@ -583,7 +583,7 @@ class EventNotificationServiceTest {
 
   @Test
   void getFeed_clampsZeroPerPageToOne() {
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(any(), any()))
         .thenReturn(List.of());
     when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
 
@@ -734,6 +734,52 @@ class EventNotificationServiceTest {
         "user-1", "message.new", null, "Title", "Text", null, 1L, 1L);
     verify(eventNotificationRepository).save(eventCaptor.capture());
     assertEquals(EventNotificationService.CATEGORY_SYSTEM, eventCaptor.getValue().getCategory());
+  }
+
+  @Test
+  void messageEventsWithTheSameMatrixEventIdCollapseToOneRow() {
+    // #942: the Matrix sync listener and the frontend POST both announce the
+    // same message — the event-id-derived dedup key keeps exactly one row.
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+    when(eventNotificationRepository.existsByRecipientUserIdAndDeduplicationKey(
+            "asker-1", "message.new:$evt-1"))
+        .thenReturn(false, true);
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder()
+            .messageId("$evt-1")
+            .roomId("!room-1:matrix.example")
+            .senderId("someone-else")
+            .build();
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "someone-else", null, false, "Someone", envelope);
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "someone-else", null, false, "Someone", envelope);
+
+    verify(deduplicationWriter, times(1)).persistInNewTransaction(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getDeduplicationKey()).isEqualTo("message.new:$evt-1");
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void messageEventsWithoutAMatrixEventIdStillPersistUnconditionally() {
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "someone-else", "body");
+
+    verify(eventNotificationRepository).save(any());
+    verify(deduplicationWriter, never()).persistInNewTransaction(any());
   }
 
   @Test
@@ -960,7 +1006,7 @@ class EventNotificationServiceTest {
     n.setReadDate(LocalDateTime.of(2026, 1, 1, 12, 0));
     n.setCreateDate(LocalDateTime.of(2026, 1, 1, 11, 0));
 
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(any(), any()))
         .thenReturn(List.of(n));
     when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(0L);
 
@@ -985,7 +1031,7 @@ class EventNotificationServiceTest {
     n.setCreateDate(LocalDateTime.now());
     n.setReadDate(null);
 
-    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDesc(any(), any()))
+    when(eventNotificationRepository.findByRecipientUserIdOrderByCreateDateDescIdDesc(any(), any()))
         .thenReturn(List.of(n));
     when(eventNotificationRepository.countByRecipientUserIdAndReadDateIsNull(any())).thenReturn(1L);
 
@@ -1093,7 +1139,9 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", envelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    // #942: envelope events carry a Matrix event id and persist through the
+    // dedup writer instead of a plain save.
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getEventType()).isEqualTo("message.new");
   }
 
@@ -1114,7 +1162,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createThreadReplyNotificationFromRoom(
         "!room-1:matrix.example", "sender", "thread-root-1", envelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getEventType()).isEqualTo("thread.reply.new");
   }
 
@@ -1140,7 +1188,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", null, false, null, imageEnvelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getText()).contains("image");
   }
 
@@ -1162,7 +1210,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", null, false, null, fileEnvelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getText()).contains("file");
   }
 
@@ -1184,7 +1232,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", null, false, null, audioEnvelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getText()).contains("audio message");
   }
 
@@ -1206,7 +1254,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", null, false, null, videoEnvelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     assertThat(eventCaptor.getValue().getText()).contains("video message");
   }
 
@@ -1258,7 +1306,7 @@ class EventNotificationServiceTest {
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", null, false, null, envelope);
 
-    verify(eventNotificationRepository).save(eventCaptor.capture());
+    verify(deduplicationWriter).persistInNewTransaction(eventCaptor.capture());
     String text = eventCaptor.getValue().getText();
     assertThat(text).contains("evt-123");
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -865,6 +865,31 @@ class EventNotificationServiceTest {
   }
 
   @Test
+  void overlongMatrixEventIdPersistsUnconditionallyInsteadOfSilentlyDropping() {
+    // #942 review: deduplication_key is VARCHAR(191). An oversized client-supplied
+    // event id must not reach createEventOnce, where the truncation failure would be
+    // misread as "already persisted" and the notification silently dropped.
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+    PrivacyEnvelope envelope =
+        PrivacyEnvelope.builder()
+            .messageId("$" + "x".repeat(250))
+            .roomId("!room-1:matrix.example")
+            .senderId("someone-else")
+            .build();
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "someone-else", null, false, "Someone", envelope);
+
+    verify(eventNotificationRepository).save(any());
+    verify(deduplicationWriter, never()).persistInNewTransaction(any());
+  }
+
+  @Test
   void messageEventsWithoutAMatrixEventIdStillPersistUnconditionally() {
     Session session = sessionMock();
     User user = mock(User.class);


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-UserService#942
Refs OpenResilienceInitiative/ORISO-Frontend#844 (bug epic)
Frontend counterpart (sends the event id): OpenResilienceInitiative/ORISO-Frontend#882

## Why

Two hygiene defects in the event pipeline (timeline audit 2026-08-01):

1. `message.new` is produced by **two independent paths** — the Matrix sync listener and the frontend's `POST /message-events` — with no dedup key, so one message could yield two rows for the same recipient.
2. `create_date` had **second precision** and the feed query had no tiebreaker: fan-out bursts write many rows in the same second, so the order could flip between two polls — which breaks any client-side anchor (e.g. the Next-notification queue).

## What changed

1. **Dedup**: `message.new` / `thread.reply.new` derive `"<eventType>:<matrixEventId>"` as deduplication key and persist through the existing dedup writer (unique per recipient, replica-race safe). The listener already carries the event id in its `PrivacyEnvelope`; the POST endpoint accepts an optional `matrixEventId` and the frontend now sends it (FE#859). Without an event id (legacy callers) events persist unconditionally, as before.
2. **Ordering**: changeset `0080` migrates `create_date`/`read_date` to `DATETIME(3)`; the feed orders by `create_date DESC, id DESC`. Existing rows keep their timestamps.

Deployment note: environments running with Liquibase disabled need the `0080` ALTER applied manually (`migrate.sql`).

## Verification

- Notification suites green: EventNotificationService **73** (2 new dedup cases), Controller **11** (1 new envelope case), TeamDiscussion 11, GroupChatLifecycle 4, ReplicaIT 1, Matrix contract test 1
- New tests: same Matrix event id via both paths → exactly one persisted row with key `message.new:$evt-1`; no event id → legacy unconditional persist

### Reviewer test plan

- [ ] On Pre-Dev (with FE#859 deployed): send one client message into an accepted session → the consultant's feed (`GET /users/event-notifications`) contains exactly **one** `message.new` for it, also after a second poll
- [ ] Reply in a thread → exactly one `thread.reply.new` per recipient
- [ ] Produce 5+ events within one second (e.g. group-chat fan-out) → two consecutive feed fetches return the identical order
- [ ] Apply changeset 0080 against a Pre-Dev schema copy → no failure, existing `create_date` values unchanged (seconds precision retained as `.000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Matrix event IDs and privacy metadata to message notifications, including content classification and attachment status.
  * Prevented duplicate notifications when the same event is received multiple times.

* **Bug Fixes**
  * Improved notification feed ordering for consistent results.
  * Enhanced timestamp precision for notification creation and read times.
  * Preserved handling for events without Matrix event IDs and validated notification requests.

* **Tests**
  * Added coverage for deduplication, ordering, validation, and privacy metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->