### PR TITLE
Fix Matrix invite retry handling

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -40,6 +41,10 @@ public class MatrixRoomClient {
       "/_matrix/client/r0/rooms/{roomId}/state/m.room.power_levels";
   private static final String ENDPOINT_MEMBERSHIP =
       "/_matrix/client/r0/rooms/{roomId}/state/m.room.member/{userId}";
+  private static final int INVITE_USER_MAX_ATTEMPTS = 3;
+  private static final long DEFAULT_INVITE_RETRY_DELAY_MS = 1000L;
+  private static final Pattern RETRY_AFTER_MS_PATTERN =
+      Pattern.compile("\"retry_after_ms\"\\s*:\\s*(\\d+)");
 
   private final MatrixConfig matrixConfig;
   private final RestTemplate restTemplate;
@@ -113,42 +118,88 @@ public class MatrixRoomClient {
   public ResponseEntity<MatrixInviteUserResponseDTO> inviteUserToRoom(
       String roomId, String userId, String accessToken) throws MatrixInviteUserException {
 
+    var headers = getClientHttpHeaders(accessToken);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    var inviteRequest = new MatrixInviteUserRequestDTO();
+    inviteRequest.setUserId(userId);
+
+    HttpEntity<MatrixInviteUserRequestDTO> request = new HttpEntity<>(inviteRequest, headers);
+
+    var url = buildUrl(ENDPOINT_INVITE_USER, Map.of("roomId", roomId));
+
+    for (int attempt = 1; attempt <= INVITE_USER_MAX_ATTEMPTS; attempt++) {
+      try {
+        log.info("Inviting Matrix user: {} to room: {} at URL: {}", userId, roomId, url);
+
+        var response = restTemplate.postForEntity(url, request, MatrixInviteUserResponseDTO.class);
+
+        log.info("Successfully invited Matrix user: {} to room: {}", userId, roomId);
+
+        return response;
+      } catch (HttpClientErrorException ex) {
+        if (isRateLimited(ex) && attempt < INVITE_USER_MAX_ATTEMPTS) {
+          waitBeforeInviteRetry(userId, roomId, attempt, retryAfterMs(ex));
+          continue;
+        }
+
+        log.error(
+            "Matrix Error: Could not invite user ({}) to room ({}) in Matrix. Status: {}, Response: {}",
+            userId,
+            roomId,
+            ex.getStatusCode(),
+            ex.getResponseBodyAsString());
+        throw new MatrixInviteUserException(
+            String.format(
+                "Could not invite user (%s) to room (%s) in Matrix: %s",
+                userId, roomId, ex.getResponseBodyAsString()));
+      } catch (Exception ex) {
+        log.error(
+            "Matrix Error: Could not invite user ({}) to room ({}) in Matrix. Reason",
+            userId,
+            roomId,
+            ex);
+        throw new MatrixInviteUserException(
+            String.format("Could not invite user (%s) to room (%s) in Matrix", userId, roomId));
+      }
+    }
+
+    throw new MatrixInviteUserException(
+        String.format("Could not invite user (%s) to room (%s) in Matrix", userId, roomId));
+  }
+
+  private boolean isRateLimited(HttpClientErrorException ex) {
+    return ex.getStatusCode().value() == 429
+        || ex.getResponseBodyAsString().contains("M_LIMIT_EXCEEDED");
+  }
+
+  private long retryAfterMs(HttpClientErrorException ex) {
+    var matcher = RETRY_AFTER_MS_PATTERN.matcher(ex.getResponseBodyAsString());
+    if (matcher.find()) {
+      try {
+        return Long.parseLong(matcher.group(1));
+      } catch (NumberFormatException ignored) {
+        return DEFAULT_INVITE_RETRY_DELAY_MS;
+      }
+    }
+    return DEFAULT_INVITE_RETRY_DELAY_MS;
+  }
+
+  private void waitBeforeInviteRetry(String userId, String roomId, int attempt, long retryAfterMs)
+      throws MatrixInviteUserException {
+    log.warn(
+        "Matrix invite for user {} to room {} was rate limited; retrying attempt {} of {} after {} ms",
+        userId,
+        roomId,
+        attempt + 1,
+        INVITE_USER_MAX_ATTEMPTS,
+        retryAfterMs);
     try {
-      var headers = getClientHttpHeaders(accessToken);
-      headers.setContentType(MediaType.APPLICATION_JSON);
-
-      var inviteRequest = new MatrixInviteUserRequestDTO();
-      inviteRequest.setUserId(userId);
-
-      HttpEntity<MatrixInviteUserRequestDTO> request = new HttpEntity<>(inviteRequest, headers);
-
-      var url = buildUrl(ENDPOINT_INVITE_USER, Map.of("roomId", roomId));
-      log.info("Inviting Matrix user: {} to room: {} at URL: {}", userId, roomId, url);
-
-      var response = restTemplate.postForEntity(url, request, MatrixInviteUserResponseDTO.class);
-
-      log.info("Successfully invited Matrix user: {} to room: {}", userId, roomId);
-
-      return response;
-    } catch (HttpClientErrorException ex) {
-      log.error(
-          "Matrix Error: Could not invite user ({}) to room ({}) in Matrix. Status: {}, Response: {}",
-          userId,
-          roomId,
-          ex.getStatusCode(),
-          ex.getResponseBodyAsString());
+      Thread.sleep(retryAfterMs);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       throw new MatrixInviteUserException(
-          String.format(
-              "Could not invite user (%s) to room (%s) in Matrix: %s",
-              userId, roomId, ex.getResponseBodyAsString()));
-    } catch (Exception ex) {
-      log.error(
-          "Matrix Error: Could not invite user ({}) to room ({}) in Matrix. Reason",
-          userId,
-          roomId,
-          ex);
-      throw new MatrixInviteUserException(
-          String.format("Could not invite user (%s) to room (%s) in Matrix", userId, roomId));
+          String.format("Interrupted while retrying Matrix invite for user (%s)", userId), ex);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomService.java
@@ -105,7 +105,14 @@ public class AgencyPreAssignmentRoomService {
       // message for an audience that does not yet contain the department. Consultants-first makes
       // every membership view the asker's client can ever observe already include the department.
       joinAgencyConsultants(session, roomId, agencyToken);
-      inviteUser(roomId, user, agencyToken);
+      if (!inviteUser(roomId, user, agencyToken)) {
+        log.error(
+            "Asker {} could not be invited to Matrix holding room {} for session {}; room id will not be persisted.",
+            user.getUserId(),
+            roomId,
+            session.getId());
+        return;
+      }
 
       session.setMatrixRoomId(roomId);
       sessionService.saveSession(session);
@@ -158,20 +165,22 @@ public class AgencyPreAssignmentRoomService {
     }
   }
 
-  private void inviteUser(String roomId, User user, String agencyToken) {
+  private boolean inviteUser(String roomId, User user, String agencyToken) {
     try {
       sessionRoomGateway.inviteUser(roomId, user.getMatrixUserId(), agencyToken);
 
       String userToken = sessionRoomGateway.loginAsUser(user.getMatrixUserId());
       if (!isBlank(userToken)) {
-        sessionRoomGateway.joinRoom(roomId, userToken);
+        return sessionRoomGateway.joinRoom(roomId, userToken);
       }
+      return true;
     } catch (MatrixInviteUserException ex) {
       log.error(
           "Failed to invite user {} to holding room {}: {}",
           user.getUserId(),
           roomId,
           ex.getMessage());
+      return false;
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -174,6 +175,33 @@ class MatrixRoomClientTest {
         .isInstanceOf(
             de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException.class)
         .hasMessageContaining("Could not invite user");
+  }
+
+  @Test
+  void inviteUserToRoom_ShouldRetry_WhenMatrixRateLimitsInvite() throws Exception {
+    var responseBody = new MatrixInviteUserResponseDTO();
+    when(restTemplate.postForEntity(
+            eq(uri(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/invite")),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(MatrixInviteUserResponseDTO.class)))
+        .thenThrow(
+            HttpClientErrorException.create(
+                HttpStatus.TOO_MANY_REQUESTS,
+                "Too Many Requests",
+                null,
+                "{\"errcode\":\"M_LIMIT_EXCEEDED\",\"retry_after_ms\":1}"
+                    .getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8))
+        .thenReturn(ResponseEntity.ok(responseBody));
+
+    var response = matrixRoomClient.inviteUserToRoom(ROOM_ID, USER_ID, ACCESS_TOKEN);
+
+    assertThat(response.getBody()).isSameAs(responseBody);
+    verify(restTemplate, times(2))
+        .postForEntity(
+            eq(uri(API_URL + "/_matrix/client/r0/rooms/" + ENCODED_ROOM_ID + "/invite")),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(MatrixInviteUserResponseDTO.class));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyPreAssignmentRoomServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
+import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
@@ -294,10 +295,39 @@ class AgencyPreAssignmentRoomServiceTest {
   }
 
   @Test
+  @DisplayName("ensureHoldingRoom does not persist when the asker invite fails")
+  void ensureHoldingRoom_doesNotPersist_whenAskerInviteFails() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    org.mockito.Mockito.doThrow(new MatrixInviteUserException("rate limited"))
+        .when(sessionRoomGateway)
+        .inviteUser(NEW_ROOM_ID, USER_MATRIX_ID, AGENCY_TOKEN);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionService, never()).saveSession(any());
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
+  @DisplayName("ensureHoldingRoom does not persist when the asker cannot join after invite")
+  void ensureHoldingRoom_doesNotPersist_whenAskerJoinFails() throws Exception {
+    stubHappyPathUntilRoomCreation();
+    when(sessionRoomGateway.loginAsUser(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(sessionRoomGateway.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(false);
+
+    underTest.ensureHoldingRoom(session, user);
+
+    verify(sessionService, never()).saveSession(any());
+    assertNull(session.getMatrixRoomId());
+  }
+
+  @Test
   @DisplayName("a directly addressed enquiry is not fanned out to the whole department")
   void ensureHoldingRoom_skipsDepartment_whenConsultantDirectlySet() throws Exception {
     stubHappyPathUntilRoomCreation();
     session.setIsConsultantDirectlySet(true);
+    when(sessionRoomGateway.loginAsUser(USER_MATRIX_ID)).thenReturn(USER_TOKEN);
+    when(sessionRoomGateway.joinRoom(NEW_ROOM_ID, USER_TOKEN)).thenReturn(true);
 
     underTest.ensureHoldingRoom(session, user);
 


### PR DESCRIPTION
## Summary
- retry Matrix room invites when Synapse returns `429` / `M_LIMIT_EXCEEDED`, honoring `retry_after_ms` when present
- do not persist `session.matrix_room_id` unless the asker invite/join path succeeds
- add coverage for Matrix invite retry and for avoiding broken persisted rooms when inviter/joiner fails

## Why
During predev testing, UserService created a Matrix room and joined consultants, but Synapse rate-limited the actual asker invite. The session was still saved with `matrix_room_id`, so later refresh/open attempts hit 403 because the asker was not invited/member of the room.

Closes #990

## Tests
- `./mvnw -q -Dtest=MatrixRoomClientTest,AgencyPreAssignmentRoomServiceTest test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invitations now automatically retry when Matrix temporarily rate-limits requests, improving reliability during busy periods.
  - Temporary rate-limit delays are respected before retrying, with clear failure handling if attempts are exhausted.
  - Holding-room sessions are no longer saved when inviting or joining an asker fails, preventing incomplete room records.
  - Successful invitations and joins continue through the existing room setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->