### PR TITLE
P0: stop double-decoding registration passwords (#959)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegate.java
@@ -29,8 +29,6 @@ import de.caritas.cob.userservice.api.service.auth.PasswordResetService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import jakarta.transaction.Transactional;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -112,7 +110,6 @@ class UserRegistrationControllerDelegate {
     if (!userHelper.isUsernameValid(user.getUsername())) {
       throw new BadRequestException("Username is invalid");
     }
-    decodePassword(user);
     user.setNewUserAccount(true);
     var sessionId = createUserFacade.createUserAccountWithInitializedConsultingType(user);
 
@@ -124,12 +121,6 @@ class UserRegistrationControllerDelegate {
     }
 
     return ResponseEntity.status(status).build();
-  }
-
-  private void decodePassword(UserDTO user) {
-    if (user.getPassword() != null) {
-      user.setPassword(URLDecoder.decode(user.getPassword(), StandardCharsets.UTF_8));
-    }
   }
 
   private void validateUserHasChosenTopicIfTopicsFeatureIsEnabled(UserDTO user) {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserRegistrationControllerDelegateTest.java
@@ -123,7 +123,7 @@ class UserRegistrationControllerDelegateTest {
   }
 
   @Test
-  void registerUserShouldDecodePasswordSetNewUserAndReturnCreated() {
+  void registerUserShouldKeepDeserializedPasswordSetNewUserAndReturnCreated() {
     var user = newUserDto();
     user.setPassword("pa%20ss");
     when(userHelper.isUsernameValid(USERNAME)).thenReturn(true);
@@ -133,7 +133,7 @@ class UserRegistrationControllerDelegateTest {
     var response = delegate.registerUser(user);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-    assertThat(user.getPassword()).isEqualTo("pa ss");
+    assertThat(user.getPassword()).isEqualTo("pa%20ss");
     assertThat(user.isNewUserAccount()).isTrue();
   }
 


### PR DESCRIPTION
Closes #959.

## What changed

- remove the second URL decode in UserRegistrationControllerDelegate
- preserve the password value already produced by UserDTO deserialization
- update the controller regression test to prove percent sequences are not decoded a second time

## Why

UserDTO.password already uses UrlDecodePasswordJsonDeserializer. Decoding again in the controller can silently change legal passwords after registration, so registration returns 201 but subsequent Keycloak login fails.

## Verification

- red test first: controller changed pa%20ss to pa ss
- targeted controller and password-deserializer tests pass
- full Maven test suite passes
- Maven package passes
- git diff --check passes