### PR TITLE
fix: repair missing support room schema

### DIFF
--- a/src/main/resources/db/changelog/changeset/0081_support_room_repair/0081_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0081_support_room_repair/0081_changeSet.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <!--
+    Repair a non-linear PreDev migration history: the ADR-018 replacement
+    changeset removed support_room after 0079 had already been recorded. A
+    later pre-dev image therefore skipped 0079 and failed Hibernate validation.
+  -->
+  <changeSet id="0081-support-room-repair" author="frank">
+    <sqlFile
+      path="db/changelog/changeset/0081_support_room_repair/migrate.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"
+      endDelimiter=";"/>
+    <!-- 0079 owns the canonical table. Rolling back this repair must not
+         remove it and recreate the same recorded-but-missing schema drift. -->
+    <rollback>
+      <sql>SELECT 1;</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0081_support_room_repair/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0081_support_room_repair/migrate.sql
@@ -1,0 +1,25 @@
+-- Restore the canonical 0079 table when a divergent ADR-018 hot-deploy
+-- removed it while leaving DATABASECHANGELOG history intact. Idempotent for
+-- normal databases where 0079's table and indexes still exist.
+CREATE TABLE IF NOT EXISTS userservice.support_room (
+  id VARCHAR(36) NOT NULL,
+  handshake_id VARCHAR(36) NOT NULL,
+  matrix_room_id VARCHAR(255) NOT NULL,
+  support_admin_id VARCHAR(36) NOT NULL,
+  support_admin_matrix_id VARCHAR(255) NULL,
+  consultant_id VARCHAR(36) NOT NULL,
+  status VARCHAR(16) NOT NULL,
+  close_reason VARCHAR(16) NULL,
+  create_date DATETIME NOT NULL,
+  expiry_date DATETIME NOT NULL,
+  closed_date DATETIME NULL,
+  tenant_id BIGINT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_support_room_status_expiry
+  ON userservice.support_room (status, expiry_date);
+CREATE INDEX IF NOT EXISTS idx_support_room_consultant
+  ON userservice.support_room (consultant_id, status);
+CREATE INDEX IF NOT EXISTS idx_support_room_support_admin
+  ON userservice.support_room (support_admin_id, status);

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -134,6 +134,8 @@
     file="db/changelog/changeset/0078_handshake/0078_changeSet.xml" />
   <include
     file="db/changelog/changeset/0079_support_room/0079_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0081_support_room_repair/0081_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/SupportRoomMigrationConvergenceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/SupportRoomMigrationConvergenceIT.java
@@ -1,0 +1,90 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Proves that the canonical changelog converges after a divergent hot-deploy removed {@code
+ * support_room} but left changeset 0079 recorded as executed.
+ */
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class SupportRoomMigrationConvergenceIT {
+
+  private static final String CHANGELOG = "db/changelog/userservice-master.xml";
+  private static final String REPAIR_CHANGESET_ID = "0081-support-room-repair";
+  private static final String REPAIR_CHANGESET_AUTHOR = "frank";
+  private static final String REPAIR_CHANGESET_FILE =
+      "db/changelog/changeset/0081_support_room_repair/0081_changeSet.xml";
+
+  @Test
+  void canonicalChangelogRepairsSupportRoomRemovedByDivergentMigration() throws Exception {
+    updateCanonicalChangelog();
+
+    try (Connection connection = openConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP TABLE IF EXISTS userservice.support_room");
+      statement.executeUpdate(
+          "DELETE FROM userservice.DATABASECHANGELOG"
+              + " WHERE ID = '"
+              + REPAIR_CHANGESET_ID
+              + "' AND AUTHOR = '"
+              + REPAIR_CHANGESET_AUTHOR
+              + "' AND FILENAME = '"
+              + REPAIR_CHANGESET_FILE
+              + "'");
+    }
+
+    assertThat(supportRoomExists()).as("drift fixture removed support_room").isFalse();
+
+    updateCanonicalChangelog();
+
+    assertThat(supportRoomExists())
+        .as("canonical changelog must converge after support_room was removed")
+        .isTrue();
+  }
+
+  private void updateCanonicalChangelog() throws Exception {
+    try (Connection connection = openConnection()) {
+      Database database =
+          DatabaseFactory.getInstance()
+              .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+      try (Liquibase liquibase =
+          new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database)) {
+        liquibase.update(new Contexts("prod"), new LabelExpression());
+      }
+    }
+  }
+
+  private boolean supportRoomExists() throws SQLException {
+    try (Connection connection = openConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result =
+            statement.executeQuery(
+                "SELECT COUNT(*) FROM information_schema.tables"
+                    + " WHERE table_schema = 'userservice' AND table_name = 'support_room'")) {
+      result.next();
+      return result.getInt(1) == 1;
+    }
+  }
+
+  private Connection openConnection() throws SQLException {
+    return DriverManager.getConnection(
+        System.getenv("LIQUIBASE_IT_DB_URL"),
+        System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"),
+        System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+  }
+}


### PR DESCRIPTION
Closes #955

## Why

PreDev could contain a recorded `0079-support-room` Liquibase changeset while the `support_room` table was still absent. With `ddl-auto=validate`, that drift caused UserService to crash and Live Chat APIs to return 502/503.

## What changed

- add an idempotent `0081` repair changeset for the missing support-room schema
- preserve existing data and recorded migration history
- add a MariaDB convergence integration test for the exact drift fixture

## Verification

- focused migration convergence test: PASS
- full UserService unit suite: 3,673 tests PASS
- Spotless / JDK 21 build: PASS
- Docker Build Cloud image started against the drifted PreDev database: PASS
- Liquibase executed `0081`; Hibernate validation completed; pod became Ready with 0 restarts

## Reviewer test plan

- [ ] Start with `0079-support-room` recorded and `support_room` absent.
- [ ] Run the canonical migration chain.
- [ ] Verify `support_room` and its three indexes (`idx_support_room_status_expiry`, `idx_support_room_consultant`, `idx_support_room_support_admin`) exist.
- [ ] Start UserService with schema validation enabled and verify it becomes Ready.
- [ ] Re-run the migration and verify it remains idempotent.

## Scope

This deliberately does not refactor UserService. Recent UserService improvements, including #930 and #931, remain intact and are already present in the branch ancestry; neither covers this database convergence failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)