### PR TITLE
feat: provision counsellors from accepted account invites

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserRespon
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixLoginRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixPasswordUpdateRequestDTO;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixReactivateUserRequestDTO;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
@@ -236,6 +237,9 @@ public class MatrixSynapseService implements MatrixUserClient {
 
       return response;
     } catch (HttpClientErrorException ex) {
+      if (isReservedMatrixUserId(ex)) {
+        return reactivateDeletedUser(username, password);
+      }
       log.error(
           "Matrix Error: Could not create user ({}) in Matrix. Status: {}, Response: {}",
           username,
@@ -256,6 +260,66 @@ public class MatrixSynapseService implements MatrixUserClient {
       throws MatrixCreateUserException {
     var response = createUser(username, password, displayName);
     return response == null || response.getBody() == null ? null : response.getBody().getUserId();
+  }
+
+  private boolean isReservedMatrixUserId(HttpClientErrorException exception) {
+    return exception.getStatusCode().value() == 400
+        && exception.getResponseBodyAsString().contains("\"M_USER_IN_USE\"");
+  }
+
+  private ResponseEntity<MatrixCreateUserResponseDTO> reactivateDeletedUser(
+      String username, String password) throws MatrixCreateUserException {
+    String matrixUserId =
+        "@" + username.toLowerCase(java.util.Locale.ROOT) + ":" + matrixConfig.getServerName();
+    try {
+      String adminToken = getAdminAccessToken();
+      if (adminToken == null) {
+        throw new MatrixCreateUserException(
+            "Could not reactivate Matrix user without an admin token");
+      }
+
+      URI userUri =
+          MatrixUrlBuilder.buildUrl(
+              matrixConfig, ENDPOINT_UPDATE_USER_ADMIN, java.util.Map.of("userId", matrixUserId));
+      var headers = getClientHttpHeaders(adminToken);
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      var adminRequest = new HttpEntity<>(headers);
+      var existingUser =
+          restTemplate.exchange(
+              userUri, org.springframework.http.HttpMethod.GET, adminRequest, java.util.Map.class);
+      if (existingUser.getBody() == null
+          || !Boolean.TRUE.equals(existingUser.getBody().get("deactivated"))) {
+        throw new MatrixCreateUserException(
+            String.format("Matrix user (%s) is already active", username));
+      }
+
+      var reactivateRequest = new MatrixReactivateUserRequestDTO(false);
+      restTemplate.exchange(
+          userUri,
+          org.springframework.http.HttpMethod.PUT,
+          new HttpEntity<>(reactivateRequest, headers),
+          java.util.Map.class);
+
+      var passwordRequest = new MatrixPasswordUpdateRequestDTO();
+      passwordRequest.setPassword(password);
+      passwordRequest.setLogoutDevices(false);
+      restTemplate.exchange(
+          userUri,
+          org.springframework.http.HttpMethod.PUT,
+          new HttpEntity<>(passwordRequest, headers),
+          java.util.Map.class);
+
+      var body = new MatrixCreateUserResponseDTO();
+      body.setUserId(matrixUserId);
+      log.info("Successfully reactivated deleted Matrix user: {}", matrixUserId);
+      return ResponseEntity.ok(body);
+    } catch (MatrixCreateUserException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      log.error("Matrix Error: Could not reactivate deleted user ({})", username, exception);
+      throw new MatrixCreateUserException(
+          String.format("Could not reactivate deleted Matrix user (%s)", username));
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixReactivateUserRequestDTO.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/dto/MatrixReactivateUserRequestDTO.java
@@ -1,0 +1,11 @@
+package de.caritas.cob.userservice.api.adapters.matrix.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** Synapse admin request used only to reactivate a previously deleted ORISO identity. */
+@Getter
+@AllArgsConstructor
+public class MatrixReactivateUserRequestDTO {
+  private boolean deactivated;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -13,6 +13,8 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.WaiveTwoFactorCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.CounsellorInviteProvisioningService;
+import de.caritas.cob.userservice.api.service.accountinvite.CounsellorInviteProvisioningService.ProvisionCounsellorCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailPreviewService;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailPreviewService.InviteEmailPreview;
@@ -47,6 +49,7 @@ public class AccountInviteController {
           + " 'AUTHORIZATION_RESTRICTED_AGENCY_ADMIN')";
 
   private final @NonNull AccountInviteService accountInviteService;
+  private final @NonNull CounsellorInviteProvisioningService counsellorInviteProvisioningService;
   private final @NonNull InviteEmailTemplateService templateService;
   private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
   private final @NonNull InviteEmailPreviewService previewService;
@@ -178,8 +181,16 @@ public class AccountInviteController {
   })
   public ResponseEntity<AccountInviteResponseDTO> acceptInvite(
       @PathVariable String token, @RequestBody(required = false) AcceptInviteRequestDTO request) {
-    String acceptedByUserId = request == null ? null : request.acceptedByUserId;
-    AccountInvite invite = accountInviteService.acceptInvite(token, acceptedByUserId);
+    AccountInvite invite =
+        counsellorInviteProvisioningService.acceptInvite(
+            token,
+            request == null
+                ? null
+                : new ProvisionCounsellorCommand(
+                    request.username,
+                    request.password,
+                    request.formalLanguage,
+                    request.acceptedByUserId));
     AccountInviteResponseDTO response =
         AccountInviteResponseDTO.from(
             invite, latestDeliveryStatus(invite), accountInviteService.calculateAccessGate(invite));
@@ -188,6 +199,16 @@ public class AccountInviteController {
             ? AcceptPhase.PENDING_2FA_ACTIVATION.name()
             : AcceptPhase.COMPLETED.name();
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/users/account-invites/{token}")
+  public ResponseEntity<AccountInviteResponseDTO> getInvite(@PathVariable String token) {
+    AccountInvite invite = accountInviteService.requireActiveInvite(token);
+    return ResponseEntity.ok(
+        AccountInviteResponseDTO.from(
+            invite,
+            latestDeliveryStatus(invite),
+            accountInviteService.calculateAccessGate(invite)));
   }
 
   @PreAuthorize(ADMIN_AUTH)
@@ -348,6 +369,9 @@ public class AccountInviteController {
   }
 
   public static class AcceptInviteRequestDTO {
+    public String username;
+    public String password;
+    public Boolean formalLanguage;
     public String acceptedByUserId;
   }
 
@@ -412,6 +436,7 @@ public class AccountInviteController {
     public Long agencyId;
     public Long departmentId;
     public String provisioningStatus;
+    public String provisionedUserId;
     public String inviteStatus;
     public String emailVerificationStatus;
     public String emailDeliveryStatus;
@@ -459,7 +484,9 @@ public class AccountInviteController {
       dto.lastName = invite.getLastName();
       dto.agencyId = invite.getAgencyId();
       dto.departmentId = invite.getDepartmentId();
-      dto.provisioningStatus = null;
+      dto.provisioningStatus =
+          invite.getProvisioningStatus() == null ? null : invite.getProvisioningStatus().name();
+      dto.provisionedUserId = invite.getProvisionedUserId();
       dto.inviteStatus = invite.getStatus() == null ? null : invite.getStatus().name();
       dto.emailVerificationStatus =
           invite.getEmailVerificationStatus() == null

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -299,8 +299,14 @@ class UserAccountControllerDelegate {
       DeleteUserAccountDTO deleteUserAccountDTO) {
     var username = authenticatedUser.getUsername();
     var password = deleteUserAccountDTO.getPassword();
-    var encodedUsername = usernameTranscoder.encodeUsername(username);
-    if (!identityManager.validatePasswordIgnoring2fa(encodedUsername, password)) {
+    var passwordValid = identityManager.validatePasswordIgnoring2fa(username, password);
+    if (!passwordValid) {
+      var encodedUsername = usernameTranscoder.encodeUsername(username);
+      passwordValid =
+          !encodedUsername.equals(username)
+              && identityManager.validatePasswordIgnoring2fa(encodedUsername, password);
+    }
+    if (!passwordValid) {
       var message = String.format("Could not log in user %s into Keycloak", username);
       throw new BadRequestException(message);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilter.java
@@ -116,6 +116,11 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
             || lowerUri.endsWith("/users/password-reset/confirm")) {
           return true;
         }
+        // Account-invite acceptance is another public bootstrap endpoint. The random invite token
+        // is the bearer secret; the recipient does not have a login session or CSRF cookie yet.
+        if (lowerUri.matches(".*/users/account-invites/[^/]+/accept$")) {
+          return true;
+        }
       }
       // Invite-link redeem is a public bootstrap endpoint too — anyone opening the shared link
       // hits it before any session / CSRF cookie exists.

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantAdminService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.admin.service.tenant;
 import de.caritas.cob.userservice.api.config.CacheManagerConfig;
 import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.TenantControllerApi;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
@@ -32,5 +33,8 @@ public class TenantAdminService {
   private void addDefaultHeaders(ApiClient apiClient) {
     HttpHeaders headers = this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
+    if (TenantContext.getCurrentTenant() != null) {
+      apiClient.addDefaultHeader("tenantId", TenantContext.getCurrentTenant().toString());
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -142,6 +142,8 @@ public class SecurityConfig {
                     "/users/magic-link/consume",
                     "/users/password-reset/request",
                     "/users/password-reset/confirm",
+                    "/users/account-invites/*",
+                    "/service/users/account-invites/*",
                     "/users/invitelinks/*/redeem")
                 .permitAll()
                 .requestMatchers(
@@ -154,6 +156,11 @@ public class SecurityConfig {
                     "/service/users/password-reset/request",
                     "/users/password-reset/confirm",
                     "/service/users/password-reset/confirm")
+                .permitAll()
+                .requestMatchers(
+                    HttpMethod.POST,
+                    "/users/account-invites/*/accept",
+                    "/service/users/account-invites/*/accept")
                 .permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**")
                 .permitAll()

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.model;
 
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteProvisioningStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
@@ -82,6 +83,18 @@ public class AccountInvite {
   @Column(name = "status", nullable = false, length = 32)
   @Builder.Default
   private AccountInviteStatus status = AccountInviteStatus.DRAFT;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "provisioning_status", nullable = false, length = 32)
+  @Builder.Default
+  private AccountInviteProvisioningStatus provisioningStatus =
+      AccountInviteProvisioningStatus.PENDING;
+
+  @Column(name = "provisioned_user_id", length = 36)
+  private String provisionedUserId;
+
+  @Column(name = "provisioning_failure_reason", length = 1024)
+  private String provisioningFailureReason;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "email_verification_status", nullable = false, length = 32)

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteProvisioningStatus.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteProvisioningStatus.java
@@ -1,0 +1,8 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+public enum AccountInviteProvisioningStatus {
+  PENDING,
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -118,6 +118,7 @@ public class AccountInviteService {
               .departmentId(command.departmentId())
               .expiresAt(resolveExpiry(now, command.expiresInDays()))
               .status(AccountInviteStatus.DRAFT)
+              .provisioningStatus(AccountInviteProvisioningStatus.PENDING)
               .emailVerificationStatus(EmailVerificationStatus.PENDING)
               .twoFactorStatus(defaultTwoFactorStatus(command.targetRole()))
               .createdByUserId(authenticatedUser.getUserId())
@@ -374,6 +375,30 @@ public class AccountInviteService {
       return invite;
     }
     throw new AccountInviteLinkException(AccountInviteLinkException.Reason.CONSUMED);
+  }
+
+  /** Resolves an invite by its raw link token without any state checks. */
+  @Transactional(readOnly = true)
+  public AccountInvite findInviteByToken(String rawToken) {
+    if (isBlank(rawToken)) {
+      throw new BadRequestException("Invite token is required");
+    }
+    return accountInviteRepository
+        .findByTokenHash(hash(rawToken))
+        .orElseThrow(() -> new NotFoundException("Account invite not found"));
+  }
+
+  @Transactional
+  public AccountInvite requireActiveInvite(String rawToken) {
+    AccountInvite invite = findInviteByToken(rawToken);
+    LocalDateTime now = LocalDateTime.now();
+    if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
+      throw new BadRequestException("Account invite expired");
+    }
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT) {
+      throw new BadRequestException("Account invite is not active");
+    }
+    return invite;
   }
 
   public AccountAccessGateStatus calculateAccessGate(AccountInvite invite) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/CounsellorInviteProvisioningService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/CounsellorInviteProvisioningService.java
@@ -1,0 +1,187 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.CreateConsultantSaga;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.httpheader.TechnicalAccessTokenContext;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantData;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CounsellorInviteProvisioningService {
+
+  private static final String DEFAULT_ROLE_SET = "CONSULTANT_DEFAULT";
+
+  private final @NonNull AccountInviteService accountInviteService;
+  private final @NonNull AccountInviteRepository accountInviteRepository;
+  private final @NonNull ConsultantAdminFacade consultantAdminFacade;
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull CreateConsultantSaga createConsultantSaga;
+  private final @NonNull IdentityAuthentication identityAuthentication;
+  private final @NonNull IdentityClientConfig identityClientConfig;
+
+  @Transactional(noRollbackFor = RuntimeException.class)
+  public AccountInvite acceptInvite(String rawToken, ProvisionCounsellorCommand command) {
+    AccountInvite invite = accountInviteService.findInviteByToken(rawToken);
+    if (invite.getTargetRole() != AccountInviteTargetRole.COUNSELLOR) {
+      return accountInviteService.acceptInvite(
+          rawToken, command == null ? null : command.acceptedByUserId());
+    }
+    if (invite.getStatus() != AccountInviteStatus.EMAIL_SENT
+        || (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(LocalDateTime.now()))) {
+      // Already-processed or expired links keep the ORISO-Admin#569 resume/consumed contract
+      // (idempotent 200 while the 2FA gate is pending, 410 with a reason code otherwise). No
+      // caller-supplied user id is recorded on this path — provisioning identity is always the
+      // server-created consultant id.
+      return accountInviteService.acceptInvite(rawToken, null);
+    }
+    if (invite.getProvisioningStatus() == AccountInviteProvisioningStatus.IN_PROGRESS) {
+      throw new ConflictException("Account invite provisioning is already in progress");
+    }
+    validate(command, invite);
+
+    invite.setProvisioningStatus(AccountInviteProvisioningStatus.IN_PROGRESS);
+    invite.setProvisioningFailureReason(null);
+    invite.setUpdateDate(LocalDateTime.now());
+    accountInviteRepository.save(invite);
+
+    String consultantId = null;
+    var technicalUser = identityClientConfig.getTechnicalUser();
+    String technicalAccessToken =
+        identityAuthentication
+            .login(technicalUser.getUsername(), technicalUser.getPassword())
+            .accessToken();
+    TechnicalAccessTokenContext.set(technicalAccessToken);
+    TenantData requestTenant = snapshotTenantContext();
+    TenantContext.setCurrentTenant(invite.getTenantId());
+    try {
+      var consultant = consultantAdminFacade.createNewConsultant(toConsultant(command, invite));
+      if (consultant.getEmbedded() == null || consultant.getEmbedded().getId() == null) {
+        throw new IllegalStateException("Consultant provisioning returned no user id");
+      }
+      consultantId = consultant.getEmbedded().getId();
+      invite.setProvisionedUserId(consultantId);
+      invite.setUpdateDate(LocalDateTime.now());
+      accountInviteRepository.save(invite);
+
+      consultantAdminFacade.createNewConsultantAgency(
+          consultantId,
+          new CreateConsultantAgencyDTO()
+              .agencyId(invite.getAgencyId())
+              .roleSetKey(DEFAULT_ROLE_SET));
+
+      AccountInvite accepted = accountInviteService.acceptInvite(rawToken, consultantId);
+      accepted.setProvisionedUserId(consultantId);
+      accepted.setProvisioningStatus(AccountInviteProvisioningStatus.COMPLETED);
+      accepted.setProvisioningFailureReason(null);
+      accepted.setUpdateDate(LocalDateTime.now());
+      return accountInviteRepository.save(accepted);
+    } catch (RuntimeException failure) {
+      rollbackPartiallyCreatedConsultant(consultantId, failure);
+      invite.setProvisionedUserId(null);
+      invite.setProvisioningStatus(AccountInviteProvisioningStatus.FAILED);
+      invite.setProvisioningFailureReason(truncate(failure.getMessage(), 1024));
+      invite.setUpdateDate(LocalDateTime.now());
+      accountInviteRepository.save(invite);
+      throw failure;
+    } finally {
+      restoreTenantContext(requestTenant);
+      TechnicalAccessTokenContext.clear();
+    }
+  }
+
+  private static TenantData snapshotTenantContext() {
+    TenantData tenantData = TenantContext.getCurrentTenantData();
+    return tenantData == null
+        ? null
+        : new TenantData(tenantData.getTenantId(), tenantData.getSubdomain());
+  }
+
+  private static void restoreTenantContext(TenantData tenantData) {
+    if (tenantData == null) {
+      TenantContext.clear();
+    } else {
+      TenantContext.setCurrentTenantData(tenantData);
+    }
+  }
+
+  private void rollbackPartiallyCreatedConsultant(String consultantId, RuntimeException failure) {
+    if (consultantId == null) {
+      return;
+    }
+    try {
+      consultantRepository
+          .findById(consultantId)
+          .ifPresent(createConsultantSaga::rollbackCreateNewConsultant);
+    } catch (RuntimeException rollbackFailure) {
+      failure.addSuppressed(rollbackFailure);
+    }
+  }
+
+  private static String truncate(String value, int maxLength) {
+    if (value == null || value.length() <= maxLength) {
+      return value;
+    }
+    return value.substring(0, maxLength);
+  }
+
+  private static CreateConsultantDTO toConsultant(
+      ProvisionCounsellorCommand command, AccountInvite invite) {
+    return new CreateConsultantDTO()
+        .username(command.username().trim())
+        .password(command.password())
+        .firstname(invite.getFirstName())
+        .lastname(invite.getLastName())
+        .email(invite.getRecipientEmail().trim().toLowerCase())
+        .formalLanguage(command.formalLanguage())
+        .absent(false)
+        .tenantId(invite.getTenantId())
+        .isGroupchatConsultant(false)
+        .topicIds(List.of(invite.getDepartmentId()));
+  }
+
+  private static void validate(ProvisionCounsellorCommand command, AccountInvite invite) {
+    if (command == null) {
+      throw new BadRequestException("Request body is required");
+    }
+    if (isBlank(command.username())) {
+      throw new BadRequestException("username is required");
+    }
+    if (isBlank(command.password())) {
+      throw new BadRequestException("password is required");
+    }
+    if (command.formalLanguage() == null) {
+      throw new BadRequestException("formalLanguage is required");
+    }
+    if (invite.getTenantId() == null
+        || invite.getAgencyId() == null
+        || invite.getDepartmentId() == null) {
+      throw new BadRequestException("Counsellor invite requires tenant, agency and department");
+    }
+    if (isBlank(invite.getFirstName()) || isBlank(invite.getLastName())) {
+      throw new BadRequestException("Counsellor invite requires first and last name");
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  public record ProvisionCounsellorCommand(
+      String username, String password, Boolean formalLanguage, String acceptedByUserId) {}
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplier.java
@@ -42,7 +42,8 @@ public class SecurityHeaderSupplier {
    */
   public HttpHeaders getKeycloakAndCsrfHttpHeaders() {
     var header = getCsrfHttpHeaders();
-    var currentAccessToken = authenticatedUser.getAccessToken();
+    var currentAccessToken =
+        TechnicalAccessTokenContext.get().orElseGet(authenticatedUser::getAccessToken);
     if (StringUtils.isNotBlank(currentAccessToken)) {
       this.addKeycloakAuthorizationHeader(header, currentAccessToken);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/httpheader/TechnicalAccessTokenContext.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/httpheader/TechnicalAccessTokenContext.java
@@ -1,0 +1,23 @@
+package de.caritas.cob.userservice.api.service.httpheader;
+
+import java.util.Optional;
+
+/** Request-thread override for authenticated service-to-service calls in public workflows. */
+public final class TechnicalAccessTokenContext {
+
+  private static final ThreadLocal<String> ACCESS_TOKEN = new ThreadLocal<>();
+
+  private TechnicalAccessTokenContext() {}
+
+  public static void set(String accessToken) {
+    ACCESS_TOKEN.set(accessToken);
+  }
+
+  public static Optional<String> get() {
+    return Optional.ofNullable(ACCESS_TOKEN.get());
+  }
+
+  public static void clear() {
+    ACCESS_TOKEN.remove();
+  }
+}

--- a/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/0081_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/0081_changeSet.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+  <changeSet id="0081_account_invite_provisioning" author="oriso">
+    <sqlFile
+      path="db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"/>
+    <rollback>
+      <sqlFile
+        path="db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning-rollback.sql"
+        relativeToChangelogFile="false"
+        splitStatements="true"
+        stripComments="true"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning-rollback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE account_invite
+  DROP COLUMN provisioning_failure_reason,
+  DROP COLUMN provisioned_user_id,
+  DROP COLUMN provisioning_status;

--- a/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning.sql
+++ b/src/main/resources/db/changelog/changeset/0081_account_invite_provisioning/account-invite-provisioning.sql
@@ -1,0 +1,4 @@
+ALTER TABLE account_invite
+  ADD COLUMN provisioning_status VARCHAR(32) NOT NULL DEFAULT 'PENDING' AFTER status,
+  ADD COLUMN provisioned_user_id VARCHAR(36) NULL AFTER provisioning_status,
+  ADD COLUMN provisioning_failure_reason VARCHAR(1024) NULL AFTER provisioned_user_id;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -136,6 +136,8 @@
     file="db/changelog/changeset/0079_support_room/0079_changeSet.xml" />
   <include
     file="db/changelog/changeset/0080_event_notification_millis/0080_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0081_account_invite_provisioning/0081_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -531,6 +531,70 @@ class MatrixSynapseServiceTest {
   }
 
   @Test
+  void createUser_reactivatesDeactivatedSynapseIdentityWhenLocalpartIsStillReserved()
+      throws Exception {
+    matrixConfig.setServerName("matrix.example.com");
+    stubAdminLogin();
+    when(restTemplate.getForEntity(REGISTER_URL, String.class))
+        .thenReturn(ResponseEntity.ok("{\"nonce\":\"nonce-abc\"}"));
+    when(restTemplate.postForEntity(
+            eq(REGISTER_URL), any(HttpEntity.class), eq(MatrixCreateUserResponseDTO.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST,
+                "Bad Request",
+                null,
+                "{\"errcode\":\"M_USER_IN_USE\",\"error\":\"User ID already taken.\"}"
+                    .getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+    when(restTemplate.exchange(
+            eq(
+                URI.create(
+                    "https://matrix.example.com/_synapse/admin/v2/users/"
+                        + "%40newuser%3Amatrix.example.com")),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of("deactivated", true)));
+    var updateCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.exchange(
+            eq(
+                URI.create(
+                    "https://matrix.example.com/_synapse/admin/v2/users/"
+                        + "%40newuser%3Amatrix.example.com")),
+            eq(HttpMethod.PUT),
+            any(HttpEntity.class),
+            eq(Map.class)))
+        .thenReturn(ResponseEntity.ok(Map.of()));
+
+    var response = matrixSynapseService().createUser("newuser", "new-secret", "New User");
+
+    assertThat(response.getBody().getUserId()).isEqualTo("@newuser:matrix.example.com");
+    verify(restTemplate, times(2))
+        .exchange(
+            eq(
+                URI.create(
+                    "https://matrix.example.com/_synapse/admin/v2/users/"
+                        + "%40newuser%3Amatrix.example.com")),
+            eq(HttpMethod.PUT),
+            updateCaptor.capture(),
+            eq(Map.class));
+    assertThat(updateCaptor.getAllValues().get(0).getHeaders().getFirst("Authorization"))
+        .isEqualTo("Bearer " + ADMIN_TOKEN);
+    assertThat(updateCaptor.getAllValues().get(0).getBody())
+        .usingRecursiveComparison()
+        .isEqualTo(
+            new de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixReactivateUserRequestDTO(
+                false));
+    assertThat(updateCaptor.getAllValues().get(1).getBody())
+        .isInstanceOf(MatrixPasswordUpdateRequestDTO.class);
+    var passwordUpdate =
+        (MatrixPasswordUpdateRequestDTO) updateCaptor.getAllValues().get(1).getBody();
+    assertThat(passwordUpdate.getPassword()).isEqualTo("new-secret");
+    assertThat(passwordUpdate.isLogoutDevices()).isFalse();
+  }
+
+  @Test
   void createUser_unexpectedError_throwsMatrixCreateUserException() {
     // Network failures during registration must not leak as unchecked exceptions.
     when(restTemplate.getForEntity(REGISTER_URL, String.class))

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -20,6 +20,8 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.InviteSendResult;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.CounsellorInviteProvisioningService;
+import de.caritas.cob.userservice.api.service.accountinvite.CounsellorInviteProvisioningService.ProvisionCounsellorCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailDeliveryStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailPreviewService;
 import de.caritas.cob.userservice.api.service.accountinvite.InviteEmailTemplateKind;
@@ -46,6 +48,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 class AccountInviteControllerTest {
 
   @Mock private AccountInviteService accountInviteService;
+  @Mock private CounsellorInviteProvisioningService counsellorInviteProvisioningService;
   @Mock private InviteEmailTemplateService templateService;
   @Mock private InviteEmailDeliveryRepository deliveryRepository;
   @Mock private InviteEmailPreviewService previewService;
@@ -56,7 +59,11 @@ class AccountInviteControllerTest {
   void setUp() {
     controller =
         new AccountInviteController(
-            accountInviteService, templateService, deliveryRepository, previewService);
+            accountInviteService,
+            counsellorInviteProvisioningService,
+            templateService,
+            deliveryRepository,
+            previewService);
   }
 
   @Test
@@ -171,9 +178,14 @@ class AccountInviteControllerTest {
     // Business reason: valid invitation acceptance should transition invite state and return
     // confirmation data.
     var request = new AccountInviteController.AcceptInviteRequestDTO();
+    request.username = "invited-counsellor";
+    request.password = "test-password";
+    request.formalLanguage = true;
     request.acceptedByUserId = "user-1";
     var invite = sampleInvite();
-    when(accountInviteService.acceptInvite("token-1", "user-1")).thenReturn(invite);
+    var command =
+        new ProvisionCounsellorCommand("invited-counsellor", "test-password", true, "user-1");
+    when(counsellorInviteProvisioningService.acceptInvite("token-1", command)).thenReturn(invite);
     when(accountInviteService.calculateAccessGate(invite))
         .thenReturn(AccountAccessGateStatus.READY);
     when(deliveryRepository.findFirstByAccountInviteIdOrderByCreateDateDesc(10L))
@@ -184,7 +196,7 @@ class AccountInviteControllerTest {
     var response = controller.acceptInvite("token-1", request);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    verify(accountInviteService).acceptInvite("token-1", "user-1");
+    verify(counsellorInviteProvisioningService).acceptInvite("token-1", command);
     // No pending mandatory 2FA on this invite: the onboarding phase is terminal.
     assertNotNull(response.getBody());
     assertEquals("COMPLETED", response.getBody().phase);
@@ -197,7 +209,7 @@ class AccountInviteControllerTest {
     var invite = sampleInvite();
     invite.setStatus(AccountInviteStatus.ACCEPTED);
     invite.setTwoFactorStatus(TwoFactorGateStatus.PENDING_SETUP);
-    when(accountInviteService.acceptInvite("token-3", null)).thenReturn(invite);
+    when(counsellorInviteProvisioningService.acceptInvite("token-3", null)).thenReturn(invite);
     when(accountInviteService.calculateAccessGate(invite))
         .thenReturn(AccountAccessGateStatus.BLOCKED_TWO_FACTOR);
 
@@ -211,18 +223,32 @@ class AccountInviteControllerTest {
   }
 
   @Test
+  void getInvite_validTokenReturnsRecipientDetailsWithoutAcceptingIt() {
+    var invite = sampleInvite();
+    when(accountInviteService.requireActiveInvite("token-details")).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_INVITE);
+
+    var response = controller.getInvite("token-details");
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(invite.getRecipientEmail(), response.getBody().recipientEmail);
+    verify(accountInviteService).requireActiveInvite("token-details");
+  }
+
+  @Test
   void acceptInvite_nullBody_passesNullAcceptedByUserId() {
     // Business reason: anonymous acceptance flows must still work without explicit requester
     // payload.
     var invite = sampleInvite();
-    when(accountInviteService.acceptInvite("token-2", null)).thenReturn(invite);
+    when(counsellorInviteProvisioningService.acceptInvite("token-2", null)).thenReturn(invite);
     when(accountInviteService.calculateAccessGate(invite))
         .thenReturn(AccountAccessGateStatus.READY);
 
     var response = controller.acceptInvite("token-2", null);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    verify(accountInviteService).acceptInvite("token-2", null);
+    verify(counsellorInviteProvisioningService).acceptInvite("token-2", null);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteCounsellorProvisioningIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteCounsellorProvisioningIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -39,7 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("testing")
-@AutoConfigureTestDatabase
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 class AccountInviteCounsellorProvisioningIT {
 
   private static final String RAW_TOKEN = "emailed-counsellor-token";

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteCounsellorProvisioningIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteCounsellorProvisioningIT.java
@@ -1,0 +1,122 @@
+package de.caritas.cob.userservice.api.adapters.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase
+class AccountInviteCounsellorProvisioningIT {
+
+  private static final String RAW_TOKEN = "emailed-counsellor-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @MockitoBean private ConsultantAdminFacade consultantAdminFacade;
+
+  @BeforeEach
+  void configureConsultantProvisioning() {
+    when(consultantAdminFacade.createNewConsultant(any(CreateConsultantDTO.class)))
+        .thenReturn(
+            new ConsultantAdminResponseDTO()
+                .embedded(new ConsultantDTO().id("provisioned-counsellor-id")));
+  }
+
+  @Test
+  void acceptingEmailedCounsellorInviteCreatesRoutedLoginAccount() throws Exception {
+    accountInviteRepository.save(
+        AccountInvite.builder()
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .tenantId(79L)
+            .recipientEmail("lisa.simpson@oriso.org")
+            .firstName("Lisa")
+            .lastName("Simpson")
+            .agencyId(275L)
+            .departmentId(2L)
+            .tokenHash(sha256(RAW_TOKEN))
+            .expiresAt(LocalDateTime.now().plusDays(1))
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .emailVerificationStatus(EmailVerificationStatus.PENDING)
+            .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+            .createDate(LocalDateTime.now())
+            .build());
+
+    mockMvc
+        .perform(
+            post("/users/account-invites/{token}/accept", RAW_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "username": "codex_invited_counsellor",
+                      "password": "Valid-Test-Password-2026!",
+                      "formalLanguage": true
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.inviteStatus").value("ACCEPTED"))
+        .andExpect(jsonPath("$.provisioningStatus").value("COMPLETED"))
+        .andExpect(jsonPath("$.provisionedUserId").isNotEmpty())
+        .andExpect(jsonPath("$.tenantId").value(79))
+        .andExpect(jsonPath("$.agencyId").value(275))
+        .andExpect(jsonPath("$.departmentId").value(2));
+
+    ArgumentCaptor<CreateConsultantDTO> consultantCaptor =
+        ArgumentCaptor.forClass(CreateConsultantDTO.class);
+    verify(consultantAdminFacade).createNewConsultant(consultantCaptor.capture());
+    CreateConsultantDTO consultant = consultantCaptor.getValue();
+    assertThat(consultant.getUsername()).isEqualTo("codex_invited_counsellor");
+    assertThat(consultant.getEmail()).isEqualTo("lisa.simpson@oriso.org");
+    assertThat(consultant.getTenantId()).isEqualTo(79L);
+    assertThat(consultant.getTopicIds()).containsExactly(2L);
+
+    ArgumentCaptor<CreateConsultantAgencyDTO> agencyCaptor =
+        ArgumentCaptor.forClass(CreateConsultantAgencyDTO.class);
+    verify(consultantAdminFacade)
+        .createNewConsultantAgency(eq("provisioned-counsellor-id"), agencyCaptor.capture());
+    assertThat(agencyCaptor.getValue().getAgencyId()).isEqualTo(275L);
+    assertThat(agencyCaptor.getValue().getRoleSetKey()).isEqualTo("CONSULTANT_DEFAULT");
+  }
+
+  private static String sha256(String value) throws Exception {
+    return HexFormat.of()
+        .formatHex(
+            MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -684,12 +684,43 @@ class UserAccountControllerDelegateTest {
     var deleteUserAccountDTO = new DeleteUserAccountDTO();
     deleteUserAccountDTO.setPassword("correct");
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
-    when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.validatePasswordIgnoring2fa(USERNAME, "correct")).thenReturn(true);
 
     var response = delegate.deactivateAndFlagUserAccountForDeletion(deleteUserAccountDTO);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(userAccountProvider).deactivateAndFlagUserAccountForDeletion();
+  }
+
+  @Test
+  void deactivateAndFlagUserAccountForDeletion_plainMatrixUsername_validatesPlainIdentity() {
+    var deleteUserAccountDTO = new DeleteUserAccountDTO();
+    deleteUserAccountDTO.setPassword("correct");
+    when(authenticatedUser.getUsername()).thenReturn(USERNAME);
+    when(identityManager.validatePasswordIgnoring2fa(USERNAME, "correct")).thenReturn(true);
+
+    var response = delegate.deactivateAndFlagUserAccountForDeletion(deleteUserAccountDTO);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(identityManager).validatePasswordIgnoring2fa(USERNAME, "correct");
+    verify(usernameTranscoder, never()).encodeUsername(USERNAME);
+    verify(userAccountProvider).deactivateAndFlagUserAccountForDeletion();
+  }
+
+  @Test
+  void deactivateAndFlagUserAccountForDeletion_legacyEncodedUsername_fallsBackToEncodedIdentity() {
+    var deleteUserAccountDTO = new DeleteUserAccountDTO();
+    deleteUserAccountDTO.setPassword("correct");
+    when(authenticatedUser.getUsername()).thenReturn(USERNAME);
+    when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn("enc.username");
+    when(identityManager.validatePasswordIgnoring2fa(USERNAME, "correct")).thenReturn(false);
+    when(identityManager.validatePasswordIgnoring2fa("enc.username", "correct")).thenReturn(true);
+
+    var response = delegate.deactivateAndFlagUserAccountForDeletion(deleteUserAccountDTO);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    verify(identityManager).validatePasswordIgnoring2fa(USERNAME, "correct");
+    verify(identityManager).validatePasswordIgnoring2fa("enc.username", "correct");
     verify(userAccountProvider).deactivateAndFlagUserAccountForDeletion();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/StatelessCsrfFilterTest.java
@@ -89,6 +89,18 @@ public class StatelessCsrfFilterTest {
   }
 
   @Test
+  void accountInviteAcceptanceShouldNotRequireCsrfBeforeLogin()
+      throws IOException, ServletException {
+    when(request.getRequestURI()).thenReturn("/service/users/account-invites/emailed-token/accept");
+    when(request.getMethod()).thenReturn("POST");
+
+    csrfFilter.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verifyNoMoreInteractions(accessDeniedHandler);
+  }
+
+  @Test
   public void doFilterInternal_Should_executeFilterChain_When_requestHasCsrfWhitelistHeader()
       throws IOException, ServletException {
     when(request.getRequestURI()).thenReturn("uri");

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantAdminServiceTest.java
@@ -1,0 +1,38 @@
+package de.caritas.cob.userservice.api.admin.service.tenant;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.config.apiclient.TenantAdminServiceApiControllerFactory;
+import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.tenantadminservice.generated.ApiClient;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.TenantControllerApi;
+import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+class TenantAdminServiceTest {
+
+  @Test
+  void getTenantByIdForwardsCurrentTenantContextToDownstreamService() {
+    var securityHeaderSupplier = mock(SecurityHeaderSupplier.class);
+    var controllerFactory = mock(TenantAdminServiceApiControllerFactory.class);
+    var controller = mock(TenantControllerApi.class);
+    var apiClient = mock(ApiClient.class);
+    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
+    when(controllerFactory.createControllerApi()).thenReturn(controller);
+    when(controller.getApiClient()).thenReturn(apiClient);
+    when(controller.getTenantById(20L)).thenReturn(new TenantDTO());
+    TenantContext.setCurrentTenant(20L);
+
+    try {
+      new TenantAdminService(securityHeaderSupplier, controllerFactory).getTenantById(20L);
+
+      verify(apiClient).addDefaultHeader("tenantId", "20");
+    } finally {
+      TenantContext.clear();
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/CounsellorInviteProvisioningServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/CounsellorInviteProvisioningServiceTest.java
@@ -1,0 +1,161 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantDTO;
+import de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade;
+import de.caritas.cob.userservice.api.admin.service.consultant.create.CreateConsultantSaga;
+import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
+import de.caritas.cob.userservice.api.service.accountinvite.CounsellorInviteProvisioningService.ProvisionCounsellorCommand;
+import de.caritas.cob.userservice.api.service.httpheader.TechnicalAccessTokenContext;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CounsellorInviteProvisioningServiceTest {
+
+  private final AccountInviteService accountInviteService = mock(AccountInviteService.class);
+  private final AccountInviteRepository accountInviteRepository =
+      mock(AccountInviteRepository.class);
+  private final ConsultantAdminFacade consultantAdminFacade = mock(ConsultantAdminFacade.class);
+  private final ConsultantRepository consultantRepository = mock(ConsultantRepository.class);
+  private final CreateConsultantSaga createConsultantSaga = mock(CreateConsultantSaga.class);
+  private final IdentityAuthentication identityAuthentication = mock(IdentityAuthentication.class);
+  private final IdentityClientConfig identityClientConfig = mock(IdentityClientConfig.class);
+
+  private CounsellorInviteProvisioningService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new CounsellorInviteProvisioningService(
+            accountInviteService,
+            accountInviteRepository,
+            consultantAdminFacade,
+            consultantRepository,
+            createConsultantSaga,
+            identityAuthentication,
+            identityClientConfig);
+    var technicalUser = new TechnicalUserConfig();
+    technicalUser.setUsername("technical-user");
+    technicalUser.setPassword("technical-password");
+    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
+    when(identityAuthentication.login("technical-user", "technical-password"))
+        .thenReturn(new IdentityLogin("technical-token", 60, 60, null));
+    when(accountInviteRepository.save(any(AccountInvite.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  void failedAgencyAssignmentMarksInviteFailedAndKeepsItRetryable() {
+    AccountInvite invite = activeCounsellorInvite();
+    when(accountInviteService.findInviteByToken("raw-token")).thenReturn(invite);
+    when(consultantAdminFacade.createNewConsultant(any(CreateConsultantDTO.class)))
+        .thenReturn(
+            new ConsultantAdminResponseDTO()
+                .embedded(new ConsultantDTO().id("partially-created-consultant")));
+    Consultant partiallyCreatedConsultant = mock(Consultant.class);
+    when(consultantRepository.findById("partially-created-consultant"))
+        .thenReturn(Optional.of(partiallyCreatedConsultant));
+    doThrow(new IllegalStateException("agency assignment failed"))
+        .when(consultantAdminFacade)
+        .createNewConsultantAgency(
+            org.mockito.ArgumentMatchers.eq("partially-created-consultant"),
+            any(CreateConsultantAgencyDTO.class));
+
+    assertThatThrownBy(
+            () ->
+                service.acceptInvite(
+                    "raw-token",
+                    new ProvisionCounsellorCommand(
+                        "invited-counsellor", "test-password", true, null)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("agency assignment failed");
+
+    assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+    assertThat(invite.getProvisioningStatus()).isEqualTo(AccountInviteProvisioningStatus.FAILED);
+    assertThat(invite.getProvisionedUserId()).isNull();
+    verify(createConsultantSaga).rollbackCreateNewConsultant(partiallyCreatedConsultant);
+  }
+
+  @Test
+  void inviteAlreadyBeingProvisionedDoesNotCreateDuplicateConsultant() {
+    AccountInvite invite = activeCounsellorInvite();
+    invite.setProvisioningStatus(AccountInviteProvisioningStatus.IN_PROGRESS);
+    when(accountInviteService.findInviteByToken("raw-token")).thenReturn(invite);
+
+    assertThatThrownBy(
+            () ->
+                service.acceptInvite(
+                    "raw-token",
+                    new ProvisionCounsellorCommand(
+                        "invited-counsellor", "test-password", true, null)))
+        .isInstanceOf(
+            de.caritas.cob.userservice.api.exception.httpresponses.ConflictException.class)
+        .hasMessageContaining("already in progress");
+
+    verifyNoInteractions(consultantAdminFacade);
+  }
+
+  @Test
+  void acceptCounsellorInviteUsesInviteTenantAndRestoresRequestTenant() {
+    AccountInvite invite = activeCounsellorInvite();
+    when(accountInviteService.findInviteByToken("raw-token")).thenReturn(invite);
+    when(consultantAdminFacade.createNewConsultant(any(CreateConsultantDTO.class)))
+        .thenAnswer(
+            invocation -> {
+              assertThat(TenantContext.getCurrentTenant()).isEqualTo(79L);
+              assertThat(TechnicalAccessTokenContext.get()).contains("technical-token");
+              return new ConsultantAdminResponseDTO()
+                  .embedded(new ConsultantDTO().id("created-consultant"));
+            });
+    when(accountInviteService.acceptInvite("raw-token", "created-consultant")).thenReturn(invite);
+    TenantContext.setCurrentTenant(1L);
+
+    try {
+      service.acceptInvite(
+          "raw-token",
+          new ProvisionCounsellorCommand("invited-counsellor", "test-password", true, null));
+
+      assertThat(TenantContext.getCurrentTenant()).isEqualTo(1L);
+      assertThat(TechnicalAccessTokenContext.get()).isEmpty();
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  private static AccountInvite activeCounsellorInvite() {
+    return AccountInvite.builder()
+        .targetRole(AccountInviteTargetRole.COUNSELLOR)
+        .tenantId(79L)
+        .recipientEmail("lisa.simpson@oriso.org")
+        .firstName("Lisa")
+        .lastName("Simpson")
+        .agencyId(275L)
+        .departmentId(2L)
+        .status(AccountInviteStatus.EMAIL_SENT)
+        .provisioningStatus(AccountInviteProvisioningStatus.PENDING)
+        .expiresAt(LocalDateTime.now().plusDays(1))
+        .createDate(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/httpheader/SecurityHeaderSupplierTest.java
@@ -64,6 +64,19 @@ public class SecurityHeaderSupplierTest {
   }
 
   @Test
+  public void getKeycloakAndCsrfHttpHeaders_Should_PreferTechnicalWorkflowToken() {
+    TechnicalAccessTokenContext.set("technical-token");
+
+    try {
+      HttpHeaders result = securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+
+      assertThat(result.get("Authorization").get(0), is("Bearer technical-token"));
+    } finally {
+      TechnicalAccessTokenContext.clear();
+    }
+  }
+
+  @Test
   public void getKeycloakAndCsrfHttpHeaders_Should_ReturnHeaderWithValidCsrfHeaderProperties() {
     when(authenticatedUser.getAccessToken()).thenReturn(BEARER_TOKEN);
 

--- a/tests/contracts/test_openapi_contract_gate.py
+++ b/tests/contracts/test_openapi_contract_gate.py
@@ -90,15 +90,18 @@ class OpenApiContractGateTest(unittest.TestCase):
             "#/components/schemas/AgencyLinks",
             full_response["properties"]["_links"]["$ref"],
         )
+        # AgencyLinks is deliberately flattened (no allOf): oasdiff does not merge
+        # allOf, so `self` and friends must be direct properties for the consumer
+        # contracts in AgencyService (#232) and TenantService (#162) to hold.
         agency_links = provider["components"]["schemas"]["AgencyLinks"]
-        self.assertEqual(
-            "#/components/schemas/DefaultLinks",
-            agency_links["allOf"][0]["$ref"],
-        )
-        self.assertIn(
-            "postcodeRanges",
-            agency_links["allOf"][1]["properties"],
-        )
+        self.assertNotIn("allOf", agency_links)
+        self.assertEqual("object", agency_links["type"])
+        self.assertIn("self", agency_links["required"])
+        for link in ("self", "update", "delete", "postcodeRanges"):
+            self.assertEqual(
+                "#/components/schemas/HalLink",
+                agency_links["properties"][link]["$ref"],
+            )
 
         sort_field = agency_admin["components"]["schemas"]["Sort"]["properties"][
             "field"


### PR DESCRIPTION
## Why

Emailed counsellor invites could be accepted, but no login-capable account was ever created — the invite lifecycle stopped at the invite row. This finishes the rescued `save/account-invite-lifecycle-wip` branch: accepting a valid emailed COUNSELLOR invite now provisions the Keycloak/consultant account, assigns the invite's agency, and records provisioning state on the invite.

## What

- **`CounsellorInviteProvisioningService`**: on POST accept of a COUNSELLOR invite, creates the consultant via `ConsultantAdminFacade` (Keycloak + DB + Matrix), assigns the invite's agency with the `CONSULTANT_DEFAULT` role set, and tracks `provisioningStatus` (`PENDING`/`IN_PROGRESS`/`COMPLETED`/`FAILED`) with saga rollback and retryability on failure.
- **Caller-supplied user id is never trusted (#483 acceptance criterion)**: for COUNSELLOR invites `request.acceptedByUserId` is ignored entirely — the provisioned identity is always the server-created consultant id, which is also what gets recorded on the invite. For non-COUNSELLOR flows (pre-dating this branch) `acceptedByUserId` remains a pure audit column (`claimForAcceptance` write only); it is never used as account identity or for authorization anywhere.
- **Technical service-account token gate**: `TechnicalAccessTokenContext` (request-thread override in `SecurityHeaderSupplier`) lets the anonymous public accept flow perform authenticated service-to-service calls with the technical user's token, scoped and cleared in a `finally`.
- **Public endpoints**: new GET `/users/account-invites/{token}` for the acceptance page; SecurityConfig `permitAll` + `StatelessCsrfFilter` exemption for the anonymous accept POST.
- **Liquibase 0081** (renumbered from the rescued 0071 — 0071–0080 were taken on pre-dev meanwhile, most recently 0080_event_notification_millis): adds `provisioning_status`, `provisioned_user_id`, `provisioning_failure_reason` to `account_invite`, with rollback SQL.
- **Matrix Synapse re-invite fix**: `M_USER_IN_USE` on user creation now reactivates a soft-deleted Matrix user (admin API) and resets its password, so re-invited counsellors whose old account was deleted get a working Matrix login again.
- **`TenantAdminService`** forwards the current tenant context as `tenantId` header on downstream calls.

### Rebase integration (beyond the rescued branch)

The branch was 470 commits behind pre-dev; rebased with conflict resolution plus these deliberate adaptations:

1. Ported to the pre-dev identity port split: `IdentityAuthentication.login(...)` instead of the removed `IdentityClient.loginUser(...)`.
2. Dropped the WIP's direct `MailService` free-text dispatch — superseded by `InviteMailDispatchService` (#914) already on pre-dev.
3. Preserved the ORISO-Admin#569 accept resume/consumed contract: already-processed or expired counsellor links delegate to the existing accept mapping (idempotent 200 with `phase=PENDING_2FA_ACTIVATION`, 410 with reason codes) instead of the WIP's plain 400 guard.
4. Fixed the IT's datasource config: the rescued WIP used bare `@AutoConfigureTestDatabase`, which replaced the application-testing H2 (MODE=MariaDB) datasource with plain H2 and broke Spring context startup on the seed script (this is exactly what the `tests/ci` required-CI contract test rejects). Now `@AutoConfigureTestDatabase(replace = Replace.NONE)` like every other Spring Boot IT in this repo.

5. Repaired the pre-existing red `openapi contract gate tests` check: pre-dev commit e1c92f87 flattened `AgencyLinks` in `api/useradminservice.yaml` but left `tests/contracts/test_openapi_contract_gate.py` asserting the old `allOf` composition — the OpenAPI Contracts workflow has been failing on pre-dev's own push runs since. The assertion now pins the flattened shape (no `allOf`, `self` required, direct `HalLink` properties), matching e1c92f87's intent.

## Testing

Ran locally (offline Maven, JDK 21):

- `mvn test -Dtest='AccountInviteControllerTest,CounsellorInviteProvisioningServiceTest,AccountInviteServiceTest,MatrixSynapseServiceTest,UserAccountControllerDelegateTest,StatelessCsrfFilterTest,TenantAdminServiceTest,SecurityHeaderSupplierTest'` — **228 tests, 0 failures, 0 errors, 0 skipped**.
- `AccountInviteCounsellorProvisioningIT` — **passes locally** (1 test, 0 failures) after the `Replace.NONE` datasource fix above.
- `tests/ci` contract suite (`python3 -m unittest discover -s tests/ci`) — 7 tests, OK.
- `mvn test-compile` (whole module incl. Spotless) — BUILD SUCCESS.

Closes OpenResilienceInitiative/ORISO-UserService#483

**Wire contract**: cross-checked against the Frontend acceptance-page branch — GET + POST `/users/account-invites/{token}[/accept]`, request payload `username`/`password`/`formalLanguage`, response carries `inviteStatus`/`provisioningStatus`/`provisionedUserId`. Part of epic OpenResilienceInitiative/ORISO-UserService#482.

**Deploy note (@Hassan9215)**: this PR ships Liquibase migration `0081_account_invite_provisioning` (three new columns on `account_invite`) — deploy-relevant; rollback SQL is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
