### PR TITLE
[Stability] Complete identity role membership read boundary (replay of #796)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class IdentityManager implements IdentityManaging {
   private final IdentityEmailAddressUpdater identityEmailAddressUpdater;
   private final IdentityAuthentication identityAuthentication;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final IdentityRoleLookup identityRoleLookup;
   private final IdentitySecondFactor identitySecondFactor;
   private final IdentityUsernameAvailability identityUsernameAvailability;
   private final UsernameTranscoder usernameTranscoder;
@@ -98,6 +100,6 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean hasRole(String userId, UserRole role) {
-    return identityClient.userHasRole(userId, role.getValue());
+    return identityRoleLookup.findAllByUserId(userId).stream().anyMatch(role.getValue()::equals);
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -11,7 +11,6 @@ import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
-import de.caritas.cob.userservice.api.config.auth.Authority;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -914,50 +913,6 @@ public class KeycloakService
       keycloakClient.getUsersResource().get(userId).remove();
     } catch (NotFoundException e) {
       log.warn("User {} not found in Keycloak, skipping deletion.", userId);
-    }
-  }
-
-  /**
-   * Returns true if the given user has the provided authority.
-   *
-   * @param userId Keycloak user ID
-   * @param authority Keycloak authority
-   * @return true if user hast provided authority
-   */
-  public boolean userHasAuthority(String userId, String authority) {
-    try {
-      return getUserRoles(userId).stream()
-          .map(role -> UserRole.getRoleByValue(role.getName()))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .map(Authority::getAuthoritiesByUserRole)
-          .anyMatch(currentAuthority -> currentAuthority.contains(authority));
-    } catch (Exception ex) {
-      var error = String.format("Could not get roles for user id %s", userId);
-      log.error("Keycloak error: " + error, ex);
-      throw new KeycloakException(error);
-    }
-  }
-
-  /**
-   * Returns true if the given user has the provided role.
-   *
-   * @param userId Keycloak user ID
-   * @param userRole Keycloak role
-   * @return true if user hast provided role
-   */
-  public boolean userHasRole(String userId, String userRole) {
-    try {
-      return getUserRoles(userId).stream()
-          .map(this::toUserRole)
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .map(UserRole::getValue)
-          .anyMatch(userRole::equals);
-    } catch (Exception ex) {
-      var error = String.format("Could not get roles for user id %s", userId);
-      log.error("Keycloak error: " + error, ex);
-      throw new KeycloakException(error);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -21,8 +21,4 @@ public interface IdentityClient {
   void removeRoleIfPresent(final String userId, final String roleName);
 
   void updateRole(final String userId, final String roleName);
-
-  boolean userHasAuthority(String userId, String authority);
-
-  boolean userHasRole(String userId, String userRole);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/IdentityManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
@@ -13,6 +14,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
 import de.caritas.cob.userservice.api.port.out.IdentitySecondFactor;
 import de.caritas.cob.userservice.api.port.out.IdentityUsernameAvailability;
 import java.util.Optional;
@@ -34,6 +36,7 @@ class IdentityManagerTest {
   @Mock private IdentityEmailAddressUpdater identityEmailAddressUpdater;
   @Mock private IdentityAuthentication identityAuthentication;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private IdentityRoleLookup identityRoleLookup;
   @Mock private IdentitySecondFactor identitySecondFactor;
   @Mock private IdentityUsernameAvailability identityUsernameAvailability;
   @Spy private UsernameTranscoder usernameTranscoder = new UsernameTranscoder();
@@ -149,6 +152,25 @@ class IdentityManagerTest {
         .thenReturn(Optional.of(new IdentityEmailOwner(null)));
 
     assertThat(identityManager.isEmailAvailableOrOwn(ENCODED_USERNAME, EMAIL)).isFalse();
+  }
+
+  @Test
+  void hasRoleShouldReadTheRoleListOnceThroughTheFocusedPort() {
+    // The behaviour the removed IdentityClient#userHasRole provided: one external
+    // read, then an in-process compare against the requested application role.
+    when(identityRoleLookup.findAllByUserId("consultant-id"))
+        .thenReturn(java.util.List.of("user", "consultant"));
+
+    assertThat(identityManager.hasRole("consultant-id", UserRole.CONSULTANT)).isTrue();
+
+    verify(identityRoleLookup).findAllByUserId("consultant-id");
+  }
+
+  @Test
+  void hasRoleShouldRejectARoleTheUserDoesNotHold() {
+    when(identityRoleLookup.findAllByUserId("user-id")).thenReturn(java.util.List.of("user"));
+
+    assertThat(identityManager.hasRole("user-id", UserRole.CONSULTANT)).isFalse();
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Maps;
 import de.caritas.cob.userservice.api.adapters.keycloak.dto.KeycloakLoginResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
-import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.config.observability.OutboundHttpMetrics;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -1138,56 +1137,6 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void userHasAuthority_Should_returnTrue_When_userHasAuthority() {
-    RoleRepresentation roleRepresentation = mock(RoleRepresentation.class);
-    when(roleRepresentation.getName()).thenReturn("user");
-    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
-    when(roleScopeResource.listAll()).thenReturn(singletonList(roleRepresentation));
-    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
-    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
-    UserResource userResource = mock(UserResource.class);
-    when(userResource.roles()).thenReturn(roleMappingResource);
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    boolean hasAuthority =
-        this.keycloakService.userHasAuthority("user", AuthorityValue.USER_DEFAULT);
-
-    assertThat(hasAuthority, is(true));
-  }
-
-  @Test
-  public void userHasAuthority_Should_returnThrowKeycloakException_When_userHasNoRoles() {
-    assertThrows(
-        KeycloakException.class,
-        () -> {
-          UserResource userResource = mock(UserResource.class);
-          UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-          when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-          this.keycloakService.userHasAuthority("user", "authority");
-        });
-  }
-
-  @Test
-  public void userHasAuthority_Should_returnFalse_When_userHasNotAuthority() {
-    RoleRepresentation roleRepresentation = mock(RoleRepresentation.class);
-    when(roleRepresentation.getName()).thenReturn("user");
-    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
-    when(roleScopeResource.listAll()).thenReturn(singletonList(roleRepresentation));
-    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
-    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
-    UserResource userResource = mock(UserResource.class);
-    when(userResource.roles()).thenReturn(roleMappingResource);
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    boolean hasAuthority = this.keycloakService.userHasAuthority("user", AuthorityValue.USER_ADMIN);
-
-    assertThat(hasAuthority, is(false));
-  }
-
-  @Test
   public void deactivateUser_Should_deactivateUser() {
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = mock(UsersResource.class);
@@ -1610,33 +1559,6 @@ public class KeycloakServiceTest {
     UserResource userResource = mock(UserResource.class);
     when(userResource.roles()).thenReturn(roleMappingResource);
     return userResource;
-  }
-
-  @Test
-  public void userHasRole_Should_ReturnTrue_When_UserHasRole() {
-    UserResource userResource = givenUserResourceWithRealmRoles("user");
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    assertThat(keycloakService.userHasRole(USER_ID, "user"), is(true));
-  }
-
-  @Test
-  public void userHasRole_Should_ReturnFalse_When_UserDoesNotHaveRole() {
-    UserResource userResource = givenUserResourceWithRealmRoles("consultant");
-    UsersResource usersResource = givenUsersResourceWithAnyUserId(userResource);
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    assertThat(keycloakService.userHasRole(USER_ID, "user"), is(false));
-  }
-
-  @Test
-  public void userHasRole_Should_ThrowKeycloakException_When_LookupFails() {
-    UsersResource usersResource = mock(UsersResource.class);
-    when(usersResource.get(any())).thenThrow(new RuntimeException("boom"));
-    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
-
-    assertThrows(KeycloakException.class, () -> keycloakService.userHasRole(USER_ID, "user"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceIT.java
@@ -85,8 +85,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
-
     AgencyDTO agencyDTO = new AgencyDTO();
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
@@ -122,7 +120,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     ExtendedConsultingTypeResponseDTO extendedConsultingTypeResponseDTO =
         new ExtendedConsultingTypeResponseDTO();
     AgencyDTO agencyDTO = new AgencyDTO();
@@ -168,7 +165,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
     when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));
 
     var consultant = createConsultantWithoutAgencyAndSession();
-    when(keycloakService.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     var roles = givenRoleSets(consultingType, roleSetName);
 
     consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -271,7 +267,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
           Consultant consultant = createConsultantWithoutAgencyAndSession();
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO = new CreateConsultantAgencyDTO();
-          when(keycloakService.userHasRole(any(), any())).thenReturn(false);
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
               consultant.getId(), createConsultantAgencyDTO);
@@ -288,7 +283,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(this.agencyService.getAgency(any())).thenReturn(null);
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -306,7 +300,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
               new CreateConsultantAgencyDTO().roleSetKey("valid role set");
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(agencyService.getAgency(any())).thenThrow(new InternalServerErrorException(""));
 
           this.consultantAgencyRelationCreatorService.createNewConsultantAgency(
@@ -326,7 +319,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
           when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(1)).thenReturn(true);
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =
@@ -350,7 +342,6 @@ class ConsultantAgencyRelationCreatorServiceIT {
 
           when(agencyService.getAgency(1731L)).thenReturn(emigrationAgency);
           when(agencyService.getAgency(2L)).thenReturn(agencyDTO);
-          when(keycloakService.userHasRole(any(), any())).thenReturn(true);
           when(consultingTypeManager.isConsultantBoundedToAgency(15)).thenReturn(true);
 
           CreateConsultantAgencyDTO createConsultantAgencyDTO =

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.util.Lists;
@@ -125,8 +123,6 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
     createConsultantAgencyDTO.setAgencyId(15L);
     createConsultantAgencyDTO.setRoleSetKey("valid-role-set");
 
-    when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
-
     AgencyDTO agencyDTO = new AgencyDTO();
     agencyDTO.setId(15L);
     agencyDTO.setTeamAgency(false);
@@ -169,7 +165,6 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
 
     CreateConsultantAgencyDTO createConsultantAgencyDTO =
         new CreateConsultantAgencyDTO().agencyId(15L).roleSetKey("valid-role-set");
-    when(identityClient.userHasRole(eq(consultant.getId()), any())).thenReturn(true);
     AgencyDTO agencyDTO = new AgencyDTO().id(15L).teamAgency(false).consultingType(0).tenantId(83L);
     when(agencyService.getAgency(15L)).thenReturn(agencyDTO);
     when(agencyService.getAgenciesWithoutCaching(List.of(15L))).thenReturn(List.of(agencyDTO));

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -228,7 +228,6 @@ public class ConsultantAgencyRelationCreatorServiceTest {
                 LogService::logInfo));
 
     verify(identityRoleLookup).findAllByUserId("consultant Id");
-    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService, never()).saveConsultantAgency(any());
   }
 
@@ -267,7 +266,6 @@ public class ConsultantAgencyRelationCreatorServiceTest {
         LogService::logInfo);
 
     verify(identityRoleLookup).findAllByUserId("consultant Id");
-    verify(identityClient, never()).userHasRole(anyString(), anyString());
     verify(consultantAgencyService).saveConsultantAgency(any(ConsultantAgency.class));
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -14,6 +14,8 @@ import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityLogin;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
+import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.keycloak.admin.client.resource.UserResource;
@@ -142,8 +144,10 @@ public class KeycloakTestConfig {
       public void deactivateUser(String userId) {}
 
       @Override
-      public boolean userHasRole(String userId, String userRole) {
-        return true;
+      public List<String> findAllByUserId(String userId) {
+        // Preserves the previous `userHasRole -> true` behaviour of this shared double:
+        // every role is reported, so role-gated integration paths stay open.
+        return Arrays.stream(UserRole.values()).map(UserRole::getValue).toList();
       }
     };
   }

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -118,6 +118,25 @@ class ModuleBoundaryContractTest(unittest.TestCase):
             + "\n".join(offenders),
         )
 
+    def test_broad_identity_client_does_not_expose_role_membership_predicates(self):
+        """Role membership is read through the focused lookup, not the broad client.
+
+        `userHasRole` duplicated what `IdentityRoleLookup#findAllByUserId` already
+        returns, and `userHasAuthority` had no caller at all. Re-adding either would
+        put role policy back behind an outbound predicate the application cannot see.
+        """
+        identity_client = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        )
+        source = identity_client.read_text()
+
+        for forbidden in ("userHasRole", "userHasAuthority"):
+            self.assertNotIn(
+                forbidden,
+                source,
+                f"IdentityClient must not expose {forbidden}; use IdentityRoleLookup",
+            )
+
     def test_session_module_depends_on_ports_not_chat_adapters(self):
         session_module = (
             ROOT


### PR DESCRIPTION
Replay of #796 directly onto `pre-dev`. The original targets `refactor/identity-second-factor-793`, whose PR (#794) was closed — no route to `pre-dev`, same as #778 → #1037.

## Change

`IdentityManager.hasRole` reached through the broad outbound `IdentityClient` for a predicate the focused `IdentityRoleLookup` already answers. It now reads the role list once and compares in-process; `userHasRole` and `userHasAuthority` come off the broad port and its Keycloak adapter.

## Behaviour-preserving — verified, not assumed

- The removed `userHasRole` mapped each raw Keycloak name through `UserRole.getRoleByValue` (an exact `.equals`) then compared the canonical value. The requested value **is** an enum value, so that round-trip could never change the outcome — the direct compare is equivalent.
- Both paths call the same `getUserRoles` and wrap failures in the same `KeycloakException` with the same message.
- `userHasAuthority` had **no caller in main** — dead code.

## Test changes follow from that

- Removed the six adapter tests for the deleted methods. **No coverage lost**: `findAllByUserId_*` already covers the same lookup and its exception path.
- `IdentityManagerTest` had **no `hasRole` coverage at all**, so deleting the old tests would have left the new logic untested. Added match / no-match cases asserting the single read through the focused port.
- The `userHasRole` stubs in the three `ConsultantAgencyRelationCreatorService` tests were **already dead** — that service moved to `identityRoleLookup` in an earlier step, so they stubbed a method production no longer calls.
- The shared `KeycloakTestConfig` double overrode `userHasRole -> true` and provided no `findAllByUserId`, so integration paths would have fallen through to **real Keycloak**. Replaced with an equivalent all-roles `findAllByUserId`.
- Boundary ratchet: `IdentityClient` may not expose either predicate. Confirmed it bites — re-adding `userHasRole` fails the test, reverting passes it.

## Verification

- `./mvnw clean test` → **3,954 unit tests, 0 failures, 0 errors**
- `suite-inventory.py --require unit` → 3,954 across 450 reports
- CI contracts → **97 tests, OK**
- Spotless clean

Refs #795, parent #335. Supersedes #796.