### PR TITLE
fix(chat): keep internal team chats out of the deactivation sweep (#984)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatService.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api.workflow.deactivate.service;
 import de.caritas.cob.userservice.api.actions.chat.StopChatActionCommand;
 import de.caritas.cob.userservice.api.actions.registry.ActionsRegistry;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -28,8 +29,22 @@ public class DeactivateGroupChatService {
   public void deactivateStaleGroupChats() {
     var deactivationTime = LocalDateTime.now().minusMinutes(deactivatePeriodMinutes);
     this.chatRepository.findAllByActiveIsTrue().stream()
+        .filter(isDeactivatable())
         .filter(isChatOutsideOfDeactivationTime(deactivationTime))
         .forEach(this::deactivateStaleActiveChat);
+  }
+
+  /**
+   * Internal team chats are persistent rooms for colleagues, not scheduled sessions that end.
+   *
+   * <p>They carry a duration like every other chat, so the sweep used to reach them once that
+   * duration had passed. For a non-repetitive chat {@link StopChatActionCommand} deletes the chat
+   * and shuts down its Matrix room, which destroyed the room and its history roughly an hour after
+   * a counsellor first opened it - without any user action and with no way back. See
+   * ORISO-UserService#984.
+   */
+  private Predicate<Chat> isDeactivatable() {
+    return chat -> chat.getConversationType() != ConversationType.INTERNAL_GROUP;
   }
 
   private Predicate<Chat> isChatOutsideOfDeactivationTime(LocalDateTime deactivationTime) {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/deactivate/service/DeactivateGroupChatServiceTest.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.actions.ActionCommandMockProvider;
 import de.caritas.cob.userservice.api.actions.chat.StopChatActionCommand;
 import de.caritas.cob.userservice.api.actions.registry.ActionsRegistry;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.port.out.ChatRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -118,6 +120,61 @@ class DeactivateGroupChatServiceTest {
     this.deactivateGroupChatService.deactivateStaleGroupChats();
 
     verify(this.commandMockProvider.getActionMock(StopChatActionCommand.class)).execute(chat);
+  }
+
+  @Test
+  void deactivateStaleGroupChats_Should_leaveInternalTeamChatsAlone_When_theyAreLongOverdue() {
+    var internalChat = new Chat();
+    internalChat.setDuration(60);
+    internalChat.setActive(true);
+    internalChat.setUpdateDate(LocalDateTime.now().minusDays(30));
+    internalChat.setConversationType(ConversationType.INTERNAL_GROUP);
+    when(this.chatRepository.findAllByActiveIsTrue()).thenReturn(List.of(internalChat));
+
+    this.deactivateGroupChatService.deactivateStaleGroupChats();
+
+    verifyNoMoreInteractions(
+        this.actionsRegistry, this.commandMockProvider.getActionMock(StopChatActionCommand.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ConversationType.class,
+      names = {"INTERNAL_GROUP"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void deactivateStaleGroupChats_Should_stillStopEveryOtherModality(
+      ConversationType conversationType) {
+    var chat = new Chat();
+    chat.setDuration(60);
+    chat.setActive(true);
+    chat.setUpdateDate(LocalDateTime.now().minusDays(30));
+    chat.setConversationType(conversationType);
+    when(this.chatRepository.findAllByActiveIsTrue()).thenReturn(List.of(chat));
+    when(this.actionsRegistry.buildContainerForType(Chat.class))
+        .thenReturn(commandMockProvider.getActionContainer(Chat.class));
+
+    this.deactivateGroupChatService.deactivateStaleGroupChats();
+
+    verify(this.commandMockProvider.getActionMock(StopChatActionCommand.class)).execute(chat);
+  }
+
+  /**
+   * Rows written before the modality column existed carry a null conversation type. They must keep
+   * the previous behaviour rather than silently become undeletable.
+   */
+  @Test
+  void deactivateStaleGroupChats_Should_stillStopChats_When_theConversationTypeIsUnset() {
+    var legacyChat = new Chat();
+    legacyChat.setDuration(60);
+    legacyChat.setActive(true);
+    legacyChat.setUpdateDate(LocalDateTime.now().minusDays(30));
+    when(this.chatRepository.findAllByActiveIsTrue()).thenReturn(List.of(legacyChat));
+    when(this.actionsRegistry.buildContainerForType(Chat.class))
+        .thenReturn(commandMockProvider.getActionContainer(Chat.class));
+
+    this.deactivateGroupChatService.deactivateStaleGroupChats();
+
+    verify(this.commandMockProvider.getActionMock(StopChatActionCommand.class)).execute(legacyChat);
   }
 
   private static List<LocalDateTime> createOverdueUpdateDates() {


### PR DESCRIPTION
Closes #984

## Why

An internal team chat that a counsellor ever opened was deleted — together with its Matrix room and its history — roughly an hour later. No user action, no warning, no way back.

Three facts combined:

1. `CreateChatFacade.java:124` sets `active = false` on every V2-created group chat, internal ones included.
2. The frontend creates internal team chats with `duration: 60` and `repetitive: false`, start time now.
3. `DeactivateGroupChatService` sweeps every active chat once `startDate + duration` has passed, and `StopChatActionCommand:55-58` handles a **non-repetitive** chat by calling `chatService.deleteChat(chat)` *and* `matrixChatShutdownService.shutdownRoom(chat)`.

So the moment a counsellor pressed "Chat starten" — the workaround the waiting-room UI invited, see ORISO-Frontend#979 — a 60-minute timer to deletion began. That contradicts the product definition of internal team chats as persistent rooms.

## What changed

One predicate: `INTERNAL_GROUP` chats are excluded from the deactivation sweep. The modality is already persisted correctly by `ChatConverter` and the column exists on the entity, so no schema change is needed.

## Why not the other option

The issue offered a second route — create internal chats with `active = true`. Deliberately not taken:

- It would not fix the problem on its own. An active internal chat is still swept, so the exclusion is required either way.
- It would break the start flow. ORISO-Frontend#1001 deliberately keeps the join/start button for internal chats, because the room still has to be opened server-side before messages can flow. A chat created active would make `StartChatFacade` answer `409 Conflict` on that button.

If the `active = false` state later turns out to cause other confusion, that is a separate change with its own frontend coordination — it is not a prerequisite for stopping the data loss.

## Legacy rows

Chats written before the modality column carry a null `conversation_type`. They keep the previous behaviour rather than silently becoming undeletable — covered by a test.

## Tests

`DeactivateGroupChatServiceTest`, 13/13 green on JDK 21:

- an overdue `INTERNAL_GROUP` chat is left alone
- every other modality is still stopped (parameterised over the enum, excluding `INTERNAL_GROUP`, so a new modality is covered automatically)
- a chat with an unset conversation type is still stopped

The first test was verified to **fail** without the production change, so it guards something rather than merely passing.

## Reviewer test plan

- [ ] `mvn -Dtest=DeactivateGroupChatServiceTest test` is green
- [ ] On Pre-Dev, as a counsellor, create an internal team chat with a colleague and press "Chat starten"
- [ ] Exchange messages
- [ ] After `startDate + duration` has passed and the sweep has run, the chat is still in the list, its history intact, and its Matrix room still resolves
- [ ] **Regression:** a scheduled group chat or self-help circle that has run past its duration is still deactivated and cleaned up as before
- [ ] A legacy group chat with no `conversation_type` (if any exist on Pre-Dev) is still deactivated

## Data check worth doing separately

Pre-Dev and `dev` may already have lost internal team chats this way. Worth looking before someone reports it as an unrelated mystery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal group chats are no longer deactivated by the stale-chat cleanup process.
  * Other conversation types, including legacy chats without a type, continue to be deactivated as expected.

* **Tests**
  * Added coverage confirming the updated deactivation behavior across conversation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->