### PR TITLE
fix: join department consultants into holding room before the asker

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
@@ -98,8 +98,14 @@ public class AgencyPreAssignmentRoomService {
         return;
       }
 
-      inviteUser(roomId, user, agencyToken);
+      // Order is load-bearing (ADR-002 §1, #199): the department joins while the asker is not a
+      // member yet. The asker's Matrix client discovers the room via /sync the moment they are
+      // invited — independent of when this method returns — so inviting the asker first opens a
+      // window in which their client can snapshot the membership list and encrypt the first
+      // message for an audience that does not yet contain the department. Consultants-first makes
+      // every membership view the asker's client can ever observe already include the department.
       joinAgencyConsultants(session, roomId, agencyToken);
+      inviteUser(roomId, user, agencyToken);
 
       session.setMatrixRoomId(roomId);
       sessionService.saveSession(session);
@@ -126,6 +132,11 @@ public class AgencyPreAssignmentRoomService {
    * <p>A directly addressed enquiry (public counsellor link, appointment booking) is deliberately
    * excluded — the advice seeker chose one counsellor, and fanning that case out to the whole
    * department would widen its audience beyond what they consented to.
+   *
+   * <p>Department membership is a best-effort side effect, never a precondition (see {@link
+   * AgencySilentMembershipService#joinAgencyConsultants}): since it now runs before the asker is
+   * invited, an unexpected failure here must not abort the asker's own invite/join or the room
+   * persist — otherwise a single consultant-lookup hiccup would kill the whole enquiry.
    */
   private void joinAgencyConsultants(Session session, String roomId, String agencyToken) {
     if (Boolean.TRUE.equals(session.getIsConsultantDirectlySet())) {
@@ -135,7 +146,16 @@ public class AgencyPreAssignmentRoomService {
       return;
     }
 
-    agencySilentMembershipService.joinAgencyConsultants(session.getAgencyId(), roomId, agencyToken);
+    try {
+      agencySilentMembershipService.joinAgencyConsultants(
+          session.getAgencyId(), roomId, agencyToken);
+    } catch (RuntimeException ex) {
+      log.error(
+          "Department membership for room {} of session {} failed; continuing with asker-only room: {}",
+          roomId,
+          session.getId(),
+          ex.getMessage());
+    }
   }
 
   private void inviteUser(String roomId, User user, String agencyToken) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
@@ -232,14 +232,18 @@ class AgencyPreAssignmentRoomServiceTest {
 
   @Test
   @DisplayName(
-      "FE#811: the agency's consultants join the fresh room, before any message can be sent")
-  void ensureHoldingRoom_joinsAgencyConsultantsAsSilentMembers() throws Exception {
+      "FE#811/#199: the agency's consultants join the fresh room BEFORE the asker is invited")
+  void ensureHoldingRoom_joinsAgencyConsultantsBeforeAsker() throws Exception {
     stubHappyPathUntilRoomCreation();
+    when(sessionRoomGateway.loginAsUser(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(sessionRoomGateway.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
 
     underTest.ensureHoldingRoom(session, user);
 
     // Membership must be established while the room is still empty: a consultant joined after the
-    // first message holds no Megolm key for it (FE#811 / ADR-002 §1).
+    // first message holds no Megolm key for it (FE#811 / ADR-002 §1). The asker's client can see
+    // the room via /sync from the moment of their invite, so the department must already be in by
+    // then — consultants first, asker second, persist last.
     var inOrder =
         org.mockito.Mockito.inOrder(
             sessionRoomGateway, agencySilentMembershipService, sessionService);
@@ -247,7 +251,46 @@ class AgencyPreAssignmentRoomServiceTest {
     inOrder
         .verify(agencySilentMembershipService)
         .joinAgencyConsultants(AGENCY_ID, NEW_ROOM_ID, AGENCY_TOKEN);
+    inOrder.verify(sessionRoomGateway).inviteUser(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+    inOrder.verify(sessionRoomGateway).joinRoom(NEW_ROOM_ID, USER_TOKEN);
     inOrder.verify(sessionService).saveSession(session);
+  }
+
+  @Test
+  @DisplayName("a department without a single joinable consultant still gets the asker their room")
+  void ensureHoldingRoom_provisionsRoomForAsker_whenNoConsultantJoined() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    // AgencySilentMembershipService reports "nobody joined" (no consultants, or none usable).
+    when(agencySilentMembershipService.joinAgencyConsultants(AGENCY_ID, NEW_ROOM_ID, AGENCY_TOKEN))
+        .thenReturn(0);
+    when(sessionRoomGateway.loginAsUser(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(sessionRoomGateway.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionRoomGateway).inviteUser(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+    verify(sessionRoomGateway).joinRoom(NEW_ROOM_ID, USER_TOKEN);
+    verify(sessionService).saveSession(session);
+    assertEquals(NEW_ROOM_ID, session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("an unexpected department-membership failure never costs the asker their enquiry")
+  void ensureHoldingRoom_provisionsRoomForAsker_whenSilentMembershipThrows() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    // Department membership runs BEFORE the asker's invite now, so a blow-up here (e.g. the
+    // consultant lookup) must be contained — it is a side effect, not a precondition.
+    when(agencySilentMembershipService.joinAgencyConsultants(AGENCY_ID, NEW_ROOM_ID, AGENCY_TOKEN))
+        .thenThrow(new RuntimeException("consultant lookup failed"));
+    when(sessionRoomGateway.loginAsUser(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(sessionRoomGateway.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionRoomGateway).inviteUser(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+    verify(sessionRoomGateway).joinRoom(NEW_ROOM_ID, USER_TOKEN);
+    verify(sessionService).saveSession(session);
+    assertEquals(NEW_ROOM_ID, session.getMatrixRoomId());
   }
 
   @Test


### PR DESCRIPTION
## Why

ADR-002 §1 requires the department to be in the Megolm audience of a one-to-one conversation from the very first message. `AgencySilentMembershipService` (FE#811) already joins the department at room creation, but `AgencyPreAssignmentRoomService.ensureHoldingRoom` invited and joined the **asker first** and the department **second**. The asker's Matrix client discovers the room via `/sync` the moment they are invited — independent of when the backend call returns — so there was a window in which the client could snapshot the membership list before the department had joined and encrypt the first message for an audience excluding the counsellors, leaving early history undecryptable on handover.

This branch was rescued from `save/case-handover-membership-fix-wip`. Its parallel implementation of department membership (own repository lookups inside `AgencyPreAssignmentRoomService`) has since been superseded on `pre-dev` by `AgencySilentMembershipService`; what survives is the WIP's actual point — the membership **ordering** — rebased onto the current architecture.

## What

- `ensureHoldingRoom` now runs create room -> **join department** -> invite/join asker -> persist. Every membership view the asker's client can ever observe already includes the department.
- Failure containment for the reorder: an unexpected `RuntimeException` from `agencySilentMembershipService.joinAgencyConsultants(...)` (e.g. the consultant lookup) is caught and logged instead of propagating. Previously such an exception was uncaught (only `MatrixCreateRoomException` was handled) and — with the department now running before the asker — would have aborted the asker's own invite/join and the room persist, killing the whole enquiry over a best-effort side effect. Per the membership service's contract, department membership is a side effect, never a precondition.

## Testing

`JAVA_HOME=<jdk21> ./mvnw -B test -Dtest='AgencyPreAssignmentRoomServiceTest,AgencySilentMembershipServiceTest'` — Tests run: 21, Failures: 0, Errors: 0
`JAVA_HOME=<jdk21> ./mvnw -B test -Dtest='CreateEnquiryMessageFacadeMatrixRoomProvisioningTest'` — Tests run: 2, Failures: 0, Errors: 0
`./mvnw -B test-compile` — BUILD SUCCESS; `./mvnw -B spotless:check` — BUILD SUCCESS

New/updated coverage:
- Order pinned end to end: create -> `joinAgencyConsultants` -> asker invite -> asker join -> persist (`ensureHoldingRoom_joinsAgencyConsultantsBeforeAsker`).
- No joinable department consultant (service reports 0 joined): the asker still gets their room, session persisted (`ensureHoldingRoom_provisionsRoomForAsker_whenNoConsultantJoined`).
- Membership service throws: asker still invited/joined, room persisted (`ensureHoldingRoom_provisionsRoomForAsker_whenSilentMembershipThrows`).
- Mid-loop per-consultant failures were already pinned on `pre-dev` in `AgencySilentMembershipServiceTest` (best-effort per consultant, invite-rejection tolerated, unresolvable account skipped) — unchanged and still green.

All tests are plain Mockito unit tests; no Docker/Mongo needed.

## Issue linkage

Refs OpenResilienceInitiative/ORISO-UserService#199

This PR fixes only the membership **ordering** (and its failure containment). Of #199's acceptance criteria, "all department counsellors are room members at creation" is delivered by the existing `AgencySilentMembershipService` — though agency-wide, not scoped to the department (agency x topic) — and the "silent" client-side properties (hidden, muted, no notifications until reveal) plus the no-invite-then-kick guarantee on access grant are not addressed here and remain open under #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-room setup by adding agency consultants before inviting the user.
  * User invitations and session creation now continue even when consultant membership setup fails.
  * Improved reliability when no consultant can be added to the room.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->