### PR TITLE
Allow Liquibase context override

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -57,7 +57,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # Single master changelog (see application.properties); SPRING_LIQUIBASE_ENABLED
 # is the cluster-level kill switch (defaults true).
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=dev,seed
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:dev,seed}
 
 # ---------------- Local App Settings ----------------
 app.base.url=${APP_BASE_URL:http://localhost:8082}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -58,7 +58,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # required so that changesets tagged context="seed" do NOT run here (Liquibase
 # runs context-tagged changesets when no runtime context is given).
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=prod
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:prod}
 
 # ---------------- Local App Settings ----------------
 app.base.url=${APP_BASE_URL:http://localhost:8082}

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -46,7 +46,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # is the cluster-level kill switch (defaults true). Explicit context keeps
 # seed-tagged changesets out (see application-prod.properties note).
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=staging
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:staging}
 
 # ---------------- Local App Settings ----------------
 app.base.url=${APP_BASE_URL:http://localhost:8082}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.data.jpa.repositories.bootstrap-mode=default
 spring.liquibase.change-log=classpath:db/changelog/userservice-master.xml
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
 # local (default profile) also applies seed/demo changesets
-spring.liquibase.contexts=local,seed
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:local,seed}
 
 # ---------------- Redis ----------------
 # Boot 4 uses spring.data.redis.*; fall back to the old SPRING_REDIS_* env vars so that


### PR DESCRIPTION
## Summary
- keep the service-owned userservice master changelog path in the image
- allow Helm/runtime to override Liquibase contexts via SPRING_LIQUIBASE_CONTEXTS
- preserve existing profile defaults when the env var is unset

## Validation
- mvn -q -DskipTests validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring database migration contexts through the `SPRING_LIQUIBASE_CONTEXTS` environment variable.
  - Environment-specific defaults remain available for local, development, staging, and production deployments.
  - This allows migration and seed data behavior to be adjusted without changing application configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->