### PR TITLE
[Stability] Route user identity policy through input port (replay of #778)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegate.java
@@ -1,7 +1,5 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
-import static java.util.Objects.nonNull;
-
 import de.caritas.cob.userservice.api.adapters.web.dto.AbsenceDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.DeleteUserAccountDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.EmailNotificationsDTO;
@@ -28,8 +26,8 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.DecryptionService;
 import de.caritas.cob.userservice.api.service.LogService;
@@ -54,7 +52,7 @@ class UserAccountControllerDelegate {
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull DecryptionService decryptionService;
   private final @NonNull ConsultantDataFacade consultantDataFacade;
-  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentityPolicy identityPolicy;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull Messaging messenger;
@@ -128,7 +126,7 @@ class UserAccountControllerDelegate {
             partialUserData,
             otpInfoDTO,
             videoChatConfig.getE2eEncryptionEnabled(),
-            identityClientConfig.getDisplayNameAllowedForConsultants());
+            identityPolicy.isConsultantDisplayNameAllowed());
 
     return new ResponseEntity<>(fullUserData, HttpStatus.OK);
   }
@@ -159,7 +157,7 @@ class UserAccountControllerDelegate {
   }
 
   private boolean isOtpAllowed() {
-    return identityClientConfig.isOtpAllowed(authenticatedUser.getRoles());
+    return identityPolicy.isTwoFactorAuthenticationAllowed(authenticatedUser.getRoles());
   }
 
   private IdentityOtpCredential retrieveOtpCredentialIfAllowed() {
@@ -229,10 +227,7 @@ class UserAccountControllerDelegate {
       email = userAccountProvider.retrieveValidatedUser().getEmail();
     }
 
-    boolean hasRealEmail =
-        nonNull(email)
-            && !email.isBlank()
-            && !email.endsWith(identityClientConfig.getEmailDummySuffix());
+    boolean hasRealEmail = identityPolicy.isProfileEmailUsableForMagicLink(email);
     if (!hasRealEmail) {
       throw new BadRequestException(
           "Magic link login can only be enabled when a profile email is set.");

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -58,7 +58,6 @@ import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
@@ -114,7 +113,6 @@ public class UserController implements UsersApi {
   private final @NotNull ConsultantDataFacade consultantDataFacade;
   private final @NotNull SessionDataService sessionDataService;
   private final @NotNull SessionArchiveService sessionArchiveService;
-  private final @NonNull IdentityClientConfig identityClientConfig;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull Messaging messenger;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegate.java
@@ -9,7 +9,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Locale;
 import lombok.NonNull;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 class UserTwoFactorAuthControllerDelegate {
 
   private final @NonNull AuthenticatedUser authenticatedUser;
-  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentityPolicy identityPolicy;
   private final @NonNull IdentityManaging identityManager;
   private final @NonNull AccountManaging accountManager;
   private final @NonNull AccountInviteService accountInviteService;
@@ -99,7 +99,7 @@ class UserTwoFactorAuthControllerDelegate {
    * disabled cannot sidestep the policy by choosing the email flow.
    */
   private void assertTwoFactorAuthAllowed() {
-    if (!identityClientConfig.isOtpAllowed(authenticatedUser.getRoles())) {
+    if (!identityPolicy.isTwoFactorAuthenticationAllowed(authenticatedUser.getRoles())) {
       throw new ConflictException("2FA is disabled for user role");
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.config.auth;
 
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,7 +20,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Validated
 @Configuration
 @ConfigurationProperties(prefix = "identity")
-public class IdentityConfig implements IdentityClientConfig {
+public class IdentityConfig implements IdentityClientConfig, IdentityPolicy {
 
   private static final char PATH_SEPARATOR = '/';
 
@@ -87,5 +88,26 @@ public class IdentityConfig implements IdentityClientConfig {
             && otpAllowedForSingleTenantAdmins
         || roles.contains(UserRole.RESTRICTED_AGENCY_ADMIN.getValue())
             && otpAllowedForRestrictedAgencyAdmins;
+  }
+
+  @Override
+  public boolean isTwoFactorAuthenticationAllowed(Set<String> roles) {
+    return isOtpAllowed(roles);
+  }
+
+  @Override
+  public boolean isConsultantDisplayNameAllowed() {
+    return Boolean.TRUE.equals(displayNameAllowedForConsultants);
+  }
+
+  /**
+   * Null, blank and dummy addresses are all "not usable" — the classification lives here rather
+   * than in the caller so the dummy-suffix rule has exactly one definition.
+   */
+  @Override
+  public boolean isProfileEmailUsableForMagicLink(String email) {
+    return StringUtils.hasText(email)
+        && emailDummySuffix != null
+        && !email.endsWith(emailDummySuffix);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityPolicy.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/in/IdentityPolicy.java
@@ -1,0 +1,24 @@
+package de.caritas.cob.userservice.api.port.in;
+
+import java.util.Set;
+
+/**
+ * Application-owned identity policy decisions needed by inbound adapters.
+ *
+ * <p>Inbound adapters ask this port a question ("may this user use 2FA?") instead of reading the
+ * outbound {@code IdentityClientConfig} and drawing the conclusion themselves. Keeping the rule on
+ * this side of the boundary is what stops provider configuration — role flags, the dummy-email
+ * suffix — from leaking into controllers, where it would have to be re-derived by every caller.
+ */
+public interface IdentityPolicy {
+
+  boolean isTwoFactorAuthenticationAllowed(Set<String> roles);
+
+  boolean isConsultantDisplayNameAllowed();
+
+  /**
+   * Whether a profile email can receive a Magic Link. Accounts created without an address carry a
+   * generated dummy one, which is deliverable to nobody.
+   */
+  boolean isProfileEmailUsableForMagicLink(String email);
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAccountControllerDelegateTest.java
@@ -42,8 +42,8 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.service.ConsultantService;
 import de.caritas.cob.userservice.api.service.DecryptionService;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
@@ -68,7 +68,7 @@ class UserAccountControllerDelegateTest {
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private DecryptionService decryptionService;
   @Mock private ConsultantDataFacade consultantDataFacade;
-  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityPolicy identityPolicy;
   @Mock private IdentityManaging identityManager;
   @Mock private AccountManaging accountManager;
   @Mock private Messaging messenger;
@@ -94,7 +94,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenThrow(new RuntimeException("OTP down"));
     when(userDtoMapper.userDataOf(
@@ -119,7 +119,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
@@ -138,7 +138,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), anyBoolean(), anyBoolean()))
         .thenReturn(fullUserData);
 
@@ -158,7 +158,8 @@ class UserAccountControllerDelegateTest {
     consultant.setEmail("dummy@example.invalid");
     when(authenticatedUser.isConsultant()).thenReturn(true);
     when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
-    when(identityClientConfig.getEmailDummySuffix()).thenReturn("@example.invalid");
+    when(identityPolicy.isProfileEmailUsableForMagicLink("dummy@example.invalid"))
+        .thenReturn(false);
 
     assertThatThrownBy(() -> delegate.patchUser(patchUserDTO))
         .isInstanceOf(BadRequestException.class);
@@ -321,9 +322,9 @@ class UserAccountControllerDelegateTest {
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.of(consultantMap));
     when(userDtoMapper.displayNameOf(consultantMap)).thenReturn("Display Name");
     when(messenger.getAvailability(USER_ID)).thenReturn(true);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(true);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(true);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(true);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(true), eq(true)))
         .thenReturn(fullUserData);
 
@@ -345,9 +346,9 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isAgencySuperAdmin()).thenReturn(true);
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(keycloakUserDataProvider.retrieveAuthenticatedUserData()).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -373,9 +374,9 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getRoles()).thenReturn(roles);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
     when(askerDataProvider.retrieveData(user)).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -402,11 +403,11 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.getUsername()).thenReturn(USERNAME);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(new User());
     when(askerDataProvider.retrieveData(any(User.class))).thenReturn(partialUserData);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(true);
     when(usernameTranscoder.encodeUsername(USERNAME)).thenReturn(USERNAME);
     when(identityManager.getOtpCredential(USERNAME)).thenReturn(otpInfo);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), eq(otpInfo), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -429,9 +430,9 @@ class UserAccountControllerDelegateTest {
     when(consultantDataProvider.retrieveData(any(Consultant.class))).thenReturn(partialUserData);
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.empty());
     when(messenger.getAvailability(USER_ID)).thenReturn(false);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -456,9 +457,9 @@ class UserAccountControllerDelegateTest {
     when(accountManager.findConsultant(USER_ID))
         .thenThrow(new RuntimeException("display name down"));
     when(messenger.getAvailability(USER_ID)).thenReturn(true);
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -481,9 +482,9 @@ class UserAccountControllerDelegateTest {
     when(consultantDataProvider.retrieveData(any(Consultant.class))).thenReturn(partialUserData);
     when(accountManager.findConsultant(USER_ID)).thenReturn(Optional.empty());
     when(messenger.getAvailability(USER_ID)).thenThrow(new RuntimeException("availability down"));
-    when(identityClientConfig.isOtpAllowed(roles)).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(roles)).thenReturn(false);
     when(videoChatConfig.getE2eEncryptionEnabled()).thenReturn(false);
-    when(identityClientConfig.getDisplayNameAllowedForConsultants()).thenReturn(false);
+    when(identityPolicy.isConsultantDisplayNameAllowed()).thenReturn(false);
     when(userDtoMapper.userDataOf(eq(partialUserData), isNull(), eq(false), eq(false)))
         .thenReturn(fullUserData);
 
@@ -587,7 +588,7 @@ class UserAccountControllerDelegateTest {
     when(authenticatedUser.isConsultant()).thenReturn(false);
     when(authenticatedUser.isAdviceSeeker()).thenReturn(true);
     when(userAccountProvider.retrieveValidatedUser()).thenReturn(user);
-    when(identityClientConfig.getEmailDummySuffix()).thenReturn("@example.invalid");
+    when(identityPolicy.isProfileEmailUsableForMagicLink("user@example.org")).thenReturn(true);
     when(userDtoMapper.mapOf(patchUserDTO, authenticatedUser)).thenReturn(Optional.of(patchMap));
     when(accountManager.patchUser(patchMap)).thenReturn(Optional.of(patchMap));
     when(userDtoMapper.preferredLanguageOf(patchUserDTO)).thenReturn(Optional.empty());

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -47,12 +47,12 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.model.identity.IdentitySession;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
@@ -337,7 +337,7 @@ class UserControllerIT {
 
   @MockitoBean
   @SuppressWarnings("unused")
-  private IdentityClientConfig identityClientConfig;
+  private IdentityPolicy identityPolicy;
 
   @MockitoBean
   @SuppressWarnings("unused")
@@ -570,7 +570,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_NotActivateIfSingleTenantAdminButNotConfiguredToUse2Fa()
       throws Exception {
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.SINGLE_TENANT_ADMIN.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -585,7 +585,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_NotActivateIfTenantSuperAdminButNotConfiguredToUse2Fa()
       throws Exception {
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.TENANT_ADMIN.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     mvc.perform(
             put(PATH_ACTIVATE_2FA)
@@ -600,7 +600,7 @@ class UserControllerIT {
   void activateTwoFactorAuthByApp_Should_Activate() throws Exception {
     when(authenticatedUser.getUsername()).thenReturn("username");
     when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.CONSULTANT.getValue()));
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(true);
     when(identityManager.setUpOneTimePassword(anyString(), anyString(), anyString()))
         .thenReturn(true);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserTwoFactorAuthControllerDelegateTest.java
@@ -19,7 +19,7 @@ import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
-import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -38,7 +38,7 @@ class UserTwoFactorAuthControllerDelegateTest {
   private static final String SECRET = "12345678901234567890123456789012";
 
   @Mock private AuthenticatedUser authenticatedUser;
-  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityPolicy identityPolicy;
   @Mock private IdentityManaging identityManager;
   @Mock private AccountManaging accountManager;
   @Mock private AccountInviteService accountInviteService;
@@ -154,7 +154,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByAppShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -165,7 +165,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void startTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(
             () -> delegate.startTwoFactorAuthByEmailSetup(new EmailDTO("person@example.org")))
@@ -177,7 +177,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void finishTwoFactorAuthByEmailSetupShouldRejectRoleWithoutOtpPolicy() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.finishTwoFactorAuthByEmailSetup(OTP))
         .isInstanceOf(ConflictException.class)
@@ -228,7 +228,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_consultantDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -239,7 +239,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_singleTenantAdminDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -250,7 +250,7 @@ class UserTwoFactorAuthControllerDelegateTest {
 
   @Test
   void activateTwoFactorAuthByApp_tenantSuperAdminDisabled_throwsConflictException() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(false);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(false);
 
     assertThatThrownBy(() -> delegate.activateTwoFactorAuthByApp(oneTimePassword()))
         .isInstanceOf(ConflictException.class)
@@ -264,6 +264,6 @@ class UserTwoFactorAuthControllerDelegateTest {
   }
 
   private void allowOtpForCurrentRoles() {
-    when(identityClientConfig.isOtpAllowed(anySet())).thenReturn(true);
+    when(identityPolicy.isTwoFactorAuthenticationAllowed(anySet())).thenReturn(true);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.config.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.validation.ConstraintViolation;
@@ -43,6 +44,53 @@ class IdentityConfigTest {
   void teardownEach() {
     identityConfig = null;
     violations = null;
+  }
+
+  @Test
+  void isProfileEmailUsableForMagicLinkShouldRejectDummyNullAndBlankAddresses() {
+    givenAValidIdentityConfig();
+    identityConfig.setEmailDummySuffix("@dummy.oriso.org");
+
+    // The rule the web layer used to inline; owning it here gives it one definition.
+    assertTrue(identityConfig.isProfileEmailUsableForMagicLink("real.user@example.org"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink(null));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink(""));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("   "));
+  }
+
+  @Test
+  void isConsultantDisplayNameAllowedShouldReadTheConfiguredFlagNullSafely() {
+    givenAValidIdentityConfig();
+
+    identityConfig.setDisplayNameAllowedForConsultants(true);
+    assertTrue(identityConfig.isConsultantDisplayNameAllowed());
+
+    identityConfig.setDisplayNameAllowedForConsultants(false);
+    assertFalse(identityConfig.isConsultantDisplayNameAllowed());
+
+    // Boxed Boolean: an unset flag must not throw on unboxing.
+    identityConfig.setDisplayNameAllowedForConsultants(null);
+    assertFalse(identityConfig.isConsultantDisplayNameAllowed());
+  }
+
+  @Test
+  void isTwoFactorAuthenticationAllowedShouldMirrorTheOtpRolePolicy() {
+    givenAValidIdentityConfig();
+    identityConfig.setOtpAllowedForUsers(true);
+    identityConfig.setOtpAllowedForConsultants(false);
+
+    var users = Set.of(UserRole.USER.getValue());
+    var consultants = Set.of(UserRole.CONSULTANT.getValue());
+
+    // The port is a rename of the existing rule, not a second implementation of it.
+    assertTrue(identityConfig.isTwoFactorAuthenticationAllowed(users));
+    assertEquals(
+        identityConfig.isOtpAllowed(users), identityConfig.isTwoFactorAuthenticationAllowed(users));
+    assertFalse(identityConfig.isTwoFactorAuthenticationAllowed(consultants));
+    assertEquals(
+        identityConfig.isOtpAllowed(consultants),
+        identityConfig.isTwoFactorAuthenticationAllowed(consultants));
   }
 
   @Test

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -90,6 +90,34 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             "application services or outbound adapters:\n" + "\n".join(offenders),
         )
 
+    def test_user_web_boundaries_do_not_import_outbound_identity_configuration(self):
+        """The web layer asks an application policy, it does not read provider config.
+
+        Reading `IdentityClientConfig` here put the OTP role rule, the consultant
+        display-name flag and the dummy-email suffix in the controllers, so each
+        caller re-derived the rule. This keeps the seam closed.
+        """
+        sources = [
+            CONTROLLERS / "UserController.java",
+            *CONTROLLERS.glob("User*ControllerDelegate.java"),
+        ]
+        forbidden_import = (
+            "import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;"
+        )
+        offenders = [
+            str(source.relative_to(ROOT))
+            for source in sources
+            if forbidden_import in source.read_text()
+        ]
+
+        self.assertEqual(
+            [],
+            offenders,
+            "User web adapters must ask an application-owned identity policy "
+            "instead of reading outbound identity configuration:\n"
+            + "\n".join(offenders),
+        )
+
     def test_session_module_depends_on_ports_not_chat_adapters(self):
         session_module = (
             ROOT


### PR DESCRIPTION
Replay of #778 directly onto `pre-dev`.

## Why a replay

#778 targets `refactor/identity-username-input-775`, whose own PR (#776) was **closed**. Every base in that stack is a closed PR, so none of it could reach `pre-dev`. Six earlier steps of this refactor were already re-landed the same way (`replay/identity-authentication-789`, `replay/batch-identity-role-assignment-803-direct`, and four more), so this follows the established pattern. Reapplied against current `pre-dev`, not cherry-picked.

## Problem

The user web adapter read the **outbound** `IdentityClientConfig` to make three application decisions, leaking provider configuration into controllers and forcing each caller to re-derive the rule. Most visibly the magic-link check knew what a dummy-email suffix is:

```java
nonNull(email) && !email.isBlank()
    && !email.endsWith(identityClientConfig.getEmailDummySuffix())
```

## Changes

- New `port.in.IdentityPolicy` — the three decisions as questions (`isTwoFactorAuthenticationAllowed`, `isConsultantDisplayNameAllowed`, `isProfileEmailUsableForMagicLink`). `IdentityConfig` implements it, so the same validated configuration answers; the rule just has one definition now.
- `UserAccountControllerDelegate` and `UserTwoFactorAuthControllerDelegate` switch to the port. `UserController`'s `IdentityClientConfig` field was entirely unused — removed.
- Boundary ratchet in `tests/ci/test_module_boundaries.py`: no `User*` controller or delegate may import `IdentityClientConfig`.
- `IdentityConfigTest` covers the moved dummy-email rule (real / dummy / null / blank / whitespace), the null-safe display-name flag, and that the 2FA method is a rename of the existing OTP rule rather than a second implementation.

**No behaviour change** — every decision returns what the previous inline read returned.

## Verification

- `./mvnw clean test` → **3,958 unit tests, 0 failures**
- `suite-inventory.py --require unit` → exit 0, 3,958 across 450 reports
- CI contracts → **96 tests, OK**
- Ratchet proven to bite: reintroducing the import fails the test, reverting passes it
- Spotless clean

Refs #777, parent #335. Supersedes #778.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized identity policy checks for two-factor authentication, consultant display names, and Magic Link email validation.
  * Improved handling of missing or unusable profile email addresses for Magic Links.

* **Bug Fixes**
  * Ensured two-factor authentication availability consistently follows configured role permissions.
  * Added support for safely handling unset consultant display-name settings.

* **Tests**
  * Expanded coverage for identity permissions, email validation, display-name settings, and two-factor authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->