### PR TITLE
fix(security): bump log4j to 2.25.5 on pre-dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<adapters.web.dto.path>
 			${project.groupId}.${project.artifactId}.api.adapters.web.dto
 		</adapters.web.dto.path>
-		<log4j.version>2.25.4</log4j.version> <!-- force safe version due to https://logging.apache.org/log4j/2.x/security.html -->
+		<log4j.version>2.25.5</log4j.version> <!-- force safe version due to https://logging.apache.org/log4j/2.x/security.html -->
 		<commons-text.version>1.10.0</commons-text.version>
 		<commons-validator.version>1.10.1</commons-validator.version>
 		<liquibase.version>4.27.0</liquibase.version>


### PR DESCRIPTION
Applies the log4j security update **to `pre-dev`, where it actually ships**. Supersedes #1009.

## Why #1009 could not work where it sits

Dependabot opened it against `main`. GitHub always opens **security** updates against the repository default branch, and `target-branch:` in `dependabot.yml` only redirects *version* updates — so no config change can move them. `main` here is a release branch **127 commits behind `pre-dev`**.

## This is the OPPOSITE fix to the other dependency work in this pass

Worth flagging, because the symptom looks identical and pattern-matching would have got it wrong.

In ORISO-TenantService and ORISO-AgencyService the poms pinned dependencies **below** what the Spring Boot BOM manages, and the correct fix was to **delete** the override:

| repo | pin vs BOM | fix |
|---|---|---|
| TenantService | 7.0.1 pinned vs 7.0.2 managed, split across 8 artifacts | **delete** the pin |
| AgencyService | h2 1.4.200 pinned vs 2.4.240 managed | **delete** the pin |
| **UserService (this PR)** | **2.25.4 pinned = 2.25.4 managed** | **keep and bump** |

This pom carries a `log4j.version` property with a `<!-- force safe version due to ... -->` comment, which looks like exactly the same anti-pattern. It is not:

> **Spring Boot 4.0.7 manages log4j at 2.25.4 — precisely what the pin already said.**

Deleting the override here would resolve to **2.25.4** and leave the advisory open. The pin is the *only* way to get **above** the BOM, so it is kept and bumped to 2.25.5. I verified this by temporarily removing the pin and reading the resolved version, rather than assuming the earlier pattern held.

## The lesson in that comment

The pin was itself added *as* a security fix. It then went stale, and became the thing **holding the vulnerable version in place**. A pin that freezes a security-sensitive dependency needs an owner, or it quietly turns into the vulnerability it was added to prevent. Worth a follow-up convention rather than leaving it to be rediscovered.

## Resolution after the bump

All three artifacts move together (the property drives all of them):

```
org.apache.logging.log4j:log4j-api:jar:2.25.5
org.apache.logging.log4j:log4j-core:jar:2.25.5
org.apache.logging.log4j:log4j-to-slf4j:jar:2.25.5
```

## Verification

Local, JDK 21: `./mvnw -B test` → **3954 tests, 0 failures, 0 errors**.

## Reviewer test plan

- [ ] CI is green
- [ ] `./mvnw dependency:list | grep log4j` shows 2.25.5 for all three artifacts
- [ ] Agree the pin should stay (it is above the BOM), rather than be removed
- [ ] Consider a convention for security pins that must be revisited when Boot moves
- [ ] Close #1009 once this lands

Refs #1009