### PR TITLE
fix(admin): treat an unset user limit as unlimited instead of crashing

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
@@ -494,9 +494,14 @@ public class CreateConsultantSaga {
       long numberOfActiveConsultants =
           consultantService.getNumberOfActiveConsultants(createConsultantDTO.getTenantId());
 
-      assert nonNull(tenantById.getLicensing());
-      Integer allowedNumberOfUsers = tenantById.getLicensing().getAllowedNumberOfUsers();
-      if (numberOfActiveConsultants >= allowedNumberOfUsers) {
+      // No configured limit means no limit. Every tenant created through the invite flow has
+      // `licensing_allowed_users = NULL` — only the seed tenant carries a number — so unboxing it
+      // straight into the comparison killed consultant creation for every new tenant with a bare
+      // 500. The previous `assert nonNull(...)` guard could not catch that: Java disables
+      // assertions at runtime unless `-ea` is passed, so it never executed in production.
+      var licensing = tenantById.getLicensing();
+      Integer allowedNumberOfUsers = isNull(licensing) ? null : licensing.getAllowedNumberOfUsers();
+      if (nonNull(allowedNumberOfUsers) && numberOfActiveConsultants >= allowedNumberOfUsers) {
         throw new CustomValidationHttpStatusException(
             HttpStatusExceptionReason.NUMBER_OF_LICENSES_EXCEEDED);
       }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
@@ -121,6 +121,64 @@ public class CreateConsultantSagaTenantAwareIT {
   }
 
   @Test
+  public void createNewConsultant_Should_succeed_When_tenantHasNoConfiguredUserLimit() {
+    // Every tenant created through the invite flow has licensing_allowed_users = NULL — measured on
+    // Pre-Dev: only the seed tenant carries a limit. `allowedNumberOfUsers` was unboxed straight
+    // into a comparison, so creating the first consultant for such a tenant died with a
+    // NullPointerException and the admin saw a bare 500. No limit configured means no limit.
+    TenantContext.setCurrentTenant(1L);
+    when(keycloakService.createUser(any(), anyString(), any()))
+        .thenReturn(easyRandom.nextObject(CreatedIdentity.class));
+    var tenant =
+        new TenantDTO()
+            .licensing(new Licensing().allowedNumberOfUsers(null))
+            .settings(
+                new de.caritas.cob.userservice.tenantadminservice.generated.web.model.Settings()
+                    .featureGroupChatV2Enabled(false));
+    when(tenantAdminService.getTenantById(Mockito.anyLong())).thenReturn(tenant);
+
+    CreateConsultantDTO createConsultantDTO = this.easyRandom.nextObject(CreateConsultantDTO.class);
+    createConsultantDTO.setUsername(VALID_USERNAME);
+    createConsultantDTO.setEmail(VALID_EMAILADDRESS);
+    createConsultantDTO.setIsGroupchatConsultant(false);
+    createConsultantDTO.setTenantId(1L);
+
+    ConsultantAdminResponseDTO consultant =
+        createConsultantSaga.createNewConsultant(createConsultantDTO);
+
+    assertThat(consultant.getEmbedded(), notNullValue());
+    assertThat(consultant.getEmbedded().getId(), notNullValue());
+    rollbackDBState();
+  }
+
+  @Test
+  public void createNewConsultant_Should_succeed_When_tenantHasNoLicensingBlockAtAll() {
+    // The previous guard was `assert nonNull(...)`, which Java disables at runtime unless -ea is
+    // passed — so it never protected anything in production.
+    TenantContext.setCurrentTenant(1L);
+    when(keycloakService.createUser(any(), anyString(), any()))
+        .thenReturn(easyRandom.nextObject(CreatedIdentity.class));
+    var tenant =
+        new TenantDTO()
+            .settings(
+                new de.caritas.cob.userservice.tenantadminservice.generated.web.model.Settings()
+                    .featureGroupChatV2Enabled(false));
+    when(tenantAdminService.getTenantById(Mockito.anyLong())).thenReturn(tenant);
+
+    CreateConsultantDTO createConsultantDTO = this.easyRandom.nextObject(CreateConsultantDTO.class);
+    createConsultantDTO.setUsername(VALID_USERNAME);
+    createConsultantDTO.setEmail(VALID_EMAILADDRESS);
+    createConsultantDTO.setIsGroupchatConsultant(false);
+    createConsultantDTO.setTenantId(1L);
+
+    ConsultantAdminResponseDTO consultant =
+        createConsultantSaga.createNewConsultant(createConsultantDTO);
+
+    assertThat(consultant.getEmbedded(), notNullValue());
+    rollbackDBState();
+  }
+
+  @Test
   public void
       createNewConsultant_Should_addConsultantAndGroupChatConsultantRole_When_isGroupChatConsultantFlagIsEnabled() {
     // given


### PR DESCRIPTION
Unblocks canvas steps 8-14 of OpenResilienceInitiative/ORISO-E2E#57. Reported by Riccardo.

## Problem

Creating a consultant for a tenant onboarded through the invite flow returns **500**:

```
NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because "allowedNumberOfUsers" is null
  at CreateConsultantSaga.assertLicensesNotExceeded
```

This is not an edge case. Measured on Pre-Dev:

| tenant | licensing_allowed_users | origin |
|---|---|---|
| 1 (`online-beratung`) | 100000 | seed |
| 4, 5, 7, 8, 10 | **NULL** | invite flow |

**Every** tenant created through the invite flow has no limit, so a tenant admin can never create their first counsellor admin — which blocks the entire agency and legal chain behind it.

## Cause

```java
assert nonNull(tenantById.getLicensing());
Integer allowedNumberOfUsers = tenantById.getLicensing().getAllowedNumberOfUsers();
if (numberOfActiveConsultants >= allowedNumberOfUsers) {   // unboxes null
```

The `assert` was clearly meant to catch exactly this, but Java disables assertions at runtime unless `-ea` is passed — it never executed in production. The comparison then unboxed `null`.

## Fix

No configured limit means no limit, which is what the nullable column already implies. An explicitly configured limit still blocks exactly as before. Handles both an absent `licensing` block and a present block with a null value.

## Tests

Two cases added to `CreateConsultantSagaTenantAwareIT`, written before the fix. The first failed with Riccardo's exact stack trace. The existing limit tests — "throws when licenses are exceeded" and "counts licenses per tenant" — still pass unchanged, so the guard itself is intact.

`*Consultant*` suite: green.

## Reviewer test plan

- [ ] Onboard a tenant through the invite flow, log in as its tenant admin, and create a counsellor admin — expect: it succeeds, no 500.
- [ ] Set an explicit user limit on a tenant, fill it, then create one more consultant — expect: still rejected with `NUMBER_OF_LICENSES_EXCEEDED`.
- [ ] Create a consultant for the seed tenant, which has a large limit — expect: unchanged behaviour.
- [ ] Repeat the first step at 390px viewport width — expect: the form works and any error is readable.