### PR TITLE
Repair a Rocket.Chat-era test that asserted nothing

### DIFF
--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -201,9 +201,13 @@ public class CreateUserFacadeTest {
 
   @Test
   public void
-      createUserAccountWithInitializedConsultingType_Should_LogOutFromRocketChat_When_ConsultingTypeIsKreuzbundAndRocketChatLoginSucceeded()
+      createUserAccountWithInitializedConsultingType_Should_ProvisionMatrixAndInitializeSession_When_ConsultingTypeIsKreuzbundAndNoTenantIsSet()
           throws Exception {
-
+    // Was named "..._Should_LogOutFromRocketChat_When_...RocketChatLoginSucceeded"
+    // and asserted nothing at all — it only checked that the call did not throw,
+    // for a log-out that no longer exists. It covers the Kreuzbund path without a
+    // tenant context (the sibling test below covers it with one), so assert what
+    // that path is actually supposed to do.
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
     when(identityClient.createUser(any())).thenReturn(CREATED_IDENTITY_WITH_USER_ID);
@@ -216,6 +220,13 @@ public class CreateUserFacadeTest {
     givenMatrixProvisioningSucceeds();
 
     createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
+
+    verify(identityClient).createUser(any());
+    verify(matrixSynapseService).createUser(any(), any(), any());
+    verify(createNewSessionFacade)
+        .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
+    // The plaintext password must not survive the registration.
+    assertThat(PlainCredentialsHolder.get(), nullValue());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -219,14 +219,19 @@ public class CreateUserFacadeTest {
     givenAFullyPersistedUser();
     givenMatrixProvisioningSucceeds();
 
-    createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
+    PlainCredentialsHolder.set("plain-user", "plain-password");
+    try {
+      createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
 
-    verify(identityClient).createUser(any());
-    verify(matrixSynapseService).createUser(any(), any(), any());
-    verify(createNewSessionFacade)
-        .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
-    // The plaintext password must not survive the registration.
-    assertThat(PlainCredentialsHolder.get(), nullValue());
+      verify(identityClient).createUser(any());
+      verify(matrixSynapseService).createUser(any(), any(), any());
+      verify(createNewSessionFacade)
+          .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
+      // The plaintext password must not survive the registration.
+      assertThat(PlainCredentialsHolder.get(), nullValue());
+    } finally {
+      PlainCredentialsHolder.clear();
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes the last hand-written Rocket.Chat reference in UserService that was not a deliberate guard.

## What was there

```java
createUserAccountWithInitializedConsultingType_Should_LogOutFromRocketChat
  _When_ConsultingTypeIsKreuzbundAndRocketChatLoginSucceeded
```

The stale name was the **smaller** problem. The body had **no assertion at all** — it arranged mocks, called the facade, and ended. It could only fail by throwing. So it certified nothing, while reading in every report like coverage of a Rocket.Chat log-out that has not existed for months.

## What it is now

Renamed to what the case actually covers — the Kreuzbund consulting type *without* a tenant context, since the sibling test covers it *with* one — and given the assertions it should always have had:

- identity created
- Matrix user provisioned
- session initialised
- plaintext password cleared from `PlainCredentialsHolder`

## Verification

- `CreateUserFacadeTest`: **29/29** pass
- all `*ContractTest`: **64/64** pass
- `spotless:apply`: no diff (formatting was already correct)

## Two things worth recording

**1. The rest of the Rocket.Chat removal is already done on `pre-dev`** — further than the open issues suggested. `src/main` has **zero** references; `rcGroupId` / `rcUserId` / `rcToken` are gone from **every** API contract, replaced by `matrixRoomId`; and changeset `0074_remove_rocket_chat_room_ids` renames the columns with an archive table and `onFail="HALT"`. The remaining mentions are the `RocketChatAdapterRemovedContractTest` / `MatrixOnly*ContractTest` guards, which must name the string in order to assert its absence, plus historical CHANGELOG entries. Deleting those would weaken the guarantee, not complete it. ORISO-UserService#747 and #748 can be closed on that evidence.

**2. Running these tests locally on JDK 25 needs an extra flag.** Without it, Mockito cannot mock and *every* test in the class errors with `MockitoException` — which looks exactly like a real failure:

```bash
./mvnw test -Dtest=CreateUserFacadeTest -DargLine="-Dnet.bytebuddy.experimental=true -XX:+EnableDynamicAgentLoading"
```

`spotless:apply` also fails on JDK 25 with a `PluginContainerException`; use JDK 21 for that goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated coverage for Matrix user provisioning and session initialization.
  * Added verification that identities are created and plaintext credentials are cleared.
  * Renamed the test to reflect the current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->