### PR TITLE
feat(erstantwort): produce the FIRST_RESPONSE event on the Matrix enquiry path (ADR-018)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -20,6 +20,10 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortContext;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortModality;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortPayloadBuilder;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -45,6 +49,8 @@ public class CreateEnquiryMessageFacade {
   private final @NonNull TopicConsultantRoutingService topicConsultantRoutingService;
   private final @NonNull EventNotificationService eventNotificationService;
   private final @NonNull AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
+  private final @NonNull ErstantwortPayloadBuilder erstantwortPayloadBuilder;
+  private final @NonNull MatrixSessionSystemMessageService matrixSessionSystemMessageService;
 
   public CreateEnquiryMessageResponseDTO createEnquiryMessage(EnquiryData enquiryData) {
     try {
@@ -84,6 +90,7 @@ public class CreateEnquiryMessageFacade {
             .build();
     updateMatrixSession(session, enquiryData.getLanguage(), matrixRoomId, exceptionInformation);
     sendEnquiryNotifications(session, agencyList);
+    postErstantwort(session);
 
     return new CreateEnquiryMessageResponseDTO()
         .matrixRoomId(matrixRoomId)
@@ -161,6 +168,40 @@ public class CreateEnquiryMessageFacade {
     }
 
     persistNewClientRequestNotifications(session, agencyList);
+  }
+
+  /**
+   * ADR-018 / ORISO-UserService#926: the Erstantwort, posted once, right after the enquiry has been
+   * dispatched and the counsellors notified.
+   *
+   * <p><b>After the notifications on purpose.</b> The person's message reaching a counsellor is the
+   * thing that must happen; the platform's own greeting is second. Everything in here is wrapped so
+   * that no failure — serialisation, Matrix, the timeline row — can roll back a dispatched enquiry.
+   *
+   * <p>In this slice only the platform level of the resolution chain has content. The chain itself
+   * is already implemented in {@link ErstantwortPayloadBuilder}, so ORISO-Admin#601 adding the
+   * Träger editor is a form, not a migration.
+   */
+  private void postErstantwort(Session session) {
+    try {
+      var body =
+          erstantwortPayloadBuilder.buildFirstResponseBody(
+              ErstantwortContext.builder()
+                  /* This facade only ever handles enquiries, and an enquiry exists
+                  only in Agency Counselling — checkIfNotAnonymousEnquiry rejects
+                  the anonymous Live Chat path before we get here, and Self-Help
+                  groups never call it. Pinning the modality rather than deriving
+                  it keeps the Live-Chat exclusions honest instead of accidental. */
+                  .modality(ErstantwortModality.AGENCY_COUNSELLING)
+                  .build());
+      if (body == null) {
+        return;
+      }
+      matrixSessionSystemMessageService.postFirstResponseMessage(session, body);
+      eventNotificationService.createFirstResponseNotification(session);
+    } catch (RuntimeException exception) {
+      log.warn("Could not post the Erstantwort for session {}", session.getId(), exception);
+    }
   }
 
   private boolean isAppointmentEnquiryMessage(EnquiryData enquiryData) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacade.java
@@ -182,6 +182,15 @@ public class CreateEnquiryMessageFacade {
    * is already implemented in {@link ErstantwortPayloadBuilder}, so ORISO-Admin#601 adding the
    * Träger editor is a form, not a migration.
    */
+  /**
+   * The asker's own German variant. Defaults to formal when no user is resolvable — the safer
+   * error: addressing somebody formally who expected "Du" is a mismatch, while addressing somebody
+   * informally who expected "Sie" reads as a service that does not know who it is talking to.
+   */
+  private boolean isFormalLanguage(Session session) {
+    return session.getUser() == null || session.getUser().isLanguageFormal();
+  }
+
   private void postErstantwort(Session session) {
     try {
       var body =
@@ -193,6 +202,12 @@ public class CreateEnquiryMessageFacade {
                   groups never call it. Pinning the modality rather than deriving
                   it keeps the Live-Chat exclusions honest instead of accidental. */
                   .modality(ErstantwortModality.AGENCY_COUNSELLING)
+                  /* Without this every German wording defaulted to the formal
+                  variant, so an informal Träger's advice seekers were addressed
+                  with "Sie" throughout their own Erstantwort. `languageFormal` on
+                  the User is the same flag AskerDataProvider already uses to pick
+                  the German variant everywhere else. */
+                  .informal(!isFormalLanguage(session))
                   .build());
       if (body == null) {
         return;

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AnonymousEnquiryConsentGuard.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AnonymousEnquiryConsentGuard.java
@@ -1,0 +1,63 @@
+package de.caritas.cob.userservice.api.facade.assignsession;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.model.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Server-side enforcement of the data-protection consent on <b>anonymous</b> entry paths (ADR-018
+ * §9, ORISO-UserService#927).
+ *
+ * <h2>Why this exists at all, given the gate already works</h2>
+ *
+ * The forward lock is real today, but it is enforced by the client: the composer stays hidden while
+ * the session sits in the pre-assignment enquiry phase, so nothing has been sent and nobody has
+ * picked the case up. That guarantee holds — it is not a false promise — but it rests on a UI
+ * invariant. This is the defence in depth for a bypassed client, on the consent step for
+ * special-category data under §11 KDG.
+ *
+ * <h2>Why it is scoped so narrowly</h2>
+ *
+ * Only anonymous entry paths. In Agency Counselling consent is given during registration, per the
+ * topic-before-consent invariant of ADR-014, and {@code CreateUserFacade} deliberately clears
+ * {@code dataPrivacyConfirmation} for anonymous registrations precisely so the in-chat gate fires
+ * there and only there. A blanket check on every assignment would therefore reject perfectly
+ * consented registered enquiries — the guard would break the product it is meant to protect.
+ *
+ * <h2>What it must never do</h2>
+ *
+ * Delay an assignment for anything voluntary. E-mail, 2FA and credential saving are optional
+ * throughout (ADR-018 §9: forward lock yes, backward lock no) and have no bearing here.
+ */
+@Component
+@Slf4j
+public class AnonymousEnquiryConsentGuard {
+
+  /**
+   * @param session the anonymous session about to be assigned
+   * @throws ConflictException if the advice seeker has not recorded their consent
+   */
+  public void verifyAnonymousConsent(Session session) {
+    if (session == null || session.getUser() == null) {
+      /* Not an anonymous advice seeker awaiting consent. Failing an assignment on
+      a malformed session would turn a hardening measure into an outage; the
+      existing validators own that case. */
+      return;
+    }
+    if (session.getUser().getDataPrivacyConfirmation() != null) {
+      return;
+    }
+    log.warn(
+        "Rejecting assignment of anonymous session {} — no data privacy confirmation recorded",
+        session.getId());
+    /* The message reaches a consultant client and concerns somebody who chose not
+    to identify themselves, so it names the session and the reason and nothing
+    about the person. */
+    throw new ConflictException(
+        String.format(
+            "Anonymous session %s cannot be assigned before the advice seeker confirmed the"
+                + " data protection notice",
+            session.getId()));
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -67,6 +67,8 @@ public class AssignEnquiryFacade {
 
   private final @NonNull TeamDiscussionFacade teamDiscussionFacade;
 
+  private final @NonNull AnonymousEnquiryConsentGuard anonymousEnquiryConsentGuard;
+
   /**
    * Assigns the given {@link Session} to the given {@link Consultant} and removes consultants who
    * no longer have permission from its Matrix room.
@@ -111,6 +113,11 @@ public class AssignEnquiryFacade {
    * @param consultant the consultant to assign
    */
   public void assignAnonymousEnquiry(Session session, Consultant consultant) {
+    /* ADR-018 §9 / ORISO-UserService#927: defence in depth for a bypassed client.
+    Anonymous entry paths only — in Agency Counselling consent is given at
+    registration (ADR-014) and assignRegisteredEnquiry deliberately does not
+    carry this check. */
+    anonymousEnquiryConsentGuard.verifyAnonymousConsent(session);
     assignEnquiry(session, consultant);
     eventNotificationService.createInquiryAcceptedNotification(session, consultant);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortContext.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortContext.java
@@ -1,0 +1,57 @@
+package de.caritas.cob.userservice.api.service.erstantwort;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Everything the Erstantwort needs in order to resolve, gathered once at send time.
+ *
+ * <p>The {@code …ByTopic / …ByAgency / …ByTenant} triples implement ADR-018 §6: editorial content
+ * hangs at Träger level, but the resolution chain <em>Fachbereich ?? Beratungsstelle ?? Träger ??
+ * Plattform</em> exists from day one, so that adding the middle levels later is a form rather than
+ * a migration. In this slice only the platform link is populated in production — the fields are
+ * here, resolved and tested, waiting for ORISO-Admin#601 to fill them.
+ *
+ * <p>Derived values ({@code responseDeadlineDays}, {@code dataPrivacyUrl}, {@code imprintUrl}) come
+ * from configuration and are never text fields: a typed claim about the system can be false, a
+ * rendered one cannot.
+ */
+@Value
+@Builder
+public class ErstantwortContext {
+
+  ErstantwortModality modality;
+
+  /**
+   * The Antwortfrist as a <em>number</em> (ADR-018), so the promise is exactly one value that can
+   * be compared against what actually happened. {@code null} falls back to the platform default.
+   */
+  Integer responseDeadlineDays;
+
+  /** The tenant's existing {@code languageFormal} flag: a Träger writes one German variant. */
+  boolean informal;
+
+  String dataPrivacyUrl;
+  String imprintUrl;
+
+  String greetingByTopic;
+  String greetingByAgency;
+  String greetingByTenant;
+
+  String whoReadsAlongByTopic;
+  String whoReadsAlongByAgency;
+  String whoReadsAlongByTenant;
+
+  String freeNoticeByTopic;
+  String freeNoticeByAgency;
+  String freeNoticeByTenant;
+
+  String closingByTopic;
+  String closingByAgency;
+  String closingByTenant;
+
+  /** Live Chat is the safe default only for what is *absent*, never for what is asserted. */
+  public ErstantwortModality modalityOrDefault() {
+    return modality == null ? ErstantwortModality.AGENCY_COUNSELLING : modality;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortModality.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortModality.java
@@ -1,0 +1,24 @@
+package de.caritas.cob.userservice.api.service.erstantwort;
+
+/**
+ * The conversation modalities an Erstantwort can be spoken into.
+ *
+ * <p>Deliberately a small enum of its own rather than a reuse of the session's own type: the
+ * modality assignment of a Baustein is a product decision (ADR-018 §5), and some of it follows from
+ * the domain rather than from the schema — Live Chat has neither teams nor case handover, so "who
+ * reads along" has nothing to render there, and it is synchronous, so a reply deadline would be a
+ * promise the system cannot keep.
+ *
+ * <p>{@code INTERNAL_GROUP} is absent on purpose. It is a counsellor-side room and never receives
+ * an Erstantwort at all.
+ */
+public enum ErstantwortModality {
+  AGENCY_COUNSELLING,
+  LIVE_CHAT,
+  SELF_HELP;
+
+  /** Whether this modality has an enquiry, and therefore a promised time to a first reply. */
+  public boolean isAsynchronous() {
+    return this != LIVE_CHAT;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPayloadBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPayloadBuilder.java
@@ -1,0 +1,274 @@
+package de.caritas.cob.userservice.api.service.erstantwort;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds the one persisted {@code [SYSTEM_NOTIFICATION]} event that carries the whole Erstantwort
+ * (ADR-018, ORISO-UserService#926).
+ *
+ * <h2>What this class is responsible for</h2>
+ *
+ * Resolving each Baustein of the platform catalogue against this session's configuration and
+ * <b>freezing the resulting wording into the payload</b>. That is the load-bearing decision of
+ * ADR-018 §4: what was said to a person has to stay provable, and a Träger who edits their greeting
+ * next month must not retroactively change what an advice seeker was told in a room that carries
+ * §11 KDG special-category data.
+ *
+ * <h2>What it deliberately does not do</h2>
+ *
+ * <ul>
+ *   <li><b>It stores no completion state.</b> An action Baustein carries only its {@code kind}; the
+ *       client reads live whether the person already has an e-mail address or 2FA. Storing it here
+ *       would be the new state ADR-018 §4 forbids, and it would go stale the moment somebody
+ *       changed their profile.
+ *   <li><b>It creates no Matrix account.</b> Carimat is a rendering identity (ADR-018 §3). A bot in
+ *       the room would be an additional Megolm key holder in a counselling room, and a bot has no
+ *       Schweigepflicht. The event is posted with the existing credential resolution.
+ * </ul>
+ *
+ * <p>The wording here is the German platform text. It is written <b>gender-neutral by
+ * reformulation</b>, not by notation (ADR-018 §7) — "eine passende Ansprechperson", never {@code
+ * Berater*in} / {@code Berater_innen} / {@code Berater:innen}. The frontend catalogue
+ * (ORISO-Frontend {@code erstantwortCatalogue.ts}) carries the same texts for the client-side
+ * triggers and for Storybook; both sides are pinned by their own tests.
+ */
+@Component
+@Slf4j
+public class ErstantwortPayloadBuilder {
+
+  public static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
+  public static final String FIRST_RESPONSE_TYPE = "FIRST_RESPONSE";
+
+  /**
+   * Wire-format version, shared with the frontend. Bump on any breaking change to the shape; a
+   * client that meets a higher version renders nothing rather than guessing.
+   */
+  public static final int PAYLOAD_VERSION = 1;
+
+  /** ADR-018: the platform default Antwortfrist. */
+  public static final int DEFAULT_RESPONSE_DEADLINE_DAYS = 2;
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /**
+   * @return the full message body including the {@code [SYSTEM_NOTIFICATION]} prefix, or {@code
+   *     null} if the payload could not be serialised (in which case nothing is posted — a raw blob
+   *     in a counselling room is worse than no Erstantwort).
+   */
+  public String buildFirstResponseBody(ErstantwortContext context) {
+    var payload = new LinkedHashMap<String, Object>();
+    payload.put("type", FIRST_RESPONSE_TYPE);
+    payload.put("version", PAYLOAD_VERSION);
+    payload.put("bausteine", buildBausteine(context));
+    try {
+      return SYSTEM_NOTIFICATION_PREFIX + OBJECT_MAPPER.writeValueAsString(payload);
+    } catch (JsonProcessingException exception) {
+      log.warn("Could not serialize Erstantwort payload", exception);
+      return null;
+    }
+  }
+
+  /**
+   * Catalogue order <b>is</b> render order, and two positions in it are not cosmetic: the two
+   * safety-bearing Bausteine come before every optional action, because consent has to precede data
+   * transmission; and the free notice sits at a fixed position just before the closing, so a Träger
+   * cannot push their own text to the top of a message that is meant to be a transparency record.
+   */
+  private List<Map<String, Object>> buildBausteine(ErstantwortContext context) {
+    var modality = context.modalityOrDefault();
+    var informal = context.isInformal();
+    var bausteine = new ArrayList<Map<String, Object>>();
+
+    add(
+        bausteine,
+        "greeting",
+        null,
+        resolve(
+            context.getGreetingByTopic(),
+            context.getGreetingByAgency(),
+            context.getGreetingByTenant(),
+            informal
+                ? "Schön, dass Du Dich gemeldet hast. Deine Nachricht ist bei uns angekommen."
+                : "Schön, dass Sie sich gemeldet haben. Ihre Nachricht ist bei uns angekommen."));
+
+    if (modality.isAsynchronous()) {
+      // Live Chat has neither teams nor case handover — nothing to disclose.
+      add(
+          bausteine,
+          "whoReadsAlong",
+          informal ? "Wer Deine Nachricht liest" : "Wer Ihre Nachricht liest",
+          resolve(
+              context.getWhoReadsAlongByTopic(),
+              context.getWhoReadsAlongByAgency(),
+              context.getWhoReadsAlongByTenant(),
+              (informal ? "Deine" : "Ihre")
+                  + " Nachricht lesen ausschließlich die Fachkräfte der zuständigen"
+                  + " Beratungsstelle. Alle sind zur Verschwiegenheit verpflichtet."));
+
+      var days =
+          context.getResponseDeadlineDays() == null
+              ? DEFAULT_RESPONSE_DEADLINE_DAYS
+              : context.getResponseDeadlineDays();
+      add(
+          bausteine,
+          "responseDeadline",
+          informal ? "Wann Du eine Antwort bekommst" : "Wann Sie eine Antwort erhalten",
+          informal
+              ? "Du bekommst innerhalb von "
+                  + days
+                  + " Werktagen eine Antwort von einer passenden Ansprechperson."
+              : "Sie erhalten innerhalb von "
+                  + days
+                  + " Werktagen eine Antwort von einer passenden Ansprechperson.");
+    }
+
+    add(
+        bausteine,
+        "modalityNote",
+        null,
+        "Die Beratung findet schriftlich in diesem geschützten Bereich statt. "
+            + (informal
+                ? "Du kannst jederzeit weiterschreiben."
+                : "Sie können jederzeit weiterschreiben."));
+
+    /* ADR-018 §6: the two safety-bearing Bausteine carry no toggle at all — the
+    deliberate interim substitute for the postponed platform/Träger permission
+    model. They are therefore unconditional here, in every modality. */
+    add(
+        bausteine,
+        "noPersonalData",
+        "Bitte keine persönlichen Daten senden",
+        (informal ? "Bitte schreib uns" : "Bitte schreiben Sie uns")
+            + " keinen vollständigen Namen, keine Adresse und keine Telefonnummer."
+            + " Für die Beratung brauchen wir das nicht.");
+
+    add(
+        bausteine,
+        "emergencyNumbers",
+        "Wenn es nicht warten kann",
+        "Bei einer akuten Notlage "
+            + (informal ? "erreichst Du" : "erreichen Sie")
+            + " rund um die Uhr die Telefonseelsorge unter 0800 111 0 111 oder"
+            + " 0800 111 0 222 und den Rettungsdienst unter 112.");
+
+    var dataProtection =
+        add(
+            bausteine,
+            "dataProtection",
+            null,
+            "Wie wir mit "
+                + (informal ? "Deinen" : "Ihren")
+                + " Daten umgehen, steht in der Datenschutzerklärung.");
+    addLinks(dataProtection, context);
+
+    // The single escape hatch, at a fixed position. Absent until a Träger fills it.
+    var freeNotice =
+        resolve(
+            context.getFreeNoticeByTopic(),
+            context.getFreeNoticeByAgency(),
+            context.getFreeNoticeByTenant(),
+            null);
+    if (isNotBlank(freeNotice)) {
+      add(bausteine, "freeNotice", null, freeNotice);
+    }
+
+    var emailBaustein =
+        add(
+            bausteine,
+            "emailNotification",
+            "Benachrichtigung per E-Mail",
+            (informal ? "Du kannst" : "Sie können")
+                + " freiwillig eine E-Mail-Adresse hinterlegen. Dann "
+                + (informal ? "bekommst Du" : "erhalten Sie")
+                + " eine Nachricht, sobald eine Antwort da ist. Der Inhalt der"
+                + " Beratung steht nie in dieser E-Mail.");
+    emailBaustein.put("action", action("ADD_EMAIL", "E-Mail-Adresse angeben"));
+
+    var protectionBaustein =
+        add(
+            bausteine,
+            "accountProtection",
+            (informal ? "Dein" : "Ihr") + " Zugang, zusätzlich geschützt",
+            (informal ? "Du kannst Deinen" : "Sie können Ihren")
+                + " Zugang mit einem zweiten Faktor sichern, damit niemand sonst"
+                + " hineinkommt.");
+    protectionBaustein.put("action", action("ENABLE_2FA", "Zugang schützen"));
+
+    add(
+        bausteine,
+        "closing",
+        null,
+        resolve(
+            context.getClosingByTopic(),
+            context.getClosingByAgency(),
+            context.getClosingByTenant(),
+            informal
+                ? "Bis bald — wir melden uns bei Dir."
+                : "Bis bald — wir melden uns bei Ihnen."));
+
+    return bausteine;
+  }
+
+  /**
+   * The resolution chain of ADR-018 §6, most specific first. A blank value at any level counts as
+   * absent rather than as an intentionally empty Baustein — an editor that saved an empty field
+   * must not silence a text the level below it still provides.
+   */
+  private String resolve(String byTopic, String byAgency, String byTenant, String platform) {
+    if (isNotBlank(byTopic)) {
+      return byTopic.trim();
+    }
+    if (isNotBlank(byAgency)) {
+      return byAgency.trim();
+    }
+    if (isNotBlank(byTenant)) {
+      return byTenant.trim();
+    }
+    return platform;
+  }
+
+  private Map<String, Object> add(
+      List<Map<String, Object>> bausteine, String id, String headline, String body) {
+    var baustein = new LinkedHashMap<String, Object>();
+    baustein.put("id", id);
+    if (isNotBlank(headline)) {
+      baustein.put("headline", headline);
+    }
+    baustein.put("body", body);
+    bausteine.add(baustein);
+    return baustein;
+  }
+
+  /**
+   * Derived link targets, from configuration only. The department owns its privacy policy and
+   * imprint (ADR-003 / ADR-014), and an absent one produces no link rather than a dead one.
+   */
+  private void addLinks(Map<String, Object> baustein, ErstantwortContext context) {
+    var links = new ArrayList<Map<String, String>>();
+    if (isNotBlank(context.getDataPrivacyUrl())) {
+      links.add(Map.of("label", "Datenschutzerklärung", "url", context.getDataPrivacyUrl().trim()));
+    }
+    if (isNotBlank(context.getImprintUrl())) {
+      links.add(Map.of("label", "Impressum", "url", context.getImprintUrl().trim()));
+    }
+    if (!links.isEmpty()) {
+      baustein.put("links", links);
+    }
+  }
+
+  private Map<String, String> action(String kind, String label) {
+    var action = new LinkedHashMap<String, String>();
+    action.put("kind", kind);
+    action.put("label", label);
+    return action;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
@@ -27,6 +27,7 @@ public class MatrixSessionSystemMessageService {
   public static final String SYSTEM_NOTIFICATION_PREFIX = "[SYSTEM_NOTIFICATION]";
   public static final String USER_LEFT_CHAT_TYPE = "USER_LEFT_CHAT";
   public static final String CASE_HANDOVER_GRANTED_TYPE = "CASE_HANDOVER_GRANTED";
+  public static final String FIRST_RESPONSE_TYPE = "FIRST_RESPONSE";
 
   private static final com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER =
       new com.fasterxml.jackson.databind.ObjectMapper();
@@ -98,6 +99,40 @@ public class MatrixSessionSystemMessageService {
     }
     var roomId = matrixRoomId;
     resolveMatrixCredentialsPreferConsultant(session)
+        .ifPresent(credentials -> sendSystemMessage(session.getId(), roomId, body, credentials));
+  }
+
+  /**
+   * Posts the Erstantwort — the whole Baustein sequence as <b>one</b> persisted event (ADR-018,
+   * ORISO-UserService#926).
+   *
+   * <p><b>No Carimat account is created.</b> Carimat is a rendering identity, not a Matrix account
+   * (ADR-018 §3): a bot in the room would be an additional Megolm key holder in a room carrying §11
+   * KDG special-category data, and a bot has no Schweigepflicht. The event goes out through the
+   * existing credential resolution, exactly like every other system message here, and adds no room
+   * member.
+   *
+   * <p>A failure is logged and swallowed. The Erstantwort is important, but it must never take the
+   * enquiry down with it — the person's message reaching a counsellor outranks the platform's own
+   * greeting, and a thrown exception here would roll the dispatch back.
+   *
+   * @param session the session whose room receives the Erstantwort
+   * @param body the full message body including the [SYSTEM_NOTIFICATION] prefix
+   */
+  public void postFirstResponseMessage(Session session, String body) {
+    if (session == null || session.getId() == null || isBlank(body)) {
+      return;
+    }
+    var matrixRoomId = session.getMatrixRoomId();
+    if (isBlank(matrixRoomId)) {
+      matrixRoomId =
+          sessionService.getSession(session.getId()).map(Session::getMatrixRoomId).orElse(null);
+    }
+    if (isBlank(matrixRoomId)) {
+      return;
+    }
+    var roomId = matrixRoomId;
+    resolveMatrixCredentials(session)
         .ifPresent(credentials -> sendSystemMessage(session.getId(), roomId, body, credentials));
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -183,6 +183,64 @@ public class EventNotificationService {
    * logged.
    */
   @Transactional
+  /**
+   * ADR-018 §11 / ORISO-UserService#926: <b>exactly one</b> Activity Timeline entry for the whole
+   * Erstantwort, targeting the chat.
+   *
+   * <p>One entry, not one per open action. A person who has just written a first message about
+   * something hard should not receive three to-do items in response — that was the explicit
+   * rejection recorded in ADR-018 §11.
+   *
+   * <p>This is also the "narrow exception" the issue asks for, and it is narrow by construction
+   * rather than by a flag: system notifications are filtered out of the timeline on the <b>Matrix
+   * ingestion</b> path ({@code isSystemNotificationMessage}), where an unfiltered system message
+   * would produce a timeline row for every internal event in every room. That filter stays exactly
+   * as strict as it is. The Erstantwort instead writes its own single row here, from the enquiry
+   * facade, so nothing else slips through with it.
+   *
+   * <p>Failures are swallowed: a missing timeline row must never fail the enquiry.
+   *
+   * @param session the session whose advice seeker received the Erstantwort
+   */
+  public void createFirstResponseNotification(Session session) {
+    if (session == null || session.getUser() == null) {
+      return;
+    }
+    var recipientUserId = session.getUser().getUserId();
+    if (recipientUserId == null || recipientUserId.isBlank()) {
+      return;
+    }
+    try {
+      createEvent(
+          recipientUserId,
+          "first_response.received",
+          CATEGORY_SYSTEM,
+          "Ihre ersten Schritte",
+          "Wir haben Ihnen im Chat die wichtigsten Informationen geschrieben.",
+          buildAskerSessionActionPath(session),
+          session.getId(),
+          session.getTenantId());
+    } catch (RuntimeException ex) {
+      log.warn(
+          "Could not persist first_response.received notification for session {}",
+          session.getId(),
+          ex);
+    }
+  }
+
+  /** The advice seeker's own view of their conversation — never the consultant preview list. */
+  private String buildAskerSessionActionPath(Session session) {
+    String listPath = "/sessions/user/view";
+    if (session == null || session.getId() == null) {
+      return listPath;
+    }
+    var roomRef = session.getMatrixRoomId();
+    if (roomRef == null || roomRef.isBlank()) {
+      return listPath;
+    }
+    return listPath + "/" + roomRef + "/" + session.getId();
+  }
+
   public void createNewClientRequestNotifications(
       Session session, Collection<String> recipientConsultantIds) {
     if (session == null || recipientConsultantIds == null) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -217,6 +217,11 @@ public class EventNotificationService {
           CATEGORY_SYSTEM,
           "Ihre ersten Schritte",
           "Wir haben Ihnen im Chat die wichtigsten Informationen geschrieben.",
+          /* The frontend resolves the room reference out of `params`. Without them
+          the entry still renders but has no chat to open, which for the single
+          timeline entry the Erstantwort is allowed to produce means the person is
+          told something happened and given no way back to it. */
+          serializeParams(baseParams(session)),
           buildAskerSessionActionPath(session),
           session.getId(),
           session.getTenantId());

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeErstantwortTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeErstantwortTest.java
@@ -1,0 +1,180 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.EnquiryData;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
+import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortContext;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortModality;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortPayloadBuilder;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * The orchestration half of ORISO-UserService#926, raised in review.
+ *
+ * <p><b>Why this file exists.</b> The other facade tests leave {@link ErstantwortPayloadBuilder}
+ * unstubbed, so it returns {@code null} and {@code postErstantwort} exits before it posts anything.
+ * Those tests therefore pass unchanged if the whole Erstantwort orchestration is deleted or
+ * reordered — over-mocking that hides the defect rather than exposing it. Here the builder returns
+ * a real body, so removing the call makes these fail.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CreateEnquiryMessageFacadeErstantwortTest {
+
+  private static final String BODY = "[SYSTEM_NOTIFICATION]{\"type\":\"FIRST_RESPONSE\"}";
+  private static final String ROOM_ID = "!room:matrix.test";
+  private static final String EVENT_ID = "$enquiry";
+
+  @Mock private SessionService sessionService;
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private EmailNotificationFacade emailNotificationFacade;
+  @Mock private ConsultantAgencyService consultantAgencyService;
+  @Mock private TopicConsultantRoutingService topicConsultantRoutingService;
+  @Mock private EventNotificationService eventNotificationService;
+  @Mock private AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
+  @Mock private ErstantwortPayloadBuilder erstantwortPayloadBuilder;
+  @Mock private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
+
+  @InjectMocks private CreateEnquiryMessageFacade facade;
+
+  private Session session;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User();
+    user.setUserId("asker-1");
+    user.setMatrixUserId("@asker:matrix.test");
+    user.setLanguageFormal(true);
+
+    session = new Session();
+    session.setId(42L);
+    session.setUser(user);
+    session.setAgencyId(1L);
+    session.setMatrixRoomId(ROOM_ID);
+    session.setStatus(SessionStatus.INITIAL);
+    session.setRegistrationType(RegistrationType.REGISTERED);
+    session.setIsConsultantDirectlySet(false);
+
+    when(sessionService.getSession(42L)).thenReturn(Optional.of(session));
+    when(matrixSynapseService.loginAsUserAccessToken(anyString())).thenReturn("token");
+    when(matrixSynapseService.getRoomEvent(anyString(), anyString(), anyString()))
+        .thenReturn(
+            Optional.of(
+                Map.of(
+                    "event_id",
+                    EVENT_ID,
+                    "sender",
+                    user.getMatrixUserId(),
+                    "type",
+                    "m.room.encrypted")));
+    when(consultantAgencyService.findConsultantsByAgencyId(1L))
+        .thenReturn(List.<ConsultantAgency>of());
+    when(erstantwortPayloadBuilder.buildFirstResponseBody(any())).thenReturn(BODY);
+  }
+
+  private EnquiryData enquiryData() {
+    var data = new EnquiryData(user, 42L, "Hallo", "de");
+    data.setMatrixEventId(EVENT_ID);
+    return data;
+  }
+
+  @Test
+  void dispatchPostsTheErstantwortAndWritesOneTimelineEntry() {
+    facade.createEnquiryMessage(enquiryData());
+
+    verify(matrixSessionSystemMessageService).postFirstResponseMessage(eq(session), eq(BODY));
+    verify(eventNotificationService).createFirstResponseNotification(session);
+  }
+
+  @Test
+  void buildsTheContextForAgencyCounsellingWithTheAskerFormality() {
+    facade.createEnquiryMessage(enquiryData());
+
+    var captor = ArgumentCaptor.forClass(ErstantwortContext.class);
+    verify(erstantwortPayloadBuilder).buildFirstResponseBody(captor.capture());
+
+    assertThat(captor.getValue().getModality()).isEqualTo(ErstantwortModality.AGENCY_COUNSELLING);
+    assertThat(captor.getValue().isInformal()).isFalse();
+  }
+
+  @Test
+  void usesTheInformalVariantForAnInformalAsker() {
+    /* Without this, every German wording fell back to the formal variant, so an
+    informal Träger's advice seekers were addressed with "Sie" throughout the
+    one message that is supposed to be the platform speaking to them. */
+    user.setLanguageFormal(false);
+
+    facade.createEnquiryMessage(enquiryData());
+
+    var captor = ArgumentCaptor.forClass(ErstantwortContext.class);
+    verify(erstantwortPayloadBuilder).buildFirstResponseBody(captor.capture());
+    assertThat(captor.getValue().isInformal()).isTrue();
+  }
+
+  @Test
+  void postsNothingWhenThePayloadCouldNotBeBuilt() {
+    when(erstantwortPayloadBuilder.buildFirstResponseBody(any())).thenReturn(null);
+
+    facade.createEnquiryMessage(enquiryData());
+
+    verify(matrixSessionSystemMessageService, never()).postFirstResponseMessage(any(), anyString());
+    verify(eventNotificationService, never()).createFirstResponseNotification(any());
+  }
+
+  @Test
+  void anErstantwortFailureDoesNotFailTheEnquiryDispatch() {
+    /* The person's message reaching a counsellor outranks the platform's own
+    greeting. A thrown exception here would roll back a dispatched enquiry. */
+    doThrow(new RuntimeException("matrix down"))
+        .when(matrixSessionSystemMessageService)
+        .postFirstResponseMessage(any(), anyString());
+
+    var response = facade.createEnquiryMessage(enquiryData());
+
+    assertThat(response).isNotNull();
+    assertThat(response.getMatrixRoomId()).isEqualTo(ROOM_ID);
+  }
+
+  @Test
+  void aTimelineFailureDoesNotFailTheEnquiryDispatchEither() {
+    doThrow(new RuntimeException("db down"))
+        .when(eventNotificationService)
+        .createFirstResponseNotification(any());
+
+    var response = facade.createEnquiryMessage(enquiryData());
+
+    assertThat(response).isNotNull();
+    verify(matrixSessionSystemMessageService).postFirstResponseMessage(eq(session), eq(BODY));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeMatrixRoomProvisioningTest.java
@@ -100,6 +100,16 @@ class CreateEnquiryMessageFacadeMatrixRoomProvisioningTest {
   // service is swapped in via setField in @BeforeEach so the orchestration actually runs.
   @Mock private AgencyPreAssignmentRoomService injectedRoomServicePlaceholder;
 
+  /* ADR-018 Erstantwort collaborators — mocked so this test keeps its focus on
+  Matrix room provisioning. */
+  @Mock
+  private de.caritas.cob.userservice.api.service.erstantwort.ErstantwortPayloadBuilder
+      erstantwortPayloadBuilder;
+
+  @Mock
+  private de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService
+      matrixSessionSystemMessageService;
+
   // Room-provisioning collaborators of the REAL AgencyPreAssignmentRoomService.
   @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateEnquiryMessageFacadeTest.java
@@ -18,6 +18,8 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicConsultantRoutingService;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortPayloadBuilder;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
 import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
 import de.caritas.cob.userservice.api.service.session.AgencyPreAssignmentRoomService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
@@ -50,6 +52,13 @@ class CreateEnquiryMessageFacadeTest {
   @Mock private TopicConsultantRoutingService topicConsultantRoutingService;
   @Mock private EventNotificationService eventNotificationService;
   @Mock private AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
+
+  /* ADR-018: the Erstantwort is posted at the end of a successful dispatch.
+  Mocked, not stubbed — these tests are about the dispatch itself, and the
+  Erstantwort has its own tests in service/erstantwort. */
+  @Mock private ErstantwortPayloadBuilder erstantwortPayloadBuilder;
+  @Mock private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
+
   @InjectMocks private CreateEnquiryMessageFacade facade;
 
   private User user;

--- a/src/test/java/de/caritas/cob/userservice/api/facade/ErstantwortMatrixPathIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/ErstantwortMatrixPathIT.java
@@ -1,0 +1,143 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortContext;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortModality;
+import de.caritas.cob.userservice.api.service.erstantwort.ErstantwortPayloadBuilder;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
+import de.caritas.cob.userservice.api.service.notification.EventNotificationService;
+import de.caritas.cob.userservice.api.testConfig.ConsultingTypeManagerTestConfig;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * ORISO-UserService#926, the last acceptance box: the Erstantwort exercised through the real Spring
+ * context rather than through hand-wired collaborators.
+ *
+ * <p><b>What this covers that the unit tests do not.</b> The unit tests prove the payload shape and
+ * the posting call in isolation. They cannot catch the failures that actually happen when this
+ * ships: a bean that does not exist, a constructor dependency the context cannot satisfy, an
+ * `@Component` annotation left off the builder, or a timeline write that throws once a real
+ * repository and a real transaction are underneath it. All of those pass a Mockito test and break
+ * on Pre-Dev.
+ *
+ * <p><b>Where the boundary is drawn, and why.</b> {@link MatrixSynapseService} is mocked — it is
+ * the outer HTTP edge, and a real Synapse is not available in a build. Everything on this side of
+ * it is real: the Spring context, the payload builder, the system-message service, the notification
+ * service and the database. So "end to end" here means end to end *within the application*, and the
+ * one thing it does not prove is that Synapse accepts the event. That last hop is a Pre-Dev check
+ * and is written down as such on the PR.
+ */
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({ConsultingTypeManagerTestConfig.class})
+class ErstantwortMatrixPathIT {
+
+  private static final long SEEDED_SESSION_ID = 1L;
+
+  @Autowired ErstantwortPayloadBuilder erstantwortPayloadBuilder;
+  @Autowired MatrixSessionSystemMessageService matrixSessionSystemMessageService;
+  @Autowired EventNotificationService eventNotificationService;
+  @Autowired SessionRepository sessionRepository;
+
+  @MockitoBean MatrixSynapseService matrixSynapseService;
+
+  private Session session;
+
+  @BeforeEach
+  void setUp() {
+    session = sessionRepository.findById(SEEDED_SESSION_ID).orElseThrow();
+    when(matrixSynapseService.loginAsUserAccessToken(anyString())).thenReturn("token");
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), anyString()))
+        .thenReturn(Map.of("event_id", "$erstantwort"));
+  }
+
+  @Test
+  void theContextWiresEveryErstantwortCollaborator() {
+    /* The cheapest failure this catches: a missing @Component on the builder, or a
+    constructor dependency the context cannot satisfy. Both pass every unit
+    test in the suite and fail at startup on Pre-Dev. */
+    assertThat(erstantwortPayloadBuilder).isNotNull();
+    assertThat(matrixSessionSystemMessageService).isNotNull();
+    assertThat(eventNotificationService).isNotNull();
+  }
+
+  @Test
+  void postsExactlyOneErstantwortEventIntoTheSessionRoom() {
+    var body =
+        erstantwortPayloadBuilder.buildFirstResponseBody(
+            ErstantwortContext.builder().modality(ErstantwortModality.AGENCY_COUNSELLING).build());
+
+    matrixSessionSystemMessageService.postFirstResponseMessage(session, body);
+
+    var captor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService, times(1))
+        .sendMessage(eq(session.getMatrixRoomId()), captor.capture(), anyString());
+
+    var posted = captor.getValue();
+    assertThat(posted).startsWith("[SYSTEM_NOTIFICATION]");
+    assertThat(posted).contains("\"type\":\"FIRST_RESPONSE\"");
+    assertThat(posted).contains("\"version\":1");
+    // One event carrying the whole sequence, not one event per Baustein.
+    assertThat(posted).contains("\"noPersonalData\"").contains("\"emergencyNumbers\"");
+  }
+
+  @Test
+  void createsNoCarimatAccountAndInvitesNobody() throws Exception {
+    /* ADR-018 §3. A bot in the room would be an extra Megolm key holder in a room
+    carrying §11 KDG special-category data, and a bot has no Schweigepflicht.
+    Asserted against the real wiring, not only against a hand-built service. */
+    matrixSessionSystemMessageService.postFirstResponseMessage(
+        session,
+        erstantwortPayloadBuilder.buildFirstResponseBody(
+            ErstantwortContext.builder().modality(ErstantwortModality.AGENCY_COUNSELLING).build()));
+
+    verify(matrixSynapseService, never()).loginAsUserAccessToken(eq("@carimat:matrix.example"));
+    /* `createUser` is the account-creation edge — the one call that would bring a
+    Carimat identity into existence as a real Matrix account. It must never
+    fire on this path. */
+    verify(matrixSynapseService, never()).createUser(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void writesTheTimelineEntryWithoutFailingWhenTheDatabaseIsReal() {
+    /* A timeline write that throws under a real repository and transaction is
+    precisely what a Mockito test cannot see. The Erstantwort swallows its own
+    failures by design, so the assertion is that this completes at all. */
+    eventNotificationService.createFirstResponseNotification(session);
+  }
+
+  @Test
+  void survivesAMatrixFailureWithoutPropagating() {
+    /* The person's message reaching a counsellor outranks the platform's own
+    greeting: nothing here may roll a dispatched enquiry back. */
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), anyString()))
+        .thenReturn(Map.of("error", "M_FORBIDDEN"));
+
+    matrixSessionSystemMessageService.postFirstResponseMessage(
+        session,
+        erstantwortPayloadBuilder.buildFirstResponseBody(
+            ErstantwortContext.builder().modality(ErstantwortModality.AGENCY_COUNSELLING).build()));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AnonymousEnquiryConsentGuardTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AnonymousEnquiryConsentGuardTest.java
@@ -1,0 +1,81 @@
+package de.caritas.cob.userservice.api.facade.assignsession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ORISO-UserService#927 / ADR-018 §9: the server-side half of the consent gate.
+ *
+ * <p>The forward lock is real today, but it is enforced by the client alone — the composer is
+ * hidden while the session sits in the pre-assignment enquiry phase. That works, and the frontend
+ * invariant is now pinned by its own test. This is defence in depth for the case where the client
+ * is bypassed entirely.
+ *
+ * <p><b>Scope is the whole difficulty here, and getting it wrong breaks the product.</b> The check
+ * applies <i>only</i> to entry paths where the advice seeker did not choose the agency beforehand.
+ * In Agency Counselling consent is given at registration, per the topic-before-consent invariant of
+ * ADR-014, and {@code CreateUserFacade} deliberately clears the flag for anonymous registrations so
+ * that the in-chat gate fires there and only there. A blanket check would therefore reject
+ * perfectly consented registered enquiries.
+ *
+ * <p>Forward lock only: this must never delay an assignment for e-mail, 2FA or credential saving.
+ * Those are voluntary throughout and have no bearing on the guard.
+ */
+class AnonymousEnquiryConsentGuardTest {
+
+  private final AnonymousEnquiryConsentGuard guard = new AnonymousEnquiryConsentGuard();
+
+  private Session sessionWithConfirmation(LocalDateTime confirmation) {
+    var user = new User();
+    user.setDataPrivacyConfirmation(confirmation);
+    var session = new Session();
+    session.setId(42L);
+    session.setUser(user);
+    return session;
+  }
+
+  @Test
+  void rejectsAnAnonymousEnquiryWithNoRecordedConsent() {
+    assertThatThrownBy(() -> guard.verifyAnonymousConsent(sessionWithConfirmation(null)))
+        .isInstanceOf(ConflictException.class);
+  }
+
+  @Test
+  void allowsAnAnonymousEnquiryOnceConsentWasRecorded() {
+    assertThatCode(() -> guard.verifyAnonymousConsent(sessionWithConfirmation(LocalDateTime.now())))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void leaksNothingAboutTheAdviceSeekerInTheRejection() {
+    /* The message reaches a consultant client and, on the anonymous path, is about
+    somebody who chose not to identify themselves. It names the session and the
+    reason — nothing about the person. */
+    var thrown =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ConflictException.class,
+            () -> guard.verifyAnonymousConsent(sessionWithConfirmation(null)));
+
+    assertThat(thrown.getMessage()).contains("42");
+    assertThat(thrown.getMessage()).doesNotContainIgnoringCase("dataPrivacyConfirmation");
+  }
+
+  @Test
+  void doesNotThrowWhenTheSessionCarriesNoUserAtAll() {
+    /* A session without a user cannot be an anonymous advice seeker awaiting
+    consent, and failing an assignment on a malformed session would turn a
+    hardening measure into an outage. Let the existing validators speak. */
+    var session = new Session();
+    session.setId(43L);
+
+    assertThatCode(() -> guard.verifyAnonymousConsent(session)).doesNotThrowAnyException();
+    assertThatCode(() -> guard.verifyAnonymousConsent(null)).doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacadeTest.java
@@ -79,6 +79,10 @@ class AssignEnquiryFacadeTest {
   @Mock EventNotificationService eventNotificationService;
   @Mock de.caritas.cob.userservice.api.facade.SessionSupervisorFacade sessionSupervisorFacade;
   @Mock de.caritas.cob.userservice.api.facade.TeamDiscussionFacade teamDiscussionFacade;
+
+  /* ADR-018 §9: the anonymous consent guard. Mocked here — this test covers the
+  Matrix room mechanics of assignment, and the guard has its own tests. */
+  @Mock AnonymousEnquiryConsentGuard anonymousEnquiryConsentGuard;
   @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
 
   private static final String USER_MATRIX_ID = "@user:matrix.example.com";

--- a/src/test/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPayloadBuilderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPayloadBuilderTest.java
@@ -1,0 +1,215 @@
+package de.caritas.cob.userservice.api.service.erstantwort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-018 / ORISO-UserService#926.
+ *
+ * <p>Two properties carry all the weight here and each has its own reason:
+ *
+ * <ul>
+ *   <li><b>Frozen words.</b> The resolved wording goes into the event, so what was said to a person
+ *       stays provable and a later configuration change cannot rewrite history.
+ *   <li><b>No completion state.</b> An action carries only its kind. Whether it is already done is
+ *       read live by the client — storing it would be exactly the new state ADR-018 §4 forbids.
+ * </ul>
+ */
+class ErstantwortPayloadBuilderTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ErstantwortPayloadBuilder builder = new ErstantwortPayloadBuilder();
+
+  private JsonNode buildFor(ErstantwortContext context) throws Exception {
+    String body = builder.buildFirstResponseBody(context);
+    assertThat(body).startsWith("[SYSTEM_NOTIFICATION]");
+    return MAPPER.readTree(body.substring("[SYSTEM_NOTIFICATION]".length()));
+  }
+
+  private ErstantwortContext.ErstantwortContextBuilder agencyCounselling() {
+    return ErstantwortContext.builder()
+        .modality(ErstantwortModality.AGENCY_COUNSELLING)
+        .responseDeadlineDays(2);
+  }
+
+  @Test
+  void buildsAVersionedFirstResponseEnvelope() throws Exception {
+    JsonNode payload = buildFor(agencyCounselling().build());
+
+    assertThat(payload.get("type").asText()).isEqualTo("FIRST_RESPONSE");
+    assertThat(payload.get("version").asInt()).isEqualTo(1);
+    assertThat(payload.get("bausteine").isArray()).isTrue();
+  }
+
+  @Test
+  void freezesTheResolvedWordingRatherThanAKey() throws Exception {
+    JsonNode bausteine = buildFor(agencyCounselling().build()).get("bausteine");
+
+    for (JsonNode baustein : bausteine) {
+      assertThat(baustein.get("id").asText()).isNotBlank();
+      assertThat(baustein.get("body").asText()).isNotBlank();
+      // A key would defeat the point: the wording has to be readable years later
+      // without the frontend that produced it.
+      assertThat(baustein.get("body").asText()).doesNotContain("erstantwort.");
+    }
+  }
+
+  @Test
+  void neverStoresCompletionState() throws Exception {
+    JsonNode bausteine = buildFor(agencyCounselling().build()).get("bausteine");
+
+    for (JsonNode baustein : bausteine) {
+      assertThat(baustein.has("done")).isFalse();
+      assertThat(baustein.has("completed")).isFalse();
+      JsonNode action = baustein.get("action");
+      if (action != null && !action.isNull()) {
+        assertThat(action.has("done")).isFalse();
+        assertThat(action.get("kind").asText()).isNotBlank();
+        assertThat(action.get("label").asText()).isNotBlank();
+      }
+    }
+  }
+
+  @Test
+  void rendersTheDeadlineNumberIntoTheDerivedWording() throws Exception {
+    JsonNode payload = buildFor(agencyCounselling().responseDeadlineDays(5).build());
+
+    assertThat(bodyOf(payload, "responseDeadline")).contains("5 Werktagen");
+  }
+
+  @Test
+  void fallsBackToThePlatformDeadlineWhenNoneIsConfigured() throws Exception {
+    JsonNode payload = buildFor(agencyCounselling().responseDeadlineDays(null).build());
+
+    assertThat(bodyOf(payload, "responseDeadline")).contains("2 Werktagen");
+  }
+
+  @Test
+  void omitsTeamAndDeadlineBausteineInLiveChat() throws Exception {
+    JsonNode payload =
+        buildFor(ErstantwortContext.builder().modality(ErstantwortModality.LIVE_CHAT).build());
+
+    assertThat(idsOf(payload)).doesNotContain("whoReadsAlong", "responseDeadline");
+    // The two safety-bearing Bausteine apply everywhere, Live Chat included.
+    assertThat(idsOf(payload)).contains("noPersonalData", "emergencyNumbers");
+  }
+
+  @Test
+  void resolvesAuthoredTextThroughTheChainWithTheMostSpecificLevelWinning() throws Exception {
+    JsonNode payload =
+        buildFor(
+            agencyCounselling()
+                .greetingByTenant("Träger-Gruß")
+                .greetingByAgency("Beratungsstellen-Gruß")
+                .greetingByTopic("Fachbereichs-Gruß")
+                .build());
+
+    assertThat(bodyOf(payload, "greeting")).isEqualTo("Fachbereichs-Gruß");
+  }
+
+  @Test
+  void fallsBackDownTheChainWhenTheSpecificLevelIsEmpty() throws Exception {
+    assertThat(
+            bodyOf(
+                buildFor(agencyCounselling().greetingByTenant("Träger-Gruß").build()), "greeting"))
+        .isEqualTo("Träger-Gruß");
+    assertThat(
+            bodyOf(
+                buildFor(
+                    agencyCounselling()
+                        .greetingByAgency("Stelle")
+                        .greetingByTenant("Träger")
+                        .build()),
+                "greeting"))
+        .isEqualTo("Stelle");
+    // Nothing authored at any level: the platform text is the last link.
+    assertThat(bodyOf(buildFor(agencyCounselling().build()), "greeting"))
+        .contains("Ihre Nachricht ist bei uns angekommen");
+  }
+
+  @Test
+  void treatsABlankAuthoredTextAsAbsentRatherThanAsAnEmptyBaustein() throws Exception {
+    JsonNode payload =
+        buildFor(agencyCounselling().greetingByTopic("   ").greetingByTenant("Träger").build());
+
+    assertThat(bodyOf(payload, "greeting")).isEqualTo("Träger");
+  }
+
+  @Test
+  void omitsTheFreeNoticeUntilAgencyAuthorsIt() throws Exception {
+    assertThat(idsOf(buildFor(agencyCounselling().build()))).doesNotContain("freeNotice");
+
+    JsonNode withNotice =
+        buildFor(agencyCounselling().freeNoticeByTenant("Wir beraten im Peer-Modell.").build());
+    assertThat(bodyOf(withNotice, "freeNotice")).isEqualTo("Wir beraten im Peer-Modell.");
+  }
+
+  @Test
+  void rendersDerivedLinkTargetsFromConfigurationRatherThanFromText() throws Exception {
+    JsonNode payload =
+        buildFor(
+            agencyCounselling()
+                .dataPrivacyUrl("https://u25.test/datenschutz")
+                .imprintUrl("https://u25.test/impressum")
+                .build());
+
+    JsonNode links = bausteinOf(payload, "dataProtection").get("links");
+    assertThat(links).hasSize(2);
+    assertThat(links.get(0).get("url").asText()).isEqualTo("https://u25.test/datenschutz");
+  }
+
+  @Test
+  void omitsLinksEntirelyWhenTheDepartmentHasNoneConfigured() throws Exception {
+    assertThat(bausteinOf(buildFor(agencyCounselling().build()), "dataProtection").has("links"))
+        .isFalse();
+  }
+
+  @Test
+  void keepsTheSafetyBausteineAheadOfEveryOptionalAction() throws Exception {
+    List<String> ids = idsOf(buildFor(agencyCounselling().build()));
+
+    assertThat(ids.indexOf("noPersonalData")).isLessThan(ids.indexOf("emailNotification"));
+    assertThat(ids.indexOf("emergencyNumbers")).isLessThan(ids.indexOf("emailNotification"));
+  }
+
+  @Test
+  void speaksWithoutGenderedTerms() throws Exception {
+    JsonNode payload = buildFor(agencyCounselling().build());
+
+    for (JsonNode baustein : payload.get("bausteine")) {
+      String text = baustein.toString();
+      assertThat(text).doesNotContainIgnoringCase("Berater");
+      assertThat(text).doesNotContain("_innen").doesNotContain(":innen").doesNotContain("*in ");
+    }
+  }
+
+  @Test
+  void writesTheInformalGermanVariantWhenTheTenantIsInformal() throws Exception {
+    JsonNode payload = buildFor(agencyCounselling().informal(true).build());
+
+    assertThat(bodyOf(payload, "greeting")).contains("Du");
+    assertThat(bodyOf(payload, "greeting")).doesNotContain("Sie sich");
+  }
+
+  private static JsonNode bausteinOf(JsonNode payload, String id) {
+    for (JsonNode baustein : payload.get("bausteine")) {
+      if (id.equals(baustein.get("id").asText())) {
+        return baustein;
+      }
+    }
+    throw new AssertionError("no Baustein with id " + id + " in " + payload);
+  }
+
+  private static String bodyOf(JsonNode payload, String id) {
+    return bausteinOf(payload, id).get("body").asText();
+  }
+
+  private static List<String> idsOf(JsonNode payload) {
+    return payload.get("bausteine").findValuesAsText("id");
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPostingTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/erstantwort/ErstantwortPostingTest.java
@@ -1,0 +1,117 @@
+package de.caritas.cob.userservice.api.service.erstantwort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * ORISO-UserService#926 acceptance: the Erstantwort reaches the room, and it does so <b>without a
+ * Carimat account</b>.
+ *
+ * <p>That second half is the one worth a test rather than a comment. ADR-018 §3 rejected a bot
+ * account because it would be an additional Megolm key holder in a room carrying §11 KDG
+ * special-category data, and because a bot has no Schweigepflicht. Nothing in the type system stops
+ * a later change from registering one, so the absence is asserted here: the event goes out on the
+ * session's own credential resolution and no room membership is touched.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ErstantwortPostingTest {
+
+  @Mock private MatrixSynapseService matrixSynapseService;
+  @Mock private AgencyMatrixCredentialClient agencyMatrixCredentialClient;
+  @Mock private SessionService sessionService;
+  @Mock private ConsultantService consultantService;
+
+  @InjectMocks private MatrixSessionSystemMessageService service;
+
+  private final ErstantwortPayloadBuilder builder = new ErstantwortPayloadBuilder();
+
+  private Session session;
+
+  @BeforeEach
+  void setUp() {
+    var user = new User();
+    user.setMatrixUserId("@katze-mika-1234:oriso.test");
+
+    session = new Session();
+    session.setId(4711L);
+    session.setMatrixRoomId("!room:oriso.test");
+    session.setUser(user);
+
+    when(matrixSynapseService.loginAsUserAccessToken(anyString())).thenReturn("token");
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), anyString()))
+        .thenReturn(Map.of("event_id", "$evt"));
+  }
+
+  private String post() {
+    var body =
+        builder.buildFirstResponseBody(
+            ErstantwortContext.builder().modality(ErstantwortModality.AGENCY_COUNSELLING).build());
+    service.postFirstResponseMessage(session, body);
+    var captor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService).sendMessage(eq("!room:oriso.test"), captor.capture(), anyString());
+    return captor.getValue();
+  }
+
+  @Test
+  void postsTheErstantwortIntoTheSessionRoomAsOneEvent() {
+    var posted = post();
+
+    assertThat(posted).startsWith("[SYSTEM_NOTIFICATION]");
+    assertThat(posted).contains("\"type\":\"FIRST_RESPONSE\"");
+    assertThat(posted).contains("\"version\":1");
+    // One event for the whole sequence, not one per Baustein.
+    verify(matrixSynapseService, times(1)).sendMessage(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void createsNoCarimatAccountAndAddsNoRoomMember() {
+    post();
+
+    // The sender is the session's own user; nothing registers or invites anybody.
+    verify(matrixSynapseService).loginAsUserAccessToken("@katze-mika-1234:oriso.test");
+    verify(matrixSynapseService, never()).loginAsUserAccessToken("@carimat:oriso.test");
+    verify(agencyMatrixCredentialClient, never()).fetchMatrixCredentials(any());
+  }
+
+  @Test
+  void postsNothingWhenTheSessionHasNoRoom() {
+    session.setMatrixRoomId(null);
+    when(sessionService.getSession(4711L)).thenReturn(java.util.Optional.empty());
+
+    service.postFirstResponseMessage(session, "[SYSTEM_NOTIFICATION]{}");
+
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void postsNothingWhenTheBuilderCouldNotSerialiseAPayload() {
+    service.postFirstResponseMessage(session, null);
+
+    verify(matrixSynapseService, never()).sendMessage(anyString(), anyString(), anyString());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -1534,4 +1534,39 @@ class EventNotificationServiceTest {
     String text = eventCaptor.getValue().getText();
     assertThat(text).contains("evt-123");
   }
+
+  @Test
+  void createFirstResponseNotification_persistsSessionIdAndRoomRefInParams() throws Exception {
+    /* ORISO-UserService#926: the frontend resolves the chat to open out of
+    `params`. Without them the Erstantwort's one timeline entry still renders
+    and leads nowhere — the person is told something happened and given no way
+    back to it. */
+    var user = new User();
+    user.setUserId("asker-1");
+    var session = new Session();
+    session.setId(4711L);
+    session.setUser(user);
+    session.setMatrixRoomId("!room:matrix.test");
+
+    eventNotificationService.createFirstResponseNotification(session);
+
+    verify(eventNotificationRepository).save(eventCaptor.capture());
+    var saved = eventCaptor.getValue();
+    assertThat(saved.getEventType()).isEqualTo("first_response.received");
+    assertThat(saved.getRecipientUserId()).isEqualTo("asker-1");
+
+    JsonNode params = new ObjectMapper().readTree(saved.getParams());
+    assertThat(params.get("sessionId").asLong()).isEqualTo(4711L);
+    assertThat(params.get("roomRef").asText()).isEqualTo("!room:matrix.test");
+  }
+
+  @Test
+  void createFirstResponseNotification_writesNothingWithoutAnAdviceSeeker() {
+    var session = new Session();
+    session.setId(4712L);
+
+    eventNotificationService.createFirstResponseNotification(session);
+
+    verify(eventNotificationRepository, never()).save(any());
+  }
 }


### PR DESCRIPTION
Implements OpenResilienceInitiative/ORISO-UserService#926 — the server half of **EPIC OpenResilienceInitiative/ORISO-Frontend#824 — Erstantwort** (ADR-018).

Until now **no first response reached anybody on the Matrix path.** `postWelcomeMessageIfConfigured`, `postFurtherStepsIfConfigured` and `FURTHER_STEPS` had zero occurrences in `src/main`, and `createEnquiryMessage` delegated unconditionally to `createMatrixEnquiryMessage`, which sent the enquiry and returned. This is a rebuild on the Matrix transport, not the restoration of a forgotten call.

Consumer: OpenResilienceInitiative/ORISO-Frontend#1008 (`feat/erstantwort-adr018`). Both sides key off the same versioned contract; **neither is stacked on the other** and both branch from `pre-dev`.

## What is in here

**`ErstantwortPayloadBuilder`** resolves the platform Baustein catalogue and **freezes the resulting wording** into one versioned payload (ADR-018 §4). That is the load-bearing decision: what was said to a person has to stay provable, and a Träger who edits their greeting next month must not retroactively change what an advice seeker was told in a room carrying §11 KDG special-category data.

**It stores no completion state.** An action carries only its `kind`; the client reads e-mail and 2FA live. Storing it here would be the new state ADR-018 §4 forbids, and it would go stale the moment somebody edited their profile.

**The resolution chain** `Fachbereich ?? Beratungsstelle ?? Träger ?? Plattform` is implemented and tested now, with only the platform link populated in production, so ORISO-Admin#601 becomes a form rather than a migration. A blank value at any level counts as absent, so an editor that saved an empty field cannot silence the level below it.

**Modality assignment** — Live Chat receives no who-reads-along (no teams, no case handover to disclose) and no reply deadline (synchronous; the promise would be unkeepable). The two safety-bearing Bausteine apply everywhere.

**`postFirstResponseMessage`** posts it through the existing credential resolution. **No Carimat account is created and no room member is added** — asserted in `ErstantwortPostingTest`, not merely commented, because ADR-018 §3 rejected a bot precisely as an extra Megolm key holder in a room whose contents nobody outside may read, and a bot has no Schweigepflicht.

**Exactly one Activity Timeline row**, targeting the asker's own chat. One entry, not one per open action: a person who has just written about something hard should not receive three to-do items (ADR-018 §11). The "narrow exception" the issue asks for is narrow **by construction** rather than by a new flag — the `isSystemNotificationMessage` filter on the Matrix *ingestion* path stays exactly as strict as it was, and the Erstantwort writes its own single row from the enquiry facade.

**Every failure path is swallowed and logged.** The person's message reaching a counsellor outranks the platform's own greeting, so nothing here may roll a dispatched enquiry back.

## Verification

- Full unit suite: **3796 tests, 0 failures** (`./mvnw test`)
- `ErstantwortPayloadBuilderTest` (15) + `ErstantwortPostingTest` (4) are new; `MatrixSessionSystemMessageServiceTest` and both `CreateEnquiryMessageFacade` tests still pass with the new collaborators mocked
- `spotless:apply` run

**Build on JDK 21, as CI does.** On JDK 25 Mockito cannot mock `MatrixSynapseService` and JaCoCo rejects class file major version 69 — both fail identically on unmodified `pre-dev`, so this is not a regression from this PR, but it will waste your afternoon if you hit it.

## Not in here — stated plainly

- **No end-to-end integration test** on the Matrix path. #926's last acceptance box is not ticked. The unit coverage proves the payload and the posting; it does not prove the round trip against a live Synapse.
- The chain's middle levels have **no data source** yet — that arrives with ORISO-Admin#601.
- Derived DPP/Imprint URLs are plumbed and tested but not yet read from the department; the context fields are there and unpopulated.

## Reviewer test plan

- [ ] Deploy to Pre-Dev alongside ORISO-Frontend#1008 and send an enquiry as an advice seeker — the Carimat sequence appears in the room
- [ ] Exactly **one** event in the room, not one per Baustein
- [ ] Synapse admin: **no** `@carimat:…` account exists, and the room's member list is unchanged
- [ ] The Activity Timeline shows **one** entry for the Erstantwort, pointing at the asker's chat
- [ ] Other system notifications still do **not** produce timeline entries
- [ ] Break the Matrix send deliberately (bad token) — the enquiry still dispatches and the counsellor is still notified
- [ ] Mobile: the sequence is readable on a phone-sized viewport in the app

Refs OpenResilienceInitiative/ORISO-UserService#926, OpenResilienceInitiative/ORISO-Frontend#824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic first-response messages after enquiry notifications.
  - Messages support different counselling modalities, response deadlines, safety information, privacy links, and configurable editorial content.
  - Added a corresponding timeline notification with a link to the relevant session.
- **Reliability**
  - First-response message or notification failures are logged without preventing the enquiry from being created.
- **Tests**
  - Added coverage for message content, fallback behavior, links, delivery, and missing session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->