### PR TITLE
[Stability] Focus identity account settings (replay of #802)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
+++ b/src/main/java/de/caritas/cob/userservice/api/IdentityManager.java
@@ -6,8 +6,8 @@ import de.caritas.cob.userservice.api.identity.IdentityEmailVerification;
 import de.caritas.cob.userservice.api.identity.IdentityEmailVerificationStart;
 import de.caritas.cob.userservice.api.identity.IdentityOtpCredential;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
-import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailAddressUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.IdentityRoleLookup;
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IdentityManager implements IdentityManaging {
 
-  private final IdentityClient identityClient;
+  private final IdentityAccountSettingsUpdater identityAccountSettingsUpdater;
   private final IdentityEmailAddressUpdater identityEmailAddressUpdater;
   private final IdentityAuthentication identityAuthentication;
   private final IdentityEmailOwnerLookup identityEmailOwnerLookup;
@@ -60,12 +60,12 @@ public class IdentityManager implements IdentityManaging {
 
   @Override
   public boolean changePassword(String userId, String password) {
-    return identityClient.changePassword(userId, password);
+    return identityAccountSettingsUpdater.changePassword(userId, password);
   }
 
   @Override
   public void changeLanguage(String userId, String language) {
-    identityClient.changeLanguage(userId, language);
+    identityAccountSettingsUpdater.changePreferredLanguage(userId, language);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.model.OtpInfoDTO;
 import de.caritas.cob.userservice.api.model.Success;
 import de.caritas.cob.userservice.api.model.SuccessWithEmail;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
@@ -89,6 +90,7 @@ import org.springframework.web.client.RestClientResponseException;
 @RequiredArgsConstructor
 public class KeycloakService
     implements IdentityAccountRemover,
+        IdentityAccountSettingsUpdater,
         IdentityAuthentication,
         IdentityClient,
         IdentityDeactivator,
@@ -144,6 +146,7 @@ public class KeycloakService
    * @param password Keycloak password
    * @return true if password change was successful
    */
+  @Override
   public boolean changePassword(final String userId, final String password) {
     try {
       updatePassword(userId, password);
@@ -155,7 +158,8 @@ public class KeycloakService
     return true;
   }
 
-  public void changeLanguage(final String userId, final String locale) {
+  @Override
+  public void changePreferredLanguage(final String userId, final String locale) {
     UserResource userResource = keycloakClient.getUsersResource().get(userId);
     var user = userResource.toRepresentation();
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAccountSettingsUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityAccountSettingsUpdater.java
@@ -1,0 +1,15 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/**
+ * Focused outbound contract for changes a user makes to their own account settings.
+ *
+ * <p>Separate from the broad {@code IdentityClient}: provisioning and administrative password
+ * resets are a different concern with a different blast radius, and keeping self-service settings
+ * here means a caller cannot reach the provisioning surface just to change a language.
+ */
+public interface IdentityAccountSettingsUpdater {
+
+  boolean changePassword(String userId, String password);
+
+  void changePreferredLanguage(String userId, String language);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -6,10 +6,6 @@ import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 
 public interface IdentityClient {
 
-  boolean changePassword(final String userId, final String password);
-
-  void changeLanguage(final String userId, final String language);
-
   CreatedIdentity createUser(final UserDTO user);
 
   CreatedIdentity createUser(final UserDTO user, final String firstName, final String lastName);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1200,7 +1200,7 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
     verify(userResource, Mockito.never()).update(userRepresentation);
@@ -1224,7 +1224,7 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
     verify(userResource).update(userRepresentation);
@@ -1253,7 +1253,7 @@ public class KeycloakServiceTest {
     when(userRepresentation.getAttributes()).thenReturn(attributeMap);
 
     // when
-    this.keycloakService.changeLanguage("userId", "de");
+    this.keycloakService.changePreferredLanguage("userId", "de");
 
     // then
     verify(userResource).update(userRepresentation);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -143,6 +144,7 @@ class UserAdminControllerE2EIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.IdentityConfig;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -86,6 +87,7 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -74,6 +74,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.User;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -181,6 +182,7 @@ class UserControllerAuthorizationIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -51,6 +51,7 @@ import de.caritas.cob.userservice.api.port.in.IdentityPolicy;
 import de.caritas.cob.userservice.api.port.in.Messaging;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -300,6 +301,7 @@ class UserControllerIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class
@@ -1605,7 +1607,8 @@ class UserControllerIT {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
 
-    verify(identityClient, times(0)).changePassword(anyString(), anyString());
+    verify((IdentityAccountSettingsUpdater) identityClient, times(0))
+        .changePassword(anyString(), anyString());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.model.Admin.AdminType;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -74,6 +75,7 @@ class CreateAdminServiceIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/update/UpdateAdminServiceIT.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.admin.service.admin.search.RetrieveAdminSe
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Admin;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -54,6 +55,7 @@ public class UpdateAdminServiceIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTenantAwareIT.java
@@ -24,6 +24,7 @@ import de.caritas.cob.userservice.api.model.UserAgency;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -97,6 +98,7 @@ class ConsultantAgencyRelationCreatorServiceTenantAwareIT {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceBase.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.UpdateAdminConsultantDTO;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
+import de.caritas.cob.userservice.api.port.out.IdentityAccountSettingsUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDeactivator;
@@ -53,6 +54,7 @@ public class ConsultantUpdateServiceBase {
         IdentityProfileLookup.class,
         IdentityProfileUpdater.class,
         IdentityRoleLookup.class,
+        IdentityAccountSettingsUpdater.class,
         IdentityRoleUpdater.class,
         IdentitySecondFactor.class,
         IdentityUsernameAvailability.class

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -55,7 +55,7 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public void changeLanguage(String userId, String locale) {
+      public void changePreferredLanguage(String userId, String locale) {
         UserResource userResource = keycloakClient.getUsersResource().get(userId);
         UserRepresentation user = getUserRepresentationAndCreateNewUserIfNotExist(userResource);
         super.changeLanguageForTheUser(locale, userResource, user);

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -137,6 +137,36 @@ class ModuleBoundaryContractTest(unittest.TestCase):
                 f"IdentityClient must not expose {forbidden}; use IdentityRoleLookup",
             )
 
+    def test_broad_identity_client_does_not_carry_self_service_account_settings(self):
+        """Self-service settings live on a focused port, not the provisioning client.
+
+        `changePassword` and `changeLanguage` on the broad client sat next to user
+        creation and deletion, so a caller reaching for a language change also had
+        the provisioning surface in hand.
+        """
+        identity_client = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        )
+        source = identity_client.read_text()
+
+        for forbidden in ("changePassword", "changeLanguage"):
+            self.assertNotIn(
+                forbidden,
+                source,
+                f"IdentityClient must not expose {forbidden}; "
+                "use IdentityAccountSettingsUpdater",
+            )
+
+    def test_identity_manager_does_not_depend_on_the_broad_identity_client(self):
+        """The application service now reaches only focused outbound ports."""
+        manager = ROOT / "src/main/java/de/caritas/cob/userservice/api/IdentityManager.java"
+
+        self.assertNotIn(
+            "import de.caritas.cob.userservice.api.port.out.IdentityClient;",
+            manager.read_text(),
+            "IdentityManager must depend on focused identity ports, not the broad client",
+        )
+
     def test_session_module_depends_on_ports_not_chat_adapters(self):
         session_module = (
             ROOT


### PR DESCRIPTION
Replay of #802 directly onto `pre-dev`, on top of #1038 (#796's replay). The original targets `refactor/remove-identity-session-close-799`, whose PR (#800) was closed.

## Change

`changePassword` and `changeLanguage` sat on the broad `IdentityClient`, next to user creation and deletion — a caller that only wanted to change a language held the whole provisioning surface. They move to a focused `IdentityAccountSettingsUpdater`, and with them the **last broad-client dependency leaves `IdentityManager`**.

`changeLanguage` is renamed `changePreferredLanguage`; the adapter tests and the shared Spring double follow.

## Checked before applying

`IdentityManager` is the only caller of either method in `main`, so removing them from the broad port strands nothing.

This PR depends on #1038 — it deletes the `IdentityClient` field outright, which only compiles once `hasRole` no longer uses it.

## Test wiring

Follows this repo's existing pattern rather than adding beans: the identity mock in each Spring test declares its ports via `extraInterfaces`, so `IdentityAccountSettingsUpdater.class` joins that list in the seven affected tests. (I first added a separate `@MockitoBean`, then replaced it after reading how the original PR and the surrounding tests do it.)

`UserControllerIT`'s "password was never changed" assertion is **kept**, not dropped — it now verifies against the focused port, since that is where the self-service change lives.

## Ratchets

Two, both confirmed to bite by reintroducing the regression and watching them fail:
- `IdentityClient` may not carry `changePassword` / `changeLanguage`
- `IdentityManager` may not import the broad client at all

## Verification

- `./mvnw clean test` → **3,954 unit tests, 0 failures, 0 errors**
- `suite-inventory.py --require unit` → 3,954 across 450 reports
- CI contracts → **99 tests, OK**
- Spotless clean

Refs #801, parent #335. Supersedes #802.