### PR TITLE
fix(matrixrtc): resolve call policy in technical tenant context

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallPolicyDenialReason.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallPolicyDenialReason.java
@@ -8,6 +8,7 @@ package de.caritas.cob.userservice.api.service.matrixrtc;
  */
 public enum CallPolicyDenialReason {
   NOT_ROOM_MEMBER,
+  ROOM_MEMBERS_UNAVAILABLE,
   NO_TENANT_CONTEXT,
   TENANT_SETTINGS_UNAVAILABLE,
   CALLS_DISABLED_FOR_TENANT

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallPolicyDenialReason.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/CallPolicyDenialReason.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+/**
+ * Reason a {@link MatrixRtcCallPolicyService} denied a call-policy request.
+ *
+ * <p>These codes are safe to log: unlike the raw Matrix room id / user id involved in a denied
+ * request, a reason code alone does not expose conversation or user identifiers to log consumers.
+ */
+public enum CallPolicyDenialReason {
+  NOT_ROOM_MEMBER,
+  NO_TENANT_CONTEXT,
+  TENANT_SETTINGS_UNAVAILABLE,
+  CALLS_DISABLED_FOR_TENANT
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -5,6 +5,9 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +17,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class MatrixRtcCallPolicyService {
+
+  private static final int CORRELATION_ID_HEX_CHARS = 12;
 
   private final @NonNull MatrixRtcPolicyContextResolver contextResolver;
   private final @NonNull TenantService tenantService;
@@ -45,29 +50,36 @@ public class MatrixRtcCallPolicyService {
   }
 
   private CallMediaPolicy resolveCrossTenant(String sourceRoomId, String matrixUserId) {
+    // Denial logs below must never carry the raw Matrix room id / user id: those identify a
+    // conversation and its participant to anyone with log access. correlationId is a one-way
+    // hash of the pair, stable for this request, so denials for the same room+user can still be
+    // correlated across log lines without exposing either identifier.
+    var correlationId = correlationId(sourceRoomId, matrixUserId);
+
     var currentMembers = matrixSynapseService.getRoomMembers(sourceRoomId);
     if (currentMembers.isEmpty() || !currentMembers.get().contains(matrixUserId)) {
       log.info(
-          "Call policy denied for room {}: user {} is not a current room member",
-          sourceRoomId,
-          matrixUserId);
+          "Call policy denied [{}]: reason={}",
+          correlationId,
+          CallPolicyDenialReason.NOT_ROOM_MEMBER);
       return CallMediaPolicy.denied();
     }
 
     var context = contextResolver.resolve(sourceRoomId);
     if (context.isEmpty() || context.get().tenantId() == null) {
       log.info(
-          "Call policy denied for room {}: no session, chat, supervision or team discussion with"
-              + " a tenant id resolves to this room",
-          sourceRoomId);
+          "Call policy denied [{}]: reason={}",
+          correlationId,
+          CallPolicyDenialReason.NO_TENANT_CONTEXT);
       return CallMediaPolicy.denied();
     }
 
     var tenant = getTenant(context.get().tenantId());
     if (tenant == null || tenant.getSettings() == null) {
       log.info(
-          "Call policy denied for room {}: tenant {} settings could not be loaded",
-          sourceRoomId,
+          "Call policy denied [{}]: reason={}, tenant={}",
+          correlationId,
+          CallPolicyDenialReason.TENANT_SETTINGS_UNAVAILABLE,
           context.get().tenantId());
       return CallMediaPolicy.denied();
     }
@@ -75,8 +87,9 @@ public class MatrixRtcCallPolicyService {
     var settings = tenant.getSettings();
     if (!enabled(settings.getFeatureCallsEnabled())) {
       log.info(
-          "Call policy denied for room {}: featureCallsEnabled is off for tenant {}",
-          sourceRoomId,
+          "Call policy denied [{}]: reason={}, tenant={}",
+          correlationId,
+          CallPolicyDenialReason.CALLS_DISABLED_FOR_TENANT,
           context.get().tenantId());
       return CallMediaPolicy.denied();
     }
@@ -122,5 +135,25 @@ public class MatrixRtcCallPolicyService {
 
   private boolean enabled(Boolean value) {
     return !Boolean.FALSE.equals(value);
+  }
+
+  /**
+   * Derives a one-way, non-reversible correlation value for a (room id, user id) pair, safe to
+   * include in logs. Same pair always hashes to the same value, so repeated denials for the same
+   * room and user can be correlated without ever logging the raw Matrix identifiers.
+   */
+  private static String correlationId(String sourceRoomId, String matrixUserId) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      var hash =
+          digest.digest((sourceRoomId + ':' + matrixUserId).getBytes(StandardCharsets.UTF_8));
+      var hex = new StringBuilder(hash.length * 2);
+      for (byte value : hash) {
+        hex.append(String.format("%02x", value));
+      }
+      return hex.substring(0, CORRELATION_ID_HEX_CHARS);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -57,7 +57,14 @@ public class MatrixRtcCallPolicyService {
     var correlationId = correlationId(sourceRoomId, matrixUserId);
 
     var currentMembers = matrixSynapseService.getRoomMembers(sourceRoomId);
-    if (currentMembers.isEmpty() || !currentMembers.get().contains(matrixUserId)) {
+    if (currentMembers.isEmpty()) {
+      log.info(
+          "Call policy denied [{}]: reason={}",
+          correlationId,
+          CallPolicyDenialReason.ROOM_MEMBERS_UNAVAILABLE);
+      return CallMediaPolicy.denied();
+    }
+    if (!currentMembers.get().contains(matrixUserId)) {
       log.info(
           "Call policy denied [{}]: reason={}",
           correlationId,

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -5,9 +5,6 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +15,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class MatrixRtcCallPolicyService {
 
-  private static final int CORRELATION_ID_HEX_CHARS = 12;
-
   private final @NonNull MatrixRtcPolicyContextResolver contextResolver;
   private final @NonNull TenantService tenantService;
   private final @NonNull MatrixSynapseService matrixSynapseService;
+  private final @NonNull MatrixRtcCorrelationIdHasher correlationIdHasher;
 
   public CallMediaPolicy resolve(String sourceRoomId, String matrixUserId) {
     if (sourceRoomId == null
@@ -51,10 +47,11 @@ public class MatrixRtcCallPolicyService {
 
   private CallMediaPolicy resolveCrossTenant(String sourceRoomId, String matrixUserId) {
     // Denial logs below must never carry the raw Matrix room id / user id: those identify a
-    // conversation and its participant to anyone with log access. correlationId is a one-way
-    // hash of the pair, stable for this request, so denials for the same room+user can still be
-    // correlated across log lines without exposing either identifier.
-    var correlationId = correlationId(sourceRoomId, matrixUserId);
+    // conversation and its participant to anyone with log access. correlationId is a keyed
+    // (HMAC) hash of the pair, stable for this request, so denials for the same room+user can
+    // still be correlated across log lines without exposing either identifier or letting a log
+    // consumer confirm a candidate pair by hashing it themselves.
+    var correlationId = correlationIdHasher.correlationId(sourceRoomId, matrixUserId);
 
     var currentMembers = matrixSynapseService.getRoomMembers(sourceRoomId);
     if (currentMembers.isEmpty()) {
@@ -142,25 +139,5 @@ public class MatrixRtcCallPolicyService {
 
   private boolean enabled(Boolean value) {
     return !Boolean.FALSE.equals(value);
-  }
-
-  /**
-   * Derives a one-way, non-reversible correlation value for a (room id, user id) pair, safe to
-   * include in logs. Same pair always hashes to the same value, so repeated denials for the same
-   * room and user can be correlated without ever logging the raw Matrix identifiers.
-   */
-  private static String correlationId(String sourceRoomId, String matrixUserId) {
-    try {
-      var digest = MessageDigest.getInstance("SHA-256");
-      var hash =
-          digest.digest((sourceRoomId + ':' + matrixUserId).getBytes(StandardCharsets.UTF_8));
-      var hex = new StringBuilder(hash.length * 2);
-      for (byte value : hash) {
-        hex.append(String.format("%02x", value));
-      }
-      return hex.substring(0, CORRELATION_ID_HEX_CHARS);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyService.java
@@ -2,14 +2,17 @@ package de.caritas.cob.userservice.api.service.matrixrtc;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MatrixRtcCallPolicyService {
 
   private final @NonNull MatrixRtcPolicyContextResolver contextResolver;
@@ -24,23 +27,57 @@ public class MatrixRtcCallPolicyService {
       return CallMediaPolicy.denied();
     }
 
+    // The call-policy endpoint is whitelisted from HttpTenantFilter, so this thread has no
+    // tenant context. Without technical context TenantAspect enables the Hibernate
+    // tenantFilter with tenantId=null, the room-to-session lookup matches nothing, and every
+    // call is denied regardless of tenant settings.
+    var callerTenant = TenantContext.getCurrentTenant();
+    try {
+      TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+      return resolveCrossTenant(sourceRoomId, matrixUserId);
+    } finally {
+      if (callerTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenant(callerTenant);
+      }
+    }
+  }
+
+  private CallMediaPolicy resolveCrossTenant(String sourceRoomId, String matrixUserId) {
     var currentMembers = matrixSynapseService.getRoomMembers(sourceRoomId);
     if (currentMembers.isEmpty() || !currentMembers.get().contains(matrixUserId)) {
+      log.info(
+          "Call policy denied for room {}: user {} is not a current room member",
+          sourceRoomId,
+          matrixUserId);
       return CallMediaPolicy.denied();
     }
 
     var context = contextResolver.resolve(sourceRoomId);
     if (context.isEmpty() || context.get().tenantId() == null) {
+      log.info(
+          "Call policy denied for room {}: no session, chat, supervision or team discussion with"
+              + " a tenant id resolves to this room",
+          sourceRoomId);
       return CallMediaPolicy.denied();
     }
 
     var tenant = getTenant(context.get().tenantId());
     if (tenant == null || tenant.getSettings() == null) {
+      log.info(
+          "Call policy denied for room {}: tenant {} settings could not be loaded",
+          sourceRoomId,
+          context.get().tenantId());
       return CallMediaPolicy.denied();
     }
 
     var settings = tenant.getSettings();
     if (!enabled(settings.getFeatureCallsEnabled())) {
+      log.info(
+          "Call policy denied for room {}: featureCallsEnabled is off for tenant {}",
+          sourceRoomId,
+          context.get().tenantId());
       return CallMediaPolicy.denied();
     }
 
@@ -57,6 +94,10 @@ public class MatrixRtcCallPolicyService {
     try {
       return tenantService.getRestrictedTenantDataFresh(tenantId);
     } catch (RuntimeException tenantServiceFailure) {
+      log.warn(
+          "Call policy tenant lookup failed for tenant {}: {}",
+          tenantId,
+          tenantServiceFailure.getMessage());
       return null;
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCorrelationIdHasher.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCorrelationIdHasher.java
@@ -1,0 +1,51 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Derives a keyed correlation value for a Matrix room id / user id pair, for use in {@link
+ * MatrixRtcCallPolicyService} denial logs.
+ *
+ * <p>This is deliberately HMAC-SHA256, not a plain digest: an unkeyed hash of the pair would let
+ * anyone with a candidate room id and user id confirm whether it matches a logged correlation value
+ * simply by hashing it themselves. Keying the hash with a secret only this service holds closes
+ * that confirmation channel. Mirrors {@code ConsultantIdentityHasher}'s pseudonymization pattern in
+ * the statistics package.
+ */
+@Component
+public class MatrixRtcCorrelationIdHasher {
+
+  private static final String ALGORITHM = "HmacSHA256";
+  private static final int CORRELATION_ID_HEX_CHARS = 12;
+
+  @Value("${matrixrtc.call-policy.hmac-secret}")
+  private String secret;
+
+  private Mac mac;
+
+  @PostConstruct
+  void init() throws NoSuchAlgorithmException, InvalidKeyException {
+    if (secret == null || secret.isBlank()) {
+      throw new IllegalStateException(
+          "matrixrtc.call-policy.hmac-secret must be set (MATRIXRTC_CALL_POLICY_HMAC_SECRET)");
+    }
+    mac = Mac.getInstance(ALGORITHM);
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), ALGORITHM));
+  }
+
+  /** Returns the truncated, hex-encoded HMAC-SHA256 of the given room id / user id pair. */
+  public synchronized String correlationId(String sourceRoomId, String matrixUserId) {
+    var hex =
+        Hex.encodeHexString(
+            mac.doFinal((sourceRoomId + ':' + matrixUserId).getBytes(StandardCharsets.UTF_8)));
+    return hex.substring(0, CORRELATION_ID_HEX_CHARS);
+  }
+}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -93,4 +93,5 @@ keycloak.ssl-required=none
 matrix.apiUrl=${MATRIX_API_URL:http://localhost:8008}
 matrix.event-listener.enabled=false
 statistics.message-count.hmac-secret=${STATISTICS_MESSAGE_COUNT_HMAC_SECRET:test-hmac-secret}
+matrixrtc.call-policy.hmac-secret=${MATRIXRTC_CALL_POLICY_HMAC_SECRET:test-hmac-secret}
 matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:secret}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,6 +75,11 @@ service.encryption.appkey=
 # secret keeps the two purposes cryptographically independent.
 statistics.message-count.hmac-secret=${STATISTICS_MESSAGE_COUNT_HMAC_SECRET:}
 
+# Secret for HMAC-SHA256 correlation ids in MatrixRTC call-policy denial logs (see
+# MatrixRtcCorrelationIdHasher). A dedicated secret, independent of the ones above, so none of
+# these purposes can be cross-correlated if one secret leaks.
+matrixrtc.call-policy.hmac-secret=${MATRIXRTC_CALL_POLICY_HMAC_SECRET:}
+
 # ---------------- User Workflows ----------------
 user.account.deleteworkflow.cron=0 0 0 * * ?
 user.account.deleteworkflow.claim.duration=PT12H

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MatrixRtcCallPolicyServiceTest {
@@ -54,7 +55,8 @@ class MatrixRtcCallPolicyServiceTest {
                 sessionSupervisorRepository,
                 teamDiscussionRepository),
             tenantService,
-            matrixSynapseService);
+            matrixSynapseService,
+            correlationIdHasher());
     when(matrixSynapseService.getRoomMembers(ROOM_ID))
         .thenReturn(Optional.of(List.of(MATRIX_USER_ID)));
   }
@@ -272,6 +274,13 @@ class MatrixRtcCallPolicyServiceTest {
     } finally {
       TenantContext.clear();
     }
+  }
+
+  private MatrixRtcCorrelationIdHasher correlationIdHasher() {
+    var hasher = new MatrixRtcCorrelationIdHasher();
+    ReflectionTestUtils.setField(hasher, "secret", "test-hmac-secret");
+    ReflectionTestUtils.invokeMethod(hasher, "init");
+    return hasher;
   }
 
   private Session session(ConversationType conversationType) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Settings;
 import java.util.List;
@@ -231,6 +232,46 @@ class MatrixRtcCallPolicyServiceTest {
         .thenThrow(new IllegalStateException("tenant service unavailable"));
 
     assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(CallMediaPolicy.denied());
+  }
+
+  @Test
+  void resolvesRoomLookupInTechnicalTenantContext() {
+    // The call-policy endpoint is whitelisted from HttpTenantFilter, so resolve() runs
+    // without tenant context. TenantAspect would then enable the Hibernate tenantFilter
+    // with tenantId=null and the room lookup could never match; only technical context
+    // disables the filter.
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    var tenantDuringLookup = new java.util.concurrent.atomic.AtomicReference<Long>();
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID))
+        .thenAnswer(
+            invocation -> {
+              tenantDuringLookup.set(TenantContext.getCurrentTenant());
+              return Optional.of(session);
+            });
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(tenant(enabledSettings()));
+
+    TenantContext.clear();
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(new CallMediaPolicy(true, true));
+    assertThat(tenantDuringLookup.get()).isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
+    assertThat(TenantContext.getCurrentTenant()).isNull();
+  }
+
+  @Test
+  void restoresCallerTenantContextAfterResolution() {
+    var session = session(ConversationType.AGENCY_COUNSELLING);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(session));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(tenant(enabledSettings()));
+
+    TenantContext.setCurrentTenant(42L);
+    try {
+      assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+          .isEqualTo(new CallMediaPolicy(true, true));
+      assertThat(TenantContext.getCurrentTenant()).isEqualTo(42L);
+    } finally {
+      TenantContext.clear();
+    }
   }
 
   private Session session(ConversationType conversationType) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCorrelationIdHasherTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCorrelationIdHasherTest.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.userservice.api.service.matrixrtc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MatrixRtcCorrelationIdHasherTest {
+
+  private static final String ROOM_ID = "!source:matrix.oriso.org";
+  private static final String MATRIX_USER_ID = "@participant:matrix.oriso.org";
+
+  private MatrixRtcCorrelationIdHasher newHasher(String secret) {
+    var hasher = new MatrixRtcCorrelationIdHasher();
+    ReflectionTestUtils.setField(hasher, "secret", secret);
+    ReflectionTestUtils.invokeMethod(hasher, "init");
+    return hasher;
+  }
+
+  @Test
+  void correlationIdShouldBeDeterministicForSameRoomAndUserIdAndSecret() {
+    var hasher = newHasher("secret-a");
+
+    assertThat(hasher.correlationId(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(hasher.correlationId(ROOM_ID, MATRIX_USER_ID));
+  }
+
+  @Test
+  void correlationIdShouldDifferForDifferentRoomOrUserIds() {
+    var hasher = newHasher("secret-a");
+
+    assertThat(hasher.correlationId(ROOM_ID, MATRIX_USER_ID))
+        .isNotEqualTo(hasher.correlationId(ROOM_ID, "@someone-else:matrix.oriso.org"))
+        .isNotEqualTo(hasher.correlationId("!other:matrix.oriso.org", MATRIX_USER_ID));
+  }
+
+  @Test
+  void correlationIdShouldDifferAcrossSecrets_soACandidatePairCannotBeConfirmedWithoutTheSecret() {
+    assertThat(newHasher("secret-a").correlationId(ROOM_ID, MATRIX_USER_ID))
+        .isNotEqualTo(newHasher("secret-b").correlationId(ROOM_ID, MATRIX_USER_ID));
+  }
+
+  @Test
+  void correlationIdShouldNeverContainTheRawRoomOrUserId() {
+    var hasher = newHasher("secret-a");
+
+    assertThat(hasher.correlationId(ROOM_ID, MATRIX_USER_ID))
+        .doesNotContain(ROOM_ID)
+        .doesNotContain(MATRIX_USER_ID);
+  }
+
+  @Test
+  void initShouldFailFastWhenSecretIsBlank() {
+    var hasher = new MatrixRtcCorrelationIdHasher();
+    ReflectionTestUtils.setField(hasher, "secret", "");
+
+    assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(hasher, "init"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
## Problem

Element Call fails with **"Call access denied" (403)** for every user on predev, even when the user is a joined member of the session's Matrix room and all tenant call feature flags are enabled.

## Root cause

`/internal/matrixrtc/call-policy` is whitelisted from `HttpTenantFilter` (it is a cluster-internal, token-authenticated endpoint), so requests to it run **without tenant context**. `TenantAspect` fires before every repository call and, since the context is neither set nor technical, enables the Hibernate `tenantFilter` with `tenantId=null`:

```
(tenant_id = null OR (null = 1 AND tenant_id IS NULL))
```

This matches no rows, so `MatrixRtcPolicyContextResolver` never finds the session for the room, `MatrixRtcCallPolicyService` returns `CallMediaPolicy.denied()`, and the auth policy gateway fail-closes the call with 403 — silently: no log line on the whole path.

Verified on predev against session 78 / room `!WWoaRyNZzdCCHRRSXp`: the DB row has the correct `matrix_room_id` and `tenant_id=1`, tenant 1 has all call flags enabled, the user is one of 13 joined room members, yet the endpoint returned `{"audioAllowed":false,"videoAllowed":false}`.

## Fix

- Run the policy resolution under the technical tenant context (same `runCrossTenant` pattern as `AnonymousUsernameRegistry`), restoring the caller's tenant afterwards.
- Log the reason for every denial (non-member, unresolvable room, tenant lookup failure, flags off) so the next fail-closed 403 is diagnosable from userservice logs instead of requiring DB spelunking.

## Tests

- `resolvesRoomLookupInTechnicalTenantContext` — asserts the repository lookup observes `TECHNICAL_TENANT_ID` and the context is cleared afterwards (fails on pre-dev's current behavior).
- `restoresCallerTenantContextAfterResolution` — asserts a caller's tenant survives resolution.
- All 18 matrixrtc call-policy tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cross-tenant call-policy checks by correctly managing tenant context.
  * Preserved the caller’s tenant context after policy evaluation completes.
  * Improved handling and diagnostics for tenant lookup failures and denied call-policy requests.
  * Added standardized, privacy-conscious denial reasons for call-policy decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->