### PR TITLE
fix(db): refuse to start when nobody migrates or verifies the schema (#458)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Ja
 - Integration branch: `pre-dev` when used for ORISO feature work.
 - Skim `.understand-anything/` before non-trivial changes; verify graph freshness.
 - Do not invent DTOs/OpenAPI — read existing controllers and generated clients.
+- Entity changes need a Liquibase changeset in the same PR — see
+  `docs/schema-migrations.md`; the service refuses to start without one.
 - Secrets: prefer `config.env.example`; never commit `config.env` or logs with tokens.
 
 ## Done

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -1,0 +1,70 @@
+# Schema migrations on the cluster
+
+Answers issue
+[#458](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/458)
+and the drift-check part of epic
+[#351](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/351).
+
+## The decision: Liquibase on startup (option A)
+
+Migrations run **inside the application on startup**, from
+`classpath:db/changelog/userservice-master.xml`. No pre-deploy Job, no
+initContainer, no hand-written SQL.
+
+Why this and not a pre-deploy Job: the changesets ship in the same artefact as
+the code that needs them, so binding them to the same startup makes it
+impossible for the two to arrive separately — which is exactly what went wrong
+in #458. A Job is a second thing to schedule, order and monitor, and it can
+succeed against a different image than the one that ends up running.
+
+The failure mode people worry about — a migration breaking the rollout — is the
+desired behaviour here. A Kubernetes rolling update keeps the previous, working
+replica set serving until the new pod is ready, so a failed migration blocks the
+new version instead of taking the service down.
+
+## What each mechanism catches
+
+| Mechanism | Catches | On failure |
+|---|---|---|
+| `spring.liquibase.enabled=true` | changeset shipped, not applied | startup fails, rollout stalls |
+| `spring.jpa.hibernate.ddl-auto=validate` | entity changed, **no** changeset written | startup fails, rollout stalls |
+| `SchemaMigrationGuard` | someone switched either of the above off | startup fails, rollout stalls |
+
+The second row is the one that is easy to miss. Liquibase running cleanly proves
+only that the changesets that exist were applied — not that a developer wrote
+one for the column they just added to an entity. Hibernate's `validate` is what
+turns that into a boot failure instead of an `Unknown column` 500 per request.
+
+## The escape hatch
+
+`oriso.migrations.externally-managed=true` allows `spring.liquibase.enabled=false`
+for setups where a pre-deploy job or a DBA owns the migrations. It has to be set
+deliberately, so "we manage migrations elsewhere" and "somebody forgot to turn
+Liquibase back on" no longer look the same from the outside.
+
+Hibernate validation stays required either way.
+
+## Auditing an environment
+
+```bash
+kubectl get configmap -n <ns> userservice-configmap-env \
+  -o jsonpath='{.data.SPRING_LIQUIBASE_ENABLED}{"\n"}'
+
+kubectl exec -n <ns> mariadb-0 -- sh -lc \
+  'mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -N -B -e \
+   "select count(*) from userservice.DATABASECHANGELOG;
+    select id, exectype, dateexecuted from userservice.DATABASECHANGELOG
+    order by orderexecuted desc limit 5;"'
+```
+
+State recorded on 2026-08-04, when #458 was closed out:
+
+| Environment | Liquibase | changesets applied | `consultantPublicSlug` |
+|---|---|---|---|
+| Pre-Dev | enabled | 106 | `EXECUTED` 2026-07-31 14:31 |
+| dev | enabled | 102 | `EXECUTED` 2026-07-31 07:57 |
+
+Both carry the `consultant.pending_public_slug` column, and Pre-Dev's startup log
+reports `Database is up to date, no changesets to execute`. The manual SQL from
+the incident was reconciled into `DATABASECHANGELOG`, so Liquibase does not try
+to re-apply it.

--- a/src/main/java/de/caritas/cob/userservice/api/config/SchemaMigrationGuard.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/SchemaMigrationGuard.java
@@ -1,0 +1,78 @@
+package de.caritas.cob.userservice.api.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Refuses to start when this deployment would run application code against a database nobody
+ * migrates.
+ *
+ * <p>Issue #458: Pre-Dev ran with {@code spring.liquibase.enabled=false}. Changeset 0067 shipped
+ * inside the image and never reached the database, so from the moment that image was deployed every
+ * consultant query answered 500 with {@code Unknown column 'pending_public_slug'} — listing, login
+ * enrichment and deletion at once. Nothing failed at deploy time; the drift only surfaced as
+ * runtime errors, and remediation was hand-written SQL.
+ *
+ * <p>Two mechanisms would each have caught it before a single request was served: Liquibase running
+ * on startup, and Hibernate validating the mapped entities against the live schema. Both are
+ * configured correctly today. This guard is what keeps them that way — a deployment that switches
+ * either off fails during a rolling update, while the previous replica set keeps serving traffic.
+ *
+ * <p>{@code oriso.migrations.externally-managed=true} is the deliberate escape hatch for setups
+ * where a pre-deploy job or a DBA owns the migrations. Hibernate validation stays required either
+ * way: it is the check that catches code shipped without a matching changeset at all.
+ */
+@Component
+@Profile("!testing")
+public class SchemaMigrationGuard {
+
+  /**
+   * Anything that lets Hibernate create or alter tables is unsafe next to Liquibase, and anything
+   * that skips the comparison defeats the purpose. Only {@code validate} does what is wanted here.
+   */
+  private static final Set<String> ACCEPTED_DDL_AUTO_MODES = Set.of("validate");
+
+  @Value("${spring.liquibase.enabled:true}")
+  private boolean liquibaseEnabled;
+
+  @Value("${spring.jpa.hibernate.ddl-auto:}")
+  private String hibernateDdlAuto;
+
+  @Value("${oriso.migrations.externally-managed:false}")
+  private boolean migrationsExternallyManaged;
+
+  @PostConstruct
+  public void validateSchemaMigrationSetup() {
+    List<String> problems = new ArrayList<>();
+
+    if (!liquibaseEnabled && !migrationsExternallyManaged) {
+      problems.add(
+          "spring.liquibase.enabled (SPRING_LIQUIBASE_ENABLED) is false, so changesets shipped in "
+              + "this image will never be applied. Enable it, or declare that something else "
+              + "applies them by setting oriso.migrations.externally-managed=true.");
+    }
+
+    String ddlAuto =
+        hibernateDdlAuto == null ? "" : hibernateDdlAuto.trim().toLowerCase(Locale.ROOT);
+    if (!ACCEPTED_DDL_AUTO_MODES.contains(ddlAuto)) {
+      problems.add(
+          "spring.jpa.hibernate.ddl-auto is '"
+              + ddlAuto
+              + "', expected 'validate'. Without it the service starts against a schema that does "
+              + "not match its entities and fails later with 'Unknown column' at request time.");
+    }
+
+    if (!problems.isEmpty()) {
+      throw new IllegalStateException(
+          "CRITICAL: unsafe database migration setup — this deployment would run against a schema "
+              + "nobody migrates or verifies (see issue #458):\n"
+              + String.join("\n", problems.stream().map(p -> "  - " + p).toList()));
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/config/SchemaMigrationGuardTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/SchemaMigrationGuardTest.java
@@ -1,0 +1,102 @@
+package de.caritas.cob.userservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #458. Pre-Dev ran with {@code spring.liquibase.enabled=false}, so changeset 0067 shipped in
+ * the image but never reached the database. Every consultant query answered 500 with {@code Unknown
+ * column 'pending_public_slug'} — consultant listing, login enrichment and deletion at once, and
+ * the cause was invisible until someone read the schema by hand.
+ *
+ * <p>Both mechanisms that would have caught it exist and are configured correctly today. What did
+ * not exist is anything stopping a deployment from switching them off again.
+ */
+class SchemaMigrationGuardTest {
+
+  private SchemaMigrationGuard guard;
+
+  @BeforeEach
+  void setUp() {
+    guard = new SchemaMigrationGuard();
+    givenMigrationsAreExecutedOnStartup();
+  }
+
+  @Test
+  void shouldPassWhenLiquibaseRunsAndHibernateValidates() {
+    assertThatCode(guard::validateSchemaMigrationSetup).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectDisabledLiquibase() {
+    setField(guard, "liquibaseEnabled", false);
+
+    assertThatThrownBy(guard::validateSchemaMigrationSetup)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("spring.liquibase.enabled")
+        .hasMessageContaining("SPRING_LIQUIBASE_ENABLED");
+  }
+
+  @Test
+  void shouldRejectHibernateSchemaValidationBeingTurnedOff() {
+    setField(guard, "hibernateDdlAuto", "none");
+
+    assertThatThrownBy(guard::validateSchemaMigrationSetup)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("spring.jpa.hibernate.ddl-auto")
+        .hasMessageContaining("none");
+  }
+
+  @Test
+  void shouldRejectSchemaMutatingHibernateModes() {
+    setField(guard, "hibernateDdlAuto", "update");
+
+    assertThatThrownBy(guard::validateSchemaMigrationSetup)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("spring.jpa.hibernate.ddl-auto");
+  }
+
+  @Test
+  void shouldReportEveryProblemAtOnce() {
+    setField(guard, "liquibaseEnabled", false);
+    setField(guard, "hibernateDdlAuto", "none");
+
+    assertThatThrownBy(guard::validateSchemaMigrationSetup)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("spring.liquibase.enabled")
+        .hasMessageContaining("spring.jpa.hibernate.ddl-auto");
+  }
+
+  /**
+   * The escape hatch has to be deliberate. A setup where a DBA or a pre-deploy job owns the
+   * migrations is legitimate; forgetting to switch Liquibase back on is not, and the two must not
+   * look the same from the outside.
+   */
+  @Test
+  void shouldAllowDisabledLiquibaseWhenMigrationsAreDeclaredExternallyManaged() {
+    setField(guard, "liquibaseEnabled", false);
+    setField(guard, "migrationsExternallyManaged", true);
+
+    assertThatCode(guard::validateSchemaMigrationSetup).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldStillRequireHibernateValidationWhenMigrationsAreExternallyManaged() {
+    setField(guard, "migrationsExternallyManaged", true);
+    setField(guard, "hibernateDdlAuto", "none");
+
+    assertThatThrownBy(guard::validateSchemaMigrationSetup)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("spring.jpa.hibernate.ddl-auto");
+  }
+
+  private void givenMigrationsAreExecutedOnStartup() {
+    setField(guard, "liquibaseEnabled", true);
+    setField(guard, "hibernateDdlAuto", "validate");
+    setField(guard, "migrationsExternallyManaged", false);
+  }
+}


### PR DESCRIPTION
## Why

#458 asks for one decision and one guarantee: pick a migration-execution
strategy, and make a deployment fail loudly instead of serving `Unknown column`
500s.

The incident: Pre-Dev ran with `spring.liquibase.enabled=false`. Changeset 0067
shipped inside the image and never reached the database, so from the moment that
image deployed, every consultant query answered `500` with
`Unknown column 'pending_public_slug'` — consultant listing, login enrichment
and deletion at once. Nothing failed at deploy time. The remediation was
hand-written SQL.

## The decision — option A, documented

`docs/schema-migrations.md` records it: **Liquibase on startup**. The changesets
ship in the same artefact as the code that needs them, so binding both to the
same startup makes it impossible for them to arrive separately — which is
precisely what went wrong. A pre-deploy Job is a second thing to schedule and
order, and it can succeed against a different image than the one that ends up
running.

The objection to option A — "a bad migration breaks the rollout" — is the
desired behaviour. A rolling update keeps the previous replica set serving until
the new pod is ready, so a failed migration blocks the new version rather than
taking the service down.

## What this PR adds

Both mechanisms that would have caught the incident already exist and are
configured correctly **today**:

| Mechanism | Catches | On failure |
|---|---|---|
| `spring.liquibase.enabled=true` | changeset shipped, not applied | startup fails, rollout stalls |
| `spring.jpa.hibernate.ddl-auto=validate` | entity changed, **no** changeset written | startup fails, rollout stalls |

The second row matters and is easy to miss: a clean Liquibase run only proves
that the changesets which exist were applied — not that anyone wrote one for the
column just added to an entity.

What did not exist is anything keeping either setting that way. `SchemaMigrationGuard`
refuses to start when either is switched off. `oriso.migrations.externally-managed=true`
is the deliberate escape hatch for a Job- or DBA-owned setup, so "we migrate
elsewhere" and "someone forgot to switch Liquibase back on" stop looking
identical from the outside. Hibernate validation stays required either way.

## Acceptance, checked against the live clusters

> Deploying an image containing a new changeset applies that changeset on Pre-Dev
> without manual SQL

Satisfied. `SPRING_LIQUIBASE_ENABLED=true` in `userservice-configmap-env`, and
Pre-Dev's startup log reports `Database is up to date, no changesets to execute`.

> dev/other environments audited for the same missing 0067 changeset

Audited:

| Environment | Liquibase | changesets applied | `consultantPublicSlug` | `consultant.pending_public_slug` |
|---|---|---|---|---|
| Pre-Dev | enabled | 106 | `EXECUTED` 2026-07-31 14:31 | present |
| dev | enabled | 102 | `EXECUTED` 2026-07-31 07:57 | present |

The manual SQL from the incident was reconciled into `DATABASECHANGELOG` on both,
so Liquibase does not try to re-apply it — worth confirming, because an
unreconciled manual fix would have made the next startup fail on "column already
exists".

> Drift check documented (or automated) per #351

Automated by the guard, documented in `docs/schema-migrations.md`, with the audit
commands included so the next person does not have to reconstruct them.

## Verification

- `./mvnw -o test` — 3691 tests, 0 failures, BUILD SUCCESS.
- `SchemaMigrationGuardTest` — 7 cases: disabled Liquibase, `ddl-auto=none`,
  `ddl-auto=update`, both at once, the escape hatch, and that the escape hatch
  does **not** waive Hibernate validation.
- `./mvnw -o spotless:apply` — formatted.
- The guard is `@Profile("!testing")`; the `testing` profile legitimately runs
  `create-drop` with Liquibase off, and integration tests are unaffected.

## Reviewer test plan

- [ ] Start with `SPRING_LIQUIBASE_ENABLED=false`: refuses to boot, names the
      variable and the escape hatch.
- [ ] Add `oriso.migrations.externally-managed=true`: boots again.
- [ ] Override `spring.jpa.hibernate.ddl-auto=none`: refuses to boot even with
      the escape hatch set.
- [ ] Normal Pre-Dev config: boots, Liquibase logs "up to date".

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
