### PR TITLE
test: prove scheduler replica leases on MariaDB instead of H2

### DIFF
--- a/.github/workflows/mariadb-contract.yml
+++ b/.github/workflows/mariadb-contract.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Verify real MariaDB schema contracts
       run: >-
         ./mvnw -B -Dskip.unit-tests=true
-        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,ProvisioningCompensationMariaDbIT,ScheduledTaskClaimMariaDbIT,TutorialProgressServiceMariaDbReplicaIT,OrganizerMariaDbReplicaIT,DeactivateGroupChatSchedulerMariaDbReplicaIT
+        -Dtest=DatabaseChangelogDriftIT,AdminStatisticsRepositoryMariaDbIT,ProvisioningCompensationMariaDbIT,ScheduledTaskClaimMariaDbIT,TutorialProgressServiceMariaDbReplicaIT,OrganizerMariaDbReplicaIT,DeactivateGroupChatSchedulerMariaDbReplicaIT,DeleteUserAccountSchedulerMariaDbReplicaIT,DeleteUsersRegisteredOnlySchedulerMariaDbReplicaIT
         integration-test
 
     - name: Prove authenticated writes across two replicas

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUserAccountSchedulerMariaDbReplicaIT.java
@@ -16,19 +16,55 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+/**
+ * Proves that two replicas of the account-deletion scheduler run the workflow once.
+ *
+ * <p>Runs against real MariaDB because the exclusion depends on InnoDB gap locking: the {@code
+ * PESSIMISTIC_WRITE} read in {@code ScheduledTaskClaimWriter} matches no row on the first claim,
+ * and only a gap lock makes the loser wait until the winner has committed. H2 — including {@code
+ * MODE=MariaDB} — emulates the syntax but not the locking, so both replicas would pass the empty
+ * read and the loser's merge would silently turn into an UPDATE of the winner's fresh claim. The H2
+ * variant of this test therefore proved nothing and failed by timing.
+ */
 @SpringBootTest
 @ActiveProfiles("testing")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-class DeleteUserAccountSchedulerReplicaIT {
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class DeleteUserAccountSchedulerMariaDbReplicaIT {
 
   private static final String TASK_NAME = "account-deletion";
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.mariadb.jdbc.Driver");
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.liquibase.contexts", () -> "dev,seed");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MariaDBDialect");
+    registry.add("spring.jpa.defer-datasource-initialization", () -> "false");
+    registry.add("spring.sql.init.mode", () -> "never");
+    registry.add("user.account.deleteworkflow.cron", () -> "0 0 0 1 1 ?");
+  }
 
   @Autowired private ScheduledTaskClaimRepository claimRepository;
   @Autowired private ScheduledTaskClaimService taskClaimService;
@@ -54,8 +90,8 @@ class DeleteUserAccountSchedulerReplicaIT {
 
       assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
       start.countDown();
-      firstResult.get(5, TimeUnit.SECONDS);
-      secondResult.get(5, TimeUnit.SECONDS);
+      firstResult.get(15, TimeUnit.SECONDS);
+      secondResult.get(15, TimeUnit.SECONDS);
     } finally {
       start.countDown();
       executor.shutdownNow();
@@ -63,6 +99,7 @@ class DeleteUserAccountSchedulerReplicaIT {
 
     verify(tenantContextProvider, times(1)).setTechnicalContextIfMultiTenancyIsEnabled();
     verify(deletionService, times(1)).deleteUserAccounts();
+    assertThat(claimRepository.findById(TASK_NAME)).isPresent();
   }
 
   private DeleteUserAccountScheduler newScheduler(

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerMariaDbReplicaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/scheduler/DeleteUsersRegisteredOnlySchedulerMariaDbReplicaIT.java
@@ -16,19 +16,55 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+/**
+ * Proves that two replicas of the registered-only deletion scheduler run the workflow once.
+ *
+ * <p>Runs against real MariaDB because the exclusion depends on InnoDB gap locking: the {@code
+ * PESSIMISTIC_WRITE} read in {@code ScheduledTaskClaimWriter} matches no row on the first claim,
+ * and only a gap lock makes the loser wait until the winner has committed. H2 — including {@code
+ * MODE=MariaDB} — emulates the syntax but not the locking, so both replicas would pass the empty
+ * read and the loser's merge would silently turn into an UPDATE of the winner's fresh claim. The H2
+ * variant of this test therefore proved nothing and failed by timing.
+ */
 @SpringBootTest
 @ActiveProfiles("testing")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-class DeleteUsersRegisteredOnlySchedulerReplicaIT {
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+class DeleteUsersRegisteredOnlySchedulerMariaDbReplicaIT {
 
   private static final String TASK_NAME = "registered-only-user-deletion";
+
+  @DynamicPropertySource
+  private static void databaseProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", () -> System.getenv("LIQUIBASE_IT_DB_URL"));
+    registry.add(
+        "spring.datasource.username",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_USERNAME", "root"));
+    registry.add(
+        "spring.datasource.password",
+        () -> System.getenv().getOrDefault("LIQUIBASE_IT_DB_PASSWORD", "root"));
+    registry.add("spring.datasource.driver-class-name", () -> "org.mariadb.jdbc.Driver");
+    registry.add("spring.liquibase.enabled", () -> "true");
+    registry.add(
+        "spring.liquibase.change-log", () -> "classpath:db/changelog/userservice-master.xml");
+    registry.add("spring.liquibase.contexts", () -> "dev,seed");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MariaDBDialect");
+    registry.add("spring.jpa.defer-datasource-initialization", () -> "false");
+    registry.add("spring.sql.init.mode", () -> "never");
+    registry.add("user.registeredonly.deleteWorkflow.cron", () -> "0 0 0 1 1 ?");
+  }
 
   @Autowired private ScheduledTaskClaimRepository claimRepository;
   @Autowired private ScheduledTaskClaimService taskClaimService;
@@ -54,8 +90,8 @@ class DeleteUsersRegisteredOnlySchedulerReplicaIT {
 
       assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
       start.countDown();
-      firstResult.get(5, TimeUnit.SECONDS);
-      secondResult.get(5, TimeUnit.SECONDS);
+      firstResult.get(15, TimeUnit.SECONDS);
+      secondResult.get(15, TimeUnit.SECONDS);
     } finally {
       start.countDown();
       executor.shutdownNow();
@@ -64,6 +100,7 @@ class DeleteUsersRegisteredOnlySchedulerReplicaIT {
     verify(tenantContextProvider, times(1)).setTechnicalContextIfMultiTenancyIsEnabled();
     verify(deletionService, times(1)).deleteUserAccountsTimeSensitive();
     verify(deletionService, times(1)).deleteUserAccountsTimeInsensitive();
+    assertThat(claimRepository.findById(TASK_NAME)).isPresent();
   }
 
   private DeleteUsersRegisteredOnlyScheduler newScheduler(


### PR DESCRIPTION
## Problem

`DeleteUsersRegisteredOnlySchedulerReplicaIT.twoSchedulerInstancesTriggerOneRegisteredOnlyDeletionBatch` failed intermittently in the required integration gate:

```
TooManyActualInvocations: setTechnicalContextIfMultiTenancyIsEnabled() wanted 1 time, was 2
```

Both scheduler replicas ran the workflow.

## Why the test could not prove its own name

The exclusion in `ScheduledTaskClaimWriter.claim` depends on InnoDB gap locking. `findByTaskNameForUpdate` is `@Lock(PESSIMISTIC_WRITE)`; on the first claim it matches **no row**, and only a gap lock makes the losing replica wait until the winner has committed.

The integration suite runs on H2 — `application-testing.properties` line 36 sets `MODE=MariaDB` — and H2's MariaDB mode emulates syntax, not locking.

A two-connection probe against both engines confirms it. Connection A holds an open transaction after `SELECT ... FOR UPDATE` on the absent key plus an `INSERT`; connection B then issues the same `FOR UPDATE`:

| Engine | Result |
| --- | --- |
| H2 `MODE=MariaDB` | returns immediately — no gap lock |
| MariaDB 10.11 InnoDB | blocks until A commits |

This also explains the exact `was 2`. `ScheduledTaskClaim` has an **assigned** `@Id`, so `saveAndFlush` goes through `merge()`, not `persist()`. On H2 both replicas pass the empty read; the loser then re-reads, now sees the winner's committed row, and issues an `UPDATE` instead of colliding with the primary key. Both `claim()` calls return `true` and both workflows run — no unique-constraint violation ever surfaces to arbitrate. Which replica loses, and whether the test passes at all, is pure timing.

Note: running the old H2 assertion 25 times in a row on a developer machine passed 25/25. The flake does not reproduce on demand, which is why the engine-level probe above is the evidence rather than a repeat run.

## Change

Both affected tests move to real MariaDB, matching the existing `DeactivateGroupChatSchedulerMariaDbReplicaIT` pattern:

- renamed to `*MariaDbReplicaIT` and gated on `LIQUIBASE_IT_DB_URL`
- pointed at the contract database via `@DynamicPropertySource`, with each scheduler's cron pinned so the real bean cannot consume the proof claim
- assert the claim row survives the race
- added to the `mariadb-contract` job, which is a required gate alongside `required-integration-tests`

They are kept rather than deleted as redundant: `ScheduledTaskClaimMariaDbIT` proves the lease *primitive*, but nothing else proves that these specific schedulers actually route through the lease at all. Weakening the H2 assertion instead was rejected — it would leave a test that asserts nothing.

## Sibling audit

Four `*ReplicaIT` classes run on H2. Two share the defect, two do not:

| Test | Arbiter | Verdict |
| --- | --- | --- |
| `DeleteUsersRegisteredOnlySchedulerReplicaIT` | gap lock | broken — moved |
| `DeleteUserAccountSchedulerReplicaIT` | gap lock | identical defect — moved |
| `EventNotificationServiceReplicaIT` | unique index; `IDENTITY` id so `save()` persists | sound on H2 — left alone |
| `InactiveAccountNotificationServiceReplicaIT` | unique index; `IDENTITY` id so `save()` persists | sound on H2 — left alone |

The two that stay are arbitrated by a unique index, which H2 does enforce.

## Verification (JDK 21)

- Full `mariadb-contract` test list against MariaDB 10.11: **12 tests, 0 failures**, including both new classes.
- Full `scripts/ci/run-required-integration-tests.sh` on H2: `reports=92 tests=873 failures=0 errors=0 skipped=14`, exit 0. Floors are 75 reports / 830 tests.
- When skipped on H2 the classes still emit surefire reports with `tests="1"`, so neither floor changes.

## Reviewer test plan

- [ ] `mariadb-contract` job is green and its log shows `DeleteUserAccountSchedulerMariaDbReplicaIT` and `DeleteUsersRegisteredOnlySchedulerMariaDbReplicaIT` running, not skipped.
- [ ] `required integration tests` job is green and its inventory summary still reports at least 75 reports / 830 tests.
- [ ] Confirm both new classes appear as skipped in the H2 job rather than missing entirely.
- [ ] No production code changed — diff touches only the two test classes and the workflow test list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded MariaDB replica integration-test coverage for account deletion schedulers.
  * Added validation that scheduled-task claims remain persisted during concurrent processing.
  * Improved test reliability with MariaDB-specific configuration and longer execution timeouts.
  * Documented the required InnoDB locking behavior for these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->