### PR TITLE
fix(notifications): expire stale active conversation views (#952)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -889,25 +889,31 @@ public class EventNotificationService {
 
   private boolean shouldSuppressNotification(
       String recipientUserId, String roomId, String threadRootId) {
-    ActiveViewState activeView = activeViewByUserId.get(recipientUserId);
-    if (activeView == null || roomId == null || roomId.isBlank()) {
-      return false;
-    }
-    if (monotonicNanos.getAsLong() - activeView.lastHeartbeatNanos >= ACTIVE_VIEW_TTL_NANOS) {
-      activeViewByUserId.remove(recipientUserId, activeView);
-      return false;
-    }
-    if (!roomId.equals(activeView.roomId)) {
-      return false;
-    }
+    while (true) {
+      ActiveViewState activeView = activeViewByUserId.get(recipientUserId);
+      if (activeView == null || roomId == null || roomId.isBlank()) {
+        return false;
+      }
+      if (monotonicNanos.getAsLong() - activeView.lastHeartbeatNanos >= ACTIVE_VIEW_TTL_NANOS) {
+        if (activeViewByUserId.remove(recipientUserId, activeView)) {
+          return false;
+        }
+        // A concurrent heartbeat replaced the expired entry. Re-evaluate that
+        // fresh state so an active recipient remains correctly suppressed.
+        continue;
+      }
+      if (!roomId.equals(activeView.roomId)) {
+        return false;
+      }
 
-    // For room-level messages, suppress when recipient is on that room.
-    if (threadRootId == null || threadRootId.isBlank()) {
-      return true;
-    }
+      // For room-level messages, suppress when recipient is on that room.
+      if (threadRootId == null || threadRootId.isBlank()) {
+        return true;
+      }
 
-    // For thread replies, suppress only when recipient is actively inside same thread.
-    return threadRootId.equals(activeView.threadRootId);
+      // For thread replies, suppress only when recipient is actively inside same thread.
+      return threadRootId.equals(activeView.threadRootId);
+    }
   }
 
   private String buildSessionActionPath(Session session) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.service.IdentityTombstoneService;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +44,7 @@ public class EventNotificationService {
 
   private static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
   private static final String REDACTED_PREVIEW = "[content hidden]";
+  private static final long ACTIVE_VIEW_TTL_NANOS = Duration.ofSeconds(30).toNanos();
 
   private final @NonNull EventNotificationRepository eventNotificationRepository;
   private final @NonNull SessionRepository sessionRepository;
@@ -51,6 +54,7 @@ public class EventNotificationService {
   private final @NonNull EventNotificationDeduplicationWriter deduplicationWriter;
   private final Map<String, ActiveViewState> activeViewByUserId = new ConcurrentHashMap<>();
   private final ObjectMapper paramsObjectMapper = new ObjectMapper();
+  private volatile LongSupplier monotonicNanos = System::nanoTime;
 
   @Value("${privacy.notificationPreviewMode:NONE}")
   private String notificationPreviewMode;
@@ -562,7 +566,12 @@ public class EventNotificationService {
       activeViewByUserId.remove(userId);
       return;
     }
-    activeViewByUserId.put(userId, new ActiveViewState(roomId, threadRootId));
+    activeViewByUserId.put(
+        userId, new ActiveViewState(roomId, threadRootId, monotonicNanos.getAsLong()));
+  }
+
+  void setMonotonicNanosForTesting(LongSupplier monotonicNanos) {
+    this.monotonicNanos = monotonicNanos;
   }
 
   @Transactional
@@ -884,6 +893,10 @@ public class EventNotificationService {
     if (activeView == null || roomId == null || roomId.isBlank()) {
       return false;
     }
+    if (monotonicNanos.getAsLong() - activeView.lastHeartbeatNanos >= ACTIVE_VIEW_TTL_NANOS) {
+      activeViewByUserId.remove(recipientUserId, activeView);
+      return false;
+    }
     if (!roomId.equals(activeView.roomId)) {
       return false;
     }
@@ -974,10 +987,12 @@ public class EventNotificationService {
   private static class ActiveViewState {
     private final String roomId;
     private final String threadRootId;
+    private final long lastHeartbeatNanos;
 
-    private ActiveViewState(String roomId, String threadRootId) {
+    private ActiveViewState(String roomId, String threadRootId, long lastHeartbeatNanos) {
       this.roomId = roomId;
       this.threadRootId = threadRootId;
+      this.lastHeartbeatNanos = lastHeartbeatNanos;
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -474,6 +475,48 @@ class EventNotificationServiceTest {
   }
 
   @Test
+  void createMessageNotificationFromRoom_deliversWhenActiveViewHeartbeatExpired() {
+    AtomicLong nowNanos = new AtomicLong();
+    eventNotificationService.setMonotonicNanosForTesting(nowNanos::get);
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+
+    eventNotificationService.updateActiveView("asker-1", "!room-1:matrix.example", null, true);
+    nowNanos.set(java.time.Duration.ofSeconds(31).toNanos());
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "sender", "hello after browser close");
+
+    verify(eventNotificationRepository).save(any());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_heartbeatRefreshExtendsActiveView() {
+    AtomicLong nowNanos = new AtomicLong();
+    eventNotificationService.setMonotonicNanosForTesting(nowNanos::get);
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+
+    eventNotificationService.updateActiveView("asker-1", "!room-1:matrix.example", null, true);
+    nowNanos.set(java.time.Duration.ofSeconds(20).toNanos());
+    eventNotificationService.updateActiveView("asker-1", "!room-1:matrix.example", null, true);
+    nowNanos.set(java.time.Duration.ofSeconds(40).toNanos());
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "sender", "still actively viewed");
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
   void createMessageNotificationFromRoom_doesNotSuppressWhenUserIsInDifferentRoom() {
     eventNotificationService.updateActiveView("asker-1", "different-room", null, true);
 
@@ -545,6 +588,27 @@ class EventNotificationServiceTest {
         "!room-1:matrix.example", "sender", "reply", "thread-root-1");
 
     verify(eventNotificationRepository, never()).save(any());
+  }
+
+  @Test
+  void createThreadReplyNotificationFromRoom_deliversWhenActiveViewHeartbeatExpired() {
+    AtomicLong nowNanos = new AtomicLong();
+    eventNotificationService.setMonotonicNanosForTesting(nowNanos::get);
+    eventNotificationService.updateActiveView(
+        "asker-1", "!room-1:matrix.example", "thread-root-1", true);
+    nowNanos.set(java.time.Duration.ofSeconds(31).toNanos());
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+
+    eventNotificationService.createThreadReplyNotificationFromRoom(
+        "!room-1:matrix.example", "sender", "reply", "thread-root-1");
+
+    verify(eventNotificationRepository).save(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -487,11 +488,44 @@ class EventNotificationServiceTest {
         .thenReturn(Optional.of(session));
 
     eventNotificationService.updateActiveView("asker-1", "!room-1:matrix.example", null, true);
-    nowNanos.set(java.time.Duration.ofSeconds(31).toNanos());
+    nowNanos.set(java.time.Duration.ofSeconds(30).toNanos());
     eventNotificationService.createMessageNotificationFromRoom(
         "!room-1:matrix.example", "sender", "hello after browser close");
 
     verify(eventNotificationRepository).save(any());
+  }
+
+  @Test
+  void createMessageNotificationFromRoom_suppressesConcurrentHeartbeatAtExpiry() {
+    AtomicLong nowNanos = new AtomicLong();
+    AtomicBoolean refreshOnExpiryCheck = new AtomicBoolean();
+    AtomicBoolean refreshing = new AtomicBoolean();
+    eventNotificationService.setMonotonicNanosForTesting(
+        () -> {
+          if (refreshOnExpiryCheck.get() && refreshing.compareAndSet(false, true)) {
+            eventNotificationService.updateActiveView(
+                "asker-1", "!room-1:matrix.example", null, true);
+            refreshing.set(false);
+            refreshOnExpiryCheck.set(false);
+          }
+          return nowNanos.get();
+        });
+
+    Session session = sessionMock();
+    User user = mock(User.class);
+    when(user.getUserId()).thenReturn("asker-1");
+    when(session.getUser()).thenReturn(user);
+    when(sessionRepository.findByMatrixRoomId("!room-1:matrix.example"))
+        .thenReturn(Optional.of(session));
+
+    eventNotificationService.updateActiveView("asker-1", "!room-1:matrix.example", null, true);
+    nowNanos.set(java.time.Duration.ofSeconds(30).toNanos());
+    refreshOnExpiryCheck.set(true);
+
+    eventNotificationService.createMessageNotificationFromRoom(
+        "!room-1:matrix.example", "sender", "heartbeat won expiry race");
+
+    verify(eventNotificationRepository, never()).save(any());
   }
 
   @Test


### PR DESCRIPTION
Fixes #952

Related frontend notification epic: OpenResilienceInitiative/ORISO-Frontend#844
Related frontend cleanup hardening: OpenResilienceInitiative/ORISO-Frontend#904

## Why

`activeViewByUserId` kept room/thread activity forever. When a tab or browser closed while a conversation was active, the frontend cleanup request was not guaranteed to finish. Every later `message.new` for that recipient could then be silently suppressed until some client explicitly posted `active=false`.

Fresh PreDev evidence came from Simpsons-only run `e2e-20260803-025044`: Marge's 20.52-second voice note was an encrypted Matrix event and Apu decrypted/played it before and after reload, but no recipient-scoped notification was persisted because the preceding consultant browser had closed on the room.

## What changed

- Active-view state records a monotonic last-heartbeat timestamp.
- Entries expire after 30 seconds, three times the frontend's 10-second heartbeat interval.
- Expired entries are removed atomically and no longer suppress room or thread notifications.
- Explicit `active=false`, fresh-room suppression, and same-thread suppression keep their existing behavior.
- A deterministic monotonic test clock avoids sleeps and wall-clock flakiness.

## TDD / verification

- Red: the new expiry tests failed to compile before the clock/TTL contract existed.
- Green: `EventNotificationServiceTest` — **74 passed, 0 failed** on JDK 21.
- Spotless — clean.
- `git diff --check` — clean.

## Reviewer test plan

- [ ] Open a consultant session and confirm heartbeats keep incoming room notifications suppressed while the view remains active.
- [ ] Close the consultant browser without navigating away.
- [ ] Wait at least 30 seconds, then send an encrypted text/file/audio message from the advice seeker.
- [ ] Confirm one new recipient-scoped `message.new` is persisted.
- [ ] Repeat for a thread reply and confirm expired same-thread state no longer suppresses it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active-view notification suppression now expires after 30 seconds without a heartbeat.
  * Notifications are delivered when an active view becomes stale, including message and thread-reply notifications.
  * Heartbeats refresh the active-view status and continue suppressing duplicate notifications while the view remains active.
  * Notification behavior remains consistent when a heartbeat arrives during expiration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->