### PR TITLE
docs: AI agent delivery rules (no self-merge, restore Pre-Dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,24 @@ CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Ja
 ## Done
 
 Targeted tests for touched behavior pass; package succeeds for PR-bound work; no secrets in the diff. Task notes: `docs/agent-tasks/YYYY-MM-DD_short-name/` if needed.
+
+## AI agent delivery rules
+
+Binding for every AI coding agent working in this repository. Canonical text and
+rationale: `ORISO-Docs/oriso-platform/coding-standards.mdx` (section "AI agent
+delivery rules"). Summary:
+
+- **An agent never merges its own pull request.** Not on green CI, not on "finish
+  it", not for chores or test-only changes. Delivery ends at: verified → PR open
+  with evidence and a reviewer test plan → reviewers requested → issue
+  `In review`. Merge only on an explicit, per-PR instruction naming that PR.
+- **Request reviewers in the same step that opens the PR.** A PR without
+  requested reviewers is not open for review.
+- **"Pre-Dev is free" means the server, not the branch.** Deploying images,
+  mutating config or data and running E2E on the Pre-Dev server needs no
+  approval; the `pre-dev` *branch* is review-gated like any shared branch.
+- **Restore what you borrowed.** Record image reference *and* `imagePullPolicy`
+  before swapping anything on Pre-Dev, put both back before reporting done, and
+  say so in the report.
+- **State where it was verified** in every PR body — environment and image, or
+  plainly "local only".


### PR DESCRIPTION
## Problem
This repository's `AGENTS.md` says nothing about where an AI coding agent must stop. ORISO-Admin#739 was self-merged into `pre-dev` with no reviewer requested, and three Pre-Dev deployments were left on a demo session's images with `imagePullPolicy: Never`, silently blocking every regular deploy.

## What changed
Adds an **AI agent delivery rules** section: no self-merge of own PRs, reviewers requested in the PR-open step, "Pre-Dev is free" scoped to the server rather than the `pre-dev` branch, mandatory image restore, and a stated verification environment in every PR body.

Identical boilerplate across all agent-facing ORISO repositories; the canonical long form lives in OpenResilienceInitiative/ORISO-Docs#86. Documentation only — no code, no build impact.

## Reviewer test plan
- [ ] Read the section — does the no-self-merge rule leave an agent any room to argue around it?
- [ ] Confirm the Pre-Dev wording matches how this repo's work actually uses the server.
- [ ] Confirm the reviewer names/routing implied here are right for this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)