### PR TITLE
[Stability] Move identity role assignment to focused port (replay of #806)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -584,15 +584,6 @@ public class KeycloakService
     return null;
   }
 
-  /**
-   * Assigns the role "user" to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   */
-  public void updateUserRole(final String userId) {
-    updateRole(userId, "user");
-  }
-
   @Override
   public void ensureRoles(final String userId, final Collection<String> roleNames) {
     var requestedRoles = new LinkedHashSet<>(roleNames);
@@ -627,16 +618,6 @@ public class KeycloakService
     }
   }
 
-  /**
-   * Assigns the given {@link UserRole} to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   * @param role {@link UserRole}
-   */
-  public void updateRole(final String userId, final UserRole role) {
-    this.updateRole(userId, role.getValue());
-  }
-
   @Override
   public void removeRoleIfPresent(final String userId, final String roleName) {
     // Get realm and user resources
@@ -666,24 +647,24 @@ public class KeycloakService
     return Optional.empty();
   }
 
-  /**
-   * Assigns the role with the given name to the given user ID.
-   *
-   * @param userId Keycloak user ID
-   * @param roleName Keycloak role name
-   */
-  public void updateRole(final String userId, final String roleName) {
+  @Override
+  public void assignRoles(final String userId, final Collection<String> roleNames) {
+    var requestedRoles = new LinkedHashSet<>(roleNames);
+    if (requestedRoles.isEmpty()) {
+      return;
+    }
+
     try {
-      updateRolesOnce(userId, Collections.singletonList(roleName));
+      updateRolesOnce(userId, requestedRoles);
     } catch (NotAuthorizedException e) {
       log.warn(
-          "Keycloak admin session was unauthorized while assigning role {} to user {}, forcing"
+          "Keycloak admin session was unauthorized while assigning {} roles to user {}, forcing"
               + " token refresh and retrying once",
-          roleName,
+          requestedRoles.size(),
           userId);
       recordRetry("admin-session-refresh");
       keycloakClient.refreshAdminSession();
-      updateRolesOnce(userId, Collections.singletonList(roleName));
+      updateRolesOnce(userId, requestedRoles);
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import jakarta.ws.rs.NotFoundException;
@@ -42,6 +43,7 @@ public class CreateAdminService {
   private boolean multitenancyWithSingleDomain;
 
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityPasswordUpdater identityPasswordUpdater;
   private final @NonNull IdentityAccountRemover identityAccountRemover;
   private final @NonNull UserAccountInputValidator userAccountInputValidator;
@@ -101,7 +103,8 @@ public class CreateAdminService {
             : userHelper.getRandomPassword();
     try {
       identityPasswordUpdater.updatePassword(keycloakUserId, password);
-      getDefaultRoles(adminType).forEach(role -> identityClient.updateRole(keycloakUserId, role));
+      identityRoleUpdater.assignRoles(
+          keycloakUserId, getDefaultRoles(adminType).stream().map(UserRole::getValue).toList());
       return adminRepository.save(buildAdmin(createAdminDTO, adminType, keycloakUserId));
     } catch (CustomValidationHttpStatusException e) {
       identityAccountRemover.rollbackUser(keycloakUserId);

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSaga.java
@@ -35,6 +35,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
@@ -62,6 +63,7 @@ public class CreateConsultantSaga {
 
   private static final String CREATE_CONSULTANT = "createConsultant";
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityPasswordUpdater identityPasswordUpdater;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull ConsultantPublicSlugService consultantPublicSlugService;
@@ -320,7 +322,7 @@ public class CreateConsultantSaga {
   private void updateKeyloakRolesOrRollback(
       Set<String> roles, String keycloakUserId, ConsultantCreationInput consultantCreationInput) {
     try {
-      roles.forEach(roleName -> identityClient.updateRole(keycloakUserId, roleName));
+      identityRoleUpdater.assignRoles(keycloakUserId, roles);
     } catch (Exception e) {
       log.error(
           "Unable to update roles for user with keycloak id {}. Initiating user rollback.",

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityProfileUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.MatrixUserClient;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
@@ -41,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConsultantUpdateService {
 
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityProfileUpdater identityProfileUpdater;
   private final @NonNull ConsultantService consultantService;
   private final @NonNull ConsultantPublicSlugService consultantPublicSlugService;
@@ -104,7 +106,8 @@ public class ConsultantUpdateService {
 
     if (updateConsultantDTO.getIsGroupchatConsultant() != null
         && updateConsultantDTO.getIsGroupchatConsultant()) {
-      identityClient.updateRole(consultant.getId(), GROUP_CHAT_CONSULTANT.getValue());
+      identityRoleUpdater.ensureRoles(
+          consultant.getId(), java.util.Set.of(GROUP_CHAT_CONSULTANT.getValue()));
     }
     if (updateConsultantDTO.getIsGroupchatConsultant() != null
         && !updateConsultantDTO.getIsGroupchatConsultant()) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateUserFacade.java
@@ -27,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
@@ -61,6 +62,7 @@ import org.springframework.web.client.RestClientException;
 public class CreateUserFacade {
   private final @NonNull UserVerifier userVerifier;
   private final @NonNull IdentityClient identityClient;
+  private final @NonNull IdentityRoleUpdater identityRoleUpdater;
   private final @NonNull IdentityAccountRemover identityAccountRemover;
   private final @NonNull IdentityPasswordUpdater identityPasswordUpdater;
   private final @NonNull IdentityDummyEmailUpdater identityDummyEmailUpdater;
@@ -326,7 +328,7 @@ public class CreateUserFacade {
 
   private void updateKeycloakRoleAndPassword(String userId, UserDTO userDTO, UserRole role) {
     checkIfUserIdNotNull(userId);
-    identityClient.updateRole(userId, role);
+    identityRoleUpdater.assignRoles(userId, java.util.List.of(role.getValue()));
     identityPasswordUpdater.updatePassword(userId, userDTO.getPassword());
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
-import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 
 public interface IdentityClient {
@@ -14,11 +13,5 @@ public interface IdentityClient {
 
   CreatedIdentity createUser(final UserDTO user, final String firstName, final String lastName);
 
-  void updateUserRole(final String userId);
-
-  void updateRole(final String userId, final UserRole role);
-
   void removeRoleIfPresent(final String userId, final String roleName);
-
-  void updateRole(final String userId, final String roleName);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdentityRoleUpdater.java
@@ -5,5 +5,8 @@ import java.util.Collection;
 /** Focused outbound contract for idempotent identity role assignment. */
 public interface IdentityRoleUpdater {
 
+  /** Assigns every named role. Unlike {@link #ensureRoles}, it does not read first. */
+  void assignRoles(String userId, Collection<String> roleNames);
+
   void ensureRoles(String userId, Collection<String> roleNames);
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -811,7 +811,7 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void updateRole_Should_throwKeycloakException_When_roleCouldNotBeUpdated() {
+  public void assignRoles_Should_throwKeycloakException_When_roleCouldNotBeUpdated() {
     assertThrows(
         KeycloakException.class,
         () -> {
@@ -835,12 +835,12 @@ public class KeycloakServiceTest {
           when(realmResource.roles()).thenReturn(rolesResource);
           when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-          this.keycloakService.updateRole("user", "role");
+          this.keycloakService.assignRoles("user", List.of("role"));
         });
   }
 
   @Test
-  public void updateRole_Should_updateRole_When_roleUpdateIsValid() {
+  public void assignRoles_Should_updateRole_When_roleUpdateIsValid() {
     String validRole = "role";
 
     UserResource userResource = mock(UserResource.class);
@@ -867,13 +867,13 @@ public class KeycloakServiceTest {
     when(realmResource.roles()).thenReturn(rolesResource);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    this.keycloakService.updateRole("user", validRole);
+    this.keycloakService.assignRoles("user", List.of(validRole));
 
     verify(roleScopeResource, times(1)).add(any());
   }
 
   @Test
-  public void updateRole_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
+  public void assignRoles_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
     var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
     keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);
     String validRole = "role";
@@ -899,7 +899,7 @@ public class KeycloakServiceTest {
         .thenThrow(new NotAuthorizedException("Bearer"))
         .thenReturn(realmResource);
 
-    keycloakService.updateRole("user", validRole);
+    keycloakService.assignRoles("user", List.of(validRole));
 
     verify(keycloakClient).refreshAdminSession();
     verify(outboundHttpMetrics).recordRetry("keycloak", "admin-session-refresh");
@@ -941,8 +941,8 @@ public class KeycloakServiceTest {
   }
 
   @Test
-  public void updateRole_Should_updateUserWithProvidedRole() {
-    UserRole validRole = UserRole.USER;
+  public void assignRoles_Should_updateUserWithProvidedRole() {
+    String validRole = UserRole.USER.getValue();
 
     UserResource userResource = mock(UserResource.class);
     UsersResource usersResource = mock(UsersResource.class);
@@ -951,7 +951,7 @@ public class KeycloakServiceTest {
     RoleRepresentation keycloakRoleMock = mock(RoleRepresentation.class);
     // Production verifies the assignment via RoleRepresentation#getName (isRoleAssigned), not
     // toString; otherwise the role appears unassigned and updateRole throws a KeycloakException.
-    when(keycloakRoleMock.getName()).thenReturn(validRole.getValue());
+    when(keycloakRoleMock.getName()).thenReturn(validRole);
     when(roleScopeResource.listAll()).thenReturn(singletonList(keycloakRoleMock));
     RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
     when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
@@ -968,10 +968,10 @@ public class KeycloakServiceTest {
     when(realmResource.roles()).thenReturn(rolesResource);
     when(keycloakClient.getRealmResource()).thenReturn(realmResource);
 
-    this.keycloakService.updateRole("user", validRole);
+    this.keycloakService.assignRoles("user", List.of(validRole));
 
     verify(roleScopeResource, times(1)).add(any());
-    verify(rolesResource, times(1)).get(validRole.getValue());
+    verify(rolesResource, times(1)).get(validRole);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -964,6 +964,56 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void assignRoles_Should_writeEveryDistinctRoleInASingleAdd_When_CollectionHasDuplicates() {
+    UserResource userResource = mock(UserResource.class);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.get(anyString())).thenReturn(userResource);
+    RoleScopeResource roleScopeResource = mock(RoleScopeResource.class);
+    RoleMappingResource roleMappingResource = mock(RoleMappingResource.class);
+    when(roleMappingResource.realmLevel()).thenReturn(roleScopeResource);
+    when(userResource.roles()).thenReturn(roleMappingResource);
+
+    RoleRepresentation assignedFirst = mock(RoleRepresentation.class);
+    when(assignedFirst.getName()).thenReturn("first");
+    RoleRepresentation assignedSecond = mock(RoleRepresentation.class);
+    when(assignedSecond.getName()).thenReturn("second");
+    when(roleScopeResource.listAll()).thenReturn(List.of(assignedFirst, assignedSecond));
+
+    RoleRepresentation firstRealmRole = new RoleRepresentation();
+    firstRealmRole.setName("first");
+    RoleRepresentation secondRealmRole = new RoleRepresentation();
+    secondRealmRole.setName("second");
+    RoleResource firstRoleResource = mock(RoleResource.class);
+    when(firstRoleResource.toRepresentation()).thenReturn(firstRealmRole);
+    RoleResource secondRoleResource = mock(RoleResource.class);
+    when(secondRoleResource.toRepresentation()).thenReturn(secondRealmRole);
+    RolesResource rolesResource = mock(RolesResource.class);
+    when(rolesResource.get("first")).thenReturn(firstRoleResource);
+    when(rolesResource.get("second")).thenReturn(secondRoleResource);
+
+    RealmResource realmResource = mock(RealmResource.class);
+    when(realmResource.users()).thenReturn(usersResource);
+    when(realmResource.roles()).thenReturn(rolesResource);
+    when(keycloakClient.getRealmResource()).thenReturn(realmResource);
+
+    this.keycloakService.assignRoles("user", List.of("first", "second", "first"));
+
+    ArgumentCaptor<List<RoleRepresentation>> addedRoles = ArgumentCaptor.forClass(List.class);
+    verify(roleScopeResource, times(1)).add(addedRoles.capture());
+    assertEquals(List.of(firstRealmRole, secondRealmRole), addedRoles.getValue());
+    verify(rolesResource, times(1)).get("first");
+    verify(rolesResource, times(1)).get("second");
+  }
+
+  @Test
+  public void assignRoles_Should_notTouchKeycloak_When_RoleCollectionIsEmpty() {
+    this.keycloakService.assignRoles("user", List.of());
+
+    verify(keycloakClient, never()).getRealmResource();
+  }
+
+  @Test
   public void assignRoles_Should_RefreshAdminSessionAndRetry_When_Unauthorized() {
     var outboundHttpMetrics = mock(OutboundHttpMetrics.class);
     keycloakService.setOutboundHttpMetrics(outboundHttpMetrics);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1010,7 +1010,9 @@ public class KeycloakServiceTest {
   public void assignRoles_Should_notTouchKeycloak_When_RoleCollectionIsEmpty() {
     this.keycloakService.assignRoles("user", List.of());
 
-    verify(keycloakClient, never()).getRealmResource();
+    // Not never().getRealmResource(): that would still pass if the empty path started reaching
+    // Keycloak through some other client method.
+    verifyNoInteractions(keycloakClient);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceIT.java
@@ -114,8 +114,9 @@ class CreateAdminServiceIT {
     assertNull(userDTOArgumentCaptor.getValue().getTenantId());
 
     verify((IdentityPasswordUpdater) identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isNull();
@@ -150,8 +151,9 @@ class CreateAdminServiceIT {
     assertEquals(1L, (long) userDTOArgumentCaptor.getValue().getTenantId());
 
     verify((IdentityPasswordUpdater) identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isEqualTo(1L);
@@ -190,8 +192,9 @@ class CreateAdminServiceIT {
     assertEquals(1L, (long) userDTOArgumentCaptor.getValue().getTenantId());
 
     verify((IdentityPasswordUpdater) identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isEqualTo(1L);
@@ -222,8 +225,9 @@ class CreateAdminServiceIT {
     assertNull(userDTOArgumentCaptor.getValue().getTenantId());
 
     verify((IdentityPasswordUpdater) identityClient).updatePassword(anyString(), anyString());
-    verify(identityClient).updateRole(anyString(), eq(RESTRICTED_AGENCY_ADMIN));
-    verify(identityClient).updateRole(anyString(), eq(USER_ADMIN));
+    verify((IdentityRoleUpdater) identityClient)
+        .assignRoles(
+            anyString(), eq(List.of(RESTRICTED_AGENCY_ADMIN.getValue(), USER_ADMIN.getValue())));
 
     assertThat(admin).isNotNull();
     assertThat(admin.getTenantId()).isNull();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
@@ -8,6 +8,7 @@ import static de.caritas.cob.userservice.api.config.auth.UserRole.USER_ADMIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import de.caritas.cob.userservice.api.port.out.AdminRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
@@ -43,6 +45,7 @@ class CreateAdminServiceTest {
   @InjectMocks private CreateAdminService createAdminService;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private IdentityAccountRemover identityAccountRemover;
 
@@ -82,8 +85,8 @@ class CreateAdminServiceTest {
     keycloakResponse.setUserId("kc-user-id");
     when(identityClient.createUser(any(), anyString(), anyString())).thenReturn(keycloakResponse);
     doThrow(new RuntimeException("role assignment failed"))
-        .when(identityClient)
-        .updateRole(anyString(), any(UserRole.class));
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), anyCollection());
 
     CreateAdminDTO createAdminDTO = easyRandom.nextObject(CreateAdminDTO.class);
     createAdminDTO.setUsername("valid_username");
@@ -102,8 +105,8 @@ class CreateAdminServiceTest {
     keycloakResponse.setUserId("kc-user-id");
     when(identityClient.createUser(any(), anyString(), anyString())).thenReturn(keycloakResponse);
     doThrow(new NotFoundException("HTTP 404 Not Found"))
-        .when(identityClient)
-        .updateRole(anyString(), any(UserRole.class));
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), anyCollection());
 
     CreateAdminDTO createAdminDTO = easyRandom.nextObject(CreateAdminDTO.class);
     createAdminDTO.setUsername("valid_username");

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaIT.java
@@ -11,10 +11,10 @@ import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +34,7 @@ import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportReco
 import de.caritas.cob.userservice.api.service.appointment.AppointmentService;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.Settings;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,7 +89,7 @@ public class CreateConsultantSagaIT {
         this.createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     ConsultantDTO consultant = consultantAdminResponseDTO.getEmbedded();
-    verify(keycloakService).updateRole(anyString(), eq(CONSULTANT.getValue()));
+    verify(keycloakService).assignRoles(anyString(), eq(Set.of(CONSULTANT.getValue())));
 
     assertThat(consultant, notNullValue());
     assertThat(consultant.getId(), notNullValue());
@@ -120,8 +121,7 @@ public class CreateConsultantSagaIT {
           ex.getCustomHttpHeaders().get("X-Reason").get(0),
           is(
               "DISTRIBUTED_TRANSACTION_FAILED_ON_STEP_CREATE_ACCOUNT_IN_CALCOM_OR_APPOINTMENTSERVICE"));
-      verify(keycloakService).updateRole(anyString(), eq(CONSULTANT.getValue()));
-      verify(keycloakService).updateRole(anyString(), eq(CONSULTANT.getValue()));
+      verify(keycloakService).assignRoles(anyString(), eq(Set.of(CONSULTANT.getValue())));
       verify(rollbackFacade).rollbackConsultantAccount(Mockito.any(Consultant.class));
     }
   }
@@ -143,7 +143,7 @@ public class CreateConsultantSagaIT {
       fail("Exception should be thrown");
     } catch (CustomValidationHttpStatusException ex) {
       assertThat(ex.getCustomHttpHeaders().get("X-Reason").get(0), is("PASSWORD_NOT_VALID"));
-      verify(keycloakService, Mockito.never()).updateRole(anyString(), eq(CONSULTANT.getValue()));
+      verify(keycloakService, Mockito.never()).assignRoles(anyString(), anyCollection());
       verify(rollbackFacade).rollbackConsultantAccount(Mockito.any(Consultant.class));
     }
   }
@@ -152,7 +152,9 @@ public class CreateConsultantSagaIT {
   public void createNewConsultant_Should_callRollback_When_KeycloakUpdateRoleThrowsException() {
     when(keycloakService.createUser(any(), anyString(), any()))
         .thenReturn(easyRandom.nextObject(CreatedIdentity.class));
-    doThrow(BadRequestException.class).when(keycloakService).updateRole(anyString(), anyString());
+    doThrow(BadRequestException.class)
+        .when(keycloakService)
+        .assignRoles(anyString(), anyCollection());
     CreateConsultantDTO createConsultantDTO = this.easyRandom.nextObject(CreateConsultantDTO.class);
     createConsultantDTO.setUsername(VALID_USERNAME);
     createConsultantDTO.setEmail(VALID_EMAILADDRESS);
@@ -188,9 +190,9 @@ public class CreateConsultantSagaIT {
     var consultantAdminResponseDTO = createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     // then
-    verify(keycloakService, times(2)).updateRole(anyString(), anyString());
-    verify(keycloakService).updateRole(anyString(), eq(CONSULTANT.getValue()));
-    verify(keycloakService).updateRole(anyString(), eq(GROUP_CHAT_CONSULTANT.getValue()));
+    verify(keycloakService)
+        .assignRoles(
+            anyString(), eq(Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue())));
 
     assertThat(consultantAdminResponseDTO.getEmbedded(), notNullValue());
     assertThat(consultantAdminResponseDTO.getEmbedded().getId(), notNullValue());

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTenantAwareIT.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +25,7 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantData;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.Licensing;
 import de.caritas.cob.userservice.tenantadminservice.generated.web.model.TenantDTO;
+import java.util.Set;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -205,9 +205,9 @@ public class CreateConsultantSagaTenantAwareIT {
         createConsultantSaga.createNewConsultant(createConsultantDTO);
 
     // then
-    verify(keycloakService, times(2)).updateRole(anyString(), anyString());
-    verify(keycloakService).updateRole(anyString(), eq(CONSULTANT.getValue()));
-    verify(keycloakService).updateRole(anyString(), eq(GROUP_CHAT_CONSULTANT.getValue()));
+    verify(keycloakService)
+        .assignRoles(
+            anyString(), eq(Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue())));
 
     assertThat(consultant.getEmbedded(), notNullValue());
     assertThat(consultant.getEmbedded().getId(), notNullValue());

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/CreateConsultantSagaTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -33,6 +34,7 @@ import de.caritas.cob.userservice.api.helper.UserHelper;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.port.out.identity.CreatedIdentity;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.ConsultantPublicSlugService;
@@ -68,6 +70,7 @@ class CreateConsultantSagaTest {
   @InjectMocks private CreateConsultantSaga createConsultantSaga;
 
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private ConsultantPublicSlugService consultantPublicSlugService;
   @Mock private ConsultantService consultantService;
@@ -112,7 +115,7 @@ class CreateConsultantSagaTest {
     assertThat(response, notNullValue());
     assertThat(response.getEmbedded(), notNullValue());
     assertThat(response.getEmbedded().getId(), is(KEYCLOAK_USER_ID));
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
+    verify(identityRoleUpdater).assignRoles(KEYCLOAK_USER_ID, Set.of(CONSULTANT.getValue()));
     verify(appointmentService, never()).createConsultant(any());
   }
 
@@ -230,7 +233,7 @@ class CreateConsultantSagaTest {
         () -> createConsultantSaga.createNewConsultant(validCreateConsultantDto()));
 
     verify(rollbackFacade).rollbackConsultantAccount(any(Consultant.class));
-    verify(identityClient, never()).updateRole(anyString(), anyString());
+    verify(identityRoleUpdater, never()).assignRoles(anyString(), anyCollection());
   }
 
   @Test
@@ -238,8 +241,8 @@ class CreateConsultantSagaTest {
       throws Exception {
     stubKeycloakUserCreation();
     doThrow(new RuntimeException("role update failed"))
-        .when(identityClient)
-        .updateRole(anyString(), anyString());
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), anyCollection());
 
     assertThrows(
         DistributedTransactionException.class,
@@ -283,8 +286,9 @@ class CreateConsultantSagaTest {
 
     createConsultantSaga.createNewConsultant(dto);
 
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, CONSULTANT.getValue());
-    verify(identityClient).updateRole(KEYCLOAK_USER_ID, GROUP_CHAT_CONSULTANT.getValue());
+    verify(identityRoleUpdater)
+        .assignRoles(
+            KEYCLOAK_USER_ID, Set.of(CONSULTANT.getValue(), GROUP_CHAT_CONSULTANT.getValue()));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
@@ -175,7 +175,8 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
     verify(this.keycloakService, Mockito.never())
-        .updateRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+        .ensureRoles(
+            consultant.getId(), java.util.Set.of(UserRole.GROUP_CHAT_CONSULTANT.getValue()));
     verify(this.keycloakService, Mockito.never())
         .removeRoleIfPresent(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
 
@@ -216,7 +217,7 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant(consultant.getId(), updateConsultant, false);
 
     verify(this.keycloakService, Mockito.never()).updateProfile(any(), any());
-    verify(this.keycloakService, Mockito.never()).updateRole(any(), any(String.class));
+    verify(this.keycloakService, Mockito.never()).ensureRoles(any(), any());
     verify(this.keycloakService, Mockito.never()).removeRoleIfPresent(any(), any());
     verify(this.appointmentService, Mockito.never()).syncConsultantData(any());
     verify(this.consultantPublicSlugService).requestSlug(consultant, "nikunnj-rohit");
@@ -236,7 +237,8 @@ public class ConsultantUpdateServiceTest {
     this.consultantUpdateService.updateConsultant("", updateConsultant);
 
     verify(this.keycloakService)
-        .updateRole(consultant.getId(), UserRole.GROUP_CHAT_CONSULTANT.getValue());
+        .ensureRoles(
+            consultant.getId(), java.util.Set.of(UserRole.GROUP_CHAT_CONSULTANT.getValue()));
 
     verify(this.keycloakService, times(1))
         .updateProfile(eq(consultant.getId()), any(IdentityProfileUpdate.class));

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeMatrixUserTest.java
@@ -30,6 +30,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityAccountRemover;
 import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
@@ -59,6 +60,7 @@ class CreateUserFacadeMatrixUserTest {
 
   @Mock private UserVerifier userVerifier;
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityAccountRemover identityAccountRemover;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private IdentityDummyEmailUpdater identityDummyEmailUpdater;

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -258,7 +258,8 @@ public class CreateUserFacadeTest {
     createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
     TenantContext.clear();
     verify(identityClient, times(1)).createUser(any(UserDTO.class));
-    verify(identityRoleUpdater, times(1)).assignRoles(any(), eq(List.of(UserRole.USER.getValue())));
+    verify(identityRoleUpdater, times(1))
+        .assignRoles(eq(USER_ID), eq(List.of(UserRole.USER.getValue())));
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
     verify(createNewSessionFacade, times(1))
         .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
@@ -278,7 +279,8 @@ public class CreateUserFacadeTest {
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, USER_DTO_SUCHT, UserRole.USER);
 
-    verify(identityRoleUpdater, times(1)).assignRoles(any(), eq(List.of(UserRole.USER.getValue())));
+    verify(identityRoleUpdater, times(1))
+        .assignRoles(eq(USER_ID), eq(List.of(UserRole.USER.getValue())));
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -259,7 +258,7 @@ public class CreateUserFacadeTest {
     createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
     TenantContext.clear();
     verify(identityClient, times(1)).createUser(any(UserDTO.class));
-    verify(identityRoleUpdater, times(1)).assignRoles(any(), anyCollection());
+    verify(identityRoleUpdater, times(1)).assignRoles(any(), eq(List.of(UserRole.USER.getValue())));
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
     verify(createNewSessionFacade, times(1))
         .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
@@ -279,7 +278,7 @@ public class CreateUserFacadeTest {
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, USER_DTO_SUCHT, UserRole.USER);
 
-    verify(identityRoleUpdater, times(1)).assignRoles(any(), anyCollection());
+    verify(identityRoleUpdater, times(1)).assignRoles(any(), eq(List.of(UserRole.USER.getValue())));
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
   }
 
@@ -304,7 +303,9 @@ public class CreateUserFacadeTest {
   public void
       updateIdentityAndCreateAccount_Should_AbortBeforeDatabaseWrite_When_RoleUpdateFails() {
     RuntimeException identityFailure = new RuntimeException("role update failed");
-    doThrow(identityFailure).when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
+    doThrow(identityFailure)
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), eq(List.of(UserRole.USER.getValue())));
 
     RuntimeException propagated =
         assertThrows(
@@ -323,7 +324,9 @@ public class CreateUserFacadeTest {
     PlainCredentialsHolder.set("plain-user", "plain-password");
     when(identityClient.createUser(any())).thenReturn(CREATED_IDENTITY_WITH_USER_ID);
     RuntimeException identityFailure = new RuntimeException("role update failed");
-    doThrow(identityFailure).when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
+    doThrow(identityFailure)
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), eq(List.of(UserRole.USER.getValue())));
 
     RuntimeException propagated =
         assertThrows(
@@ -682,7 +685,7 @@ public class CreateUserFacadeTest {
       updateIdentityAndCreateAccount_Should_ThrowInternalServerError_When_KeycloakFailsForAnonymousUser() {
     doThrow(new RuntimeException("kc down"))
         .when(identityRoleUpdater)
-        .assignRoles(anyString(), anyCollection());
+        .assignRoles(anyString(), eq(List.of(UserRole.ANONYMOUS.getValue())));
 
     assertThrows(
         InternalServerErrorException.class,
@@ -718,7 +721,9 @@ public class CreateUserFacadeTest {
   void updateIdentityAndCreateAccount_Should_CallUpdateDummyEmail_When_EmailIsBlank() {
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
-    doNothing().when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
+    doNothing()
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), eq(List.of(UserRole.USER.getValue())));
     doNothing()
         .when(identityPasswordUpdater)
         .updatePassword(anyString(), org.mockito.ArgumentMatchers.nullable(String.class));

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateUserFacadeTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -52,6 +53,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityClient;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdate;
 import de.caritas.cob.userservice.api.port.out.IdentityDummyEmailUpdater;
 import de.caritas.cob.userservice.api.port.out.IdentityPasswordUpdater;
+import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ApplicationSettingsService;
 import de.caritas.cob.userservice.api.service.consultingtype.TopicService;
@@ -83,6 +85,7 @@ public class CreateUserFacadeTest {
 
   @InjectMocks private CreateUserFacade createUserFacade;
   @Mock private IdentityClient identityClient;
+  @Mock private IdentityRoleUpdater identityRoleUpdater;
   @Mock private IdentityAccountRemover identityAccountRemover;
   @Mock private IdentityPasswordUpdater identityPasswordUpdater;
   @Mock private IdentityDummyEmailUpdater identityDummyEmailUpdater;
@@ -256,7 +259,7 @@ public class CreateUserFacadeTest {
     createUserFacade.createUserAccountWithInitializedConsultingType(USER_DTO_KREUZBUND);
     TenantContext.clear();
     verify(identityClient, times(1)).createUser(any(UserDTO.class));
-    verify(identityClient, times(1)).updateRole(any(), any(UserRole.class));
+    verify(identityRoleUpdater, times(1)).assignRoles(any(), anyCollection());
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
     verify(createNewSessionFacade, times(1))
         .initializeNewSession(any(), any(), any(ExtendedConsultingTypeResponseDTO.class));
@@ -276,7 +279,7 @@ public class CreateUserFacadeTest {
 
     createUserFacade.updateIdentityAndCreateAccount(USER_ID, USER_DTO_SUCHT, UserRole.USER);
 
-    verify(identityClient, times(1)).updateRole(any(), any(UserRole.class));
+    verify(identityRoleUpdater, times(1)).assignRoles(any(), anyCollection());
     verify(identityPasswordUpdater, times(1)).updatePassword(anyString(), anyString());
   }
 
@@ -301,7 +304,7 @@ public class CreateUserFacadeTest {
   public void
       updateIdentityAndCreateAccount_Should_AbortBeforeDatabaseWrite_When_RoleUpdateFails() {
     RuntimeException identityFailure = new RuntimeException("role update failed");
-    doThrow(identityFailure).when(identityClient).updateRole(anyString(), any(UserRole.class));
+    doThrow(identityFailure).when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
 
     RuntimeException propagated =
         assertThrows(
@@ -320,7 +323,7 @@ public class CreateUserFacadeTest {
     PlainCredentialsHolder.set("plain-user", "plain-password");
     when(identityClient.createUser(any())).thenReturn(CREATED_IDENTITY_WITH_USER_ID);
     RuntimeException identityFailure = new RuntimeException("role update failed");
-    doThrow(identityFailure).when(identityClient).updateRole(anyString(), any(UserRole.class));
+    doThrow(identityFailure).when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
 
     RuntimeException propagated =
         assertThrows(
@@ -678,8 +681,8 @@ public class CreateUserFacadeTest {
   void
       updateIdentityAndCreateAccount_Should_ThrowInternalServerError_When_KeycloakFailsForAnonymousUser() {
     doThrow(new RuntimeException("kc down"))
-        .when(identityClient)
-        .updateRole(anyString(), any(UserRole.class));
+        .when(identityRoleUpdater)
+        .assignRoles(anyString(), anyCollection());
 
     assertThrows(
         InternalServerErrorException.class,
@@ -715,7 +718,7 @@ public class CreateUserFacadeTest {
   void updateIdentityAndCreateAccount_Should_CallUpdateDummyEmail_When_EmailIsBlank() {
     when(consultingTypeManager.getConsultingTypeSettings(any()))
         .thenReturn(CONSULTING_TYPE_SETTINGS_KREUZBUND);
-    doNothing().when(identityClient).updateRole(anyString(), any(UserRole.class));
+    doNothing().when(identityRoleUpdater).assignRoles(anyString(), anyCollection());
     doNothing()
         .when(identityPasswordUpdater)
         .updatePassword(anyString(), org.mockito.ArgumentMatchers.nullable(String.class));

--- a/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
+++ b/src/test/java/de/caritas/cob/userservice/api/testConfig/KeycloakTestConfig.java
@@ -116,15 +116,6 @@ public class KeycloakTestConfig {
       }
 
       @Override
-      public void updateUserRole(String userId) {}
-
-      @Override
-      public void updateRole(String userId, UserRole role) {}
-
-      @Override
-      public void updateRole(String userId, String roleName) {}
-
-      @Override
       public void removeRoleIfPresent(String userId, String roleName) {}
 
       @Override

--- a/tests/ci/test_module_boundaries.py
+++ b/tests/ci/test_module_boundaries.py
@@ -137,6 +137,26 @@ class ModuleBoundaryContractTest(unittest.TestCase):
                 f"IdentityClient must not expose {forbidden}; use IdentityRoleLookup",
             )
 
+    def test_broad_identity_client_does_not_carry_role_assignment_commands(self):
+        """Role assignment is one batched call on a focused port.
+
+        The broad client offered `updateUserRole` and two `updateRole` overloads,
+        so provisioning issued one Keycloak round trip per configured role and the
+        request count grew with the role list.
+        """
+        identity_client = (
+            ROOT / "src/main/java/de/caritas/cob/userservice/api/port/out/IdentityClient.java"
+        )
+        source = identity_client.read_text()
+
+        for forbidden in ("updateUserRole", "updateRole"):
+            self.assertNotIn(
+                forbidden,
+                source,
+                f"IdentityClient must not expose {forbidden}; "
+                "use IdentityRoleUpdater#assignRoles",
+            )
+
     def test_session_module_depends_on_ports_not_chat_adapters(self):
         session_module = (
             ROOT


### PR DESCRIPTION
Replay of #806 directly onto `pre-dev`. The original targets `refactor/batch-identity-role-assignment-803`, whose PR (#804) was closed.

## Change

Provisioning issued **one Keycloak round trip per configured role**, so request volume grew with the role list. `IdentityRoleUpdater` gains an explicit `assignRoles(userId, Collection<String>)`, the four remaining writers use it, and all three role-assignment commands (`updateUserRole`, both `updateRole` overloads) leave the broad `IdentityClient`.

## Written to pre-dev's shape, not copied

Two places where a verbatim port would have been wrong:

- **`pre-dev` wraps every role write in a bounded admin-session refresh** (`NotAuthorizedException` → `refreshAdminSession` → retry once) that #806's base did not have. `assignRoles` is written with that same wrapper — copying the original would have silently dropped it from the batch path.
- **`AskerImportService` no longer calls `updateUserRole`** on `pre-dev`, so the original's changes there had nothing to apply to.

## The tests reflect the batching rather than being loosened to fit

Where a test previously verified two separate per-role calls, it now verifies **one call carrying both roles, with the exact collection**:

- `CreateAdminService` passes an ordered `List` → `eq(List.of(..))`
- `CreateConsultantSaga` passes a `Set` → `eq(Set.of(..))`, exact contents, order-independent

Assertions that were *already* role-agnostic (`any(UserRole.class)`) became `anyCollection()` — same strength, not less.

`KeycloakServiceTest`'s adapter tests are **kept and renamed**: they cover the write path and its retry, which is precisely the behaviour this moves. The shared `KeycloakTestConfig` double drops three overrides whose methods no longer exist and inherits the real batch implementation.

## Ratchet

`IdentityClient` may not expose `updateUserRole` or `updateRole`. Confirmed it bites — re-adding one fails the test, reverting passes.

## Verification

- `./mvnw clean test` → **3,954 unit tests, 0 failures, 0 errors**
- CI contracts → **98 tests, OK**
- Spotless clean

Refs #805, parent #335. Supersedes #806.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * User roles can now be assigned in batches, reducing duplicate updates.
  * Empty or duplicate role lists are handled safely.
  * Authorization failures automatically trigger a session refresh and one retry.
  * User, admin, and consultant creation or updates apply required roles in a single operation.
  * Role assignment now detects missing roles more reliably.

* **Tests**
  * Expanded coverage for bulk assignment, retries, failures, and rollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->