### PR TITLE
fix(case-handover): deserialize reason policy updates

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -38,8 +38,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -919,6 +922,8 @@ public class CaseHandoverService {
 
   @Data
   @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
   public static class CaseHandoverReason {
     private String code;
     private String label;

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/CaseHandoverControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/CaseHandoverControllerTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResponseDTO;
 import de.caritas.cob.userservice.api.service.CaseHandoverLogsService;
@@ -24,12 +27,16 @@ import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @ExtendWith(MockitoExtension.class)
 class CaseHandoverControllerTest {
@@ -38,6 +45,13 @@ class CaseHandoverControllerTest {
   @Mock private CaseHandoverLogsService caseHandoverLogsService;
 
   @InjectMocks private CaseHandoverController controller;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+  }
 
   @Test
   void listReasons_happyPath_returnsReasonList() {
@@ -76,6 +90,64 @@ class CaseHandoverControllerTest {
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(output, response.getBody());
     verify(caseHandoverService).updateReasonPolicies(input);
+  }
+
+  @Test
+  void updateReasonPolicies_validJson_deserializesAndUpdatesPolicies() throws Exception {
+    var updated =
+        List.of(
+            CaseHandoverReason.builder()
+                .code("COUNSELLOR_IS_ILL")
+                .label("Illness")
+                .clientConsentRequired(true)
+                .accessAllowed(true)
+                .enabled(true)
+                .displayOrder(10)
+                .policyAuthority("TENANT")
+                .build());
+    when(caseHandoverService.updateReasonPolicies(org.mockito.ArgumentMatchers.anyList()))
+        .thenReturn(updated);
+
+    mockMvc
+        .perform(
+            put("/service/users/case-handover/reason-policies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    [{
+                      "code": "COUNSELLOR_IS_ILL",
+                      "label": "Illness",
+                      "clientConsentRequired": true,
+                      "accessAllowed": true,
+                      "enabled": true,
+                      "displayOrder": 10,
+                      "policyAuthority": "TENANT",
+                      "clientNotificationTemplates": {"de": "Neue Beratung"}
+                    }]
+                    """))
+        .andExpect(status().isOk());
+
+    verify(caseHandoverService)
+        .updateReasonPolicies(
+            org.mockito.ArgumentMatchers.argThat(
+                policies ->
+                    policies.size() == 1
+                        && "COUNSELLOR_IS_ILL".equals(policies.get(0).getCode())
+                        && Boolean.TRUE.equals(policies.get(0).getAccessAllowed())
+                        && "Neue Beratung"
+                            .equals(policies.get(0).getClientNotificationTemplates().get("de"))));
+  }
+
+  @Test
+  void updateReasonPolicies_malformedJson_isRejectedBeforeServiceExecution() throws Exception {
+    mockMvc
+        .perform(
+            put("/service/users/case-handover/reason-policies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("[{\"code\":]"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(caseHandoverService);
   }
 
   @Test


### PR DESCRIPTION
## Problem

The Admin policy editor sends a JSON array to `PUT /service/users/case-handover/reason-policies`, but Jackson could not instantiate `CaseHandoverReason` because the Lombok builder-only DTO had no compatible creator. Platform-admin saves therefore failed before service execution.

Closes #962. Parent delivery issue: `OpenResilienceInitiative/ORISO-Admin#655`.

## Solution

- Add a public no-args constructor for Jackson deserialization.
- Keep the builder's all-args constructor private so the DTO does not gain a new public construction API.
- Add a MockMvc boundary test using the real Admin-shaped JSON payload, including nested notification templates.
- Add a malformed-JSON check proving invalid input returns 400 before the service is called.

The companion Admin permission-cascade fixes are tracked in `OpenResilienceInitiative/ORISO-Admin#656`. The diffs are independently mergeable; both are required to close the parent delivery slice.

## Validation

- Focused controller/service suite: 37 tests passed.
- Full `./mvnw test`: 3,686 tests passed.
- `./mvnw package`: passed and produced the candidate jar.
- Spotless and `git diff --check`: passed.
- Focused PreDev real-browser gate passed:
  - policy edit issued `PUT /service/users/case-handover/reason-policies` with HTTP 200;
  - the marker survived reload;
  - the original policy text was restored with a second HTTP 200 and equality after reload.

## Reviewer checklist

- [ ] Confirm the public no-args constructor is the minimum Jackson compatibility change.
- [ ] Confirm the private all-args constructor preserves Lombok builder behavior.
- [ ] Confirm the MockMvc payload matches the Admin boundary, including nested templates.
- [ ] Confirm malformed JSON cannot reach `CaseHandoverService`.
- [ ] Confirm no authorization rule or endpoint scope changed.

## Risk

This changes DTO construction only; persistence, authorization, and policy semantics are untouched. Browser proof used a disposable UserService image, and the exact regular PreDev digest was restored after the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved handling of case handover reason updates.
  - Valid update requests are now processed more reliably.
  - Malformed JSON requests are rejected before any update action is performed.
  - Added coverage to help ensure consistent behavior for valid and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->