### PR TITLE
fix(api): restore Jackson 2 null-for-primitives semantics for request DTOs

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/CustomWebMvcConfigurer.java
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.json.JsonMapper;
@@ -66,7 +67,18 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
 
     for (int index = 0; index < converters.size(); index++) {
       if (converters.get(index) instanceof JacksonJsonHttpMessageConverter converter) {
-        var mapper = (JsonMapper) converter.getMapper().rebuild().addModule(module).build();
+        // Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES for creator-bound
+        // properties; hand-written request DTOs (e.g. NewRegistrationDto's
+        // hidden primitive newUserAccount) rely on the Jackson 2 semantics
+        // where an absent field defaults the primitive instead of a 400.
+        var mapper =
+            (JsonMapper)
+                converter
+                    .getMapper()
+                    .rebuild()
+                    .addModule(module)
+                    .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                    .build();
         var replacement = new JacksonJsonHttpMessageConverter(mapper);
         replacement.setSupportedMediaTypes(converter.getSupportedMediaTypes());
         converters.set(index, replacement);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -798,7 +798,8 @@ class UserControllerIT {
 
     mvc.perform(
             post(PATH_POST_REGISTER_NEW_CONSULTING_TYPE)
-                .content(VALID_NEW_REGISTRATION_BODY.replace("}", ", \"newUserAccount\": false}"))
+                // exactly the frontend payload - newUserAccount is never sent by clients
+                .content(VALID_NEW_REGISTRATION_BODY)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated());


### PR DESCRIPTION
## Problem

Since the Spring Boot 4.0.7 / Jackson 3 upgrade (#811), `POST /users/askers/session/new` fails with 400 for every caller: Jackson 3 binds `NewRegistrationDto` via its Lombok all-args creator and `FAIL_ON_NULL_FOR_PRIMITIVES` rejects the absent hidden primitive `newUserAccount` (clients never send it). The asker profile "register another topic" flow is fully broken; reproduced on pre-dev (log 2026-08-04T19:54Z).

## Changes

- Disable `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` on the MVC message-converter mapper in `CustomWebMvcConfigurer` (same place the JsonNullable module is applied) - restores Jackson 2 semantics for all hand-written request DTOs, including `UserDTO.newUserAccount` on the main registration route.
- Re-point the valid-registration IT at the real client payload; the previous test masked the bug by injecting `newUserAccount` into the body.

## Verification

- Red first: IT with the real payload fails 400 with the exact production stack trace
- Green after: `UserControllerIT` 130/130
- Full suite: 3813 tests, 0 failures (`mvn test`, Dockerized `maven:3.9-eclipse-temurin-21`)

## Reviewer test plan

- [ ] `mvn -q test` green
- [ ] `UserControllerIT.registerNewConsultingTyp_Should_ReturnCreated_When_ProvidedWithValidRequestBody` uses the plain `VALID_NEW_REGISTRATION_BODY` (no injected fields)
- [ ] After pre-dev deploy: asker profile -> Public Data -> pick topic + postcode + agency -> Registrieren creates the enquiry (mobile too)

Closes OpenResilienceInitiative/ORISO-UserService#992

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when optional primitive values are omitted, preventing unnecessary deserialization failures.
  * Updated new consulting-type registration processing to correctly accept valid request data without requiring an unrelated account field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->