### PR TITLE
[Security] Upgrade HttpCore to fixed 5.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
 		<!-- Spring Boot 4.0.7 still manages Netty 4.2.15; 4.2.16 fixes CVE-2026-59901,
 		     CVE-2026-55831, CVE-2026-55833 and CVE-2026-56745 (image CVE gate). -->
 		<netty.version>4.2.16.Final</netty.version>
+		<!-- Spring Boot 4.0.7 still manages HttpCore 5.3.6; 5.4.3 fixes
+		     CVE-2026-54399 and is compatible with the managed HttpClient 5.5.2. -->
+		<httpcore5.version>5.4.3</httpcore5.version>
 		<springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 		<lombok.version>1.18.42</lombok.version>

--- a/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
@@ -1,0 +1,17 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class DependencySecurityContractTest {
+
+  @Test
+  void httpCoreMustStayOnTheFixedStableRelease() throws IOException {
+    assertThat(Files.readString(Path.of("pom.xml")))
+        .contains("<httpcore5.version>5.4.3</httpcore5.version>");
+  }
+}


### PR DESCRIPTION
## Summary

- override Spring Boot 4.0.7 dependency management from HttpCore 5.3.6 to the fixed stable 5.4.3 release
- keep `httpcore5` and `httpcore5-h2` on the same version
- add a source contract that prevents the security override from disappearing silently
- leave the unrelated Dependabot batch in #1002 untouched

Apache HttpClient 5.5.2 is already the managed client and explicitly supports the HttpCore 5.4 branch.

## Verification

- red-green contract proof: failed before the override, passed after it
- effective dependency tree: `httpclient5 5.5.2` -> `httpcore5 5.4.3` + `httpcore5-h2 5.4.3`
- Java 21 package gate: passed
- `git diff --check`: passed

The immutable branch image and fresh Trivy result remain required before coordinated PreDev deployment.

Closes #1014
Refs #747
Refs #1002
Refs OpenResilienceInitiative/ORISO-Frontend#302