### PR TITLE
feat(observability): emit bounded live-chat diagnostics

### DIFF
--- a/docs/live-chat-observability.md
+++ b/docs/live-chat-observability.md
@@ -1,0 +1,38 @@
+# Live-chat observability contract
+
+These signals answer bounded operational questions without putting tenant,
+topic, session, room, user, event, URL, token, email, exception text, or message
+content into metric dimensions.
+
+| Metric | Type | Allowed tags | Diagnostic use |
+| --- | --- | --- | --- |
+| `oriso.live_chat.routing.decisions` | counter | `stage=availability|eligibility`; `outcome=available|invalid_topic|no_assignment|no_eligible_consultant|availability_expired|presence_unavailable` | Separates missing assignment, absent/ineligible consultants, expired activity leases, and unavailable Matrix presence. |
+| `oriso.live_chat.routing.candidates` | distribution summary | same bounded routing tags | Shows the numeric candidate population without consultant identifiers. |
+| `oriso.live_chat.queue.visibility` | counter | `demand=none|present|unknown`; `outcome=observed|invalid_request` | Distinguishes observed empty demand, non-empty demand, and invalid requests that cannot answer the demand question. |
+| `oriso.live_chat.queue.depth` | distribution summary | none | Measures pending enquiries ahead of a request. |
+| `oriso.matrix.room.creation` | counter | `encryption=enabled|disabled`; `outcome=success|failure|skipped` | Proves encryption posture at the completed Matrix creation request, not from configuration alone. |
+| `oriso.matrix.event.processing` | counter | `event_type=message|encrypted_message|call_invite|call_answer|call_hangup|other`; `outcome=success|failure|skipped` | Separates handled, rejected, and failed Matrix events without room/event IDs. |
+| `oriso.matrix.side_effect.operations` | counter | `side_effect=mobile_push|notification`; `outcome=success|failure|skipped` | Shows asynchronous notification outcomes after each side effect completes. |
+
+All tag values originate from enums or a fixed Matrix event-type allowlist. An
+unknown Matrix event type becomes `other`; its raw value is never registered as
+a tag. Metric recording is best-effort and cannot change a business outcome if
+the meter registry fails.
+
+## Symptom routing
+
+- Empty queue and `demand=none`: no demand, not a routing outage.
+- `no_assignment`: the topic has no consultant relation.
+- `no_eligible_consultant`: assigned consultants are absent or Matrix reports
+  nobody online.
+- `availability_expired`: eligible consultants exist, but no live Redis
+  availability lease remains.
+- `presence_unavailable`: Matrix presence could not be used and the deliberate
+  assignment fallback was taken.
+- Room-creation `outcome=failure`: Matrix provisioning failed.
+- Successful room creation with `encryption=disabled`: critical security alert.
+- Event or side-effect `outcome=failure`: Matrix processing or notification
+  failure respectively.
+
+The deployment must still prove these metrics in self-hosted SigNoz on PreDev
+and then Dev. Unit tests prove the instrumentation contract, not live delivery.

--- a/docs/live-chat-observability.md
+++ b/docs/live-chat-observability.md
@@ -6,13 +6,13 @@ content into metric dimensions.
 
 | Metric | Type | Allowed tags | Diagnostic use |
 | --- | --- | --- | --- |
-| `oriso.live_chat.routing.decisions` | counter | `stage=availability|eligibility`; `outcome=available|invalid_topic|no_assignment|no_eligible_consultant|availability_expired|presence_unavailable` | Separates missing assignment, absent/ineligible consultants, expired activity leases, and unavailable Matrix presence. |
+| `oriso.live_chat.routing.decisions` | counter | `stage={availability, eligibility}`; `outcome={available, invalid_topic, no_assignment, no_eligible_consultant, availability_expired, presence_unavailable}` | Separates missing assignment, absent/ineligible consultants, expired activity leases, and unavailable Matrix presence. |
 | `oriso.live_chat.routing.candidates` | distribution summary | same bounded routing tags | Shows the numeric candidate population without consultant identifiers. |
-| `oriso.live_chat.queue.visibility` | counter | `demand=none|present|unknown`; `outcome=observed|invalid_request` | Distinguishes observed empty demand, non-empty demand, and invalid requests that cannot answer the demand question. |
+| `oriso.live_chat.queue.visibility` | counter | `demand={none, present, unknown}`; `outcome={observed, invalid_request}` | Distinguishes observed empty demand, non-empty demand, and invalid requests that cannot answer the demand question. |
 | `oriso.live_chat.queue.depth` | distribution summary | none | Measures pending enquiries ahead of a request. |
-| `oriso.matrix.room.creation` | counter | `encryption=enabled|disabled`; `outcome=success|failure|skipped` | Proves encryption posture at the completed Matrix creation request, not from configuration alone. |
-| `oriso.matrix.event.processing` | counter | `event_type=message|encrypted_message|call_invite|call_answer|call_hangup|other`; `outcome=success|failure|skipped` | Separates handled, rejected, and failed Matrix events without room/event IDs. |
-| `oriso.matrix.side_effect.operations` | counter | `side_effect=mobile_push|notification`; `outcome=success|failure|skipped` | Shows asynchronous notification outcomes after each side effect completes. |
+| `oriso.matrix.room.creation` | counter | `encryption={enabled, disabled}`; `outcome={success, failure, skipped}` | Proves encryption posture at the completed Matrix creation request, not from configuration alone. |
+| `oriso.matrix.event.processing` | counter | `event_type={message, encrypted_message, call_invite, call_answer, call_hangup, other}`; `outcome={success, failure, skipped}` | Separates handled, rejected, and failed Matrix events without room/event IDs. |
+| `oriso.matrix.side_effect.operations` | counter | `side_effect={mobile_push, notification}`; `outcome={success, failure, skipped}` | Shows asynchronous notification outcomes after each side effect completes. |
 
 All tag values originate from enums or a fixed Matrix event-type allowlist. An
 unknown Matrix event type becomes `other`; its raw value is never registered as

--- a/src/main/java/de/caritas/cob/userservice/api/Messenger.java
+++ b/src/main/java/de/caritas/cob/userservice/api/Messenger.java
@@ -3,6 +3,7 @@ package de.caritas.cob.userservice.api;
 import static java.util.Objects.isNull;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -40,6 +41,7 @@ public class Messenger implements Messaging {
   private final GroupChatMembershipService groupChatMembershipService;
   private final MatrixSynapseService matrixSynapseService;
   private final ConsultantActivityRegistry consultantActivityRegistry;
+  private final LiveChatDiagnosticMetrics diagnosticMetrics;
 
   @Value("${user.anonymous.deactivateworkflow.periodMinutes}")
   private long liveChatQueueActivePeriodMinutes;
@@ -110,17 +112,21 @@ public class Messenger implements Messaging {
   public long countPendingEnquiriesAheadOf(
       Long agencyId, Integer consultingTypeId, Long mainTopicId, LocalDateTime beforeDate) {
     if (beforeDate == null || consultingTypeId == null) {
+      diagnosticMetrics.recordInvalidQueueRequest();
       return 0L;
     }
     var minUpdateDate = LocalDateTime.now().minusMinutes(liveChatQueueActivePeriodMinutes);
-    return sessionRepository.countPendingEnquiriesAheadOf(
-        SessionStatus.NEW,
-        beforeDate,
-        consultingTypeId,
-        mainTopicId,
-        agencyId,
-        minUpdateDate,
-        RegistrationType.ANONYMOUS);
+    var queueDepth =
+        sessionRepository.countPendingEnquiriesAheadOf(
+            SessionStatus.NEW,
+            beforeDate,
+            consultingTypeId,
+            mainTopicId,
+            agencyId,
+            minUpdateDate,
+            RegistrationType.ANONYMOUS);
+    diagnosticMetrics.recordQueueDepth(queueDepth);
+    return queueDepth;
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -1,7 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.matrix;
 
-import static java.util.Objects.nonNull;
-
 import de.caritas.cob.userservice.api.adapters.matrix.config.MatrixConfig;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
@@ -80,14 +78,17 @@ public class MatrixRoomClient {
       log.info("Creating Matrix room: {} at URL: {}", roomName, url);
 
       var response = restTemplate.postForEntity(url, request, MatrixCreateRoomResponseDTO.class);
-      diagnosticMetrics.recordRoomCreation(encryptionEnabled, Outcome.SUCCESS);
-
-      if (nonNull(response.getBody()) && nonNull(response.getBody().getRoomId())) {
-        log.info(
-            "Successfully created Matrix room: {} with ID: {}",
-            roomName,
-            response.getBody().getRoomId());
+      if (response.getBody() == null
+          || response.getBody().getRoomId() == null
+          || response.getBody().getRoomId().isBlank()) {
+        throw new IllegalStateException("Matrix create-room response did not contain a room ID");
       }
+
+      diagnosticMetrics.recordRoomCreation(encryptionEnabled, Outcome.SUCCESS);
+      log.info(
+          "Successfully created Matrix room: {} with ID: {}",
+          roomName,
+          response.getBody().getRoomId());
 
       return response;
     } catch (HttpClientErrorException ex) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClient.java
@@ -7,6 +7,8 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomReques
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.Outcome;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import java.net.URI;
@@ -48,6 +50,7 @@ public class MatrixRoomClient {
 
   private final MatrixConfig matrixConfig;
   private final RestTemplate restTemplate;
+  private final LiveChatDiagnosticMetrics diagnosticMetrics;
 
   public ResponseEntity<MatrixCreateRoomResponseDTO> createRoom(
       String roomName, String roomAlias, String accessToken) throws MatrixCreateRoomException {
@@ -77,6 +80,7 @@ public class MatrixRoomClient {
       log.info("Creating Matrix room: {} at URL: {}", roomName, url);
 
       var response = restTemplate.postForEntity(url, request, MatrixCreateRoomResponseDTO.class);
+      diagnosticMetrics.recordRoomCreation(encryptionEnabled, Outcome.SUCCESS);
 
       if (nonNull(response.getBody()) && nonNull(response.getBody().getRoomId())) {
         log.info(
@@ -87,6 +91,7 @@ public class MatrixRoomClient {
 
       return response;
     } catch (HttpClientErrorException ex) {
+      diagnosticMetrics.recordRoomCreation(encryptionEnabled, Outcome.FAILURE);
       log.error(
           "Matrix Error: Could not create room ({}) in Matrix. Status: {}, Response: {}",
           roomName,
@@ -96,6 +101,7 @@ public class MatrixRoomClient {
           String.format(
               "Could not create room (%s) in Matrix: %s", roomName, ex.getResponseBodyAsString()));
     } catch (Exception ex) {
+      diagnosticMetrics.recordRoomCreation(encryptionEnabled, Outcome.FAILURE);
       log.error("Matrix Error: Could not create room ({}) in Matrix. Reason", roomName, ex);
       throw new MatrixCreateRoomException(
           String.format("Could not create room (%s) in Matrix", roomName));

--- a/src/main/java/de/caritas/cob/userservice/api/config/observability/LiveChatDiagnosticMetrics.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/observability/LiveChatDiagnosticMetrics.java
@@ -1,0 +1,157 @@
+package de.caritas.cob.userservice.api.config.observability;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Privacy-safe, bounded diagnostic signals for the live-chat and Matrix lifecycle. */
+@Component
+@RequiredArgsConstructor
+public class LiveChatDiagnosticMetrics {
+
+  static final String ROUTING_DECISIONS = "oriso.live_chat.routing.decisions";
+  static final String ROUTING_CANDIDATES = "oriso.live_chat.routing.candidates";
+  static final String QUEUE_VISIBILITY = "oriso.live_chat.queue.visibility";
+  static final String QUEUE_DEPTH = "oriso.live_chat.queue.depth";
+  static final String ROOM_CREATION = "oriso.matrix.room.creation";
+  static final String EVENT_PROCESSING = "oriso.matrix.event.processing";
+  static final String SIDE_EFFECTS = "oriso.matrix.side_effect.operations";
+
+  private final MeterRegistry meterRegistry;
+
+  public void recordRouting(RoutingStage stage, RoutingOutcome outcome, int candidateCount) {
+    safely(
+        () -> {
+          Counter.builder(ROUTING_DECISIONS)
+              .description("Bounded live-chat routing decisions")
+              .tags("stage", stage.value, "outcome", outcome.value)
+              .register(meterRegistry)
+              .increment();
+          DistributionSummary.builder(ROUTING_CANDIDATES)
+              .description("Candidate count observed at a live-chat routing stage")
+              .tags("stage", stage.value, "outcome", outcome.value)
+              .register(meterRegistry)
+              .record(Math.max(candidateCount, 0));
+        });
+  }
+
+  public void recordQueueDepth(long depth) {
+    long boundedDepth = Math.max(depth, 0);
+    safely(
+        () -> {
+          Counter.builder(QUEUE_VISIBILITY)
+              .description("Live-chat queue observations grouped by whether demand exists")
+              .tags("demand", boundedDepth == 0 ? "none" : "present", "outcome", "observed")
+              .register(meterRegistry)
+              .increment();
+          DistributionSummary.builder(QUEUE_DEPTH)
+              .description("Number of pending live-chat enquiries ahead of a request")
+              .register(meterRegistry)
+              .record(boundedDepth);
+        });
+  }
+
+  public void recordInvalidQueueRequest() {
+    safely(
+        () ->
+            Counter.builder(QUEUE_VISIBILITY)
+                .description("Live-chat queue observations grouped by whether demand exists")
+                .tags("demand", "unknown", "outcome", "invalid_request")
+                .register(meterRegistry)
+                .increment());
+  }
+
+  public void recordRoomCreation(boolean encryptionEnabled, Outcome outcome) {
+    counter(ROOM_CREATION, "encryption", encryptionEnabled ? "enabled" : "disabled", outcome);
+  }
+
+  public void recordMatrixEvent(String rawEventType, Outcome outcome) {
+    counter(EVENT_PROCESSING, "event_type", boundedEventType(rawEventType), outcome);
+  }
+
+  public void recordSideEffect(SideEffect sideEffect, Outcome outcome) {
+    counter(SIDE_EFFECTS, "side_effect", sideEffect.value, outcome);
+  }
+
+  private void counter(String name, String tagName, String tagValue, Outcome outcome) {
+    safely(
+        () ->
+            Counter.builder(name)
+                .tags(tagName, tagValue, "outcome", outcome.value)
+                .register(meterRegistry)
+                .increment());
+  }
+
+  private void safely(Runnable recording) {
+    try {
+      recording.run();
+    } catch (RuntimeException ignored) {
+      // Telemetry must never alter the live-chat or Matrix business outcome.
+    }
+  }
+
+  private String boundedEventType(String rawEventType) {
+    if (rawEventType == null) {
+      return "other";
+    }
+    return switch (rawEventType) {
+      case "m.room.message" -> "message";
+      case "m.room.encrypted" -> "encrypted_message";
+      case "m.call.invite" -> "call_invite";
+      case "m.call.answer" -> "call_answer";
+      case "m.call.hangup" -> "call_hangup";
+      default -> "other";
+    };
+  }
+
+  public enum RoutingStage {
+    AVAILABILITY("availability"),
+    ELIGIBILITY("eligibility");
+
+    private final String value;
+
+    RoutingStage(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum RoutingOutcome {
+    AVAILABLE("available"),
+    INVALID_TOPIC("invalid_topic"),
+    NO_ASSIGNMENT("no_assignment"),
+    NO_ELIGIBLE_CONSULTANT("no_eligible_consultant"),
+    AVAILABILITY_EXPIRED("availability_expired"),
+    PRESENCE_UNAVAILABLE("presence_unavailable");
+
+    private final String value;
+
+    RoutingOutcome(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum Outcome {
+    SUCCESS("success"),
+    FAILURE("failure"),
+    SKIPPED("skipped");
+
+    private final String value;
+
+    Outcome(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum SideEffect {
+    MOBILE_PUSH("mobile_push"),
+    NOTIFICATION("notification");
+
+    private final String value;
+
+    SideEffect(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingService.java
@@ -1,6 +1,9 @@
 package de.caritas.cob.userservice.api.service.consultingtype;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.RoutingOutcome;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.RoutingStage;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
@@ -27,6 +30,7 @@ public class TopicConsultantRoutingService {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull ConsultantActivityRegistry consultantActivityRegistry;
+  private final @NonNull LiveChatDiagnosticMetrics diagnosticMetrics;
 
   @Value("${consultant.availability.activeWindowMs:120000}")
   private long activeWindowMs;
@@ -45,28 +49,47 @@ public class TopicConsultantRoutingService {
    */
   public List<String> findAvailableConsultantIds(Long topicId) {
     if (topicId == null) {
+      diagnosticMetrics.recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.INVALID_TOPIC, 0);
       return Collections.emptyList();
     }
 
-    List<String> activeConsultantIds =
+    AvailableCandidates candidates =
         runCrossTenant(
             () -> {
               List<String> topicConsultantIds =
                   consultantTopicRepository.findConsultantIdsByTopicId(topicId);
               if (topicConsultantIds.isEmpty()) {
-                return Collections.emptyList();
+                return new AvailableCandidates(Collections.emptyList(), false);
               }
-              return consultantRepository.findAllByIdIn(topicConsultantIds).stream()
-                  .filter(consultant -> consultant != null && !consultant.isAbsent())
-                  .map(Consultant::getId)
-                  .collect(Collectors.toList());
+              return new AvailableCandidates(
+                  consultantRepository.findAllByIdIn(topicConsultantIds).stream()
+                      .filter(consultant -> consultant != null && !consultant.isAbsent())
+                      .map(Consultant::getId)
+                      .collect(Collectors.toList()),
+                  true);
             });
-    if (activeConsultantIds.isEmpty()) {
+    if (!candidates.hasAssignments()) {
+      diagnosticMetrics.recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.NO_ASSIGNMENT, 0);
       return Collections.emptyList();
     }
 
-    return new ArrayList<>(
-        consultantActivityRegistry.filterActive(activeConsultantIds, activeWindowMs));
+    List<String> activeConsultantIds = candidates.consultantIds();
+    if (activeConsultantIds.isEmpty()) {
+      diagnosticMetrics.recordRouting(
+          RoutingStage.AVAILABILITY, RoutingOutcome.NO_ELIGIBLE_CONSULTANT, 0);
+      return Collections.emptyList();
+    }
+
+    var availableConsultantIds =
+        new ArrayList<>(
+            consultantActivityRegistry.filterActive(activeConsultantIds, activeWindowMs));
+    diagnosticMetrics.recordRouting(
+        RoutingStage.AVAILABILITY,
+        availableConsultantIds.isEmpty()
+            ? RoutingOutcome.AVAILABILITY_EXPIRED
+            : RoutingOutcome.AVAILABLE,
+        availableConsultantIds.size());
+    return availableConsultantIds;
   }
 
   /**
@@ -88,13 +111,17 @@ public class TopicConsultantRoutingService {
     }
   }
 
+  private record AvailableCandidates(List<String> consultantIds, boolean hasAssignments) {}
+
   public List<String> findEligibleConsultantIds(Long topicId) {
     if (topicId == null) {
+      diagnosticMetrics.recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.INVALID_TOPIC, 0);
       return Collections.emptyList();
     }
 
     List<String> topicConsultantIds = consultantTopicRepository.findConsultantIdsByTopicId(topicId);
     if (topicConsultantIds.isEmpty()) {
+      diagnosticMetrics.recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.NO_ASSIGNMENT, 0);
       return Collections.emptyList();
     }
 
@@ -106,6 +133,8 @@ public class TopicConsultantRoutingService {
             .collect(Collectors.toList());
 
     if (activeConsultantIds.isEmpty()) {
+      diagnosticMetrics.recordRouting(
+          RoutingStage.ELIGIBILITY, RoutingOutcome.NO_ELIGIBLE_CONSULTANT, 0);
       return Collections.emptyList();
     }
 
@@ -125,19 +154,29 @@ public class TopicConsultantRoutingService {
     if (onlineMatrixUserIds.isPresent()) {
       // Authoritative answer from Matrix — trust it even when empty (genuinely nobody online).
       Set<String> online = onlineMatrixUserIds.get();
-      return consultants.stream()
-          .filter(consultant -> consultant != null && !consultant.isAbsent())
-          .filter(
-              consultant ->
-                  consultant.getMatrixUserId() != null
-                      && online.contains(consultant.getMatrixUserId()))
-          .map(Consultant::getId)
-          .collect(Collectors.toList());
+      var eligibleConsultantIds =
+          consultants.stream()
+              .filter(consultant -> consultant != null && !consultant.isAbsent())
+              .filter(
+                  consultant ->
+                      consultant.getMatrixUserId() != null
+                          && online.contains(consultant.getMatrixUserId()))
+              .map(Consultant::getId)
+              .collect(Collectors.toList());
+      diagnosticMetrics.recordRouting(
+          RoutingStage.ELIGIBILITY,
+          eligibleConsultantIds.isEmpty()
+              ? RoutingOutcome.NO_ELIGIBLE_CONSULTANT
+              : RoutingOutcome.AVAILABLE,
+          eligibleConsultantIds.size());
+      return eligibleConsultantIds;
     }
 
     // Presence may be disabled or temporarily unavailable. Assignment remains possible for all
     // non-absent topic consultants; the stricter public availability indicator uses the activity
     // registry in findAvailableConsultantIds.
+    diagnosticMetrics.recordRouting(
+        RoutingStage.ELIGIBILITY, RoutingOutcome.PRESENCE_UNAVAILABLE, activeConsultantIds.size());
     return activeConsultantIds;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -1,6 +1,9 @@
 package de.caritas.cob.userservice.api.service.matrix;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.Outcome;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.SideEffect;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
@@ -44,6 +47,7 @@ public class MatrixEventListenerService {
   private final @NonNull ConsultantMessageStatService consultantMessageStatService;
 
   private OutboundHttpMetrics outboundHttpMetrics;
+  private LiveChatDiagnosticMetrics diagnosticMetrics;
   private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
   // Maps Matrix room ID to session ID for quick lookup
@@ -75,6 +79,11 @@ public class MatrixEventListenerService {
   @Autowired(required = false)
   void setObservationRegistry(ObservationRegistry observationRegistry) {
     this.observationRegistry = observationRegistry;
+  }
+
+  @Autowired(required = false)
+  void setDiagnosticMetrics(LiveChatDiagnosticMetrics diagnosticMetrics) {
+    this.diagnosticMetrics = diagnosticMetrics;
   }
 
   // Backoff bounds (milliseconds) for both the token bootstrap and the sync error path.
@@ -421,37 +430,45 @@ public class MatrixEventListenerService {
     String senderId = (String) event.get("sender");
 
     if (eventType == null) {
+      recordMatrixEvent(null, Outcome.SKIPPED);
       return;
     }
 
     log.debug("🔷 Matrix event: {} in room {} from {}", eventType, roomId, senderId);
 
     // Handle different event types
-    switch (eventType) {
-      case "m.room.message":
-        // E2EE rooms deliver messages as m.room.encrypted — the payload is opaque
-        // (no msgtype/body), but sender + event id are cleartext, which is all the
-        // metadata-only notification pipeline needs (preview mode NONE).
-      case "m.room.encrypted":
-        handleRoomMessage(roomId, event);
-        break;
+    Outcome outcome = Outcome.SUCCESS;
+    try {
+      switch (eventType) {
+        case "m.room.message":
+          // E2EE rooms deliver messages as m.room.encrypted — the payload is opaque
+          // (no msgtype/body), but sender + event id are cleartext, which is all the
+          // metadata-only notification pipeline needs (preview mode NONE).
+        case "m.room.encrypted":
+          handleRoomMessage(roomId, event);
+          break;
 
-      case "m.call.invite":
-        handleCallInvite(roomId, event);
-        break;
+        case "m.call.invite":
+          handleCallInvite(roomId, event);
+          break;
 
-      case "m.call.answer":
-        handleCallAnswer(roomId, event);
-        break;
+        case "m.call.answer":
+          handleCallAnswer(roomId, event);
+          break;
 
-      case "m.call.hangup":
-        handleCallHangup(roomId, event);
-        break;
+        case "m.call.hangup":
+          handleCallHangup(roomId, event);
+          break;
 
-      default:
-        // Ignore other event types
-        break;
+        default:
+          outcome = Outcome.SKIPPED;
+          break;
+      }
+    } catch (RuntimeException | Error failure) {
+      recordMatrixEvent(eventType, Outcome.FAILURE);
+      throw failure;
     }
+    recordMatrixEvent(eventType, outcome);
   }
 
   /**
@@ -519,7 +536,9 @@ public class MatrixEventListenerService {
           () -> {
             try {
               mobilePushNotificationService.triggerMobilePushNotification(recipientIds);
+              recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.SUCCESS);
             } catch (Exception e) {
+              recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.FAILURE);
               log.error("❌ Failed to send mobile push notification", e);
             }
             // The persisted feed entry is the source of truth for the notification timeline.
@@ -537,10 +556,24 @@ public class MatrixEventListenerService {
                   && isConsultantMatrixUser(senderId)) {
                 consultantMessageStatService.recordMessageSent(senderDomainUserId, mappedSessionId);
               }
+              recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
             } catch (Exception e) {
+              recordSideEffect(SideEffect.NOTIFICATION, Outcome.FAILURE);
               log.error("❌ Failed to create event notification from room", e);
             }
           });
+    }
+  }
+
+  private void recordMatrixEvent(String eventType, Outcome outcome) {
+    if (diagnosticMetrics != null) {
+      diagnosticMetrics.recordMatrixEvent(eventType, outcome);
+    }
+  }
+
+  private void recordSideEffect(SideEffect sideEffect, Outcome outcome) {
+    if (diagnosticMetrics != null) {
+      diagnosticMetrics.recordSideEffect(sideEffect, outcome);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerService.java
@@ -445,19 +445,19 @@ public class MatrixEventListenerService {
           // (no msgtype/body), but sender + event id are cleartext, which is all the
           // metadata-only notification pipeline needs (preview mode NONE).
         case "m.room.encrypted":
-          handleRoomMessage(roomId, event);
+          outcome = handleRoomMessage(roomId, event) ? Outcome.SUCCESS : Outcome.SKIPPED;
           break;
 
         case "m.call.invite":
-          handleCallInvite(roomId, event);
+          outcome = handleCallInvite(roomId, event) ? Outcome.SUCCESS : Outcome.SKIPPED;
           break;
 
         case "m.call.answer":
-          handleCallAnswer(roomId, event);
+          outcome = handleCallAnswer(roomId, event) ? Outcome.SUCCESS : Outcome.SKIPPED;
           break;
 
         case "m.call.hangup":
-          handleCallHangup(roomId, event);
+          outcome = handleCallHangup(roomId, event) ? Outcome.SUCCESS : Outcome.SKIPPED;
           break;
 
         default:
@@ -478,12 +478,12 @@ public class MatrixEventListenerService {
    * @param event the message event
    */
   @SuppressWarnings("unchecked")
-  private void handleRoomMessage(String roomId, Map<String, Object> event) {
+  private boolean handleRoomMessage(String roomId, Map<String, Object> event) {
     String senderId = (String) event.get("sender");
     Map<String, Object> content = (Map<String, Object>) event.get("content");
 
     if (content == null) {
-      return;
+      return false;
     }
 
     String msgtype = (String) content.get("msgtype");
@@ -511,7 +511,7 @@ public class MatrixEventListenerService {
     // Get users who should receive notification (exclude sender)
     Set<String> userIds = getRecipientCandidatesForRoom(roomId);
     if (userIds == null || userIds.isEmpty()) {
-      return;
+      return false;
     }
 
     // Notify all room participants except the sender.
@@ -520,49 +520,59 @@ public class MatrixEventListenerService {
             .filter(userId -> senderDomainUserId == null || !userId.equals(senderDomainUserId))
             .collect(java.util.stream.Collectors.toList());
 
-    if (!recipientIds.isEmpty()) {
-      log.info("🔔 Triggering direct-message notification for {} users", recipientIds.size());
-
-      Long mappedSessionId = roomToSessionMap.get(roomId);
-      if (mappedSessionId == null) {
-        log.warn(
-            "No session mapping for Matrix room {}; continuing notification delivery for {} users",
-            roomId,
-            recipientIds.size());
-      }
-
-      // Notify asynchronously so the Matrix sync loop is not blocked.
-      executorService.submit(
-          () -> {
-            try {
-              mobilePushNotificationService.triggerMobilePushNotification(recipientIds);
-              recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.SUCCESS);
-            } catch (Exception e) {
-              recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.FAILURE);
-              log.error("❌ Failed to send mobile push notification", e);
-            }
-            // The persisted feed entry is the source of truth for the notification timeline.
-            // Isolate the failure domains so a push failure cannot swallow the notification row.
-            try {
-              if (threadRootId != null && !threadRootId.isBlank()) {
-                eventNotificationService.createThreadReplyNotificationFromRoom(
-                    roomId, senderDomainUserId, threadRootId, privacyEnvelope);
-              } else {
-                eventNotificationService.createMessageNotificationFromRoom(
-                    roomId, senderDomainUserId, privacyEnvelope);
-              }
-              if (mappedSessionId != null
-                  && senderDomainUserId != null
-                  && isConsultantMatrixUser(senderId)) {
-                consultantMessageStatService.recordMessageSent(senderDomainUserId, mappedSessionId);
-              }
-              recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
-            } catch (Exception e) {
-              recordSideEffect(SideEffect.NOTIFICATION, Outcome.FAILURE);
-              log.error("❌ Failed to create event notification from room", e);
-            }
-          });
+    if (recipientIds.isEmpty()) {
+      return false;
     }
+
+    log.info("🔔 Triggering direct-message notification for {} users", recipientIds.size());
+
+    Long mappedSessionId = roomToSessionMap.get(roomId);
+    if (mappedSessionId == null) {
+      log.warn(
+          "No session mapping for Matrix room {}; continuing notification delivery for {} users",
+          roomId,
+          recipientIds.size());
+    }
+
+    // Notify asynchronously so the Matrix sync loop is not blocked.
+    executorService.submit(
+        () -> {
+          try {
+            mobilePushNotificationService.triggerMobilePushNotification(recipientIds);
+            recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.SUCCESS);
+          } catch (Exception e) {
+            recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.FAILURE);
+            log.error("❌ Failed to send mobile push notification", e);
+          }
+          // The persisted feed entry is the source of truth for the notification timeline.
+          // Isolate the failure domains so a push failure cannot swallow the notification row.
+          try {
+            if (threadRootId != null && !threadRootId.isBlank()) {
+              eventNotificationService.createThreadReplyNotificationFromRoom(
+                  roomId, senderDomainUserId, threadRootId, privacyEnvelope);
+            } else {
+              eventNotificationService.createMessageNotificationFromRoom(
+                  roomId, senderDomainUserId, privacyEnvelope);
+            }
+            recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
+          } catch (Exception e) {
+            recordSideEffect(SideEffect.NOTIFICATION, Outcome.FAILURE);
+            log.error("❌ Failed to create event notification from room", e);
+            return;
+          }
+
+          if (mappedSessionId != null
+              && senderDomainUserId != null
+              && isConsultantMatrixUser(senderId)) {
+            try {
+              consultantMessageStatService.recordMessageSent(senderDomainUserId, mappedSessionId);
+            } catch (Exception e) {
+              log.error("Failed to record consultant message statistic", e);
+            }
+          }
+        });
+
+    return true;
   }
 
   private void recordMatrixEvent(String eventType, Outcome outcome) {
@@ -768,12 +778,12 @@ public class MatrixEventListenerService {
    * @param event the call invite event
    */
   @SuppressWarnings("unchecked")
-  private void handleCallInvite(String roomId, Map<String, Object> event) {
+  private boolean handleCallInvite(String roomId, Map<String, Object> event) {
     String senderId = (String) event.get("sender");
     Map<String, Object> content = (Map<String, Object>) event.get("content");
 
     if (content == null) {
-      return;
+      return false;
     }
 
     String callId = (String) content.get("call_id");
@@ -789,7 +799,7 @@ public class MatrixEventListenerService {
     // Get users who should receive notification (exclude sender)
     Set<String> userIds = roomToUsersMap.get(roomId);
     if (userIds == null || userIds.isEmpty()) {
-      return;
+      return false;
     }
 
     List<String> recipientIds =
@@ -797,9 +807,12 @@ public class MatrixEventListenerService {
             .filter(userId -> !userId.equals(senderId))
             .collect(java.util.stream.Collectors.toList());
 
-    if (!recipientIds.isEmpty()) {
-      log.info("🔔 Matrix call invite received for {} users", recipientIds.size());
+    if (recipientIds.isEmpty()) {
+      return false;
     }
+
+    log.info("🔔 Matrix call invite received for {} users", recipientIds.size());
+    return true;
   }
 
   /**
@@ -808,10 +821,11 @@ public class MatrixEventListenerService {
    * @param roomId the Matrix room ID
    * @param event the call answer event
    */
-  private void handleCallAnswer(String roomId, Map<String, Object> event) {
+  private boolean handleCallAnswer(String roomId, Map<String, Object> event) {
     String senderId = (String) event.get("sender");
     log.info("📞 Call answered in room {} by {}", roomId, senderId);
     // Additional call-state handling can be added here if needed.
+    return true;
   }
 
   /**
@@ -820,9 +834,10 @@ public class MatrixEventListenerService {
    * @param roomId the Matrix room ID
    * @param event the call hangup event
    */
-  private void handleCallHangup(String roomId, Map<String, Object> event) {
+  private boolean handleCallHangup(String roomId, Map<String, Object> event) {
     String senderId = (String) event.get("sender");
     log.info("📞 Call ended in room {} by {}", roomId, senderId);
     // Additional call-state handling can be added here if needed.
+    return true;
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/MessengerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/MessengerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -40,6 +41,7 @@ class MessengerTest {
   @Mock private SessionRepository sessionRepository;
   @Mock private UserServiceMapper mapper;
   @Mock private ConsultantActivityRegistry consultantActivityRegistry;
+  @Mock private LiveChatDiagnosticMetrics diagnosticMetrics;
 
   @Mock
   private de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService
@@ -81,6 +83,7 @@ class MessengerTest {
     long result = messenger.countPendingEnquiriesAheadOf(1L, 1, 1L, null);
 
     assertThat(result).isZero();
+    verify(diagnosticMetrics).recordInvalidQueueRequest();
     verify(sessionRepository, never())
         .countPendingEnquiriesAheadOf(any(), any(), any(), any(), any(), any(), any());
   }
@@ -90,6 +93,7 @@ class MessengerTest {
     long result = messenger.countPendingEnquiriesAheadOf(1L, null, 1L, LocalDateTime.now());
 
     assertThat(result).isZero();
+    verify(diagnosticMetrics).recordInvalidQueueRequest();
   }
 
   @Test
@@ -102,6 +106,7 @@ class MessengerTest {
     long result = messenger.countPendingEnquiriesAheadOf(10L, 2, 3L, before);
 
     assertThat(result).isEqualTo(5L);
+    verify(diagnosticMetrics).recordQueueDepth(5L);
   }
 
   // ── markAsDirectConsultant ────────────────────────────────────────────────

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -143,6 +143,23 @@ class MatrixRoomClientTest {
         .isInstanceOf(
             de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException.class)
         .hasMessage("Could not create room (Room name) in Matrix");
+    verify(diagnosticMetrics).recordRoomCreation(false, LiveChatDiagnosticMetrics.Outcome.FAILURE);
+  }
+
+  @Test
+  void createRoom_ShouldRejectSuccessfulResponseWithoutRoomId() {
+    when(restTemplate.postForEntity(
+            eq(uri(API_URL + "/_matrix/client/r0/createRoom")),
+            org.mockito.ArgumentMatchers.any(HttpEntity.class),
+            eq(MatrixCreateRoomResponseDTO.class)))
+        .thenReturn(ResponseEntity.ok(new MatrixCreateRoomResponseDTO()));
+
+    assertThatThrownBy(
+            () -> matrixRoomClient.createRoom("Room name", "room-alias", ACCESS_TOKEN, true))
+        .isInstanceOf(
+            de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException.class)
+        .hasMessage("Could not create room (Room name) in Matrix");
+    verify(diagnosticMetrics).recordRoomCreation(true, LiveChatDiagnosticMetrics.Outcome.FAILURE);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixRoomClientTest.java
@@ -13,6 +13,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomReques
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserRequestDTO;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixInviteUserResponseDTO;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -47,6 +48,7 @@ class MatrixRoomClientTest {
 
   @Mock private MatrixConfig matrixConfig;
   @Mock private RestTemplate restTemplate;
+  @Mock private LiveChatDiagnosticMetrics diagnosticMetrics;
 
   @Captor private ArgumentCaptor<HttpEntity<MatrixCreateRoomRequestDTO>> createRoomRequestCaptor;
   @Captor private ArgumentCaptor<HttpEntity<MatrixInviteUserRequestDTO>> inviteRequestCaptor;
@@ -84,6 +86,7 @@ class MatrixRoomClientTest {
     assertThat(request.getBody().getPreset()).isEqualTo("private_chat");
     assertThat(request.getBody().getVisibility()).isEqualTo("private");
     assertThat(request.getBody().getInitialState()).isEmpty();
+    verify(diagnosticMetrics).recordRoomCreation(false, LiveChatDiagnosticMetrics.Outcome.SUCCESS);
   }
 
   @Test
@@ -104,6 +107,7 @@ class MatrixRoomClientTest {
     assertThat(event.getType()).isEqualTo("m.room.encryption");
     assertThat(event.getStateKey()).isEmpty();
     assertThat(event.getContent()).isEqualTo(Map.of("algorithm", "m.megolm.v1.aes-sha2"));
+    verify(diagnosticMetrics).recordRoomCreation(true, LiveChatDiagnosticMetrics.Outcome.SUCCESS);
   }
 
   @Test
@@ -124,6 +128,7 @@ class MatrixRoomClientTest {
         .isInstanceOf(
             de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException.class)
         .hasMessageContaining("Could not create room (Room name) in Matrix");
+    verify(diagnosticMetrics).recordRoomCreation(false, LiveChatDiagnosticMetrics.Outcome.FAILURE);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/LiveChatDiagnosticMetricsTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/LiveChatDiagnosticMetricsTest.java
@@ -1,0 +1,141 @@
+package de.caritas.cob.userservice.api.config.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class LiveChatDiagnosticMetricsTest {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final LiveChatDiagnosticMetrics metrics = new LiveChatDiagnosticMetrics(registry);
+
+  @Test
+  void recordsBoundedRoutingAndQueueDiagnostics() {
+    metrics.recordRouting(
+        LiveChatDiagnosticMetrics.RoutingStage.AVAILABILITY,
+        LiveChatDiagnosticMetrics.RoutingOutcome.AVAILABILITY_EXPIRED,
+        3);
+    metrics.recordQueueDepth(0);
+
+    assertThat(
+            registry
+                .get("oriso.live_chat.routing.decisions")
+                .tag("stage", "availability")
+                .tag("outcome", "availability_expired")
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .get("oriso.live_chat.routing.candidates")
+                .tag("stage", "availability")
+                .tag("outcome", "availability_expired")
+                .summary()
+                .totalAmount())
+        .isEqualTo(3);
+    assertThat(
+            registry
+                .get("oriso.live_chat.queue.visibility")
+                .tag("demand", "none")
+                .tag("outcome", "observed")
+                .counter()
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void distinguishesInvalidQueueRequestsFromObservedEmptyDemand() {
+    metrics.recordInvalidQueueRequest();
+
+    assertThat(
+            registry
+                .get("oriso.live_chat.queue.visibility")
+                .tag("demand", "unknown")
+                .tag("outcome", "invalid_request")
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(registry.find("oriso.live_chat.queue.depth").summary()).isNull();
+  }
+
+  @Test
+  void recordsRoomEncryptionAtTheCompletedBoundary() {
+    metrics.recordRoomCreation(true, LiveChatDiagnosticMetrics.Outcome.SUCCESS);
+    metrics.recordRoomCreation(false, LiveChatDiagnosticMetrics.Outcome.FAILURE);
+
+    assertThat(
+            registry
+                .get("oriso.matrix.room.creation")
+                .tag("encryption", "enabled")
+                .tag("outcome", "success")
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .get("oriso.matrix.room.creation")
+                .tag("encryption", "disabled")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void boundsRawMatrixEventTypesAndSideEffects() {
+    metrics.recordMatrixEvent("m.room.encrypted", LiveChatDiagnosticMetrics.Outcome.SUCCESS);
+    metrics.recordMatrixEvent("m.room.secret-user-123", LiveChatDiagnosticMetrics.Outcome.FAILURE);
+    metrics.recordSideEffect(
+        LiveChatDiagnosticMetrics.SideEffect.NOTIFICATION,
+        LiveChatDiagnosticMetrics.Outcome.FAILURE);
+
+    assertThat(
+            registry
+                .get("oriso.matrix.event.processing")
+                .tag("event_type", "encrypted_message")
+                .tag("outcome", "success")
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            registry
+                .get("oriso.matrix.event.processing")
+                .tag("event_type", "other")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1);
+    assertThat(registry.getMeters().stream().map(meter -> meter.getId().getTags().toString()))
+        .noneMatch(tags -> tags.contains("secret-user-123"));
+    assertThat(
+            registry
+                .get("oriso.matrix.side_effect.operations")
+                .tag("side_effect", "notification")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void neverChangesBusinessOutcomeWhenTheRegistryFails() {
+    var failingMetrics = new LiveChatDiagnosticMetrics(new FailingCounterMeterRegistry());
+
+    assertThatCode(
+            () ->
+                failingMetrics.recordRoomCreation(false, LiveChatDiagnosticMetrics.Outcome.SUCCESS))
+        .doesNotThrowAnyException();
+  }
+
+  private static final class FailingCounterMeterRegistry extends SimpleMeterRegistry {
+
+    @Override
+    protected Counter newCounter(Meter.Id id) {
+      throw new IllegalStateException("registry unavailable");
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
@@ -184,6 +184,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findEligibleConsultantIds(null);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.INVALID_TOPIC, 0);
     verify(consultantTopicRepository, never()).findConsultantIdsByTopicId(any());
   }
 
@@ -195,6 +197,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findEligibleConsultantIds(2L);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.NO_ASSIGNMENT, 0);
   }
 
   @Test
@@ -206,6 +210,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findEligibleConsultantIds(3L);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.NO_ELIGIBLE_CONSULTANT, 0);
     verify(matrixSynapseService, never()).findOnlineMatrixUserIds(any());
   }
 
@@ -222,6 +228,7 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findEligibleConsultantIds(4L);
 
     assertThat(result).containsExactly("c1");
+    verify(diagnosticMetrics).recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.AVAILABLE, 1);
   }
 
   @Test
@@ -248,6 +255,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findEligibleConsultantIds(5L);
 
     assertThat(result).containsExactly("c1");
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.ELIGIBILITY, RoutingOutcome.PRESENCE_UNAVAILABLE, 1);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/TopicConsultantRoutingServiceTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.RoutingOutcome;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.RoutingStage;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
@@ -36,6 +39,7 @@ class TopicConsultantRoutingServiceTest {
   @Mock private ConsultantRepository consultantRepository;
   @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private ConsultantActivityRegistry consultantActivityRegistry;
+  @Mock private LiveChatDiagnosticMetrics diagnosticMetrics;
 
   @InjectMocks private TopicConsultantRoutingService service;
 
@@ -66,6 +70,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findAvailableConsultantIds(null);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.INVALID_TOPIC, 0);
     verify(consultantTopicRepository, never()).findConsultantIdsByTopicId(any());
   }
 
@@ -77,6 +83,10 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findAvailableConsultantIds(1L);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.NO_ASSIGNMENT, 0);
+    verify(diagnosticMetrics, never())
+        .recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.NO_ELIGIBLE_CONSULTANT, 0);
     verify(consultantRepository, never()).findAllByIdIn(any());
   }
 
@@ -89,6 +99,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findAvailableConsultantIds(1L);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.NO_ELIGIBLE_CONSULTANT, 0);
     verify(consultantActivityRegistry, never()).filterActive(any(), anyLong());
   }
 
@@ -103,6 +115,8 @@ class TopicConsultantRoutingServiceTest {
     List<String> result = service.findAvailableConsultantIds(1L);
 
     assertThat(result).isEmpty();
+    verify(diagnosticMetrics)
+        .recordRouting(RoutingStage.AVAILABILITY, RoutingOutcome.AVAILABILITY_EXPIRED, 0);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -1204,6 +1204,18 @@ class MatrixEventListenerServiceTest {
   }
 
   @Test
+  void processMatrixEvent_shouldRethrowHandlerFailure_andRecordFailure() {
+    var service = newService();
+    var failure = new IllegalStateException("repository unavailable");
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(SENDER_MATRIX_ID)).thenThrow(failure);
+    var event = messageEvent(SENDER_MATRIX_ID, "m.text", "hello", "$evt-failure");
+
+    assertThatThrownBy(() -> invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event))
+        .isSameAs(failure);
+    verify(diagnosticMetrics).recordMatrixEvent("m.room.message", Outcome.FAILURE);
+  }
+
+  @Test
   void handleCallInvite_shouldLogRecipientCount_whenRecipientsExist() {
     var service = newService();
     service.registerRoom(20L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
@@ -1235,6 +1247,7 @@ class MatrixEventListenerServiceTest {
 
     assertThat(logAppender.list)
         .noneMatch(e -> e.getFormattedMessage().contains("Matrix call invite received"));
+    verify(diagnosticMetrics).recordMatrixEvent("m.call.invite", Outcome.SKIPPED);
   }
 
   @Test
@@ -1456,6 +1469,38 @@ class MatrixEventListenerServiceTest {
     invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event);
 
     verifyNoInteractions(eventNotificationService);
+    verify(diagnosticMetrics).recordMatrixEvent("m.room.encrypted", Outcome.SKIPPED);
+  }
+
+  @Test
+  void handleRoomMessage_shouldKeepNotificationSuccess_whenStatisticRecordingFails() {
+    var service = newServiceWithSyncExecutor();
+    service.registerRoom(35L, MATRIX_ROOM_ID, Set.of(ASKER_DOMAIN_ID, CONSULTANT_DOMAIN_ID));
+    when(userRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.empty());
+    when(consultantRepository.findByMatrixUserIdAndDeleteDateIsNull(CONSULTANT_MATRIX_ID))
+        .thenReturn(Optional.of(consultantWithId(CONSULTANT_DOMAIN_ID)));
+    org.mockito.Mockito.doThrow(new IllegalStateException("statistics unavailable"))
+        .when(consultantMessageStatService)
+        .recordMessageSent(CONSULTANT_DOMAIN_ID, 35L);
+
+    invokeProcessMatrixEvent(
+        service,
+        MATRIX_ROOM_ID,
+        messageEvent(CONSULTANT_MATRIX_ID, "m.text", "hello", "$evt-stat-failure"));
+
+    verify(eventNotificationService)
+        .createMessageNotificationFromRoom(
+            eq(MATRIX_ROOM_ID), eq(CONSULTANT_DOMAIN_ID), any(PrivacyEnvelope.class));
+    verify(diagnosticMetrics).recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
+    verify(diagnosticMetrics, never()).recordSideEffect(SideEffect.NOTIFICATION, Outcome.FAILURE);
+    assertThat(logAppender.list)
+        .anyMatch(
+            entry ->
+                entry.getLevel().toString().equals("ERROR")
+                    && entry
+                        .getFormattedMessage()
+                        .contains("Failed to record consultant message statistic"));
   }
 
   private static Session sessionWithId(long sessionId) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixEventListenerServiceTest.java
@@ -20,6 +20,9 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.Outcome;
+import de.caritas.cob.userservice.api.config.observability.LiveChatDiagnosticMetrics.SideEffect;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -78,6 +81,7 @@ class MatrixEventListenerServiceTest {
   @Mock private SessionRepository sessionRepository;
   @Mock private RedisMessageMirrorService redisMessageMirrorService;
   @Mock private ConsultantMessageStatService consultantMessageStatService;
+  @Mock private LiveChatDiagnosticMetrics diagnosticMetrics;
 
   private Logger logger;
   private ListAppender<ILoggingEvent> logAppender;
@@ -107,16 +111,19 @@ class MatrixEventListenerServiceTest {
   }
 
   private MatrixEventListenerService newService(Optional<RedisMessageMirrorService> mirror) {
-    return new MatrixEventListenerService(
-        matrixSynapseService,
-        sessionService,
-        mobilePushNotificationService,
-        eventNotificationService,
-        mirror,
-        userRepository,
-        consultantRepository,
-        sessionRepository,
-        consultantMessageStatService);
+    var service =
+        new MatrixEventListenerService(
+            matrixSynapseService,
+            sessionService,
+            mobilePushNotificationService,
+            eventNotificationService,
+            mirror,
+            userRepository,
+            consultantRepository,
+            sessionRepository,
+            consultantMessageStatService);
+    service.setDiagnosticMetrics(diagnosticMetrics);
+    return service;
   }
 
   private MatrixEventListenerService newServiceWithSyncExecutor() {
@@ -1187,11 +1194,13 @@ class MatrixEventListenerServiceTest {
 
     assertThatCode(() -> invokeProcessMatrixEvent(service, MATRIX_ROOM_ID, event))
         .doesNotThrowAnyException();
+    verify(diagnosticMetrics).recordMatrixEvent("m.room.member", Outcome.SKIPPED);
   }
 
   @Test
   void processMatrixEvent_shouldReturnEarly_whenEventTypeNull() {
     invokeProcessMatrixEvent(newService(), MATRIX_ROOM_ID, new HashMap<>());
+    verify(diagnosticMetrics).recordMatrixEvent(null, Outcome.SKIPPED);
   }
 
   @Test
@@ -1284,6 +1293,8 @@ class MatrixEventListenerServiceTest {
             e ->
                 e.getLevel().toString().equals("ERROR")
                     && e.getFormattedMessage().contains("Failed to send mobile push notification"));
+    verify(diagnosticMetrics).recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.FAILURE);
+    verify(diagnosticMetrics).recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
   }
 
   @Test
@@ -1428,6 +1439,9 @@ class MatrixEventListenerServiceTest {
     verify(eventNotificationService)
         .createMessageNotificationFromRoom(
             eq(MATRIX_ROOM_ID), eq(ASKER_DOMAIN_ID), any(PrivacyEnvelope.class));
+    verify(diagnosticMetrics).recordMatrixEvent("m.room.encrypted", Outcome.SUCCESS);
+    verify(diagnosticMetrics).recordSideEffect(SideEffect.MOBILE_PUSH, Outcome.SUCCESS);
+    verify(diagnosticMetrics).recordSideEffect(SideEffect.NOTIFICATION, Outcome.SUCCESS);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Emit bounded Micrometer signals for live-chat routing, queue visibility, Matrix room creation, Matrix event processing, and asynchronous notification side effects.
- Distinguish assignment, eligibility, activity-window, presence, demand, encryption, and downstream side-effect outcomes without user, tenant, topic, room, event, or message identifiers.
- Document the metric and privacy contract for SigNoz diagnosis.

## Privacy and reliability contract

- Metric tags come from enums or a fixed Matrix event-type allowlist.
- Unknown Matrix event types become `other`; raw event values never become tags.
- Telemetry registry failures cannot change the live-chat or Matrix business outcome.
- Invalid queue requests remain distinct from an observed empty queue.

## Verification

- TDD red-to-green contract added for the central metric boundary.
- Focused suite: 174 tests, 0 failures.
- Full repository suite: 3,834 tests, 0 failures, 0 skipped.
- `./mvnw -B -Dmaven.test.skip=true package`: green on Java 21.
- Spotless and `git diff --check`: green.

Live SigNoz delivery is deliberately not claimed by this merged PR. It requires the pending Helm ingestion stack and fresh PreDev runtime proof.

Closes OpenResilienceInitiative/ORISO-UserService#1017
Parent: OpenResilienceInitiative/ORISO-UserService#524
Depends on: OpenResilienceInitiative/ORISO-Helm#286, OpenResilienceInitiative/ORISO-Helm#290

### Reviewer test plan

- [ ] Run focused routing tests → each documented routing and availability outcome emits a distinct bounded value.
- [ ] Run Matrix creation/event and notification tests → completed success/failure outcomes are recorded at the actual boundaries.
- [ ] Inspect metric tags and contract fixtures → protected and unbounded identifiers are absent.
- [ ] Deploy the merged build to PreDev after Helm ingestion is healthy → aggregate-only SigNoz queries show expected outcomes.
- [ ] Promote only after PreDev proof → Dev queries are fresh and environment-separated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
