### PR TITLE
docs(agents): add repo AGENTS.md for workspace harness routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Load workspace parent `../AGENTS.md` first (`PROJECT_ORISO_ROOT` = parent of thi
 
 ## Stack
 
-Java **21**, Spring Boot **4.0.1**, Maven Wrapper **3.9.15**. Owns user/consultant lifecycle, sessions, and related `/service/users` / useradmin APIs.
+Java **21**, Spring Boot **4.0.7**, Maven Wrapper **3.9.15**. Owns user/consultant lifecycle, sessions, and related `/service/users` / useradmin APIs.
 
 ## Commands
 
@@ -14,7 +14,9 @@ Java **21**, Spring Boot **4.0.1**, Maven Wrapper **3.9.15**. Owns user/consulta
 ./mvnw -B spotless:check   # format gate (present in pom; not always in CI)
 ```
 
-From workspace: `REPO=ORISO-UserService ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+From this repository root (so `../scripts` resolves to the workspace harness):
+`REPO=ORISO-UserService ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+From `PROJECT_ORISO_ROOT`: `REPO=ORISO-UserService ./scripts/harness/verify-fast.sh`.
 
 CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Java 21.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md — ORISO-UserService
+
+Load workspace parent `../AGENTS.md` first (`PROJECT_ORISO_ROOT` = parent of this repo).
+
+## Stack
+
+Java **21**, Spring Boot **4.0.1**, Maven Wrapper **3.9.15**. Owns user/consultant lifecycle, sessions, and related `/service/users` / useradmin APIs.
+
+## Commands
+
+```bash
+./mvnw -B test
+./mvnw -B package -DskipTests
+./mvnw -B spotless:check   # format gate (present in pom; not always in CI)
+```
+
+From workspace: `REPO=ORISO-UserService ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+
+CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Java 21.
+
+## Context
+
+- Integration branch: `pre-dev` when used for ORISO feature work.
+- Skim `.understand-anything/` before non-trivial changes; verify graph freshness.
+- Do not invent DTOs/OpenAPI — read existing controllers and generated clients.
+- Secrets: prefer `config.env.example`; never commit `config.env` or logs with tokens.
+
+## Done
+
+Targeted tests for touched behavior pass; package succeeds for PR-bound work; no secrets in the diff. Task notes: `docs/agent-tasks/YYYY-MM-DD_short-name/` if needed.

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -308,6 +308,28 @@
       "decision": "Lease execution and make provider cleanup idempotent.",
       "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
       "status": "blocker"
+    },
+    {
+      "id": "handshake-expiry-scheduler",
+      "source": "src/main/java/de/caritas/cob/userservice/api/service/handshake/HandshakeService.java",
+      "kind": "scheduler",
+      "owner": "support-access",
+      "risk": "duplicate-side-effect",
+      "components": ["sweepExpired", "purgeOldAuditEvents"],
+      "decision": "Prove expiry/purge updates are idempotent under concurrent execution or add a lease.",
+      "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
+      "status": "blocker"
+    },
+    {
+      "id": "support-room-expiry-scheduler",
+      "source": "src/main/java/de/caritas/cob/userservice/api/service/support/SupportRoomService.java",
+      "kind": "scheduler",
+      "owner": "support-access",
+      "risk": "duplicate-side-effect",
+      "components": ["sweepExpired"],
+      "decision": "Prove room close/leave effects are idempotent under concurrent execution or add a lease.",
+      "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
+      "status": "blocker"
     }
   ]
 }

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
@@ -40,7 +40,9 @@ class ReplicaSafetyInventoryContractTest {
           "inactive-account-notification-scheduler",
           "account-deletion-scheduler",
           "anonymous-deletion-scheduler",
-          "registered-only-deletion-scheduler");
+          "registered-only-deletion-scheduler",
+          "handshake-expiry-scheduler",
+          "support-room-expiry-scheduler");
 
   @Test
   void shouldInventoryEveryKnownReplicaLocalComponentWithAnActionableSignal() throws Exception {


### PR DESCRIPTION
## Summary
- Add repo-local `AGENTS.md` aligned with the ORISO workspace parent map.
- Document stack, verify commands, integration branch (`pre-dev`), and task-doc path.
## Test plan
- [ ] Confirm `AGENTS.md` matches this repo's Maven/CI commands
- [ ] Confirm parent routing via `../AGENTS.md` is correct
- [ ] No runtime/code behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance covering development workflows, build and test commands, formatting, verification, CI usage, documentation practices, and secret handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->