### PR TITLE
fix(config): fail at startup when the agency service URLs are missing (#351 ws3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Ja
 - Integration branch: `pre-dev` when used for ORISO feature work.
 - Skim `.understand-anything/` before non-trivial changes; verify graph freshness.
 - Do not invent DTOs/OpenAPI — read existing controllers and generated clients.
+- Controller/facade/saga changes follow `docs/api-error-contract.md` — never
+  answer `2xx` on a failed step, never `5xx` on an expected empty state.
 - Secrets: prefer `config.env.example`; never commit `config.env` or logs with tokens.
 
 ## Done

--- a/docs/api-error-contract.md
+++ b/docs/api-error-contract.md
@@ -1,0 +1,69 @@
+# API error contract
+
+Workstream 2 of epic
+[#351](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/351).
+
+## Why this exists
+
+The production incidents of 2026-07-08 shared one shape: a multi-step operation
+left the system inconsistent, and that inconsistency was either **swallowed**
+(the caller got `200` and nothing had happened) or **hard-crashed** (`500` on a
+state the API should treat as normal). Neither told the caller what to do.
+
+Two concrete cases:
+
+- `setConsultantAgencies` always answered `200`, while the ADR-003 topic
+  validator had rejected the assignment. The Admin showed success; nothing was
+  persisted.
+- `/users/data` answered `500` for a consultant without an agency. "No agency
+  yet" is an expected state, not a server fault, and the whole app died on it.
+
+## The contract
+
+| Situation | Status | Body |
+|---|---|---|
+| Input fails validation | `400` | message describing what is wrong |
+| Caller is authenticated but not allowed | `403` | none |
+| Addressed entity does not exist | `404` | none |
+| Request conflicts with current state (duplicate, concurrent change) | `409` | machine-readable reason where one exists |
+| A downstream service the call depends on failed | `424` / `502` | reason header or body |
+| Operation succeeded, nothing to return | `204` | none |
+| **Expected** empty state (no agencies, no sessions, no appointments yet) | `200` | the empty collection or an object with empty fields |
+| Everything else | `500` | none |
+
+Three rules follow from it, and they are the ones that were broken:
+
+1. **A failure never answers `2xx`.** If any step of a multi-step operation
+   fails, the response is `4xx`/`5xx`. A partial success is a failure.
+2. **An expected empty state never answers `5xx`.** "The user has no X yet" is
+   `200` with an empty payload. Reserve `500` for faults the caller cannot
+   act on.
+3. **Response bodies stay information-poor on purpose.** `ApiResponseEntityExceptionHandler`
+   deliberately withholds internal detail from `403`/`404`/`409` to avoid
+   leaking structure or existence. Put the diagnostic detail in the log, not in
+   the response.
+
+The exception-to-status mapping is enforced by
+`ApiResponseEntityExceptionHandlerTest#mappedExceptionHandlers_returnExpectedHttpStatus`.
+Add a row there whenever you add an exception type.
+
+## Review checklist
+
+Run through this on any PR that touches a controller, a facade, or a saga:
+
+- [ ] Does every `catch` block either rethrow, translate to an
+      `httpresponses` exception, or have a comment saying why swallowing is
+      correct here? A bare `catch (Exception e) { log.error(...) }` before a
+      `return` is a `200`-on-failure bug.
+- [ ] Does the operation touch more than one system (DB + Keycloak + Matrix +
+      another service)? If so, is there a rollback path, and is a failed
+      rollback surfaced rather than logged and forgotten?
+- [ ] Is any `500` in this diff reachable from an empty-but-valid state
+      (no agency, no session, no consultant)? Then it should be `200` with an
+      empty payload, or `404` if the addressed entity truly does not exist.
+- [ ] Do new validation failures produce `400` with a message the Admin or the
+      frontend can show, rather than a silent no-op?
+- [ ] Does a new endpoint appear in the mapping test above?
+- [ ] Are new required config values registered in `ConfigurationValidator`, so
+      a missing one fails at startup instead of as a runtime `500`
+      (workstream 3)?

--- a/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/ConfigurationValidator.java
@@ -43,6 +43,19 @@ public class ConfigurationValidator {
   @Value("${tenant.service.api.url:}")
   private String tenantServiceApiUrl;
 
+  /**
+   * Both agency URLs used to fall back to this service's own base URL when the environment variable
+   * was absent. The service then called itself, and the misconfiguration only surfaced as a runtime
+   * 500 on every consultant-agency read (epic #351, workstream 3). They are required now, so a
+   * deployment that lacks them fails at startup instead — during a rolling update that leaves the
+   * previous, working replica set in place.
+   */
+  @Value("${agency.service.api.url:}")
+  private String agencyServiceApiUrl;
+
+  @Value("${agency.admin.service.api.url:}")
+  private String agencyAdminServiceApiUrl;
+
   @Value("${matrix.apiUrl:}")
   private String matrixApiUrl;
 
@@ -82,6 +95,12 @@ public class ConfigurationValidator {
     }
     if (isEmpty(tenantServiceApiUrl)) {
       missingConfigs.add("tenant.service.api.url (TENANT_SERVICE_API_URL)");
+    }
+    if (isEmpty(agencyServiceApiUrl)) {
+      missingConfigs.add("agency.service.api.url (AGENCY_SERVICE_API_URL)");
+    }
+    if (isEmpty(agencyAdminServiceApiUrl)) {
+      missingConfigs.add("agency.admin.service.api.url (AGENCY_ADMIN_SERVICE_API_URL)");
     }
     if (isEmpty(matrixApiUrl)) {
       missingConfigs.add("matrix.apiUrl (MATRIX_API_URL)");

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -64,7 +64,11 @@ appointments.delete-job-enabled=true
 appointments.lifespan-in-hours=3
 
 # ---------------- Agency Service URL ----------------
-agency.service.api.url=${AGENCY_SERVICE_API_URL:}
+# Placeholder hosts, like the tenant/consulting-type entries above: the agency
+# clients are stubbed in the integration tests, but the URLs must be present
+# because ConfigurationValidator requires them since #351/ws3.
+agency.service.api.url=${AGENCY_SERVICE_API_URL:http://localhost:8085/service}
+agency.admin.service.api.url=${AGENCY_ADMIN_SERVICE_API_URL:http://localhost:8085}
 
 # ---------------- CSRF (match admin app) ----------------
 csrf.header.property=X-CSRF-Token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -140,9 +140,9 @@ springfox.docuPath=/users/docs
 # ---------------- App Service URLs ----------------
 # Use Kubernetes DNS names, e.g., http://agencyservice.caritas.svc.cluster.local:8084/service
 # NOT hardcoded IPs or localhost
-agency.service.api.url=${AGENCY_SERVICE_API_URL:${app.base.url}/service}
+agency.service.api.url=${AGENCY_SERVICE_API_URL:}
 agency.service.api.get.agencies=${agency.service.api.url}/
-agency.admin.service.api.url=${AGENCY_ADMIN_SERVICE_API_URL:${app.base.url}}
+agency.admin.service.api.url=${AGENCY_ADMIN_SERVICE_API_URL:}
 consulting.type.service.api.url=${CONSULTING_TYPE_SERVICE_API_URL:}
 appointment.service.api.url=${APPOINTMENT_SERVICE_API_URL:}
 tenant.service.api.url=${TENANT_SERVICE_API_URL:}

--- a/src/test/java/de/caritas/cob/userservice/api/config/ConfigurationValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/ConfigurationValidatorTest.java
@@ -42,6 +42,42 @@ class ConfigurationValidatorTest {
             "identity.technical-user.password (IDENTITY_TECHNICAL_USER_PASSWORD)");
   }
 
+  /**
+   * Epic #351, workstream 3. A missing AGENCY_ADMIN_SERVICE_API_URL used to fall back to this
+   * service's own base URL, so the UserService called itself and every consultant-agency read
+   * answered 500 at runtime. Startup is the only place where that is cheap to notice.
+   */
+  @Test
+  void validateConfigurationShouldRejectMissingAgencyAdminServiceApiUrl() {
+    setField(validator, "agencyAdminServiceApiUrl", "");
+
+    assertThatThrownBy(validator::validateConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("agency.admin.service.api.url (AGENCY_ADMIN_SERVICE_API_URL)");
+  }
+
+  @Test
+  void validateConfigurationShouldRejectMissingAgencyServiceApiUrl() {
+    setField(validator, "agencyServiceApiUrl", " ");
+
+    assertThatThrownBy(validator::validateConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("agency.service.api.url (AGENCY_SERVICE_API_URL)");
+  }
+
+  @Test
+  void validateConfigurationShouldReportEveryMissingValueAtOnce() {
+    setField(validator, "agencyServiceApiUrl", "");
+    setField(validator, "agencyAdminServiceApiUrl", "");
+    setField(validator, "tenantServiceApiUrl", "");
+
+    assertThatThrownBy(validator::validateConfiguration)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("agency.service.api.url")
+        .hasMessageContaining("agency.admin.service.api.url")
+        .hasMessageContaining("tenant.service.api.url");
+  }
+
   private void givenAllRequiredConfigurationValues() {
     setField(validator, "datasourceUrl", "jdbc:mariadb://mariadb/userservice");
     setField(validator, "datasourceUsername", "userservice");
@@ -53,6 +89,8 @@ class ConfigurationValidatorTest {
     setField(validator, "identityTechnicalPassword", "secret");
     setField(validator, "consultingTypeServiceApiUrl", "https://consulting-type.example/service");
     setField(validator, "tenantServiceApiUrl", "https://tenant.example/service");
+    setField(validator, "agencyServiceApiUrl", "https://agency.example/service");
+    setField(validator, "agencyAdminServiceApiUrl", "https://agency.example");
     setField(validator, "matrixApiUrl", "https://matrix.example");
     setField(validator, "matrixRegistrationSharedSecret", "secret");
   }


### PR DESCRIPTION
## Why

Epic #351 tracks the structural work behind the 2026-07-08 incidents. Its four
workstreams stood at: **1 done** (atomic consultant creation landed in
`eecd4a8a`), **2 partial**, **3 open**, **4 open**. This PR closes workstream 3
and delivers what workstream 2 asked for that was still missing.

## Workstream 3 — config drift

`application.properties` resolved both agency URLs against this service's own
base URL when the environment variables were absent:

```
agency.service.api.url=${AGENCY_SERVICE_API_URL:${app.base.url}/service}
agency.admin.service.api.url=${AGENCY_ADMIN_SERVICE_API_URL:${app.base.url}}
```

So a deployment that forgot them did not fail. The UserService called itself,
and the misconfiguration surfaced only as a runtime `500` on every
consultant-agency read — which is precisely how the missing
`AGENCY_ADMIN_SERVICE_API_URL` took Pre-Dev's consultant listing, login
enrichment and deletion down at once.

Both URLs are required now and registered in the existing
`ConfigurationValidator`. A deployment without them fails at startup instead.
Under a rolling update the previous, working replica set keeps serving, so a
loud boot failure is strictly safer than a silent partial outage.

### Verified against the live clusters before shipping

This change can only break a deploy if a cluster is missing the keys, so I
checked rather than assumed:

| Environment | `AGENCY_ADMIN_SERVICE_API_URL` | `AGENCY_SERVICE_API_URL` |
|---|---|---|
| Pre-Dev (`userservice-configmap-env`) | `http://agencyservice.caritas:8080` | `https://predev.oriso.org/service` |
| dev (`userservice-configmap-env`) | `http://agencyservice.caritas:8080` | `https://dev.oriso.org/service` |
| ORISO-Helm chart | set | set |
| workspace `docker-compose.services.yml` | **was missing** → added | set |

The `userservice` deployment reads both through `configMapKeyRef` on both
clusters. Nothing here CrashLoops on merge.

## Workstream 2 — error contract

The exception→status mapping is already correct and already pinned by
`ApiResponseEntityExceptionHandlerTest#mappedExceptionHandlers_returnExpectedHttpStatus`,
so the handler itself needed no change. What the workstream asked for and did
not exist is the written contract and the review checklist: `docs/api-error-contract.md`,
referenced from `AGENTS.md`.

It states the three rules the incidents broke — a failed step never answers
`2xx`, an expected empty state never answers `5xx`, and `403`/`404`/`409` stay
information-poor on purpose — plus a per-PR checklist for controllers, facades
and sagas.

## Still open on the epic after this

- **Workstream 2** remains partly a review discipline; the doc makes it
  checkable, it does not make it automatic.
- **Workstream 4** (post-deploy smoke gate wiring real Pre-Dev credentials into
  the ORISO-E2E money path) is E2E-repo work and overlaps ORISO-E2E#24 — handled
  there, not here.

## Verification

- `./mvnw -o test` — 3687 tests, 0 failures, BUILD SUCCESS.
- `ConfigurationValidatorTest` — 3 new cases (missing admin URL, missing agency
  URL, all missing values reported at once), 6 total, green.
- `./mvnw -o surefire:test@integration-tests -Dtest=UserServiceApplicationIT` —
  the Spring context still boots under the `testing` profile.
- `./mvnw -o spotless:check` — clean.

## Reviewer test plan

- [ ] Start the service with `AGENCY_ADMIN_SERVICE_API_URL` unset: it refuses to
      boot and names the missing key, instead of starting and 500-ing later.
- [ ] Start it with both set: boots normally.
- [ ] Local stack via `make services`: the UserService comes up with the new
      compose entry.
- [ ] Consultant listing and consultant login on Pre-Dev after deploy.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup validation for required agency service and agency administration service URLs.
  * Missing configuration values are now reported together during startup.
  * Service URLs must now be explicitly configured rather than inferred from the base URL.

* **Documentation**
  * Documented API error-handling rules, including status codes, empty responses, sensitive error details, and review guidance.

* **Tests**
  * Added coverage for missing service URLs and updated valid configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->