### PR TITLE
P0: finalize registered enquiry from encrypted Matrix event (#954)

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2493,6 +2493,9 @@ components:
           $ref: '#/components/schemas/LanguageCode'
         t:
           type: string
+        matrixEventId:
+          type: string
+          description: ID of the browser-encrypted Matrix event to finalize as the initial enquiry
 
     CreateEnquiryMessageResponseDTO:
       type: object

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -53,6 +53,8 @@ public class MatrixSynapseService implements MatrixUserClient {
   private static final String ENDPOINT_PRESENCE = "/_matrix/client/r0/presence/{userId}/status";
   private static final String ENDPOINT_SEND_MESSAGE =
       "/_matrix/client/r0/rooms/{roomId}/send/m.room.message/{txnId}";
+  private static final String ENDPOINT_ROOM_EVENT =
+      "/_matrix/client/v3/rooms/{roomId}/event/{eventId}";
   private static final String ENDPOINT_ROOM_MESSAGES = "/_matrix/client/r0/rooms/{roomId}/messages";
   private static final long PRESENCE_CACHE_TTL_MS = 10_000L;
 
@@ -1037,6 +1039,37 @@ public class MatrixSynapseService implements MatrixUserClient {
       log.error(
           "Matrix Error: Could not send message to room ({}). Reason: {}", roomId, ex.getMessage());
       return java.util.Map.of("error", ex.getMessage());
+    }
+  }
+
+  /**
+   * Reads one raw Matrix event from a room. Encrypted events remain encrypted here; this method is
+   * used only to validate event identity and metadata, never to access message plaintext.
+   */
+  public java.util.Optional<java.util.Map<String, Object>> getRoomEvent(
+      String roomId, String eventId, String accessToken) {
+    try {
+      var headers = getClientHttpHeaders(accessToken);
+      HttpEntity<Void> request = new HttpEntity<>(headers);
+      var url =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig,
+              ENDPOINT_ROOM_EVENT,
+              java.util.Map.of("roomId", roomId, "eventId", eventId));
+      var response =
+          restTemplate.exchange(
+              url, org.springframework.http.HttpMethod.GET, request, java.util.Map.class);
+      if (response.getBody() == null) {
+        return java.util.Optional.empty();
+      }
+      return java.util.Optional.of(response.getBody());
+    } catch (Exception ex) {
+      log.warn(
+          "Matrix Error: Could not read event {} from room {}: {}",
+          eventId,
+          roomId,
+          ex.getMessage());
+      return java.util.Optional.empty();
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AppointmentController.java
@@ -181,7 +181,8 @@ public class AppointmentController implements AppointmentsApi {
             null,
             null,
             enquiryAppointmentDTO.getT(),
-            enquiryAppointmentDTO.getCounselorEmail());
+            enquiryAppointmentDTO.getCounselorEmail(),
+            null);
 
     var response = createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -189,7 +189,13 @@ class UserRegistrationControllerDelegate {
     var language = consultantDtoMapper.languageOf(enquiryMessage.getLanguage());
     var enquiryData =
         new EnquiryData(
-            user, sessionId, enquiryMessage.getMessage(), language, enquiryMessage.getT(), null);
+            user,
+            sessionId,
+            enquiryMessage.getMessage(),
+            language,
+            enquiryMessage.getT(),
+            null,
+            enquiryMessage.getMatrixEventId());
 
     var response = createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -185,6 +185,13 @@ class UserRegistrationControllerDelegate {
 
   ResponseEntity<CreateEnquiryMessageResponseDTO> createEnquiryMessage(
       Long sessionId, EnquiryMessageDTO enquiryMessage) {
+    if (enquiryMessage.getMatrixEventId() != null
+        && !enquiryMessage.getMatrixEventId().isBlank()
+        && enquiryMessage.getMessage() != null
+        && !enquiryMessage.getMessage().isBlank()) {
+      throw new BadRequestException(
+          "Encrypted enquiry finalization must not include plaintext message content");
+    }
     var user = this.userAccountProvider.retrieveValidatedUser();
     var language = consultantDtoMapper.languageOf(enquiryMessage.getLanguage());
     var enquiryData =

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -73,25 +73,8 @@ public class CreateEnquiryMessageFacade {
 
     String matrixMessageEventId = "";
     if (!isAppointmentEnquiryMessage(enquiryData)) {
-      String matrixAccessToken =
-          matrixSynapseService.loginAsUserAccessToken(enquiryData.getUser().getMatrixUserId());
-      if (isBlank(matrixAccessToken)) {
-        throw new InternalServerErrorException(
-            String.format(
-                "Could not create Matrix token for enquiry user %s",
-                enquiryData.getUser().getUserId()));
-      }
-
-      var matrixResponse =
-          matrixSynapseService.sendMessage(
-              matrixRoomId, enquiryData.getMessage(), matrixAccessToken);
-      if (matrixResponse == null || matrixResponse.containsKey("error")) {
-        throw new InternalServerErrorException(
-            String.format(
-                "Could not post Matrix enquiry message to room %s for session %s",
-                matrixRoomId, session.getId()));
-      }
-      matrixMessageEventId = String.valueOf(matrixResponse.getOrDefault("event_id", ""));
+      matrixMessageEventId =
+          validateEncryptedMatrixEvent(enquiryData, matrixRoomId, enquiryData.getMatrixEventId());
     }
 
     var exceptionInformation =
@@ -106,6 +89,49 @@ public class CreateEnquiryMessageFacade {
         .matrixRoomId(matrixRoomId)
         .sessionId(enquiryData.getSessionId())
         .t(matrixMessageEventId);
+  }
+
+  private String validateEncryptedMatrixEvent(
+      EnquiryData enquiryData, String matrixRoomId, String matrixEventId) {
+    if (isBlank(matrixEventId)) {
+      throw new InternalServerErrorException(
+          String.format(
+              "Initial enquiry for session %s requires an encrypted Matrix event",
+              enquiryData.getSessionId()));
+    }
+
+    String matrixUserId = enquiryData.getUser().getMatrixUserId();
+    String matrixAccessToken = matrixSynapseService.loginAsUserAccessToken(matrixUserId);
+    if (isBlank(matrixAccessToken)) {
+      throw new InternalServerErrorException(
+          String.format(
+              "Could not validate encrypted Matrix enquiry event for user %s",
+              enquiryData.getUser().getUserId()));
+    }
+
+    var event =
+        matrixSynapseService
+            .getRoomEvent(matrixRoomId, matrixEventId, matrixAccessToken)
+            .orElseThrow(
+                () ->
+                    new InternalServerErrorException(
+                        String.format(
+                            "Could not read Matrix enquiry event %s in room %s",
+                            matrixEventId, matrixRoomId)));
+
+    if (!matrixEventId.equals(event.get("event_id"))) {
+      throw new InternalServerErrorException(
+          String.format("Matrix enquiry event response did not match %s", matrixEventId));
+    }
+    if (!"m.room.encrypted".equals(event.get("type"))) {
+      throw new InternalServerErrorException(
+          String.format("Matrix enquiry event %s is not an encrypted Matrix event", matrixEventId));
+    }
+    if (!matrixUserId.equals(event.get("sender"))) {
+      throw new InternalServerErrorException(
+          String.format("Matrix enquiry event %s was not sent by enquiry user", matrixEventId));
+    }
+    return matrixEventId;
   }
 
   private String ensureMatrixRoomForEnquiry(Session session, User user) {

--- a/src/main/java/de/caritas/cob/userservice/api/model/EnquiryData.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/EnquiryData.java
@@ -21,4 +21,5 @@ public class EnquiryData {
   private final String language;
   private String type;
   private String consultantEmail;
+  private String matrixEventId;
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -912,6 +912,38 @@ class MatrixSynapseServiceTest {
     assertThat(result.get("error")).asString().contains("room not found");
   }
 
+  @Test
+  void getRoomEvent_returnsRawEncryptedEventFromExactRoomAndEventPath() {
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    var event =
+        Map.<String, Object>of(
+            "event_id", "$encrypted", "sender", MATRIX_USER_ID, "type", "m.room.encrypted");
+    when(restTemplate.exchange(
+            any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(event));
+    var urlCaptor = ArgumentCaptor.forClass(URI.class);
+
+    var result = matrixSynapseService().getRoomEvent(MATRIX_ROOM_ID, "$encrypted", ACCESS_TOKEN);
+
+    assertThat(result).contains(event);
+    verify(restTemplate)
+        .exchange(urlCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class));
+    assertThat(urlCaptor.getValue().toString())
+        .isEqualTo(
+            "https://matrix.example/_matrix/client/v3/rooms/%21room%3Amatrix.example.com/event/%24encrypted");
+  }
+
+  @Test
+  void getRoomEvent_returnsEmptyWhenSynapseRejectsReference() {
+    matrixConfig.setApiUrl(MATRIX_BASE_URL);
+    when(restTemplate.exchange(
+            any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new RuntimeException("unknown event"));
+
+    assertThat(matrixSynapseService().getRoomEvent(MATRIX_ROOM_ID, "$missing", ACCESS_TOKEN))
+        .isEmpty();
+  }
+
   // -------------------------------------------------------------------------
   // findOnlineMatrixUserIds
   // -------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -252,6 +252,19 @@ class UserRegistrationControllerDelegateTest {
   }
 
   @Test
+  void createEnquiryMessageRejectsPlaintextAlongsideEncryptedEventReference() {
+    var enquiryMessage = org.mockito.Mockito.mock(EnquiryMessageDTO.class);
+    when(enquiryMessage.getMatrixEventId()).thenReturn("$encrypted-event");
+    when(enquiryMessage.getMessage()).thenReturn("plaintext must not cross this boundary");
+
+    assertThatThrownBy(() -> delegate.createEnquiryMessage(SESSION_ID, enquiryMessage))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("must not include plaintext");
+
+    verifyNoInteractions(createEnquiryMessageFacade);
+  }
+
+  @Test
   void deleteSessionAndInactiveUserShouldDelegateSessionDeletion() {
     var response = delegate.deleteSessionAndInactiveUser(SESSION_ID);
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
@@ -52,7 +52,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  *        -> AgencyPreAssignmentRoomService.ensureHoldingRoom
  *           -> Matrix room created, enquiry user invited + joined (membership)
  *           -> session.matrixRoomId persisted
- *     -> Matrix enquiry message sent
+ *     -> browser-encrypted Matrix enquiry event validated
  *     -> session persisted (status NEW, groupId = matrix room id)
  * </pre>
  *
@@ -178,23 +178,28 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
     when(matrixSynapseService.inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN))
         .thenReturn(ResponseEntity.ok(new MatrixInviteUserResponseDTO()));
 
-    // Enquiry-message post + membership use the user's own token.
+    // Enquiry-event validation + membership use the user's own token.
     when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
     when(matrixSynapseService.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
-    when(matrixSynapseService.sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN))
-        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+    when(matrixSynapseService.getRoomEvent(NEW_ROOM_ID, MATRIX_EVENT_ID, USER_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", USER_MATRIX_ID,
+                    "type", "m.room.encrypted")));
 
-    var response =
-        createEnquiryMessageFacade.createEnquiryMessage(
-            new EnquiryData(user, SESSION_ID, MESSAGE, null));
+    var enquiryData = new EnquiryData(user, SESSION_ID, MESSAGE, null);
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    var response = createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
 
     // Room provisioned: create -> invite -> membership.
     verify(matrixSynapseService).createRoom(anyString(), anyString(), eq(AGENCY_TOKEN));
     verify(matrixSynapseService).inviteUserToRoom(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
     verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, USER_TOKEN);
 
-    // Enquiry message posted to the provisioned room.
-    verify(matrixSynapseService).sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN);
+    // The already browser-encrypted event is validated in the provisioned room.
+    verify(matrixSynapseService).getRoomEvent(NEW_ROOM_ID, MATRIX_EVENT_ID, USER_TOKEN);
 
     // Session persisted with the provisioned room id (once by the room service, once by the
     // facade).
@@ -211,8 +216,7 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
   }
 
   @Test
-  @DisplayName(
-      "FE#811: the agency's counsellors are room members before the enquiry message is sent")
+  @DisplayName("FE#811: the agency's counsellors are room members before the enquiry is finalized")
   void createEnquiryMessage_joinsAgencyConsultantsBeforeSendingTheEnquiry() throws Exception {
     var consultantMatrixId = "@counsellor:oriso.org";
     var consultantToken = "counsellor-token";
@@ -246,21 +250,26 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
     when(matrixSynapseService.loginAsUserAccessToken(consultantMatrixId))
         .thenReturn(consultantToken);
     when(matrixSynapseService.joinRoom(eq(NEW_ROOM_ID), anyString())).thenReturn(true);
-    when(matrixSynapseService.sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN))
-        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+    when(matrixSynapseService.getRoomEvent(NEW_ROOM_ID, MATRIX_EVENT_ID, USER_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", USER_MATRIX_ID,
+                    "type", "m.room.encrypted")));
 
-    createEnquiryMessageFacade.createEnquiryMessage(
-        new EnquiryData(user, SESSION_ID, MESSAGE, null));
+    var enquiryData = new EnquiryData(user, SESSION_ID, MESSAGE, null);
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    createEnquiryMessageFacade.createEnquiryMessage(enquiryData);
 
     // The counsellor is a real member of the room...
     verify(matrixSynapseService).inviteUserToRoom(NEW_ROOM_ID, consultantMatrixId, AGENCY_TOKEN);
     verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, consultantToken);
 
-    // ...and joined BEFORE the enquiry message exists. Reversing this order is exactly the bug:
-    // a member who joins later holds no Megolm key for what was sent before them.
+    // ...and joined before the backend finalizes the referenced encrypted enquiry event.
     var inOrder = Mockito.inOrder(matrixSynapseService);
     inOrder.verify(matrixSynapseService).joinRoom(NEW_ROOM_ID, consultantToken);
-    inOrder.verify(matrixSynapseService).sendMessage(NEW_ROOM_ID, MESSAGE, USER_TOKEN);
+    inOrder.verify(matrixSynapseService).getRoomEvent(NEW_ROOM_ID, MATRIX_EVENT_ID, USER_TOKEN);
 
     RequestContextHolder.resetRequestAttributes();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -227,6 +227,26 @@ class CreateEnquiryMessageFacadeTest {
   }
 
   @Test
+  void rejectsMatrixResponseWithDifferentEventId() {
+    givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", "$different-event",
+                    "sender", MATRIX_USER_ID,
+                    "type", "m.room.encrypted")));
+
+    assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("did not match");
+
+    verify(sessionService, never()).saveSession(session);
+  }
+
+  @Test
   void provisionsMissingMatrixRoomBeforeSending() {
     session.setMatrixRoomId(null);
     givenExistingSession();

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -74,11 +74,17 @@ class CreateEnquiryMessageFacadeTest {
   }
 
   @Test
-  void sendsEnquiryThroughExistingMatrixRoomAndUpdatesSession() {
+  void finalizesEncryptedEnquiryThroughExistingMatrixRoomAndUpdatesSession() {
     givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
     when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
-    when(matrixSynapseService.sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN))
-        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", MATRIX_USER_ID,
+                    "type", "m.room.encrypted")));
 
     var response = facade.createEnquiryMessage(enquiryData);
 
@@ -91,6 +97,7 @@ class CreateEnquiryMessageFacadeTest {
     assertThat(session.getLanguageCode()).isEqualTo(LanguageCode.de);
     verify(sessionService).saveSession(session);
     verify(agencyPreAssignmentRoomService, never()).ensureHoldingRoom(session, user);
+    verify(matrixSynapseService, never()).sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN);
   }
 
   @Test
@@ -140,27 +147,81 @@ class CreateEnquiryMessageFacadeTest {
   }
 
   @Test
-  void requiresMatrixAccessTokenBeforeSending() {
+  void requiresMatrixAccessTokenBeforeValidatingEncryptedEvent() {
     givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
     when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn("");
 
     assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
         .isInstanceOf(InternalServerErrorException.class)
-        .hasMessageContaining("Could not create Matrix token");
+        .hasMessageContaining("Could not validate encrypted Matrix enquiry event");
 
     verify(matrixSynapseService, never()).sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN);
   }
 
   @Test
-  void rejectsMatrixSendErrorResponse() {
+  void rejectsMissingEncryptedMatrixEventReference() {
     givenExistingSession();
-    when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
-    when(matrixSynapseService.sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN))
-        .thenReturn(Map.of("error", "room unavailable"));
 
     assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
         .isInstanceOf(InternalServerErrorException.class)
-        .hasMessageContaining("Could not post Matrix enquiry message");
+        .hasMessageContaining("requires an encrypted Matrix event");
+
+    verify(sessionService, never()).saveSession(session);
+    verify(matrixSynapseService, never()).sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN);
+  }
+
+  @Test
+  void rejectsPlaintextMatrixEvent() {
+    givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", MATRIX_USER_ID,
+                    "type", "m.room.message")));
+
+    assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("not an encrypted Matrix event");
+
+    verify(sessionService, never()).saveSession(session);
+  }
+
+  @Test
+  void rejectsEncryptedEventFromDifferentSender() {
+    givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", "@attacker:oriso.test",
+                    "type", "m.room.encrypted")));
+
+    assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("was not sent by enquiry user");
+
+    verify(sessionService, never()).saveSession(session);
+  }
+
+  @Test
+  void rejectsUnknownMatrixEvent() {
+    givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
+    when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> facade.createEnquiryMessage(enquiryData))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessageContaining("Could not read Matrix enquiry event");
 
     verify(sessionService, never()).saveSession(session);
   }
@@ -169,9 +230,15 @@ class CreateEnquiryMessageFacadeTest {
   void provisionsMissingMatrixRoomBeforeSending() {
     session.setMatrixRoomId(null);
     givenExistingSession();
+    enquiryData.setMatrixEventId(MATRIX_EVENT_ID);
     when(matrixSynapseService.loginAsUserAccessToken(MATRIX_USER_ID)).thenReturn(MATRIX_TOKEN);
-    when(matrixSynapseService.sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN))
-        .thenReturn(Map.of("event_id", MATRIX_EVENT_ID));
+    when(matrixSynapseService.getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id", MATRIX_EVENT_ID,
+                    "sender", MATRIX_USER_ID,
+                    "type", "m.room.encrypted")));
     org.mockito.Mockito.doAnswer(
             invocation -> {
               session.setMatrixRoomId(MATRIX_ROOM_ID);
@@ -183,7 +250,7 @@ class CreateEnquiryMessageFacadeTest {
     facade.createEnquiryMessage(enquiryData);
 
     verify(agencyPreAssignmentRoomService).ensureHoldingRoom(session, user);
-    verify(matrixSynapseService).sendMessage(MATRIX_ROOM_ID, MESSAGE, MATRIX_TOKEN);
+    verify(matrixSynapseService).getRoomEvent(MATRIX_ROOM_ID, MATRIX_EVENT_ID, MATRIX_TOKEN);
   }
 
   @Test


### PR DESCRIPTION
Fixes #954

## P0 problem

The registered-enquiry endpoint impersonated the Matrix user and posted plaintext `m.room.message` into an already encrypted room. Server impersonation has no browser crypto device and therefore bypassed Megolm.

## Fix

- Add `matrixEventId` to the enquiry-finalization contract.
- Remove server-side initial-message sending from `CreateEnquiryMessageFacade`.
- Read the raw event from the exact session room and accept it only when:
  - the event exists and its returned ID matches;
  - its type is `m.room.encrypted`;
  - its sender equals the authenticated asker's Matrix user ID.
- Only after validation update `message_date` / session status and emit email plus `request.new` notifications.
- Preserve appointment behavior.

The backend never receives the enquiry plaintext in the new flow.

## Verification

- `CreateEnquiryMessageFacadeTest`: 12/12
- `MatrixSynapseServiceTest`: 57/57
- `UserRegistrationControllerDelegateTest`: 24/24
- `AppointmentControllerTest`: 10/10
- `CreateEnquiryMessageFacadeMatrixRoomProvisioningTest`: 2/2
- Java 21, Spotless clean, `git diff --check` clean

The first full suite run executed 3,678 tests and found exactly two legacy provisioning assertions that still expected the removed plaintext server send. Those contracts were updated to validate the encrypted event instead and are green in the targeted rerun.

## Coordinated rollout

Deploy together with OpenResilienceInitiative/ORISO-Frontend#911. Backend first is contract-compatible with the new field, but old Frontend clients cannot finalize registered enquiries after this security hardening, so the deployment window must be coordinated.

Real-browser PreDev proof will be attached after the combined image is deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enquiry submissions now support validation of encrypted Matrix events supplied by the requester.
  - Added retrieval of specific Matrix room events for validation.
- **Bug Fixes**
  - Plaintext, missing, unauthorized, or invalid Matrix events are rejected.
  - Appointment enquiries continue to work without event validation.
- **Tests**
  - Added coverage for successful event retrieval and invalid or missing event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->