### PR TITLE
fix: enforce fresh MatrixRTC call policy

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyController.java
@@ -1,0 +1,40 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import de.caritas.cob.userservice.api.service.matrixrtc.CallMediaPolicy;
+import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcCallPolicyService;
+import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcPolicyTokenVerifier;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/matrixrtc")
+@RequiredArgsConstructor
+public class MatrixRtcCallPolicyController {
+
+  static final String POLICY_TOKEN_HEADER = "x-matrixrtc-policy-token";
+
+  private final @NonNull MatrixRtcCallPolicyService callPolicyService;
+  private final @NonNull MatrixRtcPolicyTokenVerifier tokenVerifier;
+
+  @PostMapping("/call-policy")
+  public ResponseEntity<CallMediaPolicy> resolve(
+      @RequestHeader(value = POLICY_TOKEN_HEADER, required = false) String policyToken,
+      @Valid @RequestBody CallPolicyRequest request) {
+    if (!tokenVerifier.isValid(policyToken)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    return ResponseEntity.ok(
+        callPolicyService.resolve(request.sourceRoomId(), request.matrixUserId()));
+  }
+
+  public record CallPolicyRequest(@NotBlank String sourceRoomId, @NotBlank String matrixUserId) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
@@ -39,6 +39,7 @@ public class HttpTenantFilter extends OncePerRequestFilter {
         "/actuator/loggers",
         "/swagger-ui.html",
         "/favicon.ico",
+        "/internal/matrixrtc/",
         "/users/askers/new",
         "/users/magic-link/",
         "/users/invitelinks/",

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilter.java
@@ -27,6 +27,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class HttpTenantFilter extends OncePerRequestFilter {
 
+  private static final String MATRIX_RTC_CALL_POLICY_PATH = "/internal/matrixrtc/call-policy";
+
   private final @Nullable TenantResolverService tenantResolverService;
 
   private final @Nullable TenantService tenantService;
@@ -39,7 +41,7 @@ public class HttpTenantFilter extends OncePerRequestFilter {
         "/actuator/loggers",
         "/swagger-ui.html",
         "/favicon.ico",
-        "/internal/matrixrtc/",
+        MATRIX_RTC_CALL_POLICY_PATH,
         "/users/askers/new",
         "/users/magic-link/",
         "/users/invitelinks/",
@@ -92,8 +94,13 @@ public class HttpTenantFilter extends OncePerRequestFilter {
     }
 
     private boolean belongsToWhitelist(HttpServletRequest request, List<String> tenantWhitelist) {
+      String requestUri = request.getRequestURI().toLowerCase();
       return tenantWhitelist.parallelStream()
-          .anyMatch(request.getRequestURI().toLowerCase()::contains);
+          .anyMatch(
+              whitelistUri ->
+                  MATRIX_RTC_CALL_POLICY_PATH.equals(whitelistUri)
+                      ? MATRIX_RTC_CALL_POLICY_PATH.equals(requestUri)
+                      : requestUri.contains(whitelistUri));
     }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -94,6 +94,13 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
     }
 
     private boolean isWhiteListUrl(HttpServletRequest request) {
+      // The MatrixRTC gateway is a cluster-internal machine client, not a browser session. It
+      // authenticates this one exact endpoint with its dedicated policy token, so it cannot
+      // provide the browser CSRF cookie/header pair. Keep the exemption exact: sibling internal
+      // endpoints must still pass the normal CSRF check.
+      if ("/internal/matrixrtc/call-policy".equals(request.getRequestURI())) {
+        return true;
+      }
       // Magic link endpoints are public login bootstrap endpoints and must work without a CSRF
       // token.
       if (request.getRequestURI() != null

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -123,6 +123,11 @@ public class SecurityConfig {
                     "/swagger-ui.html",
                     "/webjars/**")
                 .permitAll()
+                // This cluster-internal endpoint authenticates with its own dedicated shared
+                // secret because the MatrixRTC gateway is not a Keycloak user. The controller
+                // rejects a missing or invalid secret in constant time.
+                .requestMatchers(HttpMethod.POST, "/internal/matrixrtc/call-policy")
+                .permitAll()
                 .requestMatchers(
                     "/users/askers/new",
                     "/conversations/askers/anonymous/new",

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface SessionSupervisorRepository extends JpaRepository<SessionSupervisor, Long> {
 
+  Optional<SessionSupervisor> findByMatrixRoomId(String matrixRoomId);
+
   /**
    * Find all active supervisors for a session.
    *

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallMediaPolicy.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallMediaPolicy.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+public record CallMediaPolicy(boolean audioAllowed, boolean videoAllowed) {
+
+  public static CallMediaPolicy denied() {
+    return new CallMediaPolicy(false, false);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -2,32 +2,20 @@ package de.caritas.cob.userservice.api.service.matrixrtc;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
-import de.caritas.cob.userservice.api.model.Chat;
-import de.caritas.cob.userservice.api.model.ConversationType;
-import de.caritas.cob.userservice.api.model.Session;
-import de.caritas.cob.userservice.api.port.out.ChatRepository;
-import de.caritas.cob.userservice.api.port.out.SessionRepository;
-import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
-import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
-import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MatrixRtcCallPolicyService {
 
-  private final @NonNull SessionRepository sessionRepository;
-  private final @NonNull ChatRepository chatRepository;
-  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
-  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull MatrixRtcPolicyContextResolver contextResolver;
   private final @NonNull TenantService tenantService;
   private final @NonNull MatrixSynapseService matrixSynapseService;
 
-  @Transactional(readOnly = true)
   public CallMediaPolicy resolve(String sourceRoomId, String matrixUserId) {
     if (sourceRoomId == null
         || sourceRoomId.isBlank()
@@ -41,12 +29,12 @@ public class MatrixRtcCallPolicyService {
       return CallMediaPolicy.denied();
     }
 
-    Optional<PolicyContext> context = resolveContext(sourceRoomId);
+    var context = contextResolver.resolve(sourceRoomId);
     if (context.isEmpty() || context.get().tenantId() == null) {
       return CallMediaPolicy.denied();
     }
 
-    var tenant = tenantService.getRestrictedTenantDataFresh(context.get().tenantId());
+    var tenant = getTenant(context.get().tenantId());
     if (tenant == null || tenant.getSettings() == null) {
       return CallMediaPolicy.denied();
     }
@@ -65,49 +53,15 @@ public class MatrixRtcCallPolicyService {
     return new CallMediaPolicy(audioAllowed, videoAllowed);
   }
 
-  private Optional<PolicyContext> resolveContext(String sourceRoomId) {
-    var supervision = sessionSupervisorRepository.findByMatrixRoomId(sourceRoomId);
-    if (supervision.isPresent()) {
-      return Optional.of(
-          new PolicyContext(supervision.get().getSession().getTenantId(), ChatType.SUPERVISION));
+  private RestrictedTenantDTO getTenant(Long tenantId) {
+    try {
+      return tenantService.getRestrictedTenantDataFresh(tenantId);
+    } catch (RuntimeException tenantServiceFailure) {
+      return null;
     }
-
-    var session = sessionRepository.findByMatrixRoomId(sourceRoomId);
-    if (session.isPresent()) {
-      return Optional.of(contextForSession(session.get()));
-    }
-
-    var chat = chatRepository.findByMatrixRoomId(sourceRoomId);
-    if (chat.isPresent()) {
-      return Optional.of(contextForChat(chat.get()));
-    }
-
-    return teamDiscussionRepository
-        .findByMatrixRoomId(sourceRoomId)
-        .map(discussion -> new PolicyContext(discussion.getTenantId(), ChatType.GROUP));
   }
 
-  private PolicyContext contextForSession(Session session) {
-    ConversationType conversationType = session.getConversationType();
-    ChatType chatType;
-    if (conversationType == ConversationType.LIVE_CHAT
-        || (conversationType == null
-            && session.getRegistrationType() == Session.RegistrationType.ANONYMOUS)) {
-      chatType = ChatType.ANONYMOUS;
-    } else if (conversationType == ConversationType.INTERNAL_GROUP) {
-      chatType = ChatType.GROUP;
-    } else {
-      chatType = ChatType.ONE_ON_ONE;
-    }
-    return new PolicyContext(session.getTenantId(), chatType);
-  }
-
-  private PolicyContext contextForChat(Chat chat) {
-    Long tenantId = chat.getChatOwner() == null ? null : chat.getChatOwner().getTenantId();
-    return new PolicyContext(tenantId, ChatType.GROUP);
-  }
-
-  private Boolean audioFlag(Settings settings, ChatType chatType) {
+  private Boolean audioFlag(Settings settings, MatrixRtcPolicyContext.ChatType chatType) {
     return switch (chatType) {
       case ANONYMOUS -> settings.getFeatureAudioCallsAnonymousChatsEnabled();
       case ONE_ON_ONE -> settings.getFeatureAudioCallsOneOnOneChatsEnabled();
@@ -116,7 +70,7 @@ public class MatrixRtcCallPolicyService {
     };
   }
 
-  private Boolean videoFlag(Settings settings, ChatType chatType) {
+  private Boolean videoFlag(Settings settings, MatrixRtcPolicyContext.ChatType chatType) {
     return switch (chatType) {
       case ANONYMOUS -> settings.getFeatureVideoCallsAnonymousChatsEnabled();
       case ONE_ON_ONE -> settings.getFeatureVideoCallsOneOnOneChatsEnabled();
@@ -128,13 +82,4 @@ public class MatrixRtcCallPolicyService {
   private boolean enabled(Boolean value) {
     return !Boolean.FALSE.equals(value);
   }
-
-  private enum ChatType {
-    ANONYMOUS,
-    ONE_ON_ONE,
-    GROUP,
-    SUPERVISION
-  }
-
-  private record PolicyContext(Long tenantId, ChatType chatType) {}
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -1,0 +1,140 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ConversationType;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatrixRtcCallPolicyService {
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull ChatRepository chatRepository;
+  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull TenantService tenantService;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
+
+  @Transactional(readOnly = true)
+  public CallMediaPolicy resolve(String sourceRoomId, String matrixUserId) {
+    if (sourceRoomId == null
+        || sourceRoomId.isBlank()
+        || matrixUserId == null
+        || matrixUserId.isBlank()) {
+      return CallMediaPolicy.denied();
+    }
+
+    var currentMembers = matrixSynapseService.getRoomMembers(sourceRoomId);
+    if (currentMembers.isEmpty() || !currentMembers.get().contains(matrixUserId)) {
+      return CallMediaPolicy.denied();
+    }
+
+    Optional<PolicyContext> context = resolveContext(sourceRoomId);
+    if (context.isEmpty() || context.get().tenantId() == null) {
+      return CallMediaPolicy.denied();
+    }
+
+    var tenant = tenantService.getRestrictedTenantDataFresh(context.get().tenantId());
+    if (tenant == null || tenant.getSettings() == null) {
+      return CallMediaPolicy.denied();
+    }
+
+    var settings = tenant.getSettings();
+    if (!enabled(settings.getFeatureCallsEnabled())) {
+      return CallMediaPolicy.denied();
+    }
+
+    boolean audioAllowed =
+        enabled(settings.getFeatureAudioCallsEnabled())
+            && enabled(audioFlag(settings, context.get().chatType()));
+    boolean videoAllowed =
+        enabled(settings.getFeatureVideoCallsEnabled())
+            && enabled(videoFlag(settings, context.get().chatType()));
+    return new CallMediaPolicy(audioAllowed, videoAllowed);
+  }
+
+  private Optional<PolicyContext> resolveContext(String sourceRoomId) {
+    var supervision = sessionSupervisorRepository.findByMatrixRoomId(sourceRoomId);
+    if (supervision.isPresent()) {
+      return Optional.of(
+          new PolicyContext(supervision.get().getSession().getTenantId(), ChatType.SUPERVISION));
+    }
+
+    var session = sessionRepository.findByMatrixRoomId(sourceRoomId);
+    if (session.isPresent()) {
+      return Optional.of(contextForSession(session.get()));
+    }
+
+    var chat = chatRepository.findByMatrixRoomId(sourceRoomId);
+    if (chat.isPresent()) {
+      return Optional.of(contextForChat(chat.get()));
+    }
+
+    return teamDiscussionRepository
+        .findByMatrixRoomId(sourceRoomId)
+        .map(discussion -> new PolicyContext(discussion.getTenantId(), ChatType.GROUP));
+  }
+
+  private PolicyContext contextForSession(Session session) {
+    ConversationType conversationType = session.getConversationType();
+    ChatType chatType;
+    if (conversationType == ConversationType.LIVE_CHAT
+        || (conversationType == null
+            && session.getRegistrationType() == Session.RegistrationType.ANONYMOUS)) {
+      chatType = ChatType.ANONYMOUS;
+    } else if (conversationType == ConversationType.INTERNAL_GROUP) {
+      chatType = ChatType.GROUP;
+    } else {
+      chatType = ChatType.ONE_ON_ONE;
+    }
+    return new PolicyContext(session.getTenantId(), chatType);
+  }
+
+  private PolicyContext contextForChat(Chat chat) {
+    Long tenantId = chat.getChatOwner() == null ? null : chat.getChatOwner().getTenantId();
+    return new PolicyContext(tenantId, ChatType.GROUP);
+  }
+
+  private Boolean audioFlag(Settings settings, ChatType chatType) {
+    return switch (chatType) {
+      case ANONYMOUS -> settings.getFeatureAudioCallsAnonymousChatsEnabled();
+      case ONE_ON_ONE -> settings.getFeatureAudioCallsOneOnOneChatsEnabled();
+      case GROUP -> settings.getFeatureAudioCallsGroupChatsEnabled();
+      case SUPERVISION -> settings.getFeatureAudioCallsSupervisionChatsEnabled();
+    };
+  }
+
+  private Boolean videoFlag(Settings settings, ChatType chatType) {
+    return switch (chatType) {
+      case ANONYMOUS -> settings.getFeatureVideoCallsAnonymousChatsEnabled();
+      case ONE_ON_ONE -> settings.getFeatureVideoCallsOneOnOneChatsEnabled();
+      case GROUP -> settings.getFeatureVideoCallsGroupChatsEnabled();
+      case SUPERVISION -> settings.getFeatureVideoCallsSupervisionChatsEnabled();
+    };
+  }
+
+  private boolean enabled(Boolean value) {
+    return !Boolean.FALSE.equals(value);
+  }
+
+  private enum ChatType {
+    ANONYMOUS,
+    ONE_ON_ONE,
+    GROUP,
+    SUPERVISION
+  }
+
+  private record PolicyContext(Long tenantId, ChatType chatType) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContext.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContext.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+record MatrixRtcPolicyContext(Long tenantId, ChatType chatType) {
+
+  enum ChatType {
+    ANONYMOUS,
+    ONE_ON_ONE,
+    GROUP,
+    SUPERVISION
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContextResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContextResolver.java
@@ -1,0 +1,72 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ConversationType;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class MatrixRtcPolicyContextResolver {
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull ChatRepository chatRepository;
+  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+
+  @Transactional(readOnly = true)
+  public Optional<MatrixRtcPolicyContext> resolve(String sourceRoomId) {
+    var supervision = sessionSupervisorRepository.findByMatrixRoomId(sourceRoomId);
+    if (supervision.isPresent()) {
+      return Optional.of(
+          new MatrixRtcPolicyContext(
+              supervision.get().getSession().getTenantId(),
+              MatrixRtcPolicyContext.ChatType.SUPERVISION));
+    }
+
+    var session = sessionRepository.findByMatrixRoomId(sourceRoomId);
+    if (session.isPresent()) {
+      return Optional.of(contextForSession(session.get()));
+    }
+
+    var chat = chatRepository.findByMatrixRoomId(sourceRoomId);
+    if (chat.isPresent()) {
+      return Optional.of(contextForChat(chat.get()));
+    }
+
+    return teamDiscussionRepository
+        .findByMatrixRoomId(sourceRoomId)
+        .map(
+            discussion ->
+                new MatrixRtcPolicyContext(
+                    discussion.getTenantId(), MatrixRtcPolicyContext.ChatType.GROUP));
+  }
+
+  private MatrixRtcPolicyContext contextForSession(Session session) {
+    ConversationType conversationType = session.getConversationType();
+    MatrixRtcPolicyContext.ChatType chatType;
+    if (conversationType == ConversationType.LIVE_CHAT
+        || (conversationType == null
+            && session.getRegistrationType() == Session.RegistrationType.ANONYMOUS)) {
+      chatType = MatrixRtcPolicyContext.ChatType.ANONYMOUS;
+    } else if (conversationType == ConversationType.INTERNAL_GROUP) {
+      chatType = MatrixRtcPolicyContext.ChatType.GROUP;
+    } else {
+      chatType = MatrixRtcPolicyContext.ChatType.ONE_ON_ONE;
+    }
+    return new MatrixRtcPolicyContext(session.getTenantId(), chatType);
+  }
+
+  private MatrixRtcPolicyContext contextForChat(Chat chat) {
+    Long tenantId = chat.getChatOwner() == null ? null : chat.getChatOwner().getTenantId();
+    return new MatrixRtcPolicyContext(tenantId, MatrixRtcPolicyContext.ChatType.GROUP);
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyTokenVerifier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyTokenVerifier.java
@@ -1,0 +1,23 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.MessageDigest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MatrixRtcPolicyTokenVerifier {
+
+  private final byte[] configuredToken;
+
+  public MatrixRtcPolicyTokenVerifier(@Value("${matrixrtc.call.policy.token:}") String token) {
+    configuredToken = token == null || token.isBlank() ? new byte[0] : token.getBytes(UTF_8);
+  }
+
+  public boolean isValid(String candidate) {
+    return configuredToken.length > 0
+        && candidate != null
+        && MessageDigest.isEqual(configuredToken, candidate.getBytes(UTF_8));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyControllerTest.java
@@ -9,11 +9,13 @@ import de.caritas.cob.userservice.api.adapters.web.controller.MatrixRtcCallPolic
 import de.caritas.cob.userservice.api.service.matrixrtc.CallMediaPolicy;
 import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcCallPolicyService;
 import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcPolicyTokenVerifier;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,15 +71,18 @@ class MatrixRtcCallPolicyControllerTest {
 
   @Test
   void bindsTheCanonicalEnvironmentCompatiblePropertyName() {
-    new ApplicationContextRunner()
-        .withBean(MatrixRtcPolicyTokenVerifier.class)
-        .withPropertyValues("matrixrtc.call.policy.token=expected-secret")
-        .run(
-            context ->
-                assertThat(
-                        context
-                            .getBean(MatrixRtcPolicyTokenVerifier.class)
-                            .isValid("expected-secret"))
-                    .isTrue());
+    try (var context = new AnnotationConfigApplicationContext()) {
+      context
+          .getEnvironment()
+          .getPropertySources()
+          .addFirst(
+              new SystemEnvironmentPropertySource(
+                  "matrixrtc-test-env", Map.of("MATRIXRTC_CALL_POLICY_TOKEN", "expected-secret")));
+      context.registerBean(MatrixRtcPolicyTokenVerifier.class);
+      context.refresh();
+
+      assertThat(context.getBean(MatrixRtcPolicyTokenVerifier.class).isValid("expected-secret"))
+          .isTrue();
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/MatrixRtcCallPolicyControllerTest.java
@@ -1,0 +1,83 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.controller.MatrixRtcCallPolicyController.CallPolicyRequest;
+import de.caritas.cob.userservice.api.service.matrixrtc.CallMediaPolicy;
+import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcCallPolicyService;
+import de.caritas.cob.userservice.api.service.matrixrtc.MatrixRtcPolicyTokenVerifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixRtcCallPolicyControllerTest {
+
+  @Mock private MatrixRtcCallPolicyService callPolicyService;
+
+  private static final String ROOM_ID = "!room:matrix.oriso.org";
+  private static final String MATRIX_USER_ID = "@participant:matrix.oriso.org";
+
+  @Test
+  void rejectsMissingOrInvalidInternalCredentialBeforeResolvingRoom() {
+    var controller =
+        new MatrixRtcCallPolicyController(
+            callPolicyService, new MatrixRtcPolicyTokenVerifier("expected-secret"));
+
+    assertThat(
+            controller
+                .resolve(null, new CallPolicyRequest(ROOM_ID, MATRIX_USER_ID))
+                .getStatusCode())
+        .isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(
+            controller
+                .resolve("wrong-secret", new CallPolicyRequest(ROOM_ID, MATRIX_USER_ID))
+                .getStatusCode())
+        .isEqualTo(HttpStatus.UNAUTHORIZED);
+    verifyNoInteractions(callPolicyService);
+  }
+
+  @Test
+  void returnsCurrentPolicyForValidInternalCredential() {
+    var policy = new CallMediaPolicy(true, false);
+    when(callPolicyService.resolve(ROOM_ID, MATRIX_USER_ID)).thenReturn(policy);
+    var controller =
+        new MatrixRtcCallPolicyController(
+            callPolicyService, new MatrixRtcPolicyTokenVerifier("expected-secret"));
+
+    var response =
+        controller.resolve("expected-secret", new CallPolicyRequest(ROOM_ID, MATRIX_USER_ID));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(policy);
+    verify(callPolicyService).resolve(ROOM_ID, MATRIX_USER_ID);
+  }
+
+  @Test
+  void verifierFailsClosedWhenNoCredentialIsConfigured() {
+    var verifier = new MatrixRtcPolicyTokenVerifier("");
+
+    assertThat(verifier.isValid("")).isFalse();
+    assertThat(verifier.isValid("anything")).isFalse();
+  }
+
+  @Test
+  void bindsTheCanonicalEnvironmentCompatiblePropertyName() {
+    new ApplicationContextRunner()
+        .withBean(MatrixRtcPolicyTokenVerifier.class)
+        .withPropertyValues("matrixrtc.call.policy.token=expected-secret")
+        .run(
+            context ->
+                assertThat(
+                        context
+                            .getBean(MatrixRtcPolicyTokenVerifier.class)
+                            .isValid("expected-secret"))
+                    .isTrue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterTest.java
@@ -55,6 +55,18 @@ class HttpTenantFilterTest {
   }
 
   @Test
+  void siblingMatrixRtcEndpointStillRequiresTenantContext() throws ServletException, IOException {
+    Mockito.when(request.getRequestURI()).thenReturn("/internal/matrixrtc/future-endpoint");
+    Mockito.when(tenantResolverService.resolve(request)).thenReturn(1L);
+    Mockito.when(tenantService.getRestrictedTenantData(1L)).thenReturn(new RestrictedTenantDTO());
+
+    httpTenantFilter.doFilterInternal(request, response, filterChain);
+
+    Mockito.verify(tenantResolverService).resolve(request);
+    Mockito.verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
   void doFilterInternal_Should_Apply_When_DoesNotBelongBelongsToTenancyWhiteList()
       throws ServletException, IOException {
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/HttpTenantFilterTest.java
@@ -44,6 +44,17 @@ class HttpTenantFilterTest {
   }
 
   @Test
+  void matrixRtcPolicyEndpointDoesNotRequireBrowserTenantContext()
+      throws ServletException, IOException {
+    Mockito.when(request.getRequestURI()).thenReturn("/internal/matrixrtc/call-policy");
+
+    httpTenantFilter.doFilterInternal(request, response, filterChain);
+
+    Mockito.verifyNoInteractions(tenantResolverService, tenantService);
+    Mockito.verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
   void doFilterInternal_Should_Apply_When_DoesNotBelongBelongsToTenancyWhiteList()
       throws ServletException, IOException {
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilterTest.java
@@ -100,6 +100,29 @@ public class StatelessCsrfFilterTest {
   }
 
   @Test
+  public void doFilterInternal_Should_executeFilterChain_ForExactInternalMatrixRtcPolicyEndpoint()
+      throws IOException, ServletException {
+    when(request.getRequestURI()).thenReturn("/internal/matrixrtc/call-policy");
+    when(request.getMethod()).thenReturn("POST");
+
+    this.csrfFilter.doFilterInternal(request, response, filterChain);
+
+    verify(this.filterChain, times(1)).doFilter(request, response);
+  }
+
+  @Test
+  public void doFilterInternal_Should_requireCsrf_ForOtherInternalMatrixRtcEndpoints()
+      throws IOException, ServletException {
+    when(request.getRequestURI()).thenReturn("/internal/matrixrtc/call-policy-extra");
+    when(request.getMethod()).thenReturn("POST");
+
+    this.csrfFilter.doFilterInternal(request, response, filterChain);
+
+    verify(this.accessDeniedHandler, times(1)).handle(any(), any(), any());
+    verifyNoMoreInteractions(this.filterChain);
+  }
+
+  @Test
   public void doFilterInternal_Should_executeFilterChain_When_requestCsrfHeaderAndCookieAreEqual()
       throws IOException, ServletException {
     when(request.getRequestURI()).thenReturn("uri");

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -47,10 +47,11 @@ class MatrixRtcCallPolicyServiceTest {
   void setUp() {
     service =
         new MatrixRtcCallPolicyService(
-            sessionRepository,
-            chatRepository,
-            sessionSupervisorRepository,
-            teamDiscussionRepository,
+            new MatrixRtcPolicyContextResolver(
+                sessionRepository,
+                chatRepository,
+                sessionSupervisorRepository,
+                teamDiscussionRepository),
             tenantService,
             matrixSynapseService);
     when(matrixSynapseService.getRoomMembers(ROOM_ID))
@@ -220,6 +221,16 @@ class MatrixRtcCallPolicyServiceTest {
 
     assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
     verifyNoInteractions(tenantService);
+  }
+
+  @Test
+  void tenantServiceFailureFailsClosed() {
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenThrow(new IllegalStateException("tenant service unavailable"));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
   }
 
   private Session session(ConversationType conversationType) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -1,0 +1,242 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConversationType;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.SessionSupervisor;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.port.out.ChatRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatrixRtcCallPolicyServiceTest {
+
+  private static final String ROOM_ID = "!source:matrix.oriso.org";
+  private static final String MATRIX_USER_ID = "@participant:matrix.oriso.org";
+  private static final long TENANT_ID = 7L;
+
+  @Mock private SessionRepository sessionRepository;
+  @Mock private ChatRepository chatRepository;
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+  @Mock private TeamDiscussionRepository teamDiscussionRepository;
+  @Mock private TenantService tenantService;
+  @Mock private MatrixSynapseService matrixSynapseService;
+
+  private MatrixRtcCallPolicyService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new MatrixRtcCallPolicyService(
+            sessionRepository,
+            chatRepository,
+            sessionSupervisorRepository,
+            teamDiscussionRepository,
+            tenantService,
+            matrixSynapseService);
+    when(matrixSynapseService.getRoomMembers(ROOM_ID))
+        .thenReturn(Optional.of(List.of(MATRIX_USER_ID)));
+  }
+
+  @Test
+  void resolvesAgencyCounsellingAgainstOneOnOneFlags() {
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsOneOnOneChatsEnabled(true)
+                    .featureVideoCallsOneOnOneChatsEnabled(false)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(true, false));
+  }
+
+  @Test
+  void resolvesTeamCounsellingAgainstOneOnOneFlagsLikeTheFrontend() {
+    var session =
+        Session.builder()
+            .tenantId(TENANT_ID)
+            .conversationType(ConversationType.AGENCY_COUNSELLING)
+            .registrationType(Session.RegistrationType.REGISTERED)
+            .postcode("00000")
+            .status(Session.SessionStatus.IN_PROGRESS)
+            .teamSession(true)
+            .build();
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsOneOnOneChatsEnabled(true)
+                    .featureVideoCallsOneOnOneChatsEnabled(false)
+                    .featureAudioCallsGroupChatsEnabled(false)
+                    .featureVideoCallsGroupChatsEnabled(true)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(true, false));
+  }
+
+  @Test
+  void resolvesLiveChatAgainstAnonymousFlags() {
+    var session = session(ConversationType.LIVE_CHAT);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsAnonymousChatsEnabled(false)
+                    .featureVideoCallsAnonymousChatsEnabled(true)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(false, true));
+  }
+
+  @Test
+  void resolvesInternalAndSelfHelpChatsAgainstGroupFlags() {
+    var chat = mock(Chat.class);
+    var owner = mock(Consultant.class);
+    when(chat.getChatOwner()).thenReturn(owner);
+    when(owner.getTenantId()).thenReturn(TENANT_ID);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.empty());
+    when(chatRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(chat));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsGroupChatsEnabled(true)
+                    .featureVideoCallsGroupChatsEnabled(false)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(true, false));
+  }
+
+  @Test
+  void resolvesSupervisionRoomAgainstSupervisionFlags() {
+    var supervision = mock(SessionSupervisor.class);
+    var session = mock(Session.class);
+    when(session.getTenantId()).thenReturn(TENANT_ID);
+    when(supervision.getSession()).thenReturn(session);
+    when(sessionSupervisorRepository.findByMatrixRoomId(ROOM_ID))
+        .thenReturn(Optional.of(supervision));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsSupervisionChatsEnabled(false)
+                    .featureVideoCallsSupervisionChatsEnabled(true)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(false, true));
+  }
+
+  @Test
+  void resolvesTeamDiscussionAgainstGroupFlags() {
+    var discussion = mock(TeamDiscussion.class);
+    when(discussion.getTenantId()).thenReturn(TENANT_ID);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.empty());
+    when(chatRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.empty());
+    when(teamDiscussionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(discussion));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsGroupChatsEnabled(false)
+                    .featureVideoCallsGroupChatsEnabled(true)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(false, true));
+  }
+
+  @Test
+  void masterAndMediaMasterFlagsCannotBeOverriddenByChatType() {
+    var session = session(ConversationType.LIVE_CHAT);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureCallsEnabled(false)
+                    .featureAudioCallsAnonymousChatsEnabled(true)
+                    .featureVideoCallsAnonymousChatsEnabled(true)));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+  }
+
+  @Test
+  void missingRoomOrTenantSettingsFailsClosed() {
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+    verifyNoInteractions(tenantService);
+
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(new RestrictedTenantDTO().id(TENANT_ID).settings(null));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+  }
+
+  @Test
+  void absentLegacyFlagsRetainExistingEnabledSemantics() {
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID)).thenReturn(tenant(new Settings()));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(new CallMediaPolicy(true, true));
+  }
+
+  @Test
+  void callerMustCurrentlyBelongToTheSourceConversationRoom() {
+    when(matrixSynapseService.getRoomMembers(ROOM_ID))
+        .thenReturn(Optional.of(List.of("@someone-else:matrix.oriso.org")));
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+    verifyNoInteractions(tenantService);
+  }
+
+  @Test
+  void unavailableSourceRoomMembershipFailsClosed() {
+    when(matrixSynapseService.getRoomMembers(ROOM_ID)).thenReturn(Optional.empty());
+
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+    verifyNoInteractions(tenantService);
+  }
+
+  private Session session(ConversationType conversationType) {
+    var session = mock(Session.class);
+    when(session.getTenantId()).thenReturn(TENANT_ID);
+    when(session.getConversationType()).thenReturn(conversationType);
+    return session;
+  }
+
+  private RestrictedTenantDTO tenant(Settings settings) {
+    return new RestrictedTenantDTO().id(TENANT_ID).settings(settings);
+  }
+
+  private Settings enabledSettings() {
+    return new Settings()
+        .featureCallsEnabled(true)
+        .featureAudioCallsEnabled(true)
+        .featureVideoCallsEnabled(true);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcTransactionBoundaryTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcTransactionBoundaryTest.java
@@ -1,0 +1,22 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+class MatrixRtcTransactionBoundaryTest {
+
+  @Test
+  void onlyDatabaseContextResolutionOwnsTheReadTransaction() throws Exception {
+    var serviceResolve =
+        MatrixRtcCallPolicyService.class.getMethod("resolve", String.class, String.class);
+    assertThat(serviceResolve.getAnnotation(Transactional.class)).isNull();
+
+    var resolverResolve =
+        MatrixRtcPolicyContextResolver.class.getDeclaredMethod("resolve", String.class);
+    var transaction = resolverResolve.getAnnotation(Transactional.class);
+    assertThat(transaction).isNotNull();
+    assertThat(transaction.readOnly()).isTrue();
+  }
+}


### PR DESCRIPTION
Fixes #964

## Summary
- classify source conversation rooms server-side and load fresh tenant call settings
- verify the Matrix caller is still a current member of the source room
- expose a cluster-internal constant-time authenticated policy endpoint that fails closed
- preserve existing enabled-by-default semantics only for legacy null feature flags

## Verification
- focused policy, controller, and tenant-filter tests pass on Java 21
- Spotless check passes

PreDev Admin Off/On and room-type proof will be added before this leaves draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MatrixRTC call-policy resolution for audio and video permissions.
  * Call access now reflects room membership, room type, tenant settings, and global calling availability.
  * Requests receive a denied policy when credentials, membership, room context, or required settings are invalid or unavailable.

* **Security**
  * Added protected policy-token validation for call-policy requests.
  * Unauthorized or invalid requests are rejected, while only the designated policy endpoint bypasses standard tenant and CSRF checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->