### PR TITLE
[Matrix-only] Correct invite-link redemption documentation

### DIFF
--- a/INVITE_LINKS_API.md
+++ b/INVITE_LINKS_API.md
@@ -1,8 +1,8 @@
 # Invite Links API — for the Frontend Developer
 
-> Backend branch: `backend-of-invite-link` (off `Rebuild`)
 > Service: `ORISO-UserService`
 > Status of redesign: agency removed from invite links — topic is the core identifier.
+> Runtime contract: `AgencyInviteLinkController.RedeemResponseDTO` on `pre-dev`.
 
 This document is the **contract**. You can build the UI against it without reading any backend
 code. If something here disagrees with what the backend does, that's a backend bug — file an
@@ -146,15 +146,19 @@ date math.
   "refreshToken": "eyJhbGciOi...",
   "expiresIn": 3600,
   "refreshExpiresIn": 1800,
-  "rcUserId": "rcUser-9012",
-  "rcToken": "rc-token-...",
-  "rcGroupId": "rc-group-..."
+  "tenantId": 12,
+  "agencyId": null,
+  "consultingTypeId": 3,
+  "topicId": 17
 }
 ```
 
-This is the **same shape** `CreateAnonymousEnquiryResponseDTO` already returns from
-`POST /conversations/askers/anonymous/new`. The visitor is now a logged-in anonymous user with a
-live-chat session ready — drop them straight into the chat UI; no second registration call.
+The authentication and session fields are the same subset returned by
+`CreateAnonymousEnquiryResponseDTO` from `POST /conversations/askers/anonymous/new`; the remaining
+fields describe the redeemed invite route. The endpoint does not return Matrix identifiers or
+Matrix access tokens. The visitor is now an authenticated anonymous ORISO user with a counselling
+session. The frontend must initialize Matrix through its normal host-owned Matrix bootstrap before
+opening the chat; no second registration call is required.
 
 **Errors:**
 

--- a/INVITE_LINKS_API.md
+++ b/INVITE_LINKS_API.md
@@ -164,11 +164,12 @@ opening the chat; no second registration call is required.
 
 | Code | Reason |
 |---|---|
-| 400 | link already used / expired / never had a topic |
+| 400 | link inactive / expired / missing required routing metadata |
 | 404 | token doesn't exist |
 
-The token lookup uses a pessimistic lock; double-clicks and parallel calls cannot redeem the same
-link twice.
+The token lookup uses a pessimistic lock, but a successful redeem deliberately leaves the link
+`ACTIVE`. Published links are reusable until expiry so multiple visitors can enter through the
+same link. A `LIVE_CHAT` request creates a new anonymous session for each successful redeem.
 
 ---
 

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -5,13 +5,13 @@ services where needed, and allows the frontend on `localhost:9001` to call it di
 
 ## 1. Java
 
-Use Java 17:
+Use Java 21, which is the version compiled by `pom.xml` and used by CI:
 
 ```bash
-/usr/libexec/java_home -V
+/usr/libexec/java_home -v 21
 ```
 
-The local run script example auto-detects Java 17 on macOS when `JAVA_HOME` is not already set.
+The local run script example selects Java 21 on macOS when `JAVA_HOME` is not already set.
 
 ## 2. Create `run-local-remote-db.sh`
 
@@ -38,9 +38,9 @@ Important values for the mixed local setup:
 
 ```env
 SERVER_SERVLET_CONTEXT_PATH=/service
-ROCKET_SYSTEMUSER_ID=rocket-chat-system-user
-ROCKET_SYSTEMUSER_USERNAME=rocket-chat-system-user
-ROCKET_SYSTEMUSER_PASSWORD=CHANGE_ME
+MATRIX_API_URL=https://matrix.oriso-dev.site
+MATRIX_SERVER_NAME=91.99.183.160
+MATRIX_REGISTRATION_SHARED_SECRET=CHANGE_ME
 AGENCY_SERVICE_API_URL=https://api.oriso-dev.site/service
 TENANT_SERVICE_API_URL=https://api.oriso-dev.site/service
 REGISTRATION_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001

--- a/documentation/local-invite-link-api-testing.md
+++ b/documentation/local-invite-link-api-testing.md
@@ -397,9 +397,6 @@ Example shape:
   "expiresIn": null,
   "refreshToken": null,
   "refreshExpiresIn": null,
-  "rcUserId": null,
-  "rcToken": null,
-  "rcGroupId": null,
   "tenantId": 1,
   "agencyId": 1,
   "consultingTypeId": 1,
@@ -409,9 +406,12 @@ Example shape:
 
 Current branch behavior:
 
-- Redeem returns metadata for frontend registration.
-- It does not create a Keycloak, Rocket.Chat, or Matrix user in this service path.
-- It does not mark the link as `USED`; links remain reusable until expiry unless stored status is changed elsewhere.
+- A `LIVE_CHAT` redeem creates an anonymous counselling session and returns its authentication
+  fields together with the route metadata.
+- Other supported invite types return route metadata without creating a session.
+- The response contains no chat-provider identifier or Matrix access token. The frontend starts
+  Matrix through its normal host-owned bootstrap.
+- Redeem does not mark an active link as `USED`; published links are reusable until expiry.
 
 ## Negative Tests
 

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -6,7 +6,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 if [ -z "${JAVA_HOME:-}" ]; then
-  export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+  export JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null || /usr/libexec/java_home)"
 fi
 export PATH="$JAVA_HOME/bin:$PATH"
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AgencyInviteLinkController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AgencyInviteLinkController.java
@@ -102,8 +102,8 @@ public class AgencyInviteLinkController {
   }
 
   // ---------------------------------------------------------------------------------------------
-  // POST /users/invitelinks/{token}/redeem — public; marks link used and returns registration
-  // metadata.
+  // POST /users/invitelinks/{token}/redeem — public; returns a new Live Chat session or
+  // registration routing metadata while the published link remains reusable until expiry.
   // ---------------------------------------------------------------------------------------------
   @PostMapping("/users/invitelinks/{token}/redeem")
   public ResponseEntity<RedeemResponseDTO> redeem(@PathVariable String token) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkService.java
@@ -35,9 +35,9 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
- * Manages one-time invite links. On redeem, the link is marked used and metadata is returned so the
- * frontend can run the standard anonymous asker registration (same flow as before the topic-based
- * redesign).
+ * Manages published invite links that remain reusable until expiry. Live Chat redemption creates an
+ * anonymous topic session; other supported invite types return routing metadata for the frontend
+ * registration flow.
  */
 @Service
 @RequiredArgsConstructor
@@ -156,8 +156,8 @@ public class AgencyInviteLinkService {
   }
 
   /**
-   * Redeem the token: validate, mark USED, return tenant/agency/consulting-type/topic metadata for
-   * the frontend registration flow. Does not create Keycloak or Matrix users on the server.
+   * Redeem the token and return session credentials or registration routing metadata. The active
+   * link remains reusable until expiry. Matrix initialization stays with the frontend host.
    */
   @Transactional
   public RedeemContext redeemWithContext(String token) {
@@ -207,7 +207,7 @@ public class AgencyInviteLinkService {
             session, link.getTenantId(), null, consultingTypeId, link.getTopicId());
       }
 
-      // Registered (non-live-chat) links keep the legacy client-side registration path.
+      // Registered (non-live-chat) links use the client-side registration path.
       Long agencyId = resolveAgencyIdForRegistration(link, consultingTypeId);
 
       // Link is reusable until expiry date — stay ACTIVE, do not mark USED.

--- a/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
@@ -12,6 +12,9 @@ class RocketChatAdapterRemovedContractTest {
   private static final Path MAIN_JAVA = Path.of("src/main/java");
   private static final Path USER_SERVICE_API = Path.of("api/userservice.yaml");
   private static final Path INVITE_LINKS_API = Path.of("INVITE_LINKS_API.md");
+  private static final Path LOCAL_INVITE_LINKS_API =
+      Path.of("documentation/local-invite-link-api-testing.md");
+  private static final Path LOCAL_DEVELOPMENT = Path.of("documentation/local-development.md");
   private static final Path MASTER_CHANGELOG =
       Path.of("src/main/resources/db/changelog/userservice-master.xml");
 
@@ -86,8 +89,31 @@ class RocketChatAdapterRemovedContractTest {
 
   @Test
   void currentInviteLinkDocumentationMustNotAdvertiseRocketChatCredentials() throws IOException {
-    assertThat(Files.readString(INVITE_LINKS_API))
-        .doesNotContain("rcUserId", "rcToken", "rcGroupId", "Rocket.Chat");
+    for (var documentation : new Path[] {INVITE_LINKS_API, LOCAL_INVITE_LINKS_API}) {
+      assertThat(Files.readString(documentation))
+          .as(documentation.toString())
+          .doesNotContain("rcUserId", "rcToken", "rcGroupId", "Rocket.Chat");
+    }
+  }
+
+  @Test
+  void localDevelopmentDocumentationMustUseCurrentJavaAndMatrixConfiguration() throws IOException {
+    assertThat(Files.readString(LOCAL_DEVELOPMENT)).doesNotContain("Java 17", "ROCKET_SYSTEMUSER_");
+    assertThat(Files.readString(Path.of("run-local-remote-db.sh.example")))
+        .contains("java_home -v 21")
+        .doesNotContain("java_home -v 17");
+  }
+
+  @Test
+  void inviteLinkCommentsMustDescribeTheReusableCurrentFlow() throws IOException {
+    var service =
+        Files.readString(
+            Path.of(
+                "src/main/java/de/caritas/cob/userservice/api/service/agencyinvitelink/"
+                    + "AgencyInviteLinkService.java"));
+    assertThat(service)
+        .doesNotContain("Manages one-time invite links", "validate, mark USED")
+        .contains("reusable until expiry");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
@@ -114,6 +114,12 @@ class RocketChatAdapterRemovedContractTest {
     assertThat(service)
         .doesNotContain("Manages one-time invite links", "validate, mark USED")
         .contains("reusable until expiry");
+
+    assertThat(
+            Files.readString(
+                Path.of(
+                    "src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java")))
+        .doesNotContain("LogOutFromRocketChat");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/RocketChatAdapterRemovedContractTest.java
@@ -11,6 +11,7 @@ class RocketChatAdapterRemovedContractTest {
 
   private static final Path MAIN_JAVA = Path.of("src/main/java");
   private static final Path USER_SERVICE_API = Path.of("api/userservice.yaml");
+  private static final Path INVITE_LINKS_API = Path.of("INVITE_LINKS_API.md");
   private static final Path MASTER_CHANGELOG =
       Path.of("src/main/resources/db/changelog/userservice-master.xml");
 
@@ -81,6 +82,12 @@ class RocketChatAdapterRemovedContractTest {
                     + "RocketChatUnauthorizedException.java"))
         .doesNotExist();
     assertThat(Files.readString(Path.of("config.env.example"))).doesNotContain("ROCKET_");
+  }
+
+  @Test
+  void currentInviteLinkDocumentationMustNotAdvertiseRocketChatCredentials() throws IOException {
+    assertThat(Files.readString(INVITE_LINKS_API))
+        .doesNotContain("rcUserId", "rcToken", "rcGroupId", "Rocket.Chat");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -203,11 +203,9 @@ public class CreateUserFacadeTest {
   public void
       createUserAccountWithInitializedConsultingType_Should_ProvisionMatrixAndInitializeSession_When_ConsultingTypeIsKreuzbundAndNoTenantIsSet()
           throws Exception {
-    // Was named "..._Should_LogOutFromRocketChat_When_...RocketChatLoginSucceeded"
-    // and asserted nothing at all — it only checked that the call did not throw,
-    // for a log-out that no longer exists. It covers the Kreuzbund path without a
-    // tenant context (the sibling test below covers it with one), so assert what
-    // that path is actually supposed to do.
+    // Covers the Kreuzbund path without a tenant context; the sibling test below covers the
+    // tenant-specific path. The assertions verify Matrix provisioning, session initialization,
+    // and credential cleanup.
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
     when(identityClient.createUser(any())).thenReturn(CREATED_IDENTITY_WITH_USER_ID);

--- a/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/agencyinvitelink/AgencyInviteLinkServiceTest.java
@@ -297,8 +297,8 @@ class AgencyInviteLinkServiceTest {
   }
 
   @Test
-  void redeem_Should_StayLegacy_When_LinkIsNotLiveChat() {
-    // A non-live-chat (registered) link keeps the legacy agency-resolution path with no session.
+  void redeem_Should_ReturnRegistrationRouting_When_LinkIsNotLiveChat() {
+    // A non-live-chat (registered) link uses the agency-resolution path without creating a session.
     AgencyInviteLink link =
         AgencyInviteLink.builder()
             .token("reg")


### PR DESCRIPTION
## Summary

- replace obsolete Rocket.Chat fields in both current invite-link redemption examples with the exact `RedeemResponseDTO` fields;
- make the Matrix boundary explicit: redemption returns no Matrix identifier or Matrix access token, and the ORISO Frontend initializes Matrix through its host-owned bootstrap;
- correct the documented redemption semantics to match production code: published links remain reusable until expiry and every successful `LIVE_CHAT` redeem creates a new anonymous session;
- replace stale service/controller comments that incorrectly described the links as one-time and claimed redemption marks them `USED`;
- update the local development path from Java 17 and Rocket.Chat system-user variables to Java 21 and Matrix configuration;
- extend the removal contract so these current docs and comments cannot drift back.

This intentionally preserves irreversible Liquibase migration records, historical changelog entries, and negative removal tests.

## Test evidence

- red proof: the focused contract failed on the obsolete invite fields, Java 17, Rocket.Chat variables, and one-time-link comments;
- focused `RocketChatAdapterRemovedContractTest` plus `AgencyInviteLinkServiceTest`: passed;
- full Java 21 suite: 3,850 tests, 0 failures/errors/skips;
- Java 21 package: passed and built `target/UserService.jar`;
- Spotless and `git diff --check`: passed.

No runtime behavior, API schema, deployment configuration, Secret, account, or environment was changed.

Closes #1022
Parent cutover: OpenResilienceInitiative/ORISO-Helm#289