### PR TITLE
ci: JaCoCo coverage % and failed-test names in PR summary

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -26,16 +26,26 @@ runs:
       ./mvnw -B test || test_status=$?
       echo "MAVEN_TEST_STATUS=${test_status}" >> "$GITHUB_ENV"
 
-  # jacoco:report is bound to the `test` phase behind surefire, so a red suite
-  # halts the build before it runs and leaves no report. The execution data is
-  # already on disk by then, written by the prepare-agent JVM as it exits, so the
-  # goal is invoked directly here rather than relying on the phase.
+  # jacoco:report is bound to the `test` phase behind surefire, so a green suite
+  # has already written the report and this step has nothing to do. Only a red
+  # suite halts the build before the goal, and only then is it invoked directly
+  # against the execution data the prepare-agent JVM left behind.
+  #
+  # That direct invocation is best-effort. Run from the command line the goal
+  # resolves the plugin's reporting dependencies, which the lifecycle-bound
+  # execution never needs and which do not reliably resolve from a restored
+  # runner cache (maven-reporting-api against a repository id the cache does not
+  # carry). Coverage is a diagnostic, so failing to produce it must never fail
+  # the build.
   - name: Generate coverage report
     if: ${{ always() }}
     shell: bash
     run: |
-      if [ -f target/jacoco.exec ]; then
-        ./mvnw -B jacoco:report
+      if [ -f target/site/jacoco/jacoco.csv ]; then
+        echo "Coverage report already written during the test phase."
+      elif [ -f target/jacoco.exec ]; then
+        ./mvnw -B jacoco:report \
+          || echo "Standalone jacoco:report failed; coverage is unavailable for this run."
       else
         echo "No target/jacoco.exec: the run did not reach the test phase."
       fi

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -14,14 +14,31 @@ runs:
       distribution: 'temurin'
       cache: maven
 
-  # failure.ignore keeps a red suite from halting the build at surefire. Surefire
-  # and jacoco:report share the `test` phase and surefire runs first, so without
-  # it the report goal never runs and coverage is missing from precisely the runs
-  # worth inspecting. The job outcome is unaffected: `Report unit inventory`
-  # below fails on any failure or error, and on an empty inventory.
+  # `shell: bash` runs with errexit, so a red suite would abort this step before
+  # any failure detail is written. Capture the status instead and let the
+  # reporting steps below run first; `Fail on the Maven test status` re-raises it
+  # once the summary is complete. Maven itself keeps its usual behaviour, so a
+  # failure that is not a test failure (a compile error, say) still surfaces.
   - name: Run Maven tests
     shell: bash
-    run: ./mvnw -B test -Dmaven.test.failure.ignore=true
+    run: |
+      test_status=0
+      ./mvnw -B test || test_status=$?
+      echo "MAVEN_TEST_STATUS=${test_status}" >> "$GITHUB_ENV"
+
+  # jacoco:report is bound to the `test` phase behind surefire, so a red suite
+  # halts the build before it runs and leaves no report. The execution data is
+  # already on disk by then, written by the prepare-agent JVM as it exits, so the
+  # goal is invoked directly here rather than relying on the phase.
+  - name: Generate coverage report
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      if [ -f target/jacoco.exec ]; then
+        ./mvnw -B jacoco:report
+      else
+        echo "No target/jacoco.exec: the run did not reach the test phase."
+      fi
 
   - name: Report failed tests
     if: ${{ always() }}
@@ -68,6 +85,19 @@ runs:
         echo
         python3 scripts/ci/suite-inventory.py --require unit
       } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # Re-raises the status held back above, now that the failing tests, the
+  # coverage and the inventory have all been written to the summary. Kept
+  # separate from the inventory gate so that a Maven failure which produced no
+  # usable reports at all still fails the job.
+  - name: Fail on the Maven test status
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      if [ "${MAVEN_TEST_STATUS:-0}" -ne 0 ]; then
+        echo "Maven test run exited ${MAVEN_TEST_STATUS}; see the failed tests section." >&2
+        exit "${MAVEN_TEST_STATUS}"
+      fi
 
   - name: Verify CI and load-test contracts
     shell: bash

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -44,8 +44,14 @@ runs:
       if [ -f target/site/jacoco/jacoco.csv ]; then
         echo "Coverage report already written during the test phase."
       elif [ -f target/jacoco.exec ]; then
-        ./mvnw -B jacoco:report \
-          || echo "Standalone jacoco:report failed; coverage is unavailable for this run."
+        # Bounded, because `|| echo` only catches a nonzero exit — not a hang.
+        # This goal resolves the plugin's reporting dependencies from the
+        # network, and no job here sets timeout-minutes, so a stalled resolve
+        # would sit until GitHub's 6h default AND take the failed-test report
+        # and the MAVEN_TEST_STATUS gate below down with it. `timeout` exits 124
+        # on expiry, which the same `||` already handles.
+        timeout --signal=TERM 5m ./mvnw -B jacoco:report \
+          || echo "Standalone jacoco:report failed or timed out; coverage is unavailable for this run."
       else
         echo "No target/jacoco.exec: the run did not reach the test phase."
       fi

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -14,92 +14,50 @@ runs:
       distribution: 'temurin'
       cache: maven
 
+  # failure.ignore keeps a red suite from halting the build at surefire. Surefire
+  # and jacoco:report share the `test` phase and surefire runs first, so without
+  # it the report goal never runs and coverage is missing from precisely the runs
+  # worth inspecting. The job outcome is unaffected: `Report unit inventory`
+  # below fails on any failure or error, and on an empty inventory.
   - name: Run Maven tests
     shell: bash
-    run: |
-      ./mvnw -B test
-      python3 - <<'PY'
-      from pathlib import Path
-      import os
-      import sys
-      import xml.etree.ElementTree as ET
+    run: ./mvnw -B test -Dmaven.test.failure.ignore=true
 
-      failed = []
-      for report in Path("target/surefire-reports").glob("TEST-*.xml"):
-          root = ET.parse(report).getroot()
-          for tc in root.iter("testcase"):
-              cls = tc.attrib.get("classname", "?")
-              name = tc.attrib.get("name", "?")
-              for child in tc:
-                  if child.tag in ("failure", "error"):
-                      failed.append((child.tag, cls, name))
-                      break
-
-      if failed:
-          lines = ["Maven reported test failures/errors:"]
-          lines.extend(f"- [{kind}] {cls}.{name}" for kind, cls, name in failed)
-          out = "\n".join(lines)
-          print(out)
-
-          summary = os.environ.get("GITHUB_STEP_SUMMARY")
-          if summary:
-              with open(summary, "a") as fh:
-                  fh.write("### Failed tests\n\n")
-                  for kind, cls, name in failed:
-                      fh.write(f"- `[{kind}]` `{cls}.{name}`\n")
-                  fh.write("\n")
-          sys.exit(1)
-      PY
-
-  - name: Report coverage summary
+  - name: Report failed tests
     if: ${{ always() }}
     shell: bash
     run: |
-      csv_path="target/site/jacoco/jacoco.csv"
-      if [ ! -f "$csv_path" ]; then
-        echo "### Coverage (JaCoCo)" >> "$GITHUB_STEP_SUMMARY"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "_No jacoco.csv found — coverage report was not produced._" >> "$GITHUB_STEP_SUMMARY"
-        exit 0
-      fi
-      python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-      import csv
+      set -o pipefail
+      {
+        echo "### Failed tests"
+        echo
+        python3 scripts/ci/failed-tests.py
+      } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      def pct(covered, missed):
-          total = covered + missed
-          return (covered / total * 100.0) if total else 100.0
+  - name: Report coverage
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      set -o pipefail
+      {
+        echo "### Coverage"
+        echo
+        python3 scripts/ci/coverage-summary.py
+      } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      with open("target/site/jacoco/jacoco.csv") as fh:
-          rows = list(csv.DictReader(fh))
+  # The summary carries totals and a per-package breakdown. Per-class and
+  # per-line detail lives in the HTML report, which is too large to inline.
+  - name: Upload coverage report
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: jacoco-coverage-report
+      path: target/site/jacoco
+      if-no-files-found: ignore
+      retention-days: 14
 
-      tot_lm = sum(int(r["LINE_MISSED"]) for r in rows)
-      tot_lc = sum(int(r["LINE_COVERED"]) for r in rows)
-      tot_bm = sum(int(r["BRANCH_MISSED"]) for r in rows)
-      tot_bc = sum(int(r["BRANCH_COVERED"]) for r in rows)
-
-      print("### Coverage (JaCoCo)")
-      print()
-      print(f"- **Lines:** {pct(tot_lc, tot_lm):.2f}% ({tot_lc}/{tot_lc + tot_lm})")
-      print(f"- **Branches:** {pct(tot_bc, tot_bm):.2f}% ({tot_bc}/{tot_bc + tot_bm})")
-      print()
-      print("<details><summary>Per-class breakdown (lowest line coverage first)</summary>")
-      print()
-      print("| Class | Line % | Branch % |")
-      print("|---|---:|---:|")
-      entries = []
-      for r in rows:
-          lp = pct(int(r["LINE_COVERED"]), int(r["LINE_MISSED"]))
-          bp = pct(int(r["BRANCH_COVERED"]), int(r["BRANCH_MISSED"]))
-          entries.append((lp, bp, r["PACKAGE"], r["CLASS"]))
-      entries.sort(key=lambda x: x[0])
-      for lp, bp, pkg, cls in entries:
-          print(f"| `{pkg}.{cls}` | {lp:.1f}% | {bp:.1f}% |")
-      print()
-      print("</details>")
-      PY
-
-  # Also guards against a vacuously green run: the failure check above passes
-  # when no report exists at all, --require does not.
+  # Owns the job outcome. Also guards against a vacuously green run: a summary
+  # of zero tests reads as clean, --require does not.
   - name: Report unit inventory
     if: ${{ always() }}
     shell: bash

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -20,22 +20,82 @@ runs:
       ./mvnw -B test
       python3 - <<'PY'
       from pathlib import Path
+      import os
       import sys
       import xml.etree.ElementTree as ET
 
-      failing_reports = []
+      failed = []
       for report in Path("target/surefire-reports").glob("TEST-*.xml"):
           root = ET.parse(report).getroot()
-          failures = int(root.attrib.get("failures", 0))
-          errors = int(root.attrib.get("errors", 0))
-          if failures or errors:
-              failing_reports.append((report, failures, errors))
+          for tc in root.iter("testcase"):
+              cls = tc.attrib.get("classname", "?")
+              name = tc.attrib.get("name", "?")
+              for child in tc:
+                  if child.tag in ("failure", "error"):
+                      failed.append((child.tag, cls, name))
+                      break
 
-      if failing_reports:
-          print("Maven reported test failures/errors:")
-          for report, failures, errors in failing_reports:
-              print(f"- {report}: failures={failures}, errors={errors}")
+      if failed:
+          lines = ["Maven reported test failures/errors:"]
+          lines.extend(f"- [{kind}] {cls}.{name}" for kind, cls, name in failed)
+          out = "\n".join(lines)
+          print(out)
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a") as fh:
+                  fh.write("### Failed tests\n\n")
+                  for kind, cls, name in failed:
+                      fh.write(f"- `[{kind}]` `{cls}.{name}`\n")
+                  fh.write("\n")
           sys.exit(1)
+      PY
+
+  - name: Report coverage summary
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      csv_path="target/site/jacoco/jacoco.csv"
+      if [ ! -f "$csv_path" ]; then
+        echo "### Coverage (JaCoCo)" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "_No jacoco.csv found — coverage report was not produced._" >> "$GITHUB_STEP_SUMMARY"
+        exit 0
+      fi
+      python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+      import csv
+
+      def pct(covered, missed):
+          total = covered + missed
+          return (covered / total * 100.0) if total else 100.0
+
+      with open("target/site/jacoco/jacoco.csv") as fh:
+          rows = list(csv.DictReader(fh))
+
+      tot_lm = sum(int(r["LINE_MISSED"]) for r in rows)
+      tot_lc = sum(int(r["LINE_COVERED"]) for r in rows)
+      tot_bm = sum(int(r["BRANCH_MISSED"]) for r in rows)
+      tot_bc = sum(int(r["BRANCH_COVERED"]) for r in rows)
+
+      print("### Coverage (JaCoCo)")
+      print()
+      print(f"- **Lines:** {pct(tot_lc, tot_lm):.2f}% ({tot_lc}/{tot_lc + tot_lm})")
+      print(f"- **Branches:** {pct(tot_bc, tot_bm):.2f}% ({tot_bc}/{tot_bc + tot_bm})")
+      print()
+      print("<details><summary>Per-class breakdown (lowest line coverage first)</summary>")
+      print()
+      print("| Class | Line % | Branch % |")
+      print("|---|---:|---:|")
+      entries = []
+      for r in rows:
+          lp = pct(int(r["LINE_COVERED"]), int(r["LINE_MISSED"]))
+          bp = pct(int(r["BRANCH_COVERED"]), int(r["BRANCH_MISSED"]))
+          entries.append((lp, bp, r["PACKAGE"], r["CLASS"]))
+      entries.sort(key=lambda x: x[0])
+      for lp, bp, pkg, cls in entries:
+          print(f"| `{pkg}.{cls}` | {lp:.1f}% | {bp:.1f}% |")
+      print()
+      print("</details>")
       PY
 
   # Also guards against a vacuously green run: the failure check above passes

--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -72,8 +72,9 @@ runs:
         python3 scripts/ci/coverage-summary.py
       } | tee -a "$GITHUB_STEP_SUMMARY"
 
-  # The summary carries totals and a per-package breakdown. Per-class and
-  # per-line detail lives in the HTML report, which is too large to inline.
+  # The summary carries totals plus collapsed per-package and per-class
+  # breakdowns. Per-LINE detail — which statements are red — only exists in the
+  # HTML report, which is far too large to inline, so it is uploaded instead.
   - name: Upload coverage report
     if: ${{ always() }}
     uses: actions/upload-artifact@v4

--- a/scripts/ci/coverage-summary.py
+++ b/scripts/ci/coverage-summary.py
@@ -21,10 +21,20 @@ import sys
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_REPORT = REPOSITORY_ROOT / "target" / "site" / "jacoco" / "jacoco.csv"
 
-# JaCoCo emits one row per class. Rendering them all buries the totals, so the
-# breakdown aggregates to packages and the per-class detail stays in the HTML
-# report published alongside the run.
 COUNTERS = ("LINE", "BRANCH")
+
+# JaCoCo emits one row per class. Both breakdowns are collapsed behind <details>
+# so neither buries the totals: packages answer "which area is thin", classes
+# answer "which file do I open". Both are ordered least-covered first, so the
+# rows worth acting on are the ones you see without scrolling.
+#
+# A step summary is capped at 1 MiB by GitHub; past that the whole section is
+# dropped rather than truncated, which would lose the totals too. At roughly
+# 90 bytes a row that is ~11k classes, far above this service's ~700, but the
+# cap below keeps a monorepo-sized report from silently costing the summary.
+# When it bites it says so in the rendered output — a table that quietly stops
+# short reads as "that is all of them".
+MAX_CLASS_ROWS = 2000
 
 
 class Coverage:
@@ -48,19 +58,64 @@ class Coverage:
         return self.covered[counter] / total * 100.0 if total else 100.0
 
 
-def collect(report: Path) -> tuple[Coverage, dict[str, Coverage]]:
+def collect(report: Path) -> tuple[Coverage, dict[str, Coverage], dict[str, Coverage]]:
     overall = Coverage()
     packages: dict[str, Coverage] = {}
+    classes: dict[str, Coverage] = {}
 
     with report.open(newline="") as handle:
         for row in csv.DictReader(handle):
             overall.add(row)
             packages.setdefault(row["PACKAGE"], Coverage()).add(row)
+            # Fully qualified: JaCoCo repeats short class names across packages
+            # (several `Mapper`s, several `Config`s), and a bare name would both
+            # collide in this dict and be useless to look up.
+            classes.setdefault(f"{row['PACKAGE']}.{row['CLASS']}", Coverage()).add(row)
 
-    return overall, packages
+    return overall, packages, classes
 
 
-def render_markdown(overall: Coverage, packages: dict[str, Coverage]) -> str:
+def coverage_rows(entries: dict[str, Coverage], label: str) -> list[str]:
+    """Least covered first; within equal coverage the larger unit leads.
+
+    Sorting by percentage alone would put a 0%-covered one-line class above a
+    0%-covered 300-line service, which inverts what a reader should look at.
+    """
+    rows = [
+        f"| {label} | Lines | Line % | Branch % |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    ordered = sorted(
+        entries.items(),
+        key=lambda item: (item[1].percentage("LINE"), -item[1].total("LINE")),
+    )
+    for name, coverage in ordered[:MAX_CLASS_ROWS]:
+        rows.append(
+            f"| `{name}` | {coverage.total('LINE'):,} | "
+            f"{coverage.percentage('LINE'):.1f}% | "
+            f"{coverage.percentage('BRANCH'):.1f}% |"
+        )
+
+    omitted = len(ordered) - MAX_CLASS_ROWS
+    if omitted > 0:
+        # Named, not silent: the omitted rows are the best-covered ones, but a
+        # table that just stops reads as though it were complete.
+        rows.extend(
+            [
+                "",
+                f"{omitted:,} better-covered rows omitted to keep the summary "
+                f"within GitHub's size limit; the full detail is in the uploaded "
+                f"HTML report.",
+            ]
+        )
+    return rows
+
+
+def render_markdown(
+    overall: Coverage,
+    packages: dict[str, Coverage],
+    classes: dict[str, Coverage],
+) -> str:
     lines = [
         "| Metric | Covered | Total | Coverage |",
         "| --- | ---: | ---: | ---: |",
@@ -74,28 +129,27 @@ def render_markdown(overall: Coverage, packages: dict[str, Coverage]) -> str:
     lines.extend(
         [
             "",
-            f"Measured over the unit suite across {len(packages):,} packages. "
-            "The integration suite runs in its own job and is not included.",
+            f"Measured over the unit suite across {len(packages):,} packages "
+            f"and {len(classes):,} classes. The integration suite runs in its own "
+            "job and is not included.",
             "",
             "<details>",
             "<summary>Per-package breakdown (least covered first)</summary>",
             "",
-            "| Package | Lines | Line % | Branch % |",
-            "| --- | ---: | ---: | ---: |",
         ]
     )
-
-    ordered = sorted(
-        packages.items(),
-        key=lambda item: (item[1].percentage("LINE"), -item[1].total("LINE")),
+    lines.extend(coverage_rows(packages, "Package"))
+    lines.extend(
+        [
+            "",
+            "</details>",
+            "",
+            "<details>",
+            "<summary>Per-class breakdown (least covered first)</summary>",
+            "",
+        ]
     )
-    for name, coverage in ordered:
-        lines.append(
-            f"| `{name}` | {coverage.total('LINE'):,} | "
-            f"{coverage.percentage('LINE'):.1f}% | "
-            f"{coverage.percentage('BRANCH'):.1f}% |"
-        )
-
+    lines.extend(coverage_rows(classes, "Class"))
     lines.extend(["", "</details>"])
     return "\n".join(lines)
 
@@ -119,7 +173,7 @@ def main() -> int:
         print("Coverage is produced by the `report` goal during the `test` phase.")
         return 0
 
-    overall, packages = collect(arguments.report)
+    overall, packages, classes = collect(arguments.report)
     if not packages:
         print(f"JaCoCo report at {arguments.report} contains no classes.")
         return 0
@@ -129,7 +183,7 @@ def main() -> int:
     # printed here rather than by the workflow step, because an `echo` after the
     # script inside the step's `{ ... } | tee` group would replace the script's
     # exit status with the echo's and mask a failing step.
-    print(render_markdown(overall, packages))
+    print(render_markdown(overall, packages, classes))
     print()
     return 0
 

--- a/scripts/ci/coverage-summary.py
+++ b/scripts/ci/coverage-summary.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+"""Renders JaCoCo line and branch coverage as a step-summary section.
+
+The run summary already reports how many tests executed. It does not say how
+much of the service those tests actually reach, so a shrinking covered share
+stayed invisible between merges. JaCoCo already runs in the build; this turns
+its CSV into the same table the summary shows for the suite inventory.
+
+Coverage is measured over the unit suite only. The integration suite runs in a
+separate job with its own execution data, so the figure here is a floor rather
+than the whole picture.
+"""
+
+import argparse
+import csv
+from pathlib import Path
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = REPOSITORY_ROOT / "target" / "site" / "jacoco" / "jacoco.csv"
+
+# JaCoCo emits one row per class. Rendering them all buries the totals, so the
+# breakdown aggregates to packages and the per-class detail stays in the HTML
+# report published alongside the run.
+COUNTERS = ("LINE", "BRANCH")
+
+
+class Coverage:
+    def __init__(self) -> None:
+        self.covered = {counter: 0 for counter in COUNTERS}
+        self.missed = {counter: 0 for counter in COUNTERS}
+
+    def add(self, row: dict) -> None:
+        for counter in COUNTERS:
+            self.covered[counter] += int(row[f"{counter}_COVERED"])
+            self.missed[counter] += int(row[f"{counter}_MISSED"])
+
+    def total(self, counter: str) -> int:
+        return self.covered[counter] + self.missed[counter]
+
+    def percentage(self, counter: str) -> float:
+        total = self.total(counter)
+        # A class with no branches at all is not 0% covered, it is not
+        # applicable. Reporting 100 keeps such packages from dragging the
+        # ordering below genuinely uncovered ones.
+        return self.covered[counter] / total * 100.0 if total else 100.0
+
+
+def collect(report: Path) -> tuple[Coverage, dict[str, Coverage]]:
+    overall = Coverage()
+    packages: dict[str, Coverage] = {}
+
+    with report.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            overall.add(row)
+            packages.setdefault(row["PACKAGE"], Coverage()).add(row)
+
+    return overall, packages
+
+
+def render_markdown(overall: Coverage, packages: dict[str, Coverage]) -> str:
+    lines = [
+        "| Metric | Covered | Total | Coverage |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for counter, label in (("LINE", "Lines"), ("BRANCH", "Branches")):
+        lines.append(
+            f"| {label} | {overall.covered[counter]:,} | {overall.total(counter):,} | "
+            f"**{overall.percentage(counter):.2f}%** |"
+        )
+
+    lines.extend(
+        [
+            "",
+            f"Measured over the unit suite across {len(packages):,} packages. "
+            "The integration suite runs in its own job and is not included.",
+            "",
+            "<details>",
+            "<summary>Per-package breakdown (least covered first)</summary>",
+            "",
+            "| Package | Lines | Line % | Branch % |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+
+    ordered = sorted(
+        packages.items(),
+        key=lambda item: (item[1].percentage("LINE"), -item[1].total("LINE")),
+    )
+    for name, coverage in ordered:
+        lines.append(
+            f"| `{name}` | {coverage.total('LINE'):,} | "
+            f"{coverage.percentage('LINE'):.1f}% | "
+            f"{coverage.percentage('BRANCH'):.1f}% |"
+        )
+
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT,
+        help="JaCoCo CSV report (default: target/site/jacoco/jacoco.csv)",
+    )
+    arguments = parser.parse_args()
+
+    # A build that fails before the report goal leaves no CSV. Say so plainly
+    # rather than failing the step: the suite inventory already decides whether
+    # the run passes, and a missing report is a symptom of that, not a cause.
+    if not arguments.report.is_file():
+        print(f"No JaCoCo report at {arguments.report}.")
+        print()
+        print("Coverage is produced by the `report` goal during the `test` phase.")
+        return 0
+
+    overall, packages = collect(arguments.report)
+    if not packages:
+        print(f"JaCoCo report at {arguments.report} contains no classes.")
+        return 0
+
+    # Trailing blank line: the next summary section's heading would otherwise sit
+    # directly under this section's closing </details> and stop rendering. It is
+    # printed here rather than by the workflow step, because an `echo` after the
+    # script inside the step's `{ ... } | tee` group would replace the script's
+    # exit status with the echo's and mask a failing step.
+    print(render_markdown(overall, packages))
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/failed-tests.py
+++ b/scripts/ci/failed-tests.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+"""Names the tests that failed, for the run summary.
+
+The suite inventory reports how many tests failed but not which ones, so the
+first step after a red run was always to open the job log and scroll. This
+lists each failing test with its assertion message.
+
+Reporting only: `suite-inventory.py --require` owns whether the job passes, so
+this exits 0 even when it finds failures. That keeps the summary sections
+ordered by usefulness rather than by which step happens to fail first.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT_DIRECTORY = REPOSITORY_ROOT / "target" / "surefire-reports"
+
+# Surefire distinguishes an assertion that did not hold from an exception that
+# escaped. Both are red, and the distinction is often the first useful clue.
+OUTCOMES = ("failure", "error")
+
+MESSAGE_LIMIT = 160
+
+
+class FailedTest:
+    def __init__(self, class_name: str, name: str, outcome: str, message: str):
+        self.class_name = class_name
+        self.name = name
+        self.outcome = outcome
+        self.message = message
+
+    @property
+    def simple_class_name(self) -> str:
+        return self.class_name.rsplit(".", 1)[-1]
+
+
+def first_line(message: str) -> str:
+    """Assertion messages are often multi-line diffs; a table needs one line."""
+    for line in message.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return (
+                stripped
+                if len(stripped) <= MESSAGE_LIMIT
+                else stripped[: MESSAGE_LIMIT - 1] + "…"
+            )
+    return ""
+
+
+def escape(value: str) -> str:
+    """Keeps a message containing a pipe from splitting the table cell."""
+    return value.replace("|", "\\|")
+
+
+def collect(report_directory: Path) -> list[FailedTest]:
+    failed = []
+
+    for report in sorted(report_directory.glob("TEST-*.xml")):
+        root = ET.parse(report).getroot()
+        for case in root.iter("testcase"):
+            for outcome in OUTCOMES:
+                element = case.find(outcome)
+                if element is None:
+                    continue
+                message = element.attrib.get("message") or element.text or ""
+                failed.append(
+                    FailedTest(
+                        case.attrib.get("classname", "?"),
+                        case.attrib.get("name", "?"),
+                        outcome,
+                        first_line(message),
+                    )
+                )
+                break
+
+    return failed
+
+
+def render_markdown(failed: list[FailedTest]) -> str:
+    if not failed:
+        return "No failing tests in this run."
+
+    lines = [
+        f"{len(failed):,} failing test{'s' if len(failed) != 1 else ''}.",
+        "",
+        "| Test | Outcome | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for test in sorted(failed, key=lambda item: (item.class_name, item.name)):
+        lines.append(
+            f"| `{test.simple_class_name}.{test.name}` | {test.outcome} | "
+            f"{escape(test.message)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Fully qualified names</summary>",
+            "",
+            "```",
+        ]
+    )
+    for test in sorted(failed, key=lambda item: (item.class_name, item.name)):
+        lines.append(f"{test.class_name}#{test.name}")
+    lines.extend(["```", "", "</details>"])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report-directory",
+        type=Path,
+        default=DEFAULT_REPORT_DIRECTORY,
+        help="Surefire/Failsafe report directory (default: target/surefire-reports)",
+    )
+    arguments = parser.parse_args()
+
+    if not arguments.report_directory.is_dir():
+        print(f"No report directory at {arguments.report_directory}.")
+        return 0
+
+    # Trailing blank line: see the note in coverage-summary.py. It belongs here
+    # rather than in the workflow step, where it would mask the step's exit
+    # status inside the `{ ... } | tee` group.
+    print(render_markdown(collect(arguments.report_directory)))
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -233,6 +233,19 @@ class CoverageSummaryTest(unittest.TestCase):
         guard = action.index("target/site/jacoco/jacoco.csv")
         self.assertLess(guard, invocation, "an existing report must short-circuit the invocation")
 
+    def test_standalone_report_generation_is_time_bounded(self):
+        """`|| echo` catches a nonzero exit, not a hang.
+
+        The goal resolves reporting dependencies over the network and no job sets
+        timeout-minutes, so an unbounded stall would run to GitHub's 6h default
+        and take the failed-test report and the status gate down with it.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        invocation = action.index("./mvnw -B jacoco:report")
+        preceding = action[max(0, invocation - 120) : invocation]
+        self.assertIn("timeout", preceding, "the standalone goal must be time-bounded")
+
     def test_does_not_suppress_test_failures_in_maven(self):
         """testFailureIgnore would hide a red suite from every consumer of the build."""
         action = MAVEN_BUILD_ACTION.read_text()

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -99,6 +99,59 @@ class CoverageSummaryTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("| Branches | 0 | 0 | **100.00%** |", result.stdout)
 
+    def test_renders_a_per_class_table_with_fully_qualified_names(self):
+        """The PR contract is a per-class table, not only per-package.
+
+        Names are qualified because JaCoCo repeats short class names across
+        packages; a bare `Config` would be ambiguous and unlookupable.
+        """
+        result = self.run_summary(
+            [
+                row("de.example.one", "Config", line_covered=1, line_missed=9),
+                row("de.example.two", "Config", line_covered=9, line_missed=1),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Per-class breakdown (least covered first)", result.stdout)
+        self.assertIn("| `de.example.one.Config` |", result.stdout)
+        self.assertIn("| `de.example.two.Config` |", result.stdout)
+
+    def test_orders_classes_least_covered_first_then_largest(self):
+        """A 0% one-liner must not outrank a 0% service class.
+
+        Percentage alone would surface the trivial file first, inverting what a
+        reader should open.
+        """
+        result = self.run_summary(
+            [
+                row("de.example", "Tiny", line_covered=0, line_missed=2),
+                row("de.example", "Huge", line_covered=0, line_missed=300),
+                row("de.example", "Covered", line_covered=10, line_missed=0),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        classes = result.stdout.split("Per-class breakdown")[1]
+        huge = classes.index("`de.example.Huge`")
+        tiny = classes.index("`de.example.Tiny`")
+        covered = classes.index("`de.example.Covered`")
+        self.assertLess(huge, tiny, "the larger 0% class must lead")
+        self.assertLess(tiny, covered, "uncovered classes must precede covered ones")
+
+    def test_names_the_rows_it_omits_when_the_table_is_capped(self):
+        """A table that silently stops reads as though it were complete."""
+        rows = [
+            row("de.example", f"Clazz{index:05d}", line_covered=1, line_missed=0)
+            for index in range(2100)
+        ]
+
+        result = self.run_summary(rows)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("better-covered rows omitted", result.stdout)
+        self.assertIn("100 better-covered rows omitted", result.stdout)
+
     def test_explains_a_missing_report_without_failing_the_step(self):
         """A build that fails before the report goal leaves no CSV behind."""
         result = self.run_summary(None)

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -163,6 +163,23 @@ class CoverageSummaryTest(unittest.TestCase):
         self.assertIn("./mvnw -B jacoco:report", action)
         self.assertIn("target/jacoco.exec", action)
 
+    def test_standalone_report_generation_cannot_fail_the_build(self):
+        """Coverage is a diagnostic; being unable to produce it is not a build failure.
+
+        Run from the command line the goal resolves the plugin's reporting
+        dependencies, which the lifecycle-bound execution never needs and which do
+        not reliably resolve from a restored runner cache. A green suite skips the
+        invocation entirely, because the test phase has already written the report.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        invocation = action.index("./mvnw -B jacoco:report")
+        following = action[invocation : invocation + 200]
+        self.assertIn("||", following, "the standalone goal must tolerate its own failure")
+
+        guard = action.index("target/site/jacoco/jacoco.csv")
+        self.assertLess(guard, invocation, "an existing report must short-circuit the invocation")
+
     def test_does_not_suppress_test_failures_in_maven(self):
         """testFailureIgnore would hide a red suite from every consumer of the build."""
         action = MAVEN_BUILD_ACTION.read_text()

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -133,16 +133,42 @@ class CoverageSummaryTest(unittest.TestCase):
             "no command may follow the inventory gate inside its pipeline group",
         )
 
-    def test_maven_test_step_lets_the_build_reach_the_jacoco_report_goal(self):
-        """Surefire and jacoco:report share the `test` phase, and surefire runs first.
+    def test_maven_status_is_held_back_until_the_summary_is_written(self):
+        """errexit would abort the step on a red suite before any detail is reported.
 
-        Without failure.ignore a red suite halts the build at surefire, the report
-        goal never runs, and coverage is missing from exactly the runs that need
-        looking at. `suite-inventory.py --require unit` still fails the job.
+        The status is captured, the reporting steps run, and it is re-raised
+        afterwards, so a failing run still fails the job but names its tests first.
         """
         action = MAVEN_BUILD_ACTION.read_text()
 
-        self.assertIn("-Dmaven.test.failure.ignore=true", action)
+        self.assertIn("./mvnw -B test || test_status=$?", action)
+        self.assertIn('MAVEN_TEST_STATUS=${test_status}', action)
+        self.assertIn('exit "${MAVEN_TEST_STATUS}"', action)
+
+        captured = action.index("MAVEN_TEST_STATUS=${test_status}")
+        reraised = action.index('exit "${MAVEN_TEST_STATUS}"')
+        for section in ("failed-tests.py", "coverage-summary.py", "suite-inventory.py"):
+            reported = action.index(section)
+            self.assertLess(captured, reported, f"{section} must run after the capture")
+            self.assertLess(reported, reraised, f"{section} must run before the re-raise")
+
+    def test_coverage_report_is_generated_outside_the_test_phase(self):
+        """jacoco:report sits behind surefire in the `test` phase.
+
+        A red suite halts the build before it, so the goal is invoked directly
+        against the execution data the agent already wrote.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        self.assertIn("./mvnw -B jacoco:report", action)
+        self.assertIn("target/jacoco.exec", action)
+
+    def test_does_not_suppress_test_failures_in_maven(self):
+        """testFailureIgnore would hide a red suite from every consumer of the build."""
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        self.assertNotIn("maven.test.failure.ignore", action)
+        self.assertNotIn("testFailureIgnore", action)
         self.assertIn("--require unit", action)
 
 

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COVERAGE_SUMMARY = ROOT / "scripts/ci/coverage-summary.py"
+MAVEN_BUILD_ACTION = ROOT / ".github/actions/maven-build/action.yml"
+
+HEADER = (
+    "GROUP,PACKAGE,CLASS,INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,"
+    "BRANCH_COVERED,LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,"
+    "METHOD_MISSED,METHOD_COVERED"
+)
+
+
+def row(
+    package: str,
+    class_name: str,
+    line_covered: int,
+    line_missed: int,
+    branch_covered: int = 0,
+    branch_missed: int = 0,
+) -> str:
+    return (
+        f"userservice,{package},{class_name},0,0,{branch_missed},{branch_covered},"
+        f"{line_missed},{line_covered},0,0,0,0"
+    )
+
+
+class CoverageSummaryTest(unittest.TestCase):
+    def run_summary(self, rows: list[str] | None):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = Path(temp_dir) / "jacoco.csv"
+            if rows is not None:
+                report.write_text("\n".join([HEADER, *rows]) + "\n")
+
+            return subprocess.run(
+                [sys.executable, COVERAGE_SUMMARY, "--report", report],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_reports_line_and_branch_percentages(self):
+        result = self.run_summary(
+            [
+                row("de.example.one", "Foo", line_covered=75, line_missed=25),
+                row(
+                    "de.example.two",
+                    "Bar",
+                    line_covered=25,
+                    line_missed=75,
+                    branch_covered=1,
+                    branch_missed=3,
+                ),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Lines | 100 | 200 | **50.00%** |", result.stdout)
+        self.assertIn("| Branches | 1 | 4 | **25.00%** |", result.stdout)
+
+    def test_orders_the_breakdown_least_covered_first(self):
+        result = self.run_summary(
+            [
+                row("de.example.covered", "Foo", line_covered=90, line_missed=10),
+                row("de.example.bare", "Bar", line_covered=1, line_missed=99),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        bare = result.stdout.index("de.example.bare")
+        covered = result.stdout.index("de.example.covered")
+        self.assertLess(bare, covered, "least covered package must come first")
+
+    def test_aggregates_classes_of_one_package_into_a_single_row(self):
+        """A per-class table would bury the totals; the HTML report carries that detail."""
+        result = self.run_summary(
+            [
+                row("de.example", "Foo", line_covered=50, line_missed=0),
+                row("de.example", "Bar", line_covered=0, line_missed=50),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.count("| `de.example` |"), 1)
+        self.assertIn("| `de.example` | 100 | 50.0% |", result.stdout)
+        self.assertIn("across 1 packages", result.stdout)
+
+    def test_counts_a_class_without_branches_as_fully_covered(self):
+        """Zero of zero branches is not applicable, not uncovered."""
+        result = self.run_summary([row("de.example", "Foo", line_covered=10, line_missed=0)])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Branches | 0 | 0 | **100.00%** |", result.stdout)
+
+    def test_explains_a_missing_report_without_failing_the_step(self):
+        """A build that fails before the report goal leaves no CSV behind."""
+        result = self.run_summary(None)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No JaCoCo report at", result.stdout)
+
+    def test_tolerates_a_report_that_contains_no_classes(self):
+        result = self.run_summary([])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("contains no classes", result.stdout)
+
+    def test_nothing_runs_after_the_inventory_gate_inside_its_pipeline(self):
+        """A command after `suite-inventory.py` in that group replaces its exit status.
+
+        The group is piped into tee, so the pipeline reports the group's status,
+        which is the status of its last command. Appending even a bare `echo` for
+        spacing makes a red suite exit 0 and the whole job report success. Blank
+        lines between summary sections are printed by the scripts instead.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        gate = action.index("suite-inventory.py --require unit")
+        remainder = action[gate:]
+        closing = remainder.index("} | tee -a")
+        between = remainder[len("suite-inventory.py --require unit") : closing].strip()
+
+        self.assertEqual(
+            between,
+            "",
+            "no command may follow the inventory gate inside its pipeline group",
+        )
+
+    def test_maven_test_step_lets_the_build_reach_the_jacoco_report_goal(self):
+        """Surefire and jacoco:report share the `test` phase, and surefire runs first.
+
+        Without failure.ignore a red suite halts the build at surefire, the report
+        goal never runs, and coverage is missing from exactly the runs that need
+        looking at. `suite-inventory.py --require unit` still fails the job.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        self.assertIn("-Dmaven.test.failure.ignore=true", action)
+        self.assertIn("--require unit", action)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_failed_tests.py
+++ b/tests/ci/test_failed_tests.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FAILED_TESTS = ROOT / "scripts/ci/failed-tests.py"
+
+
+def report(class_name: str, cases: str) -> str:
+    return (
+        f'<?xml version="1.0" encoding="UTF-8"?>'
+        f'<testsuite name="{class_name}" tests="1">{cases}</testsuite>'
+    )
+
+
+def case(class_name: str, name: str, outcome: str | None = None, message: str = "") -> str:
+    if outcome is None:
+        return f'<testcase classname="{class_name}" name="{name}"/>'
+    return (
+        f'<testcase classname="{class_name}" name="{name}">'
+        f'<{outcome} message="{message}" type="java.lang.AssertionError"/>'
+        f"</testcase>"
+    )
+
+
+class FailedTestsTest(unittest.TestCase):
+    def run_failed_tests(self, reports: dict[str, str] | None):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_directory = Path(temp_dir) / "surefire-reports"
+            if reports is not None:
+                report_directory.mkdir()
+                for file_name, content in reports.items():
+                    (report_directory / file_name).write_text(content)
+
+            return subprocess.run(
+                [sys.executable, FAILED_TESTS, "--report-directory", report_directory],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_names_a_failing_test_with_its_message(self):
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest",
+                    case("de.example.FooTest", "rejectsBlankName", "failure", "expected 1 but was 2"),
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("1 failing test.", result.stdout)
+        self.assertIn("`FooTest.rejectsBlankName`", result.stdout)
+        self.assertIn("expected 1 but was 2", result.stdout)
+        self.assertIn("de.example.FooTest#rejectsBlankName", result.stdout)
+
+    def test_distinguishes_an_error_from_a_failure(self):
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest",
+                    case("de.example.FooTest", "boom", "error", "NullPointerException"),
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| error |", result.stdout)
+
+    def test_ignores_passing_tests(self):
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest",
+                    case("de.example.FooTest", "passes")
+                    + case("de.example.FooTest", "fails", "failure", "nope"),
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("1 failing test.", result.stdout)
+        self.assertNotIn("FooTest.passes", result.stdout)
+
+    def test_reports_a_clean_run(self):
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest", case("de.example.FooTest", "passes")
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No failing tests", result.stdout)
+
+    def test_escapes_a_pipe_so_it_cannot_break_the_table(self):
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest",
+                    case("de.example.FooTest", "parses", "failure", "expected a|b but got c"),
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("expected a\\|b but got c", result.stdout)
+
+    def test_reports_zero_exit_even_with_failures(self):
+        """suite-inventory.py --require owns the job outcome; this section is reporting."""
+        result = self.run_failed_tests(
+            {
+                "TEST-de.example.FooTest.xml": report(
+                    "de.example.FooTest",
+                    case("de.example.FooTest", "fails", "failure", "nope"),
+                )
+            }
+        )
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_tolerates_a_missing_report_directory(self):
+        result = self.run_failed_tests(None)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No report directory at", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds two things to the `test, build and Docker validation` job summary so PR reviewers can read coverage and failure details without opening CI logs:

- **Coverage (JaCoCo)** — total line/branch percentages plus a collapsible per-class table (sorted by lowest line coverage first), parsed from the existing `target/site/jacoco/jacoco.csv` that JaCoCo already writes at the `test` phase (pom.xml, plugin `0.8.10`).
- **Failed tests** — upgrades the existing surefire failure check to enumerate each failing `<testcase classname=... name=.../>` from `target/surefire-reports/TEST-*.xml`, prints them to the log and appends them to `$GITHUB_STEP_SUMMARY`.

Scope is intentionally minimal: only `.github/actions/maven-build/action.yml` changes. Both `ci-pull-request.yml` and `ci-feature-branch.yml` already consume this composite action, so both pick the summary up with no workflow edits and no `pom.xml` change.

## Test plan
- [ ] Trigger the `validate` job on this PR and confirm the **Coverage (JaCoCo)** section renders with non-zero totals and a per-class table.
- [ ] Introduce a temporary failing test locally to confirm the **Failed tests** section lists `classname.name` and the job exits non-zero.
- [ ] Confirm the coverage step still runs when tests fail (guarded by `if: always()` + `-f` check on the CSV).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Test runs now continue long enough to generate failure and coverage reporting.
  - Build summaries display failed or errored test classes and methods.
  - Summaries include aggregate line and branch coverage, plus a sorted per-class breakdown.
  - Missing coverage data is clearly identified.
  - JaCoCo coverage reports can be uploaded as build artifacts and retained for 14 days.
- **Bug Fixes**
  - Test reporting and coverage details are now generated even when tests fail.
  - Build jobs still correctly fail after reporting is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->