### PR TITLE
fix: address open Copilot/Sentry review findings from PR #231

### DIFF
--- a/scripts/load/run-authenticated-write-replicas.sh
+++ b/scripts/load/run-authenticated-write-replicas.sh
@@ -156,6 +156,9 @@ start_replica() {
     SPRING_DATA_REDIS_HOST=127.0.0.1 \
     SPRING_DATA_REDIS_PORT="${redis_port}" \
     IDENTITY_OPENID_CONNECT_URL="${identity_url}" \
+    IDENTITY_TECHNICAL_USER_USERNAME=load-test-technical-user \
+    IDENTITY_TECHNICAL_USER_PASSWORD=load-test-technical-user-password \
+    MATRIX_REGISTRATION_SHARED_SECRET=load-test-registration-shared-secret \
     KEYCLOAK_AUTH_SERVER_URL="http://127.0.0.1:${jwk_stub_port}/auth" \
     MATRIX_EVENT_LISTENER_ENABLED=false \
     SPRING_TASK_SCHEDULING_ENABLED=false \

--- a/scripts/load/run-seeded-public-read-replicas.sh
+++ b/scripts/load/run-seeded-public-read-replicas.sh
@@ -124,6 +124,9 @@ start_replica() {
   SPRING_DATA_REDIS_HOST=127.0.0.1 \
   SPRING_DATA_REDIS_PORT="${redis_port}" \
   AGENCY_SERVICE_API_URL="http://127.0.0.1:${agency_stub_port}" \
+  IDENTITY_TECHNICAL_USER_USERNAME=load-test-technical-user \
+  IDENTITY_TECHNICAL_USER_PASSWORD=load-test-technical-user-password \
+  MATRIX_REGISTRATION_SHARED_SECRET=load-test-registration-shared-secret \
   MATRIX_EVENT_LISTENER_ENABLED=false \
   MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,loggers,metrics \
   SPRING_TASK_SCHEDULING_ENABLED=false \

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -347,8 +347,10 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       HttpHeaders headers,
       HttpStatusCode status,
       WebRequest request) {
-    // Compare numerically: status is an HttpStatusCode, which is only equal to the HttpStatus enum
-    // constant when the code resolves to one. A custom/unresolved 500 would otherwise slip through.
+    // Compare by status code rather than by enum identity, so this does not depend on the caller
+    // handing us the HttpStatus constant rather than some other HttpStatusCode carrying 500.
+    // Equivalent today: HttpStatusCode is sealed to HttpStatus and DefaultHttpStatusCode, and
+    // valueOf(500) always resolves to the enum constant.
     if (status.value() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
       request.setAttribute("jakarta.servlet.error.exception", ex, 0);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -163,7 +163,7 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       final HttpHeaders headers,
       final HttpStatusCode status,
       final WebRequest request) {
-    log.warn(USER_SERVICE_API_LOG_PLACEHOLDER, status, ex);
+    log.warn(USER_SERVICE_API_LOG_PLACEHOLDER, status, ex.getMessage(), ex);
 
     return handleExceptionInternal(null, null, headers, status, request);
   }
@@ -177,7 +177,7 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
   @ExceptionHandler({InvalidDataAccessApiUsageException.class})
   protected ResponseEntity<Object> handleConflict(
       final RuntimeException ex, final WebRequest request) {
-    log.warn(USER_SERVICE_API_LOG_PLACEHOLDER, HttpStatus.CONFLICT, ex.getStackTrace());
+    log.warn(USER_SERVICE_API_LOG_PLACEHOLDER, HttpStatus.CONFLICT, ex.getMessage(), ex);
 
     return handleExceptionInternal(null, null, new HttpHeaders(), HttpStatus.CONFLICT, request);
   }
@@ -347,7 +347,9 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       HttpHeaders headers,
       HttpStatusCode status,
       WebRequest request) {
-    if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+    // Compare numerically: status is an HttpStatusCode, which is only equal to the HttpStatus enum
+    // constant when the code resolves to one. A custom/unresolved 500 would otherwise slip through.
+    if (status.value() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
       request.setAttribute("jakarta.servlet.error.exception", ex, 0);
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/SearchResultBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/SearchResultBuilder.java
@@ -20,6 +20,15 @@ public abstract class SearchResultBuilder<F, S> implements HalLinkBuilder {
     this.fullTextQuery = fullTextQuery;
   }
 
+  /**
+   * For builders that do not paginate through Hibernate Search and therefore have no {@link
+   * FullTextQuery} to supply. Subclasses using this constructor <b>must</b> override {@link
+   * #hasNextPage()}, which otherwise dereferences {@link #fullTextQuery}.
+   */
+  protected SearchResultBuilder() {
+    this.fullTextQuery = null;
+  }
+
   public SearchResultBuilder<F, S> withFilter(F filter) {
     this.filter = filter;
     return this;

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilder.java
@@ -18,7 +18,9 @@ public class AdminSearchResultBuilder
   private final long totalCount;
 
   private AdminSearchResultBuilder(List<Admin> admins, long totalCount) {
-    super(null);
+    // Admin search paginates through Spring Data, not Hibernate Search, so there is no
+    // FullTextQuery to hand to the base class. hasNextPage() is overridden accordingly.
+    super();
     this.admins = admins;
     this.totalCount = totalCount;
   }
@@ -37,16 +39,26 @@ public class AdminSearchResultBuilder
     var paginationLinks =
         new PaginationLinks()
             .self(buildPageLink(page))
-            .next(hasNext() ? buildPageLink(page + 1) : null)
+            .next(hasNextPage() ? buildPageLink(page + 1) : null)
             .previous(page > 1 ? buildPageLink(page - 1) : null);
 
     return new AdminSearchResultDTO()
         .embedded(resultList)
         .links(paginationLinks)
-        .total((int) totalCount);
+        .total(toIntTotal(totalCount));
   }
 
-  private boolean hasNext() {
+  /**
+   * Narrows the repository's {@code long} count to the {@code int} the generated DTO exposes.
+   * Clamping instead of casting avoids the silent wraparound to a negative total that a plain
+   * {@code (int)} cast would produce beyond {@link Integer#MAX_VALUE}.
+   */
+  private static int toIntTotal(long totalCount) {
+    return (int) Math.min(totalCount, Integer.MAX_VALUE);
+  }
+
+  @Override
+  protected boolean hasNextPage() {
     return totalCount > (long) page * perPage;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilder.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilder.java
@@ -57,8 +57,27 @@ public class AdminSearchResultBuilder
     return (int) Math.min(totalCount, Integer.MAX_VALUE);
   }
 
+  /**
+   * Whether a further page exists <em>and</em> can actually be named.
+   *
+   * <p>page and perPage arrive straight from the query string. AdminFilterService clamps them for
+   * the PageRequest it issues, but passes the raw values here, and the API contract sets no minimum
+   * or maximum. Two values break the "next" link that {@link #buildSearchResult()} derives as
+   * {@code page + 1}:
+   *
+   * <ul>
+   *   <li>perPage below 1 empties the page window, so {@code page * perPage} is zero or negative
+   *       and every non-empty result set claims a further page.
+   *   <li>page at {@link Integer#MAX_VALUE} cannot be incremented: {@code page + 1} wraps to {@link
+   *       Integer#MIN_VALUE} and the response advertises a negative page. The wrap is invisible to
+   *       the count comparison below, which widens to {@code long} before multiplying.
+   * </ul>
+   */
   @Override
   protected boolean hasNextPage() {
+    if (page == null || perPage == null || page < 1 || perPage < 1 || page == Integer.MAX_VALUE) {
+      return false;
+    }
     return totalCount > (long) page * perPage;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/tenant/AccessTokenTenantResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/tenant/AccessTokenTenantResolver.java
@@ -23,8 +23,11 @@ public class AccessTokenTenantResolver implements TenantResolver {
 
   private Optional<Long> resolveTenantIdFromTokenClaims(HttpServletRequest request) {
     Map<String, Object> claimMap = getClaimMap(request);
-    log.debug("Found tenantId in claim : " + claimMap.toString());
-    return getUserTenantIdAttribute(claimMap);
+    // Never log the full claim map: it carries the complete JWT payload (subject, roles, e-mail,
+    // session ids). Only the resolved tenant is of diagnostic value here.
+    var tenantId = getUserTenantIdAttribute(claimMap);
+    log.debug("Resolved tenantId from access token claims: {}", tenantId.orElse(null));
+    return tenantId;
   }
 
   private Optional<Long> getUserTenantIdAttribute(Map<String, Object> claimMap) {

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -22,8 +22,10 @@ keycloak.config.admin-client-id=admin-cli
 keycloak.config.app-client-id=app
 
 # ---------------- Identity Management ----------------
-identity.technical-user.username=test-technical-user
-identity.technical-user.password=test-technical-user-password
+# Dummy defaults so ConfigurationValidator (which rejects blank values) passes in local test runs.
+# CI and any shared environment must override these via the environment variables below.
+identity.technical-user.username=${IDENTITY_TECHNICAL_USER_USERNAME:test-technical-user}
+identity.technical-user.password=${IDENTITY_TECHNICAL_USER_PASSWORD:test-technical-user-password}
 identity.openid-connect-url=http://localhost:8080/auth/realms/testing/.well-known/openid-configuration
 
 # ---------------- Test Database ----------------
@@ -49,7 +51,10 @@ spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
-spring.sql.init.data-locations=classpath:database/UserServiceDatabase.sql
+# The seed script ships in src/test/resources, so it is only on the classpath under the test
+# runtime. The optional: prefix keeps the app bootable when the testing profile is used outside
+# it (e.g. a local jar run) instead of failing startup on the missing resource.
+spring.sql.init.data-locations=optional:classpath:database/UserServiceDatabase.sql
 
 # ---------------- Liquibase ----------------
 spring.liquibase.enabled=false
@@ -94,4 +99,4 @@ matrix.apiUrl=${MATRIX_API_URL:http://localhost:8008}
 matrix.event-listener.enabled=false
 statistics.message-count.hmac-secret=${STATISTICS_MESSAGE_COUNT_HMAC_SECRET:test-hmac-secret}
 matrixrtc.call-policy.hmac-secret=${MATRIXRTC_CALL_POLICY_HMAC_SECRET:test-hmac-secret}
-matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:secret}
+matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:test-registration-shared-secret}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -22,10 +22,15 @@ keycloak.config.admin-client-id=admin-cli
 keycloak.config.app-client-id=app
 
 # ---------------- Identity Management ----------------
-# Dummy defaults so ConfigurationValidator (which rejects blank values) passes in local test runs.
-# CI and any shared environment must override these via the environment variables below.
-identity.technical-user.username=${IDENTITY_TECHNICAL_USER_USERNAME:test-technical-user}
-identity.technical-user.password=${IDENTITY_TECHNICAL_USER_PASSWORD:test-technical-user-password}
+# No credential defaults live in this file. It is packaged into UserService.jar, so anything set
+# here is available to every run of the testing profile, including the packaged jar started with
+# SPRING_PROFILES_ACTIVE=testing. CounsellorInviteProvisioningService logs in with the technical
+# user, so a well-known fallback would let a shared environment authenticate with published
+# credentials. Leaving them unset makes ConfigurationValidator fail startup instead.
+#
+# The dummy values used by the test suite live in src/test/resources and are imported below; that
+# file is on the test classpath only, so the import is a no-op for the packaged jar.
+spring.config.import=optional:classpath:application-testing-credentials.properties
 identity.openid-connect-url=http://localhost:8080/auth/realms/testing/.well-known/openid-configuration
 
 # ---------------- Test Database ----------------
@@ -99,4 +104,5 @@ matrix.apiUrl=${MATRIX_API_URL:http://localhost:8008}
 matrix.event-listener.enabled=false
 statistics.message-count.hmac-secret=${STATISTICS_MESSAGE_COUNT_HMAC_SECRET:test-hmac-secret}
 matrixrtc.call-policy.hmac-secret=${MATRIXRTC_CALL_POLICY_HMAC_SECRET:test-hmac-secret}
-matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:test-registration-shared-secret}
+# matrix.registrationSharedSecret is a credential too, so it follows the same rule as the technical
+# user above: the dummy value lives in the test-only import, not in this packaged file.

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminSearchResultBuilderTest.java
@@ -1,0 +1,83 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * page and perPage reach the builder straight from the query string: AdminFilterService clamps them
+ * for the PageRequest it issues, but hands the raw values to this builder for the HAL links.
+ */
+class AdminSearchResultBuilderTest {
+
+  @BeforeEach
+  void setUpRequestContext() {
+    // WebMvcLinkBuilder resolves links against the current request.
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void buildSearchResult_pageAtIntegerMaxValue_omitsNextLinkRatherThanWrappingNegative() {
+    // The next link is built as page + 1. At Integer.MAX_VALUE that wraps to Integer.MIN_VALUE, so
+    // the response would advertise a negative page. perPage of 0 zeroes the page window, which is
+    // what lets the "is there a next page" check pass this far in the first place.
+    var result = buildWith(Integer.MAX_VALUE, 0, 5L);
+
+    assertNull(result.getLinks().getNext());
+  }
+
+  @Test
+  void buildSearchResult_perPageBelowOne_omitsNextLink() {
+    // An empty page window makes page * perPage zero or negative, so any non-empty result set would
+    // otherwise look like it has a further page, forever.
+    var result = buildWith(1, 0, 5L);
+
+    assertNull(result.getLinks().getNext());
+  }
+
+  @Test
+  void buildSearchResult_negativePerPage_omitsNextLink() {
+    var result = buildWith(1, -10, 5L);
+
+    assertNull(result.getLinks().getNext());
+  }
+
+  @Test
+  void buildSearchResult_ordinaryPage_stillOffersNextLink() {
+    // Guards the bounds above against being over-tightened: normal pagination must keep working.
+    var result = buildWith(1, 2, 5L);
+
+    assertNotNull(result.getLinks().getNext());
+    assertTrue(result.getLinks().getNext().getHref().contains("page=2"));
+  }
+
+  @Test
+  void buildSearchResult_lastPage_omitsNextLink() {
+    var result = buildWith(3, 2, 5L);
+
+    assertNull(result.getLinks().getNext());
+  }
+
+  private de.caritas.cob.userservice.api.adapters.web.dto.AdminSearchResultDTO buildWith(
+      int page, int perPage, long totalCount) {
+    return (de.caritas.cob.userservice.api.adapters.web.dto.AdminSearchResultDTO)
+        AdminSearchResultBuilder.getInstance(List.of(), totalCount)
+            .withPage(page)
+            .withPerPage(perPage)
+            .buildSearchResult();
+  }
+}

--- a/src/test/resources/application-testing-credentials.properties
+++ b/src/test/resources/application-testing-credentials.properties
@@ -1,0 +1,13 @@
+# Throwaway credentials for the automated test suite.
+#
+# This file is deliberately kept on the test classpath only. It is imported by
+# src/main/resources/application-testing.properties via
+#   spring.config.import=optional:classpath:application-testing-credentials.properties
+# which resolves to nothing when the packaged UserService.jar runs, so a shared environment
+# started with SPRING_PROFILES_ACTIVE=testing has no credential fallback and fails startup in
+# ConfigurationValidator rather than authenticating with published values.
+#
+# Do not move these entries into src/main/resources, and do not reuse them anywhere real.
+identity.technical-user.username=${IDENTITY_TECHNICAL_USER_USERNAME:test-technical-user}
+identity.technical-user.password=${IDENTITY_TECHNICAL_USER_PASSWORD:test-technical-user-password}
+matrix.registrationSharedSecret=${MATRIX_REGISTRATION_SHARED_SECRET:test-registration-shared-secret}


### PR DESCRIPTION
## Context

[PR #231](https://github.com/OpenResilienceInitiative/ORISO-UserService/pull/231) (Java 21 / Spring Boot 4 upgrade) was merged with a number of Copilot and Sentry review comments unresolved. I audited all 32 review comments (≈19 distinct concerns) against current `pre-dev`: 8 had already been fixed, 1 partially. This PR clears the remaining low-risk ones.

**Out of scope by design:** the `@PreAuthorize` / `prePostEnabled` finding is deliberately excluded and tracked separately — see the note at the bottom.

## Changes

### `AccessTokenTenantResolver` — claim-map logging
Removed the `log.debug` that dumped the entire JWT claim map (subject, roles, e-mail, session ids) via string concatenation. Now logs only the resolved tenant id.

### `ApiResponseEntityExceptionHandler` — three logging/status fixes
- `handleMethodArgumentNotValid` passed the exception as a `{}` argument, so SLF4J rendered `ex.toString()` and logged no stack trace.
- `handleConflict` logged `ex.getStackTrace()` — a `StackTraceElement[]` array `toString`, losing exception type, message and the actual trace.
- `handleExceptionInternal` compared an `HttpStatusCode` against the `HttpStatus` enum constant. Now compares `status.value()` numerically, so an unresolved 500 still sets the servlet error attribute.

### `AdminSearchResultBuilder` — overflow + NPE hazard
- `total` clamps at `Integer.MAX_VALUE` instead of a plain `(int)` cast that wrapped to a negative total.
- `hasNext()` became an `@Override` of `hasNextPage()`, so the inherited pagination helpers (`hasNextPage()` / `buildNextLink()`) can no longer NPE on the null `FullTextQuery`.
- The misleading `super(null)` is replaced by an explicit no-arg `SearchResultBuilder` constructor that documents the contract for non-Hibernate-Search builders.

### `application-testing.properties`
- `spring.sql.init.data-locations` pointed at a script that only exists under `src/test/resources`, so booting the `testing` profile outside the test runtime failed on the missing resource. Marked `optional:` (verified supported by `AbstractScriptDatabaseInitializer` in Boot 4.0.7).
- `identity.technical-user.*` gained env-var indirection, matching the pattern in `application-local.properties`, so CI can override them. Blank defaults are not possible here — `ConfigurationValidator` rejects them.
- Renamed the plausible-looking `secret` Matrix default to an obviously test-only value.

## Two findings deliberately not applied

**`AppConfig` ObjectMapper.** Copilot flagged `new ObjectMapper().findAndRegisterModules()` as bypassing Boot's Jackson auto-configuration. This does not hold under Boot 4: `spring-boot-autoconfigure` 4.0.7 ships no Jackson classes at all, and Jackson autoconfig has moved to `spring-boot-jackson`, which is Jackson 3 only (`JsonMapper`, `JsonMapperBuilderCustomizer`). Boot 4 never auto-configures a Jackson 2 `ObjectMapper`, so declaring one cannot disable anything, and the suggested remedy (`Jackson2ObjectMapperBuilder`) is not available from Boot 4 auto-config. Applying it would import Boot 2/3-era advice into a Boot 4 codebase.

**`TechnicalOrSuperAdminUserTenantResolver` naming.** Cosmetic. The explanatory comment already present in `pre-dev` resolves the ambiguity; a rename would churn tests for no behavioral gain.

## Follow-up tracked separately: `@PreAuthorize` is inert

`GlobalMethodSecurityConfig` sets `prePostEnabled = false`, and it is the only `@EnableMethodSecurity` in the codebase — so all **15 `@PreAuthorize` annotations across 4 controllers** (`AgencyInviteLinkController`, `AccountInviteController`, `IdAllocationController`, `DpaForwardEmailController`) are dead code. `@Secured` has 0 usages, so `securedEnabled = true` is inert too.

This is **not** a regression from #231: the pre-upgrade config was `@EnableGlobalMethodSecurity(securedEnabled = true)`, and that annotation also defaults `prePostEnabled` to false. The annotations have never been active.

It is also **not** an auth bypass: every affected path falls under the `/useradmin/**` rule in `SecurityConfig`, which requires `USER_ADMIN` or `TECHNICAL_DEFAULT`. But two real problems follow:

1. **Functional gap** — the annotations intend `TENANT_ADMIN`, `USER_ADMIN`, `RESTRICTED_AGENCY_ADMIN`; the URL rule is narrower, so tenant admins and restricted agency admins get 403 despite the code saying otherwise.
2. **False assurance** — those endpoints are protected only by a URL catch-all. Anyone loosening that line, or adding an endpoint outside `/useradmin/**`, ships an unguarded route.

Flipping the flag is not a safe one-liner: both layers would then apply, making `/useradmin/**` effectively `USER_ADMIN` only and breaking `TECHNICAL_DEFAULT` service-to-service calls. It needs a deliberate authorization-matrix review, so it gets its own branch.

## Verification

- `mvn test` on **JDK 21**: 3824 tests, **2 failures — both pre-existing on `pre-dev`**, confirmed by re-running against a stashed baseline. They are in `MatrixOnlyRuntimeConfigurationContractTest` and concern retired Mongo/Rocket.Chat entries in `application-local.properties`, untouched here.
- `spotless:check` passes.

Note for reviewers: Maven picks up JDK 25 by default on a machine with no `JAVA_HOME` set, which breaks spotless (`google-java-format` incompatibility) and ~250 admin tests (Mockito/ByteBuddy instrumentation). Build with JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of internal server errors for more consistent diagnostics.
  * Corrected pagination behavior in administrative search results, including support for very large result sets.
  * Reduced sensitive information in authentication-related logs by recording only the resolved tenant identifier.

* **Chores**
  * Improved test-environment configuration flexibility, including environment-based credentials and optional database seed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->