### PR TITLE
Open internal team chats on creation instead of parking them in the waiting area (#979)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErro
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.ChatAgency;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.RegistrationType;
@@ -118,10 +119,15 @@ public class CreateChatFacade {
     log.info("Created session {} for group chat", sessionId);
 
     // Persist the Chat entity (needed for frontend - has topic field!)
-    // A Series is visible immediately, but its occurrence is opened explicitly by a counsellor.
-    // Keeping it inactive here preserves the Waiting Area and makes the opened lifecycle event
+    // A Series is visible immediately, but its occurrence is opened explicitly by a counsellor:
+    // keeping it inactive preserves the Waiting Area and makes the opened lifecycle event
     // observable exactly once through StartChatFacade.
-    chat.setActive(false);
+    //
+    // An internal team chat has no occurrence to open. It is a persistent room for colleagues,
+    // so there is nothing to wait for and nobody to open it for — creating it inactive sent
+    // counsellors into the askers' Waiting Area, countdown and all (#979). It is open on
+    // creation.
+    chat.setActive(ConversationType.INTERNAL_GROUP.equals(chat.getConversationType()));
     chat = chatService.saveChat(chat);
     Long chatId = chat.getId();
     log.info("Created chat {} for group chat", chatId);

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -198,11 +198,29 @@ class CreateChatSimplifiedGroupChatFacadeTest {
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
     Chat unsavedChat = mock(Chat.class);
+    when(unsavedChat.getConversationType()).thenReturn(ConversationType.SELF_HELP);
     doReturn(unsavedChat).when(chatConverter).convertToEntity(any(), any(), any());
 
     createChatFacade.createChatV1(chatDto, consultant);
 
     verify(unsavedChat).setActive(false);
+  }
+
+  @Test
+  void createSimplifiedGroupChatShouldOpenAnInternalTeamChatOnCreation() throws Exception {
+    // #979: a team chat has no occurrence to open, so leaving it inactive dropped colleagues
+    // into the askers' Waiting Area with a countdown to a start time nobody had chosen.
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
+        .thenReturn(matrixRoomResponse("!room:matrix.org"));
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
+    Chat unsavedChat = mock(Chat.class);
+    when(unsavedChat.getConversationType()).thenReturn(ConversationType.INTERNAL_GROUP);
+    doReturn(unsavedChat).when(chatConverter).convertToEntity(any(), any(), any());
+
+    createChatFacade.createChatV1(chatDto, consultant);
+
+    verify(unsavedChat).setActive(true);
   }
 
   @Test


### PR DESCRIPTION
Closes #979.

## Where the clock came from

`CreateChatFacade` set `active = false` on **every** group chat. The comment justifying it is about a *Series*: its occurrence is opened explicitly by a counsellor, which preserves the Waiting Area and makes the "opened" lifecycle event observable exactly once through `StartChatFacade`. That reasoning is sound — and it was applied without a case distinction.

An internal team chat has no occurrence. It is a persistent room for colleagues, so there is nothing to wait for and nobody to open it for. Created inactive, it dropped counsellors into the askers' Waiting Area: a countdown, "add to calendar", the cycling netiquette rules and a start button, all pointing at a start time nobody had chosen.

The time itself comes from the client, which fills `startDate` / `startTime` with today and now — because `Chat.start_date` and `Chat.duration` are `nullable = false` on the entity, even though both are `required = false` on the DTO. A team room has no scheduled shape; it was given one anyway.

## The fix

The entity already distinguishes the two cases: `ChatConverter` stamps `ConversationType.INTERNAL_GROUP` when no `repeatCount`, `chatInterval` or `repetitive` flag arrives, and `SELF_HELP` otherwise.

```java
chat.setActive(ConversationType.INTERNAL_GROUP.equals(chat.getConversationType()));
```

Internal team chats are created open; a Series still waits for its counsellor.

The leave path is unaffected: `JoinAndLeaveChatFacade` deletes a non-repetitive chat once no human members remain, so there is no inactive state to fall back into.

## Evidence

- New test `createSimplifiedGroupChatShouldOpenAnInternalTeamChatOnCreation`, confirmed **red before the fix** (`BUILD FAILURE` with the old `setActive(false)` restored).
- The existing "remains inactive" test now states its `ConversationType.SELF_HELP` precondition explicitly — it previously passed only because a bare `mock(Chat.class)` returns `null`.
- `CreateChatSimplifiedGroupChatFacadeTest`, `ChatConverterTest`, `JoinAndLeaveChatFacadeTest`, `StartChatFacadeTest`: **53 tests, all green.**

Built with `JAVA_HOME=$(/usr/libexec/java_home -v 21)`; spotless applied.

## Reviewer test plan

- [ ] As a counsellor, create an internal team chat with a colleague: the room opens **directly** — no countdown, no calendar entry, no netiquette rules, no start button.
- [ ] Send a message immediately after creation; it arrives.
- [ ] The invited colleague opens the chat from their session list and can write without a start action.
- [ ] Create a Gesprächskreis (with `repeatCount` / interval): the Waiting Area and start button are **unchanged**, and the countdown still shows the chosen time.
- [ ] Start that Series: the "opened" event fires exactly once, as before.
- [ ] Leave an internal team chat as the last member: the chat is deleted, as before.
- [ ] Mobile: the internal team chat opens straight into the composer.

## Note for the frontend

The companion frontend guard (`getGroupChatWaitingAreaVisibility`) stays useful after this lands: rooms created **before** this change are still `active = false` in the database and would otherwise keep showing the waiting area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Group chats are now active immediately only for internal group conversations.
  * Self-help group chats remain inactive until explicitly opened.

* **Tests**
  * Added coverage confirming the correct activation behavior for both conversation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->