### PR TITLE
Stop storing the case-handover explanation in notifications

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/actions/session/SendFinishedAnonymousConversationEventActionCommand.java
+++ b/src/main/java/de/caritas/cob/userservice/api/actions/session/SendFinishedAnonymousConversationEventActionCommand.java
@@ -42,6 +42,9 @@ public class SendFinishedAnonymousConversationEventActionCommand implements Acti
           CATEGORY_SYSTEM,
           "Conversation finished",
           "The anonymous conversation has ended.",
+          // #1010 task 1a: carry structured params so the client can render this card from its own
+          // i18n templates rather than from the stored English text.
+          eventNotificationService.buildSessionScopedParams(session),
           null,
           session.getId(),
           session.getTenantId());

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -719,10 +719,12 @@ public class CaseHandoverService {
     Consultant requester = request.getRequesterConsultant();
     String requesterName = resolveConsultantName(requester);
     postGrantedChatSystemMessage(request, session, requesterName);
-    String text =
-        String.format(
-            "%s took over your case. Reason: %s. Explanation: %s",
-            requesterName, request.getReasonLabel(), request.getExplanation());
+    // #1010 task 1a: the explanation is counsellor-written free text that can reference case
+    // content. It is no longer copied into the notification, which kept it in plaintext for good;
+    // the handover-request API serves it on demand instead.
+    String params =
+        eventNotificationService.buildCaseHandoverParams(
+            session, requesterName, request.getReasonCode(), request.getReasonLabel(), null);
 
     if (session.getUser() != null && session.getUser().getUserId() != null) {
       eventNotificationService.createEvent(
@@ -730,7 +732,9 @@ public class CaseHandoverService {
           "case.handover.granted",
           EventNotificationService.CATEGORY_SYSTEM,
           "New counsellor took over your case",
-          text,
+          String.format(
+              "%s took over your case. Reason: %s", requesterName, request.getReasonLabel()),
+          params,
           buildAskerSessionActionPath(session),
           session.getId(),
           session.getTenantId());
@@ -746,6 +750,7 @@ public class CaseHandoverService {
           String.format(
               "%s took over case #%s. Reason: %s",
               requesterName, session.getId(), request.getReasonLabel()),
+          params,
           buildConsultantSessionActionPath(session),
           session.getId(),
           session.getTenantId());
@@ -803,16 +808,23 @@ public class CaseHandoverService {
     if (session.getUser() == null || session.getUser().getUserId() == null) {
       return;
     }
+    String requesterName = resolveConsultantName(request.getRequesterConsultant());
+    // #1010 task 1a: no explanation free text in the stored notification — the client reads it
+    // from the handover request itself, which the action path and params already point at.
     eventNotificationService.createEvent(
         session.getUser().getUserId(),
         "case.handover.consent.requested",
         EventNotificationService.CATEGORY_SYSTEM,
         "Counsellor access request",
         String.format(
-            "%s requested access to your case. Reason: %s. Explanation: %s",
-            resolveConsultantName(request.getRequesterConsultant()),
+            "%s requested access to your case. Reason: %s",
+            requesterName, request.getReasonLabel()),
+        eventNotificationService.buildCaseHandoverParams(
+            session,
+            requesterName,
+            request.getReasonCode(),
             request.getReasonLabel(),
-            request.getExplanation()),
+            request.getId()),
         buildAskerSessionActionPath(session) + "?caseHandoverRequestId=" + request.getId(),
         session.getId(),
         session.getTenantId());
@@ -832,6 +844,12 @@ public class CaseHandoverService {
         String.format(
             "Client consent was declined for case #%s. Reason: %s",
             session.getId(), request.getReasonLabel()),
+        eventNotificationService.buildCaseHandoverParams(
+            session,
+            resolveConsultantName(requester),
+            request.getReasonCode(),
+            request.getReasonLabel(),
+            request.getId()),
         buildConsultantSessionActionPath(session),
         session.getId(),
         session.getTenantId());

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/EventNotificationService.java
@@ -391,6 +391,49 @@ public class EventNotificationService {
     }
   }
 
+  /**
+   * Structured params for a session-scoped event whose card needs nothing beyond the session itself
+   * (#1010, task 1a).
+   *
+   * @param session the session the event belongs to
+   * @return serialized params, or {@code null} if the session carries nothing to reference
+   */
+  public String buildSessionScopedParams(Session session) {
+    return serializeParams(baseParams(session));
+  }
+
+  /**
+   * Structured params for the case-handover events (#1010, task 1a).
+   *
+   * <p>Deliberately carries no free text. The counsellor-written explanation used to be formatted
+   * into the notification's {@code text} column and kept there indefinitely, which made {@code
+   * event_notification} the one place where counselling content sat in plaintext. It stays
+   * available on demand through the handover-request API — {@code caseHandoverRequestId} is part of
+   * the params and of the action path — so nothing is lost by not storing a copy here.
+   *
+   * @param session the session being handed over
+   * @param requesterName display name of the requesting counsellor
+   * @param reasonCode machine-readable reason, for client-side i18n
+   * @param reasonLabel human-readable reason drawn from the configured reason policy
+   * @param caseHandoverRequestId the handover request, or {@code null} when not applicable
+   * @return serialized params
+   */
+  public String buildCaseHandoverParams(
+      Session session,
+      String requesterName,
+      String reasonCode,
+      String reasonLabel,
+      Long caseHandoverRequestId) {
+    Map<String, Object> params = baseParams(session);
+    putIfPresent(params, "requesterName", requesterName);
+    putIfPresent(params, "reasonCode", reasonCode);
+    putIfPresent(params, "reasonLabel", reasonLabel);
+    if (caseHandoverRequestId != null) {
+      params.put("caseHandoverRequestId", caseHandoverRequestId);
+    }
+    return serializeParams(params);
+  }
+
   private String serializeParams(Map<String, Object> params) {
     if (params == null || params.isEmpty()) {
       return null;

--- a/src/main/resources/db/changelog/changeset/0084_event_notification_explanation_backfill/0084_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0084_event_notification_explanation_backfill/0084_changeSet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+  <changeSet id="0084-event-notification-explanation-backfill" author="frank">
+    <comment>#1010 task 1d: strip the counsellor-written handover explanation out of stored
+      event_notification text. The explanation stays available via the handover-request API.</comment>
+    <sqlFile
+      path="db/changelog/changeset/0084_event_notification_explanation_backfill/migrate.sql"
+      relativeToChangelogFile="false" splitStatements="false" stripComments="true"
+      encoding="UTF-8"/>
+    <rollback>
+      <comment>Plaintext removed on purpose — restoring it would reintroduce the finding.</comment>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0084_event_notification_explanation_backfill/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0084_event_notification_explanation_backfill/migrate.sql
@@ -1,0 +1,18 @@
+-- #1010 task 1d: remove the counsellor-written handover explanation from stored notifications.
+--
+-- notifyGranted() and notifyPendingConsent() formatted the explanation into event_notification.text
+-- as ". Explanation: <free text>" and kept it there indefinitely. The explanation is written by a
+-- counsellor and can reference case content, which made this the one place counselling content sat
+-- in plaintext. It stays available on demand through the handover-request API, so no information is
+-- lost by dropping the copy.
+--
+-- Cuts at the first marker only: everything after it -- including a marker repeated inside the
+-- explanation itself -- is removed. The leading part ("X took over your case. Reason: Y") is
+-- generated text and stays, so existing feed cards keep rendering until the frontend switches to
+-- params (task 1b/1c). LEFT and LOCATE behave identically on MariaDB and on H2 in MariaDB mode.
+-- LOCATE returns the 1-based position of the marker's leading '.', so LEFT(text, LOCATE(...))
+-- keeps that period and the sentence stays properly terminated.
+UPDATE event_notification
+SET text = LEFT(text, LOCATE('. Explanation: ', text))
+WHERE text IS NOT NULL
+  AND LOCATE('. Explanation: ', text) > 0

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -140,6 +140,8 @@
     file="db/changelog/changeset/0081_account_invite_provisioning/0081_changeSet.xml" />
   <include
     file="db/changelog/changeset/0082_scheduled_task_claim/0082_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0084_event_notification_explanation_backfill/0084_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/actions/session/SendFinishedAnonymousConversationEventActionCommandTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/actions/session/SendFinishedAnonymousConversationEventActionCommandTest.java
@@ -3,6 +3,8 @@ package de.caritas.cob.userservice.api.actions.session;
 import static de.caritas.cob.userservice.api.service.notification.EventNotificationService.CATEGORY_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -95,14 +97,15 @@ class SendFinishedAnonymousConversationEventActionCommandTest {
     doThrow(new IllegalStateException("database unavailable"))
         .when(eventNotificationService)
         .createEvent(
-            session.getConsultant().getId(),
-            "conversation.finished",
-            CATEGORY_SYSTEM,
-            "Conversation finished",
-            "The anonymous conversation has ended.",
-            null,
-            session.getId(),
-            session.getTenantId());
+            eq(session.getConsultant().getId()),
+            eq("conversation.finished"),
+            eq(CATEGORY_SYSTEM),
+            eq("Conversation finished"),
+            eq("The anonymous conversation has ended."),
+            any(),
+            eq(null),
+            eq(session.getId()),
+            eq(session.getTenantId()));
 
     assertThatCode(() -> actionCommand.execute(session)).doesNotThrowAnyException();
 
@@ -110,15 +113,18 @@ class SendFinishedAnonymousConversationEventActionCommandTest {
   }
 
   private void verifyFinishedEvent(String recipientId, Session session) {
+    // #1010 task 1a: the event now carries structured params so the client renders the card from
+    // its own i18n templates instead of the stored English sentence.
     verify(eventNotificationService)
         .createEvent(
-            recipientId,
-            "conversation.finished",
-            CATEGORY_SYSTEM,
-            "Conversation finished",
-            "The anonymous conversation has ended.",
-            null,
-            session.getId(),
-            session.getTenantId());
+            eq(recipientId),
+            eq("conversation.finished"),
+            eq(CATEGORY_SYSTEM),
+            eq("Conversation finished"),
+            eq("The anonymous conversation has ended."),
+            any(),
+            eq(null),
+            eq(session.getId()),
+            eq(session.getTenantId()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -123,7 +124,40 @@ class CaseHandoverServiceTest {
     assertEquals(requester, session.getConsultant());
     verify(sessionRepository).save(session);
     verify(eventNotificationService, atLeastOnce())
-        .createEvent(any(), any(), any(), any(), any(), any(), any(), any());
+        .createEvent(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * #1010 task 1a: the handover explanation is free text a counsellor writes and can reference case
+   * content. It used to be formatted into {@code event_notification.text}, a table with no
+   * retention that outlives the case, which made it the one place counselling content sat in
+   * plaintext. The client reads it from the handover request instead.
+   */
+  @Test
+  void requestAccess_neverCopiesTheExplanationIntoAStoredNotification() {
+    caseHandoverService.requestAccess(123L, "COUNSELLOR_IS_ILL", "Client disclosed self-harm.");
+
+    ArgumentCaptor<String> text = ArgumentCaptor.forClass(String.class);
+    verify(eventNotificationService, atLeastOnce())
+        .createEvent(any(), any(), any(), any(), text.capture(), any(), any(), any(), any());
+
+    assertTrue(
+        text.getAllValues().stream()
+            .noneMatch(value -> value != null && value.contains("Client disclosed self-harm")),
+        "stored notification text must not carry the counsellor's explanation");
+    assertTrue(
+        text.getAllValues().stream()
+            .noneMatch(value -> value != null && value.contains("Explanation")),
+        "the explanation label must be gone too, not just this sample's wording");
+  }
+
+  /** The reason stays — it is a configured label, not free text — and moves into params. */
+  @Test
+  void requestAccess_carriesRequesterAndReasonAsParams() {
+    caseHandoverService.requestAccess(123L, "COUNSELLOR_IS_ILL", "Illness cover.");
+
+    verify(eventNotificationService, atLeastOnce())
+        .buildCaseHandoverParams(any(), anyString(), eq("COUNSELLOR_IS_ILL"), any(), any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/EventNotificationServiceTest.java
@@ -75,6 +75,70 @@ class EventNotificationServiceTest {
   }
 
   // ---------------------------------------------------------------------------
+  // buildCaseHandoverParams (#1010 task 1a)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void buildCaseHandoverParams_carriesTheFieldsTheClientNeedsToRenderTheCard() throws Exception {
+    Session session = sessionMock();
+
+    String params =
+        eventNotificationService.buildCaseHandoverParams(
+            session, "Dr. Muster", "COUNSELLOR_IS_ILL", "Counsellor is ill", 88L);
+
+    JsonNode parsed = objectMapper.readTree(params);
+    assertThat(parsed.get("sessionId").asLong()).isEqualTo(100L);
+    assertThat(parsed.get("roomRef").asText()).isEqualTo("!room-1:matrix.example");
+    assertThat(parsed.get("requesterName").asText()).isEqualTo("Dr. Muster");
+    assertThat(parsed.get("reasonCode").asText()).isEqualTo("COUNSELLOR_IS_ILL");
+    assertThat(parsed.get("reasonLabel").asText()).isEqualTo("Counsellor is ill");
+    assertThat(parsed.get("caseHandoverRequestId").asLong()).isEqualTo(88L);
+  }
+
+  /**
+   * The params object is the replacement for the stored English sentence, so it must stay a set of
+   * known keys. Nothing here may become a channel for the free text task 1a removed.
+   */
+  @Test
+  void buildCaseHandoverParams_carriesNothingBeyondTheKnownKeys() throws Exception {
+    JsonNode parsed =
+        objectMapper.readTree(
+            eventNotificationService.buildCaseHandoverParams(
+                sessionMock(), "Dr. Muster", "COUNSELLOR_IS_ILL", "Counsellor is ill", 88L));
+
+    assertThat(parsed.fieldNames())
+        .toIterable()
+        .containsExactlyInAnyOrder(
+            "sessionId",
+            "roomRef",
+            "requesterName",
+            "reasonCode",
+            "reasonLabel",
+            "caseHandoverRequestId");
+  }
+
+  @Test
+  void buildCaseHandoverParams_omitsAbsentValuesRatherThanWritingNulls() throws Exception {
+    JsonNode parsed =
+        objectMapper.readTree(
+            eventNotificationService.buildCaseHandoverParams(
+                sessionMock(), "Dr. Muster", null, null, null));
+
+    assertThat(parsed.has("reasonCode")).isFalse();
+    assertThat(parsed.has("reasonLabel")).isFalse();
+    assertThat(parsed.has("caseHandoverRequestId")).isFalse();
+  }
+
+  @Test
+  void buildSessionScopedParams_carriesTheSessionReference() throws Exception {
+    JsonNode parsed =
+        objectMapper.readTree(eventNotificationService.buildSessionScopedParams(sessionMock()));
+
+    assertThat(parsed.get("sessionId").asLong()).isEqualTo(100L);
+    assertThat(parsed.get("roomRef").asText()).isEqualTo("!room-1:matrix.example");
+  }
+
+  // ---------------------------------------------------------------------------
   // createNewClientRequestNotifications
   // ---------------------------------------------------------------------------
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/ExplanationBackfillMigrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/ExplanationBackfillMigrationTest.java
@@ -1,0 +1,162 @@
+package de.caritas.cob.userservice.api.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Replays the shipped Liquibase statement of changeset {@code
+ * 0084_event_notification_explanation_backfill} against H2 in MariaDB mode (#1010, task 1d).
+ *
+ * <p>The counsellor-written handover explanation was formatted into {@code event_notification.text}
+ * and kept there indefinitely. Stopping new writes only helps going forward — the rows already
+ * stored are the actual finding, so the backfill is the part that closes it.
+ */
+class ExplanationBackfillMigrationTest {
+
+  private static final Path MIGRATE_SQL =
+      Path.of(
+          "src/main/resources/db/changelog/changeset/"
+              + "0084_event_notification_explanation_backfill/migrate.sql");
+
+  private Connection connection;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    connection =
+        DriverManager.getConnection(
+            "jdbc:h2:mem:explanation-backfill-test;MODE=MariaDB;DB_CLOSE_DELAY=0");
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          CREATE TABLE event_notification (
+            id BIGINT NOT NULL AUTO_INCREMENT,
+            recipient_user_id VARCHAR(64) NOT NULL,
+            event_type VARCHAR(100) NOT NULL,
+            category VARCHAR(20) NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            text TEXT NULL,
+            PRIMARY KEY (id)
+          )
+          """);
+    }
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP ALL OBJECTS");
+    }
+    connection.close();
+  }
+
+  @Test
+  void backfill_removesTheExplanationAndKeepsTheGeneratedPrefix() throws SQLException {
+    insert(
+        "case.handover.granted",
+        "Dr. Muster took over your case. Reason: Counsellor is ill."
+            + " Explanation: Client disclosed self-harm at the last session.");
+
+    runMigration();
+
+    assertThat(textsOf())
+        .containsExactly("Dr. Muster took over your case. Reason: Counsellor is ill.");
+  }
+
+  @Test
+  void backfill_alsoStripsAnExplanationThatRepeatsTheMarker() throws SQLException {
+    insert(
+        "case.handover.consent.requested",
+        "Dr. Muster requested access to your case. Reason: Cover."
+            + " Explanation: see below. Explanation: still free text.");
+
+    runMigration();
+
+    assertThat(textsOf())
+        .as("cutting at the first marker removes everything after it")
+        .containsExactly("Dr. Muster requested access to your case. Reason: Cover.");
+  }
+
+  @Test
+  void backfill_leavesRowsWithoutAnExplanationUntouched() throws SQLException {
+    insert("case.handover.consent.declined", "Client consent was declined for case #12. Reason: X");
+    insert("inquiry.accepted", "Your request was accepted by Dr. Muster. Chat is now active.");
+    insert("conversation.finished", null);
+
+    runMigration();
+
+    assertThat(textsOf())
+        .containsExactly(
+            "Client consent was declined for case #12. Reason: X",
+            "Your request was accepted by Dr. Muster. Chat is now active.",
+            null);
+  }
+
+  @Test
+  void backfill_leavesNoRowContainingTheExplanationMarker() throws SQLException {
+    insert("case.handover.granted", "A took over your case. Reason: R. Explanation: secret");
+    insert("case.handover.consent.requested", "B requested access. Reason: R. Explanation: secret");
+    insert("inquiry.accepted", "no marker here");
+
+    runMigration();
+
+    assertThat(textsOf())
+        .as("no stored notification may still carry counsellor free text")
+        .noneMatch(text -> text != null && text.contains("Explanation"));
+  }
+
+  private void insert(String eventType, String text) throws SQLException {
+    try (PreparedStatement insert =
+        connection.prepareStatement(
+            "INSERT INTO event_notification"
+                + " (recipient_user_id, event_type, category, title, text)"
+                + " VALUES ('user', ?, 'SYSTEM', 'title', ?)")) {
+      insert.setString(1, eventType);
+      insert.setString(2, text);
+      insert.executeUpdate();
+    }
+  }
+
+  private void runMigration() throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(readMigrationSql());
+    }
+  }
+
+  private List<String> textsOf() throws SQLException {
+    List<String> texts = new ArrayList<>();
+    try (Statement statement = connection.createStatement();
+        var resultSet = statement.executeQuery("SELECT text FROM event_notification ORDER BY id")) {
+      while (resultSet.next()) {
+        texts.add(resultSet.getString("text"));
+      }
+    }
+    return texts;
+  }
+
+  /** Reads the shipped SQL exactly as Liquibase does, minus the comment lines it strips. */
+  private static String readMigrationSql() {
+    try {
+      return Files.readString(MIGRATE_SQL, StandardCharsets.UTF_8)
+          .lines()
+          .filter(line -> !line.trim().startsWith("--"))
+          .reduce("", (a, b) -> a + "\n" + b);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Why

The DPIA found counselling content in exactly one place outside the end-to-end encrypted chat: `event_notification.text`.

`notifyGranted()` and `notifyPendingConsent()` formatted the case-handover **explanation** — free text a counsellor writes, which can quote or paraphrase what a client disclosed — into the notification body as `". Explanation: <text>"`. That table has no retention, and until PR #1011 account deletion did not touch it either, so the text stayed readable in plaintext indefinitely.

Nothing needed it there. The notification already deep-links to the handover request through `caseHandoverRequestId`, and the handover-request API serves the explanation on demand to someone entitled to read it. The stored copy bought nothing and carried the whole risk.

## What changes

- The four legacy producers now pass structured params (ADR-AT-01): `requesterName`, `reasonCode`, `reasonLabel`, `sessionId`, `roomRef`, and `caseHandoverRequestId` where it applies. The reason is a configured label from the reason policy, not free text, so it stays.
- `buildCaseHandoverParams` / `buildSessionScopedParams` keep params construction inside `EventNotificationService` next to `baseParams`, rather than spreading serialisation across producers.
- `SendFinishedAnonymousConversationEventActionCommand` now carries params too — it was the one remaining producer writing none.
- Changeset `0084` strips the explanation out of rows already stored.

## Scope note

`title`/`text` are still written. Today's frontend renders from them, and dropping them is task 1c, which is gated on the frontend reading params (task 1b). **This PR removes the free text from those columns, not the columns themselves.** The backfill cuts at the first `". Explanation: "` marker — so a marker repeated inside the explanation is removed too — and keeps the generated prefix, so existing feed cards still render.

## Verification

- `ExplanationBackfillMigrationTest` replays the shipped SQL against H2 in MariaDB mode: explanation removed, repeated marker handled, unrelated rows and NULL text untouched, and no surviving row contains the marker.
- The same statement was run against **MariaDB 10.11** with identical results.
- `CaseHandoverServiceTest` asserts no stored notification text carries the explanation — checking both the sample wording and the `Explanation` label itself, so the assertion does not pass by accident.
- `EventNotificationServiceTest` pins the params to a known key set, so params cannot quietly become a new channel for free text.
- Full `service`, `actions` and `facade` package suites pass (JDK 21).

## Note for the merge order

Touches the same tail of `userservice-master.xml` as #1011, so whichever merges second needs a one-line conflict resolution. The changesets themselves (`0083`, `0084`) are independent.

Part of #1010 — tasks 1a and 1d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
