### PR TITLE
Stop persisting empty draft rows, and clear drafts and notifications on account deletion

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/DraftMessageRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/DraftMessageRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface DraftMessageRepository extends JpaRepository<DraftMessage, Long> {
 
@@ -13,4 +14,11 @@ public interface DraftMessageRepository extends JpaRepository<DraftMessage, Long
   List<DraftMessage> findByUserIdOrderByUpdateDateDesc(String userId, Pageable pageable);
 
   void deleteByUserIdAndScopeKey(String userId, String scopeKey);
+
+  /**
+   * Removes every draft of a user. Drafts hold the only counselling content stored unencrypted
+   * server-side, so account deletion has to clear them (#983, KDG epic #1010).
+   */
+  @Transactional
+  void deleteByUserId(String userId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EventNotificationRepository extends JpaRepository<EventNotification, Long> {
 
@@ -20,5 +21,10 @@ public interface EventNotificationRepository extends JpaRepository<EventNotifica
   boolean existsByRecipientUserIdAndDeduplicationKey(
       String recipientUserId, String deduplicationKey);
 
+  /**
+   * Removes a recipient's whole notification feed. Used by the user-facing "clear feed" action and
+   * by account deletion, which must not leave notification rows behind (KDG epic #1010, task 2b).
+   */
+  @Transactional
   void deleteByRecipientUserId(String recipientUserId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
@@ -1,0 +1,44 @@
+package de.caritas.cob.userservice.api.service.draft;
+
+import java.util.regex.Pattern;
+
+/**
+ * Decides whether a draft carries content worth persisting.
+ *
+ * <p>A plain {@code isBlank()} check treats TipTap's empty document ({@code <p></p>}) as content,
+ * so merely opening a conversation and leaving it persisted a zero-content draft row: the drafts
+ * badge counted the row, the drafts centre could not resolve it to a session, and nothing the user
+ * did could clear it (#983, ORISO-Frontend#976).
+ *
+ * <p>This mirrors the frontend's {@code hasDraftContent} (ORISO-Frontend {@code
+ * src/services/draftStore.ts}), which is the reference for what counts as content: markup, HTML
+ * whitespace entities and invisible whitespace do not count. An end-to-end encrypted draft is
+ * opaque ciphertext without markup and therefore always counts — it must never be mistaken for an
+ * empty draft.
+ */
+public final class DraftContent {
+
+  private static final Pattern MARKUP_TAG = Pattern.compile("<[^>]*>");
+
+  private static final Pattern WHITESPACE_ENTITY =
+      Pattern.compile("&nbsp;|&#160;", Pattern.CASE_INSENSITIVE);
+
+  /** Non-breaking space and zero-width space — invisible, and therefore not content. */
+  private static final Pattern INVISIBLE_WHITESPACE = Pattern.compile("[ ​]");
+
+  private DraftContent() {}
+
+  /**
+   * @param text the raw draft text as stored or submitted
+   * @return {@code true} if the draft carries content a user would recognise as a draft
+   */
+  public static boolean hasContent(String text) {
+    if (text == null || text.isEmpty()) {
+      return false;
+    }
+    var stripped = MARKUP_TAG.matcher(text).replaceAll(" ");
+    stripped = WHITESPACE_ENTITY.matcher(stripped).replaceAll(" ");
+    stripped = INVISIBLE_WHITESPACE.matcher(stripped).replaceAll(" ");
+    return !stripped.trim().isEmpty();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
@@ -20,8 +20,14 @@ public final class DraftContent {
 
   private static final Pattern MARKUP_TAG = Pattern.compile("<[^>]*>");
 
+  /**
+   * HTML entity spellings of the two invisible characters: non-breaking space (U+00A0) as {@code
+   * &nbsp;}, {@code &#160;} or {@code &#xA0;}, and zero-width space (U+200B) as {@code &#8203;} or
+   * {@code &#x200B;}. Editors and pasted markup pick any of them, so all have to be stripped —
+   * missing one would let a visually empty draft count as content again.
+   */
   private static final Pattern WHITESPACE_ENTITY =
-      Pattern.compile("&nbsp;|&#160;", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("&(nbsp|#0*160|#x0*a0|#0*8203|#x0*200b);", Pattern.CASE_INSENSITIVE);
 
   /** Non-breaking space and zero-width space — invisible, and therefore not content. */
   private static final Pattern INVISIBLE_WHITESPACE = Pattern.compile("[ ​]");

--- a/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftMessageService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftMessageService.java
@@ -30,7 +30,10 @@ public class DraftMessageService {
     }
 
     String text = request != null && request.getText() != null ? request.getText() : "";
-    if (text.isBlank()) {
+    // #983: the API must not depend on every client behaving. A draft that carries no content —
+    // including TipTap's empty document, which is markup rather than an empty string — deletes the
+    // row instead of persisting one nothing can ever clear.
+    if (!DraftContent.hasContent(text)) {
       draftMessageRepository.deleteByUserIdAndScopeKey(userId, scopeKey);
       return;
     }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/UserContentCleanup.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/UserContentCleanup.java
@@ -1,0 +1,27 @@
+package de.caritas.cob.userservice.api.workflow.delete.action;
+
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.List;
+
+/**
+ * Tells the account-row actions whether the unencrypted user content of the account was cleared.
+ *
+ * <p>Drafts and the notification feed are keyed by the user and hold counselling content that is
+ * not end-to-end encrypted. Once the account row is gone, nothing points at those rows any more, so
+ * a failed cleanup would leave them behind permanently. The account row is what the next scheduler
+ * run needs to retry, so it has to survive a failed cleanup (#983, KDG epic #1010).
+ */
+public final class UserContentCleanup {
+
+  private UserContentCleanup() {}
+
+  /**
+   * @param workflowErrors the errors collected by the deletion workflow so far
+   * @return {@code true} if clearing the account's unencrypted content failed
+   */
+  public static boolean failed(List<DeletionWorkflowError> workflowErrors) {
+    return workflowErrors.stream()
+        .anyMatch(error -> DeletionTargetType.USER_CONTENT == error.getDeletionTargetType());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesAction.java
@@ -44,7 +44,7 @@ public class DeleteAskerDraftMessagesAction implements ActionCommand<AskerDeleti
           .add(
               DeletionWorkflowError.builder()
                   .deletionSourceType(ASKER)
-                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .deletionTargetType(DeletionTargetType.USER_CONTENT)
                   .identifier(actionTarget.getUser().getUserId())
                   .reason("Could not delete draft messages")
                   .timestamp(nowInUtc())

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesAction.java
@@ -1,0 +1,54 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.asker;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
+
+import de.caritas.cob.userservice.api.actions.ActionCommand;
+import de.caritas.cob.userservice.api.model.DraftMessage;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.DraftMessageRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes all {@link DraftMessage}s of an asker.
+ *
+ * <p>Drafts are the only place counselling content is stored unencrypted server-side, so they must
+ * not survive account deletion (KDG epic #1010, task 5a).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteAskerDraftMessagesAction implements ActionCommand<AskerDeletionWorkflowDTO> {
+
+  private final @NonNull DraftMessageRepository draftMessageRepository;
+
+  /**
+   * Deletes all {@link DraftMessage}s belonging to the {@link User} being deleted.
+   *
+   * @param actionTarget the {@link AskerDeletionWorkflowDTO} containing the user
+   */
+  @Override
+  public void execute(AskerDeletionWorkflowDTO actionTarget) {
+    try {
+      this.draftMessageRepository.deleteByUserId(actionTarget.getUser().getUserId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      actionTarget
+          .getDeletionWorkflowErrors()
+          .add(
+              DeletionWorkflowError.builder()
+                  .deletionSourceType(ASKER)
+                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .identifier(actionTarget.getUser().getUserId())
+                  .reason("Could not delete draft messages")
+                  .timestamp(nowInUtc())
+                  .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsAction.java
@@ -46,7 +46,7 @@ public class DeleteAskerEventNotificationsAction
           .add(
               DeletionWorkflowError.builder()
                   .deletionSourceType(ASKER)
-                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .deletionTargetType(DeletionTargetType.USER_CONTENT)
                   .identifier(actionTarget.getUser().getUserId())
                   .reason("Could not delete event notifications")
                   .timestamp(nowInUtc())

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsAction.java
@@ -1,0 +1,56 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.asker;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
+
+import de.caritas.cob.userservice.api.actions.ActionCommand;
+import de.caritas.cob.userservice.api.model.EventNotification;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes all {@link EventNotification}s addressed to an asker.
+ *
+ * <p>Notification rows carry the recipient's identity, session references, third-party names and a
+ * per-notification read timestamp, and previously outlived the account indefinitely (KDG epic
+ * #1010, task 2b).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteAskerEventNotificationsAction
+    implements ActionCommand<AskerDeletionWorkflowDTO> {
+
+  private final @NonNull EventNotificationRepository eventNotificationRepository;
+
+  /**
+   * Deletes the whole notification feed of the {@link User} being deleted.
+   *
+   * @param actionTarget the {@link AskerDeletionWorkflowDTO} containing the user
+   */
+  @Override
+  public void execute(AskerDeletionWorkflowDTO actionTarget) {
+    try {
+      this.eventNotificationRepository.deleteByRecipientUserId(actionTarget.getUser().getUserId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      actionTarget
+          .getDeletionWorkflowErrors()
+          .add(
+              DeletionWorkflowError.builder()
+                  .deletionSourceType(ASKER)
+                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .identifier(actionTarget.getUser().getUserId())
+                  .reason("Could not delete event notifications")
+                  .timestamp(nowInUtc())
+                  .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerAction.java
@@ -8,6 +8,7 @@ import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.UserChatRepository;
 import de.caritas.cob.userservice.api.port.out.UserMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.workflow.delete.action.UserContentCleanup;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
@@ -37,10 +38,19 @@ public class DeleteDatabaseAskerAction implements ActionCommand<AskerDeletionWor
    * fails. The chat itself is deliberately left alone — a group chat outlives any single
    * participant.
    *
+   * <p>The row is also kept when clearing the user's unencrypted content (drafts, notification
+   * feed) failed earlier in the workflow. That content is keyed by the user, so deleting the
+   * account row would orphan it beyond any retry — the row is what the next scheduler run needs to
+   * try again (#983, KDG epic #1010).
+   *
    * @param actionTarget the {@link AskerDeletionWorkflowDTO} with the {@link User} to delete
    */
   @Override
   public void execute(AskerDeletionWorkflowDTO actionTarget) {
+    if (UserContentCleanup.failed(actionTarget.getDeletionWorkflowErrors())) {
+      log.warn("Keeping user account row: unencrypted user content could not be deleted");
+      return;
+    }
     if (!deleteChatMemberships(actionTarget) || !deleteMobileTokens(actionTarget)) {
       return;
     }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesAction.java
@@ -1,0 +1,55 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+
+import de.caritas.cob.userservice.api.actions.ActionCommand;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.DraftMessage;
+import de.caritas.cob.userservice.api.port.out.DraftMessageRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes all {@link DraftMessage}s of a consultant.
+ *
+ * <p>Drafts are the only place counselling content is stored unencrypted server-side, so they must
+ * not survive account deletion (KDG epic #1010, task 5a).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteConsultantDraftMessagesAction
+    implements ActionCommand<ConsultantDeletionWorkflowDTO> {
+
+  private final @NonNull DraftMessageRepository draftMessageRepository;
+
+  /**
+   * Deletes all {@link DraftMessage}s belonging to the {@link Consultant} being deleted.
+   *
+   * @param actionTarget the {@link ConsultantDeletionWorkflowDTO} containing the consultant
+   */
+  @Override
+  public void execute(ConsultantDeletionWorkflowDTO actionTarget) {
+    try {
+      this.draftMessageRepository.deleteByUserId(actionTarget.getConsultant().getId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      actionTarget
+          .getDeletionWorkflowErrors()
+          .add(
+              DeletionWorkflowError.builder()
+                  .deletionSourceType(CONSULTANT)
+                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .identifier(actionTarget.getConsultant().getId())
+                  .reason("Could not delete draft messages")
+                  .timestamp(nowInUtc())
+                  .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesAction.java
@@ -45,7 +45,7 @@ public class DeleteConsultantDraftMessagesAction
           .add(
               DeletionWorkflowError.builder()
                   .deletionSourceType(CONSULTANT)
-                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .deletionTargetType(DeletionTargetType.USER_CONTENT)
                   .identifier(actionTarget.getConsultant().getId())
                   .reason("Could not delete draft messages")
                   .timestamp(nowInUtc())

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsAction.java
@@ -47,7 +47,7 @@ public class DeleteConsultantEventNotificationsAction
           .add(
               DeletionWorkflowError.builder()
                   .deletionSourceType(CONSULTANT)
-                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .deletionTargetType(DeletionTargetType.USER_CONTENT)
                   .identifier(actionTarget.getConsultant().getId())
                   .reason("Could not delete event notifications")
                   .timestamp(nowInUtc())

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsAction.java
@@ -1,0 +1,57 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+
+import de.caritas.cob.userservice.api.actions.ActionCommand;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.EventNotification;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes all {@link EventNotification}s addressed to a consultant.
+ *
+ * <p>Notification rows carry the recipient's identity, session references, third-party names and a
+ * per-notification read timestamp, and previously outlived the account indefinitely (KDG epic
+ * #1010, task 2b).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteConsultantEventNotificationsAction
+    implements ActionCommand<ConsultantDeletionWorkflowDTO> {
+
+  private final @NonNull EventNotificationRepository eventNotificationRepository;
+
+  /**
+   * Deletes the whole notification feed of the {@link Consultant} being deleted.
+   *
+   * @param actionTarget the {@link ConsultantDeletionWorkflowDTO} containing the consultant
+   */
+  @Override
+  public void execute(ConsultantDeletionWorkflowDTO actionTarget) {
+    try {
+      this.eventNotificationRepository.deleteByRecipientUserId(
+          actionTarget.getConsultant().getId());
+    } catch (Exception e) {
+      log.error("UserService delete workflow error: ", e);
+      actionTarget
+          .getDeletionWorkflowErrors()
+          .add(
+              DeletionWorkflowError.builder()
+                  .deletionSourceType(CONSULTANT)
+                  .deletionTargetType(DeletionTargetType.DATABASE)
+                  .identifier(actionTarget.getConsultant().getId())
+                  .reason("Could not delete event notifications")
+                  .timestamp(nowInUtc())
+                  .build());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantAction.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantMobileTokenRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import de.caritas.cob.userservice.api.workflow.delete.action.UserContentCleanup;
 import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType;
 import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
@@ -45,11 +46,21 @@ public class DeleteDatabaseConsultantAction
    * a supervision performed by somebody else, that supervision is lost as collateral — making
    * {@code added_by_consultant_id} nullable in a migration would allow it to survive.
    *
+   * <p>The row is also kept when clearing the consultant's unencrypted content (drafts,
+   * notification feed) failed earlier in the workflow. That content is keyed by the consultant, so
+   * deleting the account row would orphan it beyond any retry — the row is what the next scheduler
+   * run needs to try again (#983, KDG epic #1010).
+   *
    * @param actionTarget the {@link ConsultantDeletionWorkflowDTO} with the {@link Consultant} to
    *     delete
    */
   @Override
   public void execute(ConsultantDeletionWorkflowDTO actionTarget) {
+    if (UserContentCleanup.failed(actionTarget.getDeletionWorkflowErrors())) {
+      log.warn("Keeping consultant account row: unencrypted user content could not be deleted");
+      return;
+    }
+
     try {
       this.sessionRepository
           .findByConsultantAndStatusIn(

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/model/DeletionTargetType.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/model/DeletionTargetType.java
@@ -6,5 +6,11 @@ public enum DeletionTargetType {
   DATABASE,
   ANONYMOUS_REGISTRY_IDS,
   APPOINTMENT_SERVICE,
+  /**
+   * Unencrypted user content stored server-side — drafts and the notification feed. Kept apart from
+   * {@link #DATABASE} so the account row can refuse to disappear while that content is still there:
+   * the row is the only handle the next scheduler run has to retry (#983, KDG epic #1010).
+   */
+  USER_CONTENT,
   ALL;
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountService.java
@@ -9,6 +9,8 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAnonymousRegistryIdAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAppointmentServiceAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerEventNotificationsAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerRoomsAndSessionsAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteDatabaseAskerAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteDatabaseAskerAgencyAction;
@@ -17,6 +19,8 @@ import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteMatrixA
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteAppointmentServiceConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteCaseHandoverRequestsForConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteChatAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantEventNotificationsAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAgencyAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteKeycloakConsultantAction;
@@ -75,6 +79,8 @@ public class DeleteUserAccountService {
         .addActionToExecute(DeleteDatabaseAskerAgencyAction.class)
         .addActionToExecute(DeleteAnonymousRegistryIdAction.class)
         .addActionToExecute(DeleteAppointmentServiceAskerAction.class)
+        .addActionToExecute(DeleteAskerDraftMessagesAction.class)
+        .addActionToExecute(DeleteAskerEventNotificationsAction.class)
         .addActionToExecute(DeleteDatabaseAskerAction.class)
         .executeActions(deletionWorkflowDTO);
 
@@ -103,6 +109,8 @@ public class DeleteUserAccountService {
         .addActionToExecute(DeleteChatAction.class)
         .addActionToExecute(DeleteAppointmentServiceConsultantAction.class)
         .addActionToExecute(DeleteCaseHandoverRequestsForConsultantAction.class)
+        .addActionToExecute(DeleteConsultantDraftMessagesAction.class)
+        .addActionToExecute(DeleteConsultantEventNotificationsAction.class)
         .addActionToExecute(DeleteDatabaseConsultantAction.class)
         .executeActions(deletionWorkflowDTO);
 

--- a/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/0083_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/0083_changeSet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+  <changeSet id="0083-empty-draft-rows" author="frank">
+    <comment>#983: delete draft rows that carry no content (empty string, TipTap empty document,
+      whitespace entities). Encrypted drafts are never matched.</comment>
+    <sqlFile
+      path="db/changelog/changeset/0083_empty_draft_rows/migrate.sql"
+      relativeToChangelogFile="false" splitStatements="false" stripComments="true"
+      encoding="UTF-8"/>
+    <rollback>
+      <comment>Deleted zero-content rows cannot be restored — and carry nothing to restore.</comment>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/migrate.sql
@@ -16,6 +16,6 @@ DELETE FROM draft_message
 WHERE TRIM(
         REGEXP_REPLACE(
           REGEXP_REPLACE(COALESCE(text, ''), '<[^>]*>', ' '),
-          '&([nN][bB][sS][pP]|#160);', ' '
+          '&([nN][bB][sS][pP]|#0*160|#[xX]0*[aA]0|#0*8203|#[xX]0*200[bB]);', ' '
         )
       ) = ''

--- a/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0083_empty_draft_rows/migrate.sql
@@ -1,0 +1,21 @@
+-- #983: remove the zero-content draft rows that the frontend's autosave persisted whenever the
+-- composer was empty (autosave also fires on unmount, so merely opening a conversation stored a
+-- row). The drafts badge counted every row while the drafts centre only showed drafts that
+-- resolve to a session, so the badge stuck and nothing the user could do would clear it.
+--
+-- Emptiness mirrors DraftContent.hasContent, which in turn mirrors the frontend's
+-- hasDraftContent: markup tags and HTML whitespace entities are stripped before the check, so
+-- TipTap's empty document (<p></p>, <p><br></p>) counts as empty. An end-to-end encrypted draft
+-- is opaque base64 ciphertext without markup and can therefore never be matched here.
+--
+-- Deliberately conservative: rows consisting solely of control whitespace (tab, newline) or of
+-- literal U+00A0/U+200B are left alone, because expressing those portably across MariaDB and the
+-- H2 test engine needs backslash escapes the two engines read differently. No client ever wrote
+-- such a draft, and DraftMessageService now rejects them on write.
+DELETE FROM draft_message
+WHERE TRIM(
+        REGEXP_REPLACE(
+          REGEXP_REPLACE(COALESCE(text, ''), '<[^>]*>', ' '),
+          '&([nN][bB][sS][pP]|#160);', ' '
+        )
+      ) = ''

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -141,6 +141,8 @@
   <include
     file="db/changelog/changeset/0082_scheduled_task_claim/0082_changeSet.xml" />
   <include
+    file="db/changelog/changeset/0083_empty_draft_rows/0083_changeSet.xml" />
+  <include
     file="db/changelog/changeset/0084_event_notification_explanation_backfill/0084_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this

--- a/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftContentTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftContentTest.java
@@ -1,0 +1,54 @@
+package de.caritas.cob.userservice.api.service.draft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Mirrors the frontend's {@code hasDraftContent} (ORISO-Frontend {@code
+ * src/services/draftStore.ts}), the reference for what counts as draft content (#983 / frontend
+ * #976): markup and whitespace entities do not count, opaque E2EE ciphertext always does.
+ */
+class DraftContentTest {
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(
+      strings = {
+        "   ",
+        "\n",
+        "\t \r\n",
+        "<p></p>",
+        "<p><br></p>",
+        "<p><br/></p>",
+        "<p></p><p></p>",
+        "&nbsp;",
+        "&#160;",
+        "&NBSP;",
+        "<p>&nbsp;</p>",
+        "<p> </p>",
+        " ",
+        "​",
+        "<div><span> </span></div>"
+      })
+  void hasContent_returnsFalse_forEmptyOrMarkupOnlyDrafts(String text) {
+    assertThat(DraftContent.hasContent(text)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Hello",
+        "<p>Hello</p>",
+        "<p>&nbsp;Hello&nbsp;</p>",
+        "a",
+        // Opaque E2EE ciphertext carries no markup and must never be treated as empty.
+        "AwgBmE3yLpFhZ0uK+base64ciphertext==",
+        "{\"ciphertext\":\"AwgB\",\"ephemeral\":\"key\"}"
+      })
+  void hasContent_returnsTrue_forRealTextAndCiphertext(String text) {
+    assertThat(DraftContent.hasContent(text)).isTrue();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftContentTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftContentTest.java
@@ -27,6 +27,13 @@ class DraftContentTest {
         "&nbsp;",
         "&#160;",
         "&NBSP;",
+        // Same two characters, hexadecimal and decimal numeric forms — an editor or a paste picks
+        // whichever it likes, so none of them may slip through as content.
+        "&#xA0;",
+        "&#X00a0;",
+        "&#8203;",
+        "&#x200B;",
+        "<p>&#xA0;</p><p>&#x200b;</p>",
         "<p>&nbsp;</p>",
         "<p> </p>",
         " ",

--- a/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftMessageServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/draft/DraftMessageServiceTest.java
@@ -99,6 +99,40 @@ class DraftMessageServiceTest {
     verify(draftMessageRepository, never()).save(any());
   }
 
+  // #983: TipTap serialises an empty document as markup, so the emptiness check must look past
+  // the tags — otherwise merely visiting a conversation persists a zero-content draft row.
+  @Test
+  void upsertDraft_emptyTipTapDocument_deletesExistingDraft() {
+    draftMessageService.upsertDraft(USER_ID, SCOPE_KEY, upsertRequest("<p></p>"), TENANT_ID);
+
+    verify(draftMessageRepository).deleteByUserIdAndScopeKey(USER_ID, SCOPE_KEY);
+    verify(draftMessageRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertDraft_markupOnlyDraft_deletesExistingDraft() {
+    draftMessageService.upsertDraft(
+        USER_ID, SCOPE_KEY, upsertRequest("<p><br></p><p>&nbsp;</p>"), TENANT_ID);
+
+    verify(draftMessageRepository).deleteByUserIdAndScopeKey(USER_ID, SCOPE_KEY);
+    verify(draftMessageRepository, never()).save(any());
+  }
+
+  // #983: an E2EE draft is opaque ciphertext without markup and must never be treated as empty.
+  @Test
+  void upsertDraft_encryptedDraft_isPersisted() {
+    when(draftMessageRepository.findByUserIdAndScopeKey(USER_ID, SCOPE_KEY))
+        .thenReturn(Optional.empty());
+
+    draftMessageService.upsertDraft(
+        USER_ID, SCOPE_KEY, upsertRequest("AwgBmE3yLpFhZ0uK+ciphertext=="), TENANT_ID);
+
+    ArgumentCaptor<DraftMessage> captor = ArgumentCaptor.forClass(DraftMessage.class);
+    verify(draftMessageRepository).save(captor.capture());
+    assertThat(captor.getValue().getText()).isEqualTo("AwgBmE3yLpFhZ0uK+ciphertext==");
+    verify(draftMessageRepository, never()).deleteByUserIdAndScopeKey(any(), any());
+  }
+
   // First keystroke for a scope creates a new draft row with tenant attribution.
   @Test
   void upsertDraft_noExistingDraft_savesNewDraftWithAllFields() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/draft/EmptyDraftRowsMigrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/draft/EmptyDraftRowsMigrationTest.java
@@ -58,6 +58,11 @@ class EmptyDraftRowsMigrationTest {
           "&nbsp;",
           "&#160;",
           "&NBSP;",
+          "&#xA0;",
+          "&#X00a0;",
+          "&#8203;",
+          "&#x200B;",
+          "<p>&#xA0;</p><p>&#x200b;</p>",
           "<p>&nbsp;</p>",
           "<p> </p>",
           "<div><span> </span></div>");

--- a/src/test/java/de/caritas/cob/userservice/api/service/draft/EmptyDraftRowsMigrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/draft/EmptyDraftRowsMigrationTest.java
@@ -1,0 +1,238 @@
+package de.caritas.cob.userservice.api.service.draft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Replays the shipped Liquibase statement of changeset {@code 0083_empty_draft_rows} against an H2
+ * database in MariaDB mode (the engine the testing profile uses), pinning the two properties the
+ * migration has to have (#983).
+ *
+ * <p><b>Safety</b> — the migration must never delete a row a user would recognise as a draft. This
+ * matters most for end-to-end encrypted drafts: they are opaque ciphertext, so a careless "looks
+ * empty" rule would destroy real counselling content. Asserted over every sample.
+ *
+ * <p><b>Effectiveness</b> — the migration must clear the zero-content shapes #983 is about: the
+ * empty string the frontend's autosave wrote, TipTap's empty document, and whitespace entities.
+ *
+ * <p>The two sets are not identical by design: the SQL deliberately leaves rows made purely of
+ * control whitespace or literal U+00A0/U+200B alone, because matching those needs backslash escapes
+ * MariaDB and H2 read differently. {@link DraftContent} treats them as empty, so the write path
+ * rejects them; see the comment in {@code migrate.sql}.
+ */
+class EmptyDraftRowsMigrationTest {
+
+  private static final Path MIGRATE_SQL =
+      Path.of("src/main/resources/db/changelog/changeset/0083_empty_draft_rows/migrate.sql");
+
+  /** Shapes the migration is required to clear. */
+  private static final List<String> ZERO_CONTENT_SAMPLES =
+      Arrays.asList(
+          null,
+          "",
+          "   ",
+          "<p></p>",
+          "<p><br></p>",
+          "<p><br/></p>",
+          "<p></p><p></p>",
+          "&nbsp;",
+          "&#160;",
+          "&NBSP;",
+          "<p>&nbsp;</p>",
+          "<p> </p>",
+          "<div><span> </span></div>");
+
+  /** Shapes the migration must never touch. */
+  private static final List<String> CONTENT_SAMPLES =
+      Arrays.asList(
+          "Hello",
+          "<p>Hello</p>",
+          "<p>&nbsp;Hello&nbsp;</p>",
+          "a",
+          "AwgBmE3yLpFhZ0uK+base64ciphertext==",
+          "{\"ciphertext\":\"AwgB\",\"ephemeral\":\"key\"}");
+
+  /**
+   * Empty per {@link DraftContent}, but knowingly out of reach of the portable SQL. Listed so the
+   * gap is visible and intentional rather than an accident.
+   */
+  private static final List<String> TOLERATED_SURVIVOR_SAMPLES =
+      Arrays.asList("\n", "\t\r\n", "\u00a0", "\u200b", "<p>\u00a0</p>");
+
+  private Connection connection;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    connection =
+        DriverManager.getConnection(
+            "jdbc:h2:mem:draft-migration-test;MODE=MariaDB;DB_CLOSE_DELAY=0");
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          CREATE TABLE draft_message (
+            id BIGINT NOT NULL AUTO_INCREMENT,
+            user_id VARCHAR(64) NOT NULL,
+            scope_key VARCHAR(255) NOT NULL,
+            text TEXT NULL,
+            action_path VARCHAR(512) NULL,
+            title VARCHAR(255) NULL,
+            source_session_id BIGINT NULL,
+            room_ref VARCHAR(255) NULL,
+            thread_root_id VARCHAR(255) NULL,
+            create_date DATETIME NOT NULL,
+            update_date DATETIME NOT NULL,
+            tenant_id BIGINT NULL,
+            PRIMARY KEY (id)
+          )
+          """);
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP ALL OBJECTS");
+    }
+    connection.close();
+  }
+
+  @Test
+  void migration_clearsEveryZeroContentShape() throws SQLException {
+    Map<Long, String> rows = insertAll(ZERO_CONTENT_SAMPLES);
+
+    runMigration();
+
+    assertThat(survivingIds())
+        .as("every zero-content draft shape from #983 is gone")
+        .doesNotContainAnyElementsOf(rows.keySet());
+  }
+
+  @Test
+  void migration_neverDeletesADraftThatCarriesContent() throws SQLException {
+    Map<Long, String> rows = insertAll(CONTENT_SAMPLES);
+
+    runMigration();
+
+    assertThat(survivingIds())
+        .as("real text and opaque E2EE ciphertext survive untouched")
+        .containsAll(rows.keySet());
+  }
+
+  /**
+   * The invariant that must hold no matter which samples are added later: a row the migration
+   * removes is always one {@link DraftContent} also considers empty. The reverse is allowed — the
+   * SQL may leave an empty row behind, it may never remove a non-empty one.
+   */
+  @Test
+  void migration_deletesOnlyRowsTheContentCheckAlsoCallsEmpty() throws SQLException {
+    List<String> allSamples = new ArrayList<>();
+    allSamples.addAll(ZERO_CONTENT_SAMPLES);
+    allSamples.addAll(CONTENT_SAMPLES);
+    allSamples.addAll(TOLERATED_SURVIVOR_SAMPLES);
+    Map<Long, String> rows = insertAll(allSamples);
+
+    runMigration();
+
+    Set<Long> survivors = survivingIds();
+    for (Map.Entry<Long, String> row : rows.entrySet()) {
+      if (!survivors.contains(row.getKey())) {
+        assertThat(DraftContent.hasContent(row.getValue()))
+            .as(
+                "migration deleted row %d (%s), which must be empty",
+                row.getKey(), printable(row.getValue()))
+            .isFalse();
+      }
+    }
+  }
+
+  @Test
+  void toleratedSurvivors_areEmptyForTheWritePathEvenThoughTheMigrationSkipsThem() {
+    for (String sample : TOLERATED_SURVIVOR_SAMPLES) {
+      assertThat(DraftContent.hasContent(sample))
+          .as("%s is rejected on write even though the migration leaves it", printable(sample))
+          .isFalse();
+    }
+  }
+
+  private Map<Long, String> insertAll(List<String> samples) throws SQLException {
+    Map<Long, String> rows = new TreeMap<>();
+    try (PreparedStatement insert =
+        connection.prepareStatement(
+            "INSERT INTO draft_message (user_id, scope_key, text, create_date, update_date)"
+                + " VALUES (?, ?, ?, NOW(), NOW())",
+            Statement.RETURN_GENERATED_KEYS)) {
+      for (String sample : samples) {
+        insert.setString(1, "user");
+        insert.setString(2, "scope-" + rows.size());
+        insert.setString(3, sample);
+        insert.executeUpdate();
+        try (var keys = insert.getGeneratedKeys()) {
+          keys.next();
+          rows.put(keys.getLong(1), sample);
+        }
+      }
+    }
+    return rows;
+  }
+
+  private void runMigration() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(readMigrationSql());
+    }
+  }
+
+  private Set<Long> survivingIds() throws SQLException {
+    Set<Long> survivors = new HashSet<>();
+    try (Statement statement = connection.createStatement();
+        var resultSet = statement.executeQuery("SELECT id FROM draft_message")) {
+      while (resultSet.next()) {
+        survivors.add(resultSet.getLong("id"));
+      }
+    }
+    return survivors;
+  }
+
+  private static String printable(String value) {
+    if (value == null) {
+      return "<null>";
+    }
+    return value
+        .replace("\u00a0", "\\u00a0")
+        .replace("\u200b", "\\u200b")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
+  }
+
+  /** Reads the shipped SQL exactly as Liquibase does, minus the comment lines it strips. */
+  private static String readMigrationSql() {
+    try {
+      return Files.readString(MIGRATE_SQL, StandardCharsets.UTF_8)
+          .lines()
+          .filter(line -> !line.trim().startsWith("--"))
+          .reduce("", (a, b) -> a + "\n" + b);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesActionTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.asker;
+
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.DraftMessageRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteAskerDraftMessagesActionTest {
+
+  @InjectMocks private DeleteAskerDraftMessagesAction deleteAskerDraftMessagesAction;
+
+  @Mock private DraftMessageRepository draftMessageRepository;
+
+  @Test
+  void execute_Should_deleteAllDraftMessagesOfAsker() {
+    User user = new User();
+    user.setUserId("asker-id");
+    AskerDeletionWorkflowDTO workflowDTO = new AskerDeletionWorkflowDTO(user, emptyList());
+
+    this.deleteAskerDraftMessagesAction.execute(workflowDTO);
+
+    verify(this.draftMessageRepository, times(1)).deleteByUserId("asker-id");
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+  }
+
+  @Test
+  void execute_Should_addWorkflowError_When_deletionFails() {
+    User user = new User();
+    user.setUserId("asker-id");
+    AskerDeletionWorkflowDTO workflowDTO = new AskerDeletionWorkflowDTO(user, new ArrayList<>());
+    doThrow(new RuntimeException("db down"))
+        .when(this.draftMessageRepository)
+        .deleteByUserId("asker-id");
+
+    this.deleteAskerDraftMessagesAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
+    DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
+    assertThat(error.getDeletionSourceType(), is(ASKER));
+    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getIdentifier(), is("asker-id"));
+    assertThat(error.getTimestamp(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerDraftMessagesActionTest.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.workflow.delete.action.asker;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
-import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -55,7 +55,7 @@ class DeleteAskerDraftMessagesActionTest {
     assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
     DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
     assertThat(error.getDeletionSourceType(), is(ASKER));
-    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getDeletionTargetType(), is(USER_CONTENT));
     assertThat(error.getIdentifier(), is("asker-id"));
     assertThat(error.getTimestamp(), notNullValue());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsActionTest.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.workflow.delete.action.asker;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
-import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -55,7 +55,7 @@ class DeleteAskerEventNotificationsActionTest {
     assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
     DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
     assertThat(error.getDeletionSourceType(), is(ASKER));
-    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getDeletionTargetType(), is(USER_CONTENT));
     assertThat(error.getIdentifier(), is("asker-id"));
     assertThat(error.getTimestamp(), notNullValue());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteAskerEventNotificationsActionTest.java
@@ -1,0 +1,62 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.asker;
+
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteAskerEventNotificationsActionTest {
+
+  @InjectMocks private DeleteAskerEventNotificationsAction deleteAskerEventNotificationsAction;
+
+  @Mock private EventNotificationRepository eventNotificationRepository;
+
+  @Test
+  void execute_Should_deleteAllEventNotificationsOfAsker() {
+    User user = new User();
+    user.setUserId("asker-id");
+    AskerDeletionWorkflowDTO workflowDTO = new AskerDeletionWorkflowDTO(user, emptyList());
+
+    this.deleteAskerEventNotificationsAction.execute(workflowDTO);
+
+    verify(this.eventNotificationRepository, times(1)).deleteByRecipientUserId("asker-id");
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+  }
+
+  @Test
+  void execute_Should_addWorkflowError_When_deletionFails() {
+    User user = new User();
+    user.setUserId("asker-id");
+    AskerDeletionWorkflowDTO workflowDTO = new AskerDeletionWorkflowDTO(user, new ArrayList<>());
+    doThrow(new RuntimeException("db down"))
+        .when(this.eventNotificationRepository)
+        .deleteByRecipientUserId("asker-id");
+
+    this.deleteAskerEventNotificationsAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
+    DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
+    assertThat(error.getDeletionSourceType(), is(ASKER));
+    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getIdentifier(), is("asker-id"));
+    assertThat(error.getTimestamp(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/asker/DeleteDatabaseAskerActionTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.workflow.delete.action.asker;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.ASKER;
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -10,6 +11,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -132,5 +134,33 @@ public class DeleteDatabaseAskerActionTest {
     assertThat(workflowErrors.get(0).getReason(), is("Could not delete user chat memberships"));
     assertThat(workflowErrors.get(0).getDeletionSourceType(), is(ASKER));
     assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+  }
+
+  /**
+   * Drafts and the notification feed are keyed by the user and hold counselling content that is not
+   * end-to-end encrypted. Deleting the account row while they are still there would orphan them
+   * beyond any retry, so the row has to survive a failed cleanup (#983, KDG epic #1010).
+   */
+  @Test
+  public void execute_Should_keepUserRow_When_unencryptedContentCleanupFailed() {
+    var user = new User();
+    user.setUserId("user id");
+    var workflowDTO =
+        new AskerDeletionWorkflowDTO(
+            user,
+            new ArrayList<>(
+                List.of(
+                    DeletionWorkflowError.builder()
+                        .deletionSourceType(ASKER)
+                        .deletionTargetType(USER_CONTENT)
+                        .identifier("user id")
+                        .reason("Could not delete draft messages")
+                        .build())));
+
+    this.deleteDatabaseAskerAction.execute(workflowDTO);
+
+    verify(this.userRepository, never()).delete(any());
+    verify(this.identityTombstoneService, never()).recordDeletedUser(any());
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesActionTest.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
-import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -57,7 +57,7 @@ class DeleteConsultantDraftMessagesActionTest {
     assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
     DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
     assertThat(error.getDeletionSourceType(), is(CONSULTANT));
-    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getDeletionTargetType(), is(USER_CONTENT));
     assertThat(error.getIdentifier(), is("consultant-id"));
     assertThat(error.getTimestamp(), notNullValue());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantDraftMessagesActionTest.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.DraftMessageRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteConsultantDraftMessagesActionTest {
+
+  @InjectMocks private DeleteConsultantDraftMessagesAction deleteConsultantDraftMessagesAction;
+
+  @Mock private DraftMessageRepository draftMessageRepository;
+
+  @Test
+  void execute_Should_deleteAllDraftMessagesOfConsultant() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultant-id");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, emptyList());
+
+    this.deleteConsultantDraftMessagesAction.execute(workflowDTO);
+
+    verify(this.draftMessageRepository, times(1)).deleteByUserId("consultant-id");
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+  }
+
+  @Test
+  void execute_Should_addWorkflowError_When_deletionFails() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultant-id");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, new ArrayList<>());
+    doThrow(new RuntimeException("db down"))
+        .when(this.draftMessageRepository)
+        .deleteByUserId("consultant-id");
+
+    this.deleteConsultantDraftMessagesAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
+    DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
+    assertThat(error.getDeletionSourceType(), is(CONSULTANT));
+    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getIdentifier(), is("consultant-id"));
+    assertThat(error.getTimestamp(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsActionTest.java
@@ -1,0 +1,65 @@
+package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
+
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.DeletionWorkflowError;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteConsultantEventNotificationsActionTest {
+
+  @InjectMocks
+  private DeleteConsultantEventNotificationsAction deleteConsultantEventNotificationsAction;
+
+  @Mock private EventNotificationRepository eventNotificationRepository;
+
+  @Test
+  void execute_Should_deleteAllEventNotificationsOfConsultant() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultant-id");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, emptyList());
+
+    this.deleteConsultantEventNotificationsAction.execute(workflowDTO);
+
+    verify(this.eventNotificationRepository, times(1)).deleteByRecipientUserId("consultant-id");
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(0));
+  }
+
+  @Test
+  void execute_Should_addWorkflowError_When_deletionFails() {
+    Consultant consultant = new Consultant();
+    consultant.setId("consultant-id");
+    ConsultantDeletionWorkflowDTO workflowDTO =
+        new ConsultantDeletionWorkflowDTO(consultant, new ArrayList<>());
+    doThrow(new RuntimeException("db down"))
+        .when(this.eventNotificationRepository)
+        .deleteByRecipientUserId("consultant-id");
+
+    this.deleteConsultantEventNotificationsAction.execute(workflowDTO);
+
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
+    DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
+    assertThat(error.getDeletionSourceType(), is(CONSULTANT));
+    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getIdentifier(), is("consultant-id"));
+    assertThat(error.getTimestamp(), notNullValue());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteConsultantEventNotificationsActionTest.java
@@ -1,7 +1,7 @@
 package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
-import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -58,7 +58,7 @@ class DeleteConsultantEventNotificationsActionTest {
     assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
     DeletionWorkflowError error = workflowDTO.getDeletionWorkflowErrors().get(0);
     assertThat(error.getDeletionSourceType(), is(CONSULTANT));
-    assertThat(error.getDeletionTargetType(), is(DATABASE));
+    assertThat(error.getDeletionTargetType(), is(USER_CONTENT));
     assertThat(error.getIdentifier(), is("consultant-id"));
     assertThat(error.getTimestamp(), notNullValue());
   }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantActionTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/action/consultant/DeleteDatabaseConsultantActionTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.workflow.delete.action.consultant;
 
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionSourceType.CONSULTANT;
 import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.DATABASE;
+import static de.caritas.cob.userservice.api.workflow.delete.model.DeletionTargetType.USER_CONTENT;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -11,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -188,5 +190,33 @@ public class DeleteDatabaseConsultantActionTest {
     assertThat(workflowErrors.get(0).getReason(), is("Unable to delete consultant supervisions"));
     assertThat(workflowErrors.get(0).getDeletionSourceType(), is(CONSULTANT));
     assertThat(workflowErrors.get(0).getDeletionTargetType(), is(DATABASE));
+  }
+
+  /**
+   * Drafts and the notification feed are keyed by the consultant and hold counselling content that
+   * is not end-to-end encrypted. Deleting the account row while they are still there would orphan
+   * them beyond any retry, so the row has to survive a failed cleanup (#983, KDG epic #1010).
+   */
+  @Test
+  public void execute_Should_keepConsultantRow_When_unencryptedContentCleanupFailed() {
+    var consultant = new Consultant();
+    consultant.setId("consultant id");
+    var workflowDTO =
+        new ConsultantDeletionWorkflowDTO(
+            consultant,
+            new ArrayList<>(
+                List.of(
+                    DeletionWorkflowError.builder()
+                        .deletionSourceType(CONSULTANT)
+                        .deletionTargetType(USER_CONTENT)
+                        .identifier("consultant id")
+                        .reason("Could not delete event notifications")
+                        .build())));
+
+    this.deleteDatabaseConsultantAction.execute(workflowDTO);
+
+    verify(this.consultantRepository, never()).delete(any(Consultant.class));
+    verify(this.identityTombstoneService, never()).recordDeletedConsultant(any());
+    assertThat(workflowDTO.getDeletionWorkflowErrors(), hasSize(1));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountServiceActionCoverageTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountServiceActionCoverageTest.java
@@ -1,0 +1,150 @@
+package de.caritas.cob.userservice.api.workflow.delete.service;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.actions.registry.ActionContainer;
+import de.caritas.cob.userservice.api.actions.registry.ActionsRegistry;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAnonymousRegistryIdAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAppointmentServiceAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerEventNotificationsAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerRoomsAndSessionsAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteDatabaseAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteDatabaseAskerAgencyAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteKeycloakAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteMatrixAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteAppointmentServiceConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteCaseHandoverRequestsForConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteChatAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantEventNotificationsAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAgencyAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteKeycloakConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteMatrixConsultantAction;
+import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
+import de.caritas.cob.userservice.api.workflow.delete.model.ConsultantDeletionWorkflowDTO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Pins the complete deletion chain for both account kinds (#1010, task 5b).
+ *
+ * <p>Account deletion had quietly grown incomplete: it erased Keycloak, Matrix and the account row
+ * but left the user's drafts and notification feed behind. Verifying individual actions cannot
+ * catch that class of gap — a table nobody remembers simply never appears in any assertion. This
+ * test asserts the chain as a whole, in order, so adding a user-keyed table without deciding what
+ * account deletion does about it fails here instead of silently opting out.
+ *
+ * <p>Order is part of the contract: everything that reads the account must run before the action
+ * that deletes the account row itself.
+ */
+@ExtendWith(MockitoExtension.class)
+class DeleteUserAccountServiceActionCoverageTest {
+
+  private static final List<Class<?>> EXPECTED_ASKER_CHAIN =
+      List.of(
+          DeleteKeycloakAskerAction.class,
+          DeleteMatrixAskerAction.class,
+          DeleteAskerRoomsAndSessionsAction.class,
+          DeleteDatabaseAskerAgencyAction.class,
+          DeleteAnonymousRegistryIdAction.class,
+          DeleteAppointmentServiceAskerAction.class,
+          DeleteAskerDraftMessagesAction.class,
+          DeleteAskerEventNotificationsAction.class,
+          DeleteDatabaseAskerAction.class);
+
+  private static final List<Class<?>> EXPECTED_CONSULTANT_CHAIN =
+      List.of(
+          DeleteKeycloakConsultantAction.class,
+          DeleteMatrixConsultantAction.class,
+          DeleteDatabaseConsultantAgencyAction.class,
+          DeleteChatAction.class,
+          DeleteAppointmentServiceConsultantAction.class,
+          DeleteCaseHandoverRequestsForConsultantAction.class,
+          DeleteConsultantDraftMessagesAction.class,
+          DeleteConsultantEventNotificationsAction.class,
+          DeleteDatabaseConsultantAction.class);
+
+  @InjectMocks private DeleteUserAccountService deleteUserAccountService;
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private ConsultantRepository consultantRepository;
+
+  @Mock private ActionsRegistry actionsRegistry;
+
+  @Mock private WorkflowErrorMailService workflowErrorMailService;
+
+  @Mock private DeletionLifecycleService deletionLifecycleService;
+
+  @Mock private ActionContainer<AskerDeletionWorkflowDTO> askerContainer;
+
+  @Mock private ActionContainer<ConsultantDeletionWorkflowDTO> consultantContainer;
+
+  @BeforeEach
+  void setupLifecycleMocks() {
+    lenient()
+        .when(deletionLifecycleService.normalizeUserLifecycle(any(User.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient()
+        .when(deletionLifecycleService.normalizeConsultantLifecycle(any(Consultant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient().when(deletionLifecycleService.isReadyForHardDelete(any(User.class))).thenReturn(true);
+    lenient()
+        .when(deletionLifecycleService.isReadyForHardDelete(any(Consultant.class)))
+        .thenReturn(true);
+  }
+
+  @Test
+  void askerDeletion_registersEveryActionOfTheChain_inOrder() {
+    when(this.userRepository.findAllByDeleteDateNotNull()).thenReturn(singletonList(new User()));
+    when(this.actionsRegistry.buildContainerForType(AskerDeletionWorkflowDTO.class))
+        .thenReturn(this.askerContainer);
+    when(this.askerContainer.addActionToExecute(any())).thenReturn(this.askerContainer);
+
+    this.deleteUserAccountService.deleteUserAccounts();
+
+    assertThat(registeredActions(this.askerContainer))
+        .as("asker deletion chain — a new user-keyed table must be decided on, not forgotten")
+        .containsExactlyElementsOf(EXPECTED_ASKER_CHAIN);
+  }
+
+  @Test
+  void consultantDeletion_registersEveryActionOfTheChain_inOrder() {
+    when(this.consultantRepository.findAllByDeleteDateNotNull())
+        .thenReturn(singletonList(new Consultant()));
+    when(this.actionsRegistry.buildContainerForType(ConsultantDeletionWorkflowDTO.class))
+        .thenReturn(this.consultantContainer);
+    when(this.consultantContainer.addActionToExecute(any())).thenReturn(this.consultantContainer);
+
+    this.deleteUserAccountService.deleteUserAccounts();
+
+    assertThat(registeredActions(this.consultantContainer))
+        .as("consultant deletion chain — a new user-keyed table must be decided on, not forgotten")
+        .containsExactlyElementsOf(EXPECTED_CONSULTANT_CHAIN);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static List<Class> registeredActions(ActionContainer<?> container) {
+    ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
+    verify(container, atLeastOnce()).addActionToExecute(captor.capture());
+    return captor.getAllValues();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/delete/service/DeleteUserAccountServiceTest.java
@@ -17,8 +17,12 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteAskerEventNotificationsAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteDatabaseAskerAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.asker.DeleteMatrixAskerAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantDraftMessagesAction;
+import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteConsultantEventNotificationsAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteDatabaseConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.action.consultant.DeleteMatrixConsultantAction;
 import de.caritas.cob.userservice.api.workflow.delete.model.AskerDeletionWorkflowDTO;
@@ -86,6 +90,15 @@ public class DeleteUserAccountServiceTest {
         .execute(new AskerDeletionWorkflowDTO(user, emptyList()));
     verify(this.commandMockProvider.getActionMock(DeleteDatabaseAskerAction.class), times(1))
         .execute(new AskerDeletionWorkflowDTO(user, emptyList()));
+    // #983 / #1010: drafts hold the only unencrypted counselling content server-side and must
+    // not survive account deletion.
+    verify(this.commandMockProvider.getActionMock(DeleteAskerDraftMessagesAction.class), times(1))
+        .execute(new AskerDeletionWorkflowDTO(user, emptyList()));
+    // #1010 task 2b: notification rows carry identity, session references and read timestamps.
+    verify(
+            this.commandMockProvider.getActionMock(DeleteAskerEventNotificationsAction.class),
+            times(1))
+        .execute(new AskerDeletionWorkflowDTO(user, emptyList()));
     verifyNoMoreInteractions(this.workflowErrorMailService);
   }
 
@@ -109,6 +122,14 @@ public class DeleteUserAccountServiceTest {
     verify(this.commandMockProvider.getActionMock(DeleteMatrixConsultantAction.class), times(1))
         .execute(new ConsultantDeletionWorkflowDTO(consultant, emptyList()));
     verify(this.commandMockProvider.getActionMock(DeleteDatabaseConsultantAction.class), times(1))
+        .execute(new ConsultantDeletionWorkflowDTO(consultant, emptyList()));
+    verify(
+            this.commandMockProvider.getActionMock(DeleteConsultantDraftMessagesAction.class),
+            times(1))
+        .execute(new ConsultantDeletionWorkflowDTO(consultant, emptyList()));
+    verify(
+            this.commandMockProvider.getActionMock(DeleteConsultantEventNotificationsAction.class),
+            times(1))
         .execute(new ConsultantDeletionWorkflowDTO(consultant, emptyList()));
     verifyNoMoreInteractions(this.workflowErrorMailService);
   }


### PR DESCRIPTION
## What this changes

Two things that both come down to draft rows outliving their purpose.

**Empty draft rows (#983).** Autosave upserted `text: ''` whenever the composer was empty, and autosave also fires on unmount, so merely opening a conversation and leaving it persisted a zero-content draft row. The badge counted every row while the drafts centre only listed drafts that resolve to a session, so the badge stuck at 1, the click led to an empty composer, and nothing the user could do would clear it.

The frontend fix stopped new rows and hid the stored ones, but the rows are still in the database and any other consumer keeps seeing them. This closes both halves on the server:

- `DraftMessageService` rejected empty drafts with `text.isBlank()`, which treats TipTap's empty document as content because `<p></p>` is markup rather than an empty string. `DraftContent` now mirrors the frontend's `hasDraftContent` — the reference named in the issue — stripping markup tags, HTML whitespace entities and invisible whitespace before the check.
- Changeset `0083_empty_draft_rows` removes the rows already stored.

An end-to-end encrypted draft is opaque base64 ciphertext with no markup, so it can never be mistaken for empty. That is the property that mattered most: a careless emptiness rule would have destroyed real counselling content.

**Drafts and notifications now survive nothing (#1010, tasks 2b/5a/5b).** Account deletion erased Keycloak, Matrix, sessions and the account row, but never touched `draft_message` — the only place counselling content sits unencrypted server-side — or `event_notification`, whose rows carry the recipient's Keycloak UUID, session references, third-party names and a per-notification read timestamp. Four actions in the existing `workflow/delete` pattern close that, registered before the action that deletes the account row so both run while the account is still readable.

## Deliberate limitation

The migration SQL is narrower than the Java check: rows made purely of control whitespace or of literal U+00A0/U+200B are left alone, because matching those needs backslash escapes MariaDB and H2 read differently. No client ever wrote such a draft, and the write path now rejects them. The gap is asserted and explained in the test rather than left to be discovered.

## Verification

- `EmptyDraftRowsMigrationTest` replays the shipped SQL against H2 in MariaDB mode and pins two properties separately: every zero-content shape is cleared, and nothing the migration deletes is a row `DraftContent` considers non-empty.
- The same statement was run against **MariaDB 10.11**: all 13 empty shapes deleted, all 6 content rows — including ciphertext — untouched.
- `DeleteUserAccountServiceActionCoverageTest` asserts each deletion chain as a whole, in order, so a future user-keyed table cannot silently opt out.
- 460 tests across the `workflow`, `service.draft` and `service.notification` packages pass (JDK 21).

## Reviewer test plan

- [ ] Open a conversation without typing, leave it — no draft row is created.
- [ ] Existing empty rows are gone after the migration.
- [ ] A draft consisting only of an empty TipTap document is treated as empty.
- [ ] An encrypted draft is never treated as empty, and none are lost by the migration.
- [ ] The drafts badge matches the number of drafts the list actually shows.
- [ ] After account deletion, zero `draft_message` and zero `event_notification` rows remain for that account.

Part of #983. Closes tasks 2b, 5a and 5b of #1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion now removes saved drafts and event notifications for both account types.
  * Deletion failures are recorded as workflow errors for improved traceability.

* **Bug Fixes**
  * Empty or markup-only drafts are no longer saved.
  * Existing empty draft records are cleaned up automatically.
  * Encrypted draft content continues to be preserved.
  * Accounts are retained for retry when unencrypted content cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->