### PR TITLE
P0: provide Matrix UIA credential for recovery setup

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -509,7 +509,9 @@ public class MatrixSynapseService implements MatrixUserClient {
       }
 
       @SuppressWarnings("unchecked")
-      var responseBody = (java.util.Map<String, Object>) response.getBody();
+      var responseBody =
+          new java.util.HashMap<>((java.util.Map<String, Object>) response.getBody());
+      responseBody.put("interactive_auth_password", transientPassword);
       return responseBody;
     } catch (Exception ex) {
       log.error(

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageController.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -72,9 +73,10 @@ public class MatrixMessageController {
       response.put("accessToken", tokenResponse.get("access_token"));
       response.put("userId", tokenResponse.getOrDefault("user_id", matrixUserId));
       response.put("deviceId", tokenResponse.getOrDefault("device_id", ""));
+      response.put("uiaPassword", tokenResponse.getOrDefault("interactive_auth_password", ""));
       response.put("expiresInMs", MATRIX_BROWSER_TOKEN_TTL_MS);
 
-      return ResponseEntity.ok(response);
+      return ResponseEntity.ok().cacheControl(CacheControl.noStore()).body(response);
     } catch (Exception ex) {
       log.error("Could not create Matrix token for current user", ex);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -713,6 +713,7 @@ class MatrixSynapseServiceTest {
     assertThat(browserLoginBody.getDeviceId()).isEqualTo("ORISO_WEB_DEVICE_ONE");
     assertThat(browserLoginBody.getInitialDeviceDisplayName()).isEqualTo("ORISO Web");
     assertThat(browserLoginBody.getPassword()).isEqualTo(updateBody.getPassword());
+    assertThat(result.get("interactive_auth_password")).isEqualTo(updateBody.getPassword());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixMessageControllerTest.java
@@ -155,7 +155,12 @@ class MatrixMessageControllerTest {
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(userService.getUser(USER_ID)).thenReturn(Optional.of(userWithMatrixId()));
     when(matrixSynapseService.loginBrowserDevice(MATRIX_USER_ID, "ORISO_WEB_DEVICE_ONE"))
-        .thenReturn(Map.of("access_token", "abc", "user_id", MATRIX_USER_ID, "device_id", "dev1"));
+        .thenReturn(
+            Map.of(
+                "access_token", "abc",
+                "user_id", MATRIX_USER_ID,
+                "device_id", "dev1",
+                "interactive_auth_password", "ephemeral-uia-password"));
 
     var response = controller.getCurrentUserMatrixToken("ORISO_WEB_DEVICE_ONE");
 
@@ -163,6 +168,8 @@ class MatrixMessageControllerTest {
     var body = assertInstanceOf(Map.class, response.getBody());
     assertEquals("abc", body.get("accessToken"));
     assertEquals("dev1", body.get("deviceId"));
+    assertEquals("ephemeral-uia-password", body.get("uiaPassword"));
+    assertEquals("no-store", response.getHeaders().getCacheControl());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- return the transient Matrix password used by the device-bound browser login
- mark the authenticated response `Cache-Control: no-store`
- cover exact credential propagation without logging it

## Verification
- Java 21 targeted tests: 68 passed
- Java 21 full package: 3,673 passed

Cross-repo frontend: OpenResilienceInitiative/ORISO-Frontend#903

Closes #950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Matrix token responses now include the temporary authentication password needed for interactive authentication.
* **Security Improvements**
  * Token responses are marked as non-cacheable to help prevent sensitive authentication data from being stored.
* **Bug Fixes**
  * Existing Matrix login response data is preserved while adding the temporary password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->