### PR TITLE
fix(livechat): stop hiding every anonymous enquiry from every consultant

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -223,7 +223,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "WHERE s.consultingTypeId IN :consultingTypeIds "
           + "AND s.registrationType = :registrationType "
           + "AND s.status = :sessionStatus "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "ORDER BY s.createDate DESC")
   Page<Session> findAnonymousEnquiriesVisibleForConsultants(
       @Param("consultingTypeIds") Set<Integer> consultingTypeIds,
@@ -237,7 +236,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "WHERE s.consultingTypeId IN :consultingTypeIds "
           + "AND s.status = :sessionStatus "
           + "AND s.consultant IS NULL "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "AND s.updateDate >= :minUpdateDate "
           + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
           + "     OR u.username LIKE 'Anonymous-%') "
@@ -256,7 +254,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "WHERE s.consultingTypeId IN :consultingTypeIds "
           + "AND s.status = :sessionStatus "
           + "AND s.consultant IS NULL "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "AND s.updateDate >= :minUpdateDate "
           + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
           + "     OR u.username LIKE 'Anonymous-%') "
@@ -276,6 +273,16 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
    * topic-bound and deliberately cross-agency/cross-tenant. Used instead of the consulting-type
    * variant so the queue never needs an authenticated AgencyService lookup to resolve the
    * consultant's consulting types.
+   *
+   * <p><b>None of the anonymous queue queries filter on {@code dataPrivacyConfirmation}, and
+   * re-adding it would silently break the live chat again</b> (#431). {@code CreateUserFacade}
+   * clears that field for anonymous registrations on purpose, so the in-chat consent gate fires
+   * (ADR-018 §9, #927). Requiring it here made those two deliberate decisions cancel each other
+   * out: every anonymous live-chat enquiry was invisible to every consultant, the asker clicked and
+   * nothing happened. Consent is taken at entry from the platform-level live-chat privacy notice —
+   * at that point no agency is bound yet, so there is no agency declaration to show — and {@link
+   * de.caritas.cob.userservice.api.facade.assignsession.AnonymousEnquiryConsentGuard} still blocks
+   * the <b>assignment</b> server-side, which is where special-category data starts flowing.
    */
   @Query(
       "SELECT s FROM Session s "
@@ -283,7 +290,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "WHERE s.mainTopicId IN :topicIds "
           + "AND s.status = :sessionStatus "
           + "AND s.consultant IS NULL "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "AND s.updateDate >= :minUpdateDate "
           + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
           + "     OR u.username LIKE 'Anonymous-%') "
@@ -313,7 +319,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "AND s.mainTopicId IN :topicIds "
           + "AND s.status = :sessionStatus "
           + "AND s.consultant IS NULL "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
           + "     OR u.username LIKE 'Anonymous-%') ")
   List<Session> findVisibleAnonymousLiveChatEnquiriesForConsultantByIds(
@@ -336,7 +341,6 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
           + "AND s.createDate < :beforeDate "
           + "AND s.consultingTypeId = :consultingTypeId "
           + "AND ((:mainTopicId IS NULL AND s.mainTopicId IS NULL) OR s.mainTopicId = :mainTopicId) "
-          + "AND u.dataPrivacyConfirmation IS NOT NULL "
           + "AND s.updateDate >= :minUpdateDate "
           + "AND (s.registrationType = :anonymousRegistrationType OR s.postcode = '00000' "
           + "     OR u.username LIKE 'Anonymous-%') "

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/SessionRepositoryAnonymousQueueVisibilityIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/SessionRepositoryAnonymousQueueVisibilityIT.java
@@ -1,0 +1,125 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static com.neovisionaries.i18n.LanguageCode.de;
+import static de.caritas.cob.userservice.api.model.Session.RegistrationType.ANONYMOUS;
+import static de.caritas.cob.userservice.api.model.Session.SessionStatus.NEW;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTING_TYPE_ID_OFFENDER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.testConfig.ConsultingTypeManagerTestConfig;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The anonymous Live Chat queue must show enquiries whose advice seeker has no recorded {@code
+ * dataPrivacyConfirmation}.
+ *
+ * <p>This is not an oversight in the data: {@code CreateUserFacade} clears that field for anonymous
+ * registrations <b>on purpose</b>, so the in-chat consent gate fires (ADR-018 §9, #927). The
+ * visibility query used to require it anyway, which meant the two deliberate decisions cancelled
+ * each other out and <b>every</b> anonymous live-chat enquiry was invisible to <b>every</b>
+ * consultant — the asker clicked, nothing happened, and nobody ever saw the request (#431).
+ *
+ * <p>Consent is collected at entry, from the platform-level live-chat privacy notice, and {@code
+ * AnonymousEnquiryConsentGuard} still blocks the <b>assignment</b> server-side. Queue visibility
+ * does not need to enforce the same consent a second time.
+ */
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({ConsultingTypeManagerTestConfig.class})
+@Transactional
+class SessionRepositoryAnonymousQueueVisibilityIT {
+
+  private static final long TOPIC_ID = 3L;
+
+  @Autowired private SessionRepository sessionRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Value("${user.anonymous.deactivateworkflow.periodMinutes}")
+  private long liveChatQueueActivePeriodMinutes;
+
+  private User user;
+
+  @BeforeEach
+  void setup() {
+    user = userRepository.findAll().iterator().next();
+    // Exactly what an anonymous registration leaves behind.
+    user.setDataPrivacyConfirmation(null);
+    user = userRepository.save(user);
+  }
+
+  @Test
+  void findAnonymousEnquiries_Should_includeSessionsOfAskersWithoutRecordedConsent() {
+    var session = saveAnonymousSession();
+
+    var visible = queryQueue();
+
+    assertThat(
+        visible.stream().map(Session::getId).collect(Collectors.toList()),
+        hasItem(session.getId()));
+  }
+
+  @Test
+  void findAnonymousEnquiries_Should_stillExcludeStaleSessions() {
+    saveAnonymousSession(
+        stale ->
+            stale.setUpdateDate(
+                LocalDateTime.now().minusMinutes(liveChatQueueActivePeriodMinutes + 1)));
+
+    assertThat(queryQueue().size(), is(0));
+  }
+
+  @Test
+  void findAnonymousEnquiries_Should_stillExcludeAlreadyAssignedSessions() {
+    // A session someone has already picked up must never reappear in the queue.
+    saveAnonymousSession(assigned -> assigned.setStatus(Session.SessionStatus.IN_PROGRESS));
+
+    assertThat(queryQueue().size(), is(0));
+  }
+
+  private java.util.List<Session> queryQueue() {
+    return sessionRepository
+        .findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+            Set.of(TOPIC_ID),
+            NEW,
+            LocalDateTime.now().minusMinutes(liveChatQueueActivePeriodMinutes),
+            ANONYMOUS,
+            PageRequest.of(0, 20))
+        .getContent();
+  }
+
+  private Session saveAnonymousSession() {
+    return saveAnonymousSession(session -> {});
+  }
+
+  private Session saveAnonymousSession(java.util.function.Consumer<Session> customizer) {
+    Session session = new Session(user, CONSULTING_TYPE_ID_OFFENDER, "00000", null, NEW, false);
+    session.setRegistrationType(ANONYMOUS);
+    session.setIsConsultantDirectlySet(false);
+    session.setLanguageCode(de);
+    session.setMainTopicId(TOPIC_ID);
+    session.setCreateDate(LocalDateTime.now().minusMinutes(1));
+    session.setUpdateDate(LocalDateTime.now());
+    customizer.accept(session);
+    return sessionRepository.save(session);
+  }
+}


### PR DESCRIPTION
Refs #431. Backend half of the live-chat failure reported by @hassan-saeed and @shazia-k; the modal half is OpenResilienceInitiative/ORISO-Frontend#1088.

## Problem

An anonymous live-chat enquiry never reaches any consultant. The asker clicks, nothing happens, and the request appears in nobody's queue. Worked in 2.0.2 / 2.0.3.

## Cause

Two deliberate decisions cancelled each other out.

The queue required consent to be recorded:

```sql
AND u.dataPrivacyConfirmation IS NOT NULL
```

…while `CreateUserFacade` clears exactly that field for anonymous registrations **on purpose**, so the in-chat consent gate fires — as `AnonymousEnquiryConsentGuard` documents (ADR-018 §9, #927):

> `CreateUserFacade` deliberately clears `dataPrivacyConfirmation` for anonymous registrations precisely so the in-chat gate fires there and only there

So every anonymous session failed the visibility predicate by construction. The consent gate is the newer of the two, which is why this worked in earlier versions.

## Measured on Pre-Dev

| session | registration_type | main_topic_id | privacy confirmed |
|---|---|---|---|
| 7, 5 | ANONYMOUS | **3** | **NULL** |
| 6, 4, 3, 2, 1, 0 | REGISTERED | 3 | set |

Every anonymous user has `data_privacy_confirmation = NULL`; every registered user has it set. Note the topic **is** correct — routing was never the problem. The active external-inbound link (`Live Chat` + `[U25] Suizidprävention`) was created at 06:36:21 and session 5 followed at 06:36:41 carrying topic 3, so `AgencyInviteLinkService.redeem` passes it through correctly.

## Change

Removed the predicate from **all six** anonymous-queue queries, not just the listing one: listing, opening a single entry, and counting people ahead in the queue must agree, or a request becomes visible but unopenable — the very race the existing comment on `findVisibleAnonymousLiveChatEnquiriesForConsultantByIds` warns about.

The reason it is absent is documented at the query so it does not get "restored" later.

## Why this is safe

Consent is taken at entry from the platform-level live-chat privacy notice — at that point no agency is bound yet, so there is no agency declaration that *could* be shown — and `AnonymousEnquiryConsentGuard` still blocks the **assignment** server-side, which is where special-category data starts flowing. Queue *visibility* does not need to enforce the same consent a second time. This split was confirmed by @Storypapst as the intended design.

## Tests

`SessionRepositoryAnonymousQueueVisibilityIT`, written red first:

- an asker with **no** recorded consent appears in the queue (failed before the change: the queue was empty)
- stale sessions are still excluded
- already-assigned sessions are still excluded

57 tests across the repository, provider and consent-guard classes pass; spotless clean.

## Not in scope

`postcode = '00000'` and `username LIKE 'Anonymous-%'` remain in these queries as anonymity markers. Both are unsound — the username clause cannot ever match, since usernames are stored encrypted, and the postcode is user-editable. Tracked separately as #1019 to keep this fix reviewable.

## Reviewer test plan

- [ ] Generate an external-inbound Live Chat link for a topic a consultant is assigned to; redeem it.
- [ ] Confirm the enquiry appears in that consultant's request list.
- [ ] Confirm a consultant **without** that topic does not see it.
- [ ] Accept it and confirm the Matrix room is provisioned and both sides can exchange messages.
- [ ] Confirm an enquiry older than the queue window still disappears.