### PR TITLE
Age event notifications out instead of keeping them forever

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
@@ -1,10 +1,14 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.EventNotification;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventNotificationRepository extends JpaRepository<EventNotification, Long> {
 
@@ -21,4 +25,27 @@ public interface EventNotificationRepository extends JpaRepository<EventNotifica
       String recipientUserId, String deduplicationKey);
 
   void deleteByRecipientUserId(String recipientUserId);
+
+  /**
+   * Deletes notifications the recipient has already read and that are older than the cutoff (KDG
+   * epic #1010, task 2a). A read notification has served its purpose; keeping it preserves a
+   * second-precision record of when the recipient looked at what.
+   *
+   * @param cutoff read timestamps strictly before this instant are purged
+   * @return number of deleted rows
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("delete from EventNotification e where e.readDate is not null and e.readDate < :cutoff")
+  int deleteReadBefore(@Param("cutoff") LocalDateTime cutoff);
+
+  /**
+   * Deletes notifications older than the cutoff regardless of read state (KDG epic #1010, task 2a),
+   * so an unread feed cannot grow without bound.
+   *
+   * @param cutoff creation timestamps strictly before this instant are purged
+   * @return number of deleted rows
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("delete from EventNotification e where e.createDate < :cutoff")
+  int deleteCreatedBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/EventNotificationRepository.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface EventNotificationRepository extends JpaRepository<EventNotification, Long> {

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionScheduler.java
@@ -1,0 +1,36 @@
+package de.caritas.cob.userservice.api.workflow.notificationretention.scheduler;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.notificationretention.service.EventNotificationRetentionService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Scheduler for the event-notification retention purge (KDG epic #1010, task 2a). */
+@Component
+@RequiredArgsConstructor
+public class EventNotificationRetentionScheduler {
+
+  private static final String TASK_NAME = "event-notification-retention";
+
+  private final @NonNull EventNotificationRetentionService eventNotificationRetentionService;
+  private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull ScheduledTaskClaimService taskClaimService;
+
+  @Value("${event.notification.retention.claim.duration:PT12H}")
+  private Duration claimDuration;
+
+  /** Entry method to purge notifications that have outlived their retention period. */
+  @Scheduled(cron = "${event.notification.retention.cron:0 15 3 * * ?}")
+  public void purgeExpiredNotifications() {
+    if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+      return;
+    }
+    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+    this.eventNotificationRetentionService.purgeExpiredNotifications();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/service/EventNotificationRetentionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/service/EventNotificationRetentionService.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api.workflow.notificationretention.service;
+
+import de.caritas.cob.userservice.api.model.EventNotification;
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Ages {@link EventNotification} rows out of the database (KDG epic #1010, task 2a).
+ *
+ * <p>The table had no retention at all. Every row carries the recipient's Keycloak UUID, a session
+ * reference and third-party names, and {@code read_date} is a second-precision record of when the
+ * recipient looked at a given notification — an activity profile that grew for as long as the
+ * account existed. None of that has a purpose once the notification has been seen.
+ *
+ * <p>Two cutoffs rather than one: a read notification has already done its job, so it goes after
+ * the shorter period, while the absolute cutoff makes sure an unread feed cannot grow without bound
+ * either.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventNotificationRetentionService {
+
+  private final @NonNull EventNotificationRepository eventNotificationRepository;
+
+  @Value("${event.notification.retention.read.days:90}")
+  private int readRetentionDays;
+
+  @Value("${event.notification.retention.absolute.days:365}")
+  private int absoluteRetentionDays;
+
+  /**
+   * Purges notifications that have outlived their retention period.
+   *
+   * <p>A non-positive setting disables that cutoff rather than deleting everything, so a
+   * misconfigured or empty value can never wipe the table.
+   */
+  @Transactional
+  public void purgeExpiredNotifications() {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+
+    int purgedRead = 0;
+    if (readRetentionDays > 0) {
+      purgedRead = eventNotificationRepository.deleteReadBefore(now.minusDays(readRetentionDays));
+    }
+
+    int purgedAbsolute = 0;
+    if (absoluteRetentionDays > 0) {
+      purgedAbsolute =
+          eventNotificationRepository.deleteCreatedBefore(now.minusDays(absoluteRetentionDays));
+    }
+
+    if (purgedRead > 0 || purgedAbsolute > 0) {
+      log.info(
+          "Event notification retention purged {} read notifications older than {} days and {}"
+              + " notifications older than {} days",
+          purgedRead,
+          readRetentionDays,
+          purgedAbsolute,
+          absoluteRetentionDays);
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -91,6 +91,16 @@ deletion.readOnlyWindow.hours=${DELETION_READ_ONLY_WINDOW_HOURS:48}
 deletion.readOnlyWindow.tenantOverrides=${DELETION_READ_ONLY_TENANT_OVERRIDES:}
 deletion.pause.defaultMonths=${DELETION_PAUSE_DEFAULT_MONTHS:3}
 deletion.pause.maxMonths=${DELETION_PAUSE_MAX_MONTHS:12}
+# Event notification retention (KDG epic #1010, task 2a). The table previously had no retention:
+# every row carries the recipient's identity, a session reference and a second-precision read
+# timestamp. Read notifications go after the shorter period; the absolute cutoff keeps an unread
+# feed from growing without bound. Set a period to 0 to disable that cutoff.
+# Periods are the DPIA proposal and still await sign-off by the client's data-protection officer.
+event.notification.retention.read.days=${EVENT_NOTIFICATION_RETENTION_READ_DAYS:90}
+event.notification.retention.absolute.days=${EVENT_NOTIFICATION_RETENTION_ABSOLUTE_DAYS:365}
+event.notification.retention.cron=0 15 3 * * ?
+event.notification.retention.claim.duration=PT12H
+
 user.anonymous.deactivateworkflow.cron=0 0 * * * ?
 user.anonymous.deactivateworkflow.periodMinutes=360
 user.anonymous.deactivateworkflow.claim.duration=PT30M

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -330,6 +330,17 @@
       "decision": "Prove room close/leave effects are idempotent under concurrent execution or add a lease.",
       "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
       "status": "blocker"
+    },
+    {
+      "id": "event-notification-retention-scheduler",
+      "source": "src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionScheduler.java",
+      "kind": "scheduler",
+      "owner": "notifications",
+      "risk": "duplicate-side-effect",
+      "components": ["purgeExpiredNotifications"],
+      "decision": "Leases the run through ScheduledTaskClaimService; the purge itself is an idempotent bulk delete of expired rows.",
+      "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
+      "status": "bounded"
     }
   ]
 }

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
@@ -42,7 +42,8 @@ class ReplicaSafetyInventoryContractTest {
           "anonymous-deletion-scheduler",
           "registered-only-deletion-scheduler",
           "handshake-expiry-scheduler",
-          "support-room-expiry-scheduler");
+          "support-room-expiry-scheduler",
+          "event-notification-retention-scheduler");
 
   @Test
   void shouldInventoryEveryKnownReplicaLocalComponentWithAnActionableSignal() throws Exception {

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/EventNotificationRetentionRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/EventNotificationRetentionRepositoryIT.java
@@ -1,0 +1,96 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.EventNotification;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Executes the retention queries of {@link EventNotificationRepository} against the H2 testing
+ * schema (KDG epic #1010, task 2a).
+ *
+ * <p>These are bulk JPQL deletes, so nothing but a real execution proves they select the rows they
+ * are meant to — and getting the predicate wrong here deletes a user's whole feed.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class EventNotificationRetentionRepositoryIT {
+
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 14, 12, 0);
+  private static final LocalDateTime CUTOFF = NOW.minusDays(90);
+
+  @Autowired private EventNotificationRepository underTest;
+
+  @Test
+  void deleteReadBefore_removesOnlyReadNotificationsPastTheCutoff() {
+    Long staleRead = save("stale-read", NOW.minusDays(200), NOW.minusDays(120));
+    Long recentRead = save("recent-read", NOW.minusDays(200), NOW.minusDays(10));
+    Long staleUnread = save("stale-unread", NOW.minusDays(200), null);
+
+    int deleted = underTest.deleteReadBefore(CUTOFF);
+
+    assertThat(deleted).isEqualTo(1);
+    assertThat(remainingIds()).containsExactlyInAnyOrder(recentRead, staleUnread);
+    assertThat(remainingIds()).doesNotContain(staleRead);
+  }
+
+  /** An unread notification is not aged out by the read cutoff, however old it is. */
+  @Test
+  void deleteReadBefore_neverTouchesAnUnreadNotification() {
+    save("ancient-unread", NOW.minusDays(3650), null);
+
+    assertThat(underTest.deleteReadBefore(CUTOFF)).isZero();
+    assertThat(remainingIds()).hasSize(1);
+  }
+
+  @Test
+  void deleteCreatedBefore_removesEveryNotificationPastTheCutoff_readOrNot() {
+    Long oldUnread = save("old-unread", NOW.minusDays(400), null);
+    Long oldRead = save("old-read", NOW.minusDays(400), NOW.minusDays(399));
+    Long recent = save("recent", NOW.minusDays(10), null);
+
+    int deleted = underTest.deleteCreatedBefore(NOW.minusDays(365));
+
+    assertThat(deleted).isEqualTo(2);
+    assertThat(remainingIds()).containsExactly(recent);
+    assertThat(remainingIds()).doesNotContain(oldUnread, oldRead);
+  }
+
+  /** Strictly before: a row exactly on the cutoff is still inside its retention period. */
+  @Test
+  void cutoffsAreExclusive() {
+    save("exactly-on-read-cutoff", NOW.minusDays(200), CUTOFF);
+    save("exactly-on-create-cutoff", NOW.minusDays(365), null);
+
+    assertThat(underTest.deleteReadBefore(CUTOFF)).isZero();
+    assertThat(underTest.deleteCreatedBefore(NOW.minusDays(365))).isZero();
+    assertThat(remainingIds()).hasSize(2);
+  }
+
+  private Long save(String suffix, LocalDateTime createDate, LocalDateTime readDate) {
+    return underTest
+        .save(
+            EventNotification.builder()
+                .recipientUserId("recipient")
+                .eventType("case.handover.granted")
+                .category("system")
+                .title("title")
+                .deduplicationKey(suffix)
+                .createDate(createDate)
+                .readDate(readDate)
+                .build())
+        .getId();
+  }
+
+  private List<Long> remainingIds() {
+    return underTest.findAll().stream().map(EventNotification::getId).toList();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionSchedulerTest.java
@@ -1,0 +1,56 @@
+package de.caritas.cob.userservice.api.workflow.notificationretention.scheduler;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.notificationretention.service.EventNotificationRetentionService;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventNotificationRetentionSchedulerTest {
+
+  @InjectMocks private EventNotificationRetentionScheduler eventNotificationRetentionScheduler;
+
+  @Mock private EventNotificationRetentionService eventNotificationRetentionService;
+
+  @Mock private TenantContextProvider tenantContextProvider;
+
+  @Mock private ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  void setUp() {
+    setField(eventNotificationRetentionScheduler, "claimDuration", Duration.ofHours(12));
+  }
+
+  @Test
+  void purgeExpiredNotifications_purgesUnderTheTechnicalTenantContext() {
+    when(taskClaimService.tryClaim("event-notification-retention", Duration.ofHours(12)))
+        .thenReturn(true);
+
+    eventNotificationRetentionScheduler.purgeExpiredNotifications();
+
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(eventNotificationRetentionService).purgeExpiredNotifications();
+  }
+
+  /** Every replica runs the same cron, so exactly one of them may do the deleting. */
+  @Test
+  void purgeExpiredNotifications_skipsAllDownstreamCalls_When_claimIsLost() {
+    when(taskClaimService.tryClaim("event-notification-retention", Duration.ofHours(12)))
+        .thenReturn(false);
+
+    eventNotificationRetentionScheduler.purgeExpiredNotifications();
+
+    verifyNoInteractions(tenantContextProvider, eventNotificationRetentionService);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/notificationretention/service/EventNotificationRetentionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/notificationretention/service/EventNotificationRetentionServiceTest.java
@@ -1,0 +1,111 @@
+package de.caritas.cob.userservice.api.workflow.notificationretention.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.port.out.EventNotificationRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventNotificationRetentionServiceTest {
+
+  @InjectMocks private EventNotificationRetentionService eventNotificationRetentionService;
+
+  @Mock private EventNotificationRepository eventNotificationRepository;
+
+  @BeforeEach
+  void setUp() {
+    setField(eventNotificationRetentionService, "readRetentionDays", 90);
+    setField(eventNotificationRetentionService, "absoluteRetentionDays", 365);
+  }
+
+  @Test
+  void purge_appliesBothCutoffsFromTheConfiguredPeriods() {
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+
+    eventNotificationRetentionService.purgeExpiredNotifications();
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<LocalDateTime> readCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> absoluteCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(eventNotificationRepository).deleteReadBefore(readCutoff.capture());
+    verify(eventNotificationRepository).deleteCreatedBefore(absoluteCutoff.capture());
+
+    // Bracketed by the clock readings around the call rather than compared to a fixed duration,
+    // which would round down on any elapsed time and make the test a coin flip.
+    assertThat(readCutoff.getValue()).isBetween(before.minusDays(90), after.minusDays(90));
+    assertThat(absoluteCutoff.getValue()).isBetween(before.minusDays(365), after.minusDays(365));
+  }
+
+  @Test
+  void purge_appliesTheReadCutoffBeforeTheAbsoluteOne() {
+    eventNotificationRetentionService.purgeExpiredNotifications();
+
+    ArgumentCaptor<LocalDateTime> readCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> absoluteCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(eventNotificationRepository).deleteReadBefore(readCutoff.capture());
+    verify(eventNotificationRepository).deleteCreatedBefore(absoluteCutoff.capture());
+
+    assertThat(absoluteCutoff.getValue())
+        .as("the absolute cutoff must reach further back than the read cutoff")
+        .isBefore(readCutoff.getValue());
+  }
+
+  /**
+   * A misconfigured or empty period must disable its cutoff, never purge everything. Read as "0
+   * days of retention", a naive implementation would delete the whole table.
+   */
+  @Test
+  void purge_treatsANonPositiveReadPeriodAsDisabled() {
+    setField(eventNotificationRetentionService, "readRetentionDays", 0);
+
+    eventNotificationRetentionService.purgeExpiredNotifications();
+
+    verify(eventNotificationRepository, never()).deleteReadBefore(any());
+    verify(eventNotificationRepository).deleteCreatedBefore(any());
+  }
+
+  @Test
+  void purge_treatsANonPositiveAbsolutePeriodAsDisabled() {
+    setField(eventNotificationRetentionService, "absoluteRetentionDays", -1);
+
+    eventNotificationRetentionService.purgeExpiredNotifications();
+
+    verify(eventNotificationRepository).deleteReadBefore(any());
+    verify(eventNotificationRepository, never()).deleteCreatedBefore(any());
+  }
+
+  @Test
+  void purge_doesNothingWhenBothPeriodsAreDisabled() {
+    setField(eventNotificationRetentionService, "readRetentionDays", 0);
+    setField(eventNotificationRetentionService, "absoluteRetentionDays", 0);
+
+    eventNotificationRetentionService.purgeExpiredNotifications();
+
+    verifyNoInteractions(eventNotificationRepository);
+  }
+
+  @Test
+  void purge_survivesAnEmptyRun() {
+    when(eventNotificationRepository.deleteReadBefore(any())).thenReturn(0);
+    when(eventNotificationRepository.deleteCreatedBefore(any())).thenReturn(0);
+
+    eventNotificationRetentionService.purgeExpiredNotifications();
+
+    verify(eventNotificationRepository).deleteReadBefore(any());
+    verify(eventNotificationRepository).deleteCreatedBefore(any());
+  }
+}


### PR DESCRIPTION
## Why

`event_notification` had no retention at all. Every row carries the recipient's Keycloak UUID, a session reference and third-party names, and `read_date` is a second-precision record of when the recipient looked at a given notification — an activity profile that grew for as long as the account existed. None of that has a purpose once the notification has been seen.

## What changes

A nightly purge with **two cutoffs**, not one. A read notification has already done its job, so it goes after the shorter period; the absolute cutoff makes sure an unread feed cannot grow without bound either.

| Setting | Default | Environment variable |
| --- | --- | --- |
| `event.notification.retention.read.days` | 90 | `EVENT_NOTIFICATION_RETENTION_READ_DAYS` |
| `event.notification.retention.absolute.days` | 365 | `EVENT_NOTIFICATION_RETENTION_ABSOLUTE_DAYS` |

The defaults are the DPIA proposal. They are configuration rather than constants because the periods still await sign-off by the client's data-protection officer — this PR ships the mechanism, and the numbers can change without a code change.

## Two decisions worth reviewing

**A non-positive period disables its cutoff — it does not purge everything.** Read literally as "0 days of retention", the obvious implementation wipes the table on an empty or mistyped value. That reading is closed off explicitly and pinned by tests, because the failure mode is silent and total.

**Bulk JPQL rather than derived deletes.** A derived `deleteBy…` loads every expired row into the persistence context and removes them one at a time; the first run after deployment could touch a lot of rows.

The scheduler follows `DeleteUserAccountScheduler`: every replica runs the same cron, so the run is claimed through `ScheduledTaskClaimService` and exactly one replica does the deleting.

## Verification

- `EventNotificationRetentionRepositoryIT` executes both queries against the H2 testing schema. Nothing short of a real execution proves a bulk delete selects the rows it is meant to, and getting the predicate wrong here deletes a user's whole feed. It also pins both cutoffs as **exclusive**, so a row exactly on the boundary is still inside its retention period.
- `EventNotificationRetentionServiceTest` covers both cutoffs, their relative ordering, and each disable path independently.
- `EventNotificationRetentionSchedulerTest` covers the claim being won and lost.

Part of #1010 — task 2a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of expired event notifications.
  - Read notifications older than 90 days are removed, while all notifications older than 365 days are purged by default.
  - Cleanup runs daily and can be configured or disabled.

- **Reliability**
  - Coordinated execution prevents duplicate cleanup runs across service instances.

- **Tests**
  - Added coverage for retention periods, cutoff boundaries, unread notifications, disabled settings, and scheduled execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->