### PR TITLE
fix: keep case handover reasons staff-only

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -64,6 +64,29 @@ public class CaseHandoverService {
   private static final String OUTCOME_NOT_REQUESTED = "NOT_REQUESTED";
 
   /**
+   * Client-safe handover text deliberately carries no reason-derived wording. The internal policy
+   * reason may describe illness, absence, emergencies, or staffing changes and therefore must stay
+   * on staff and audit surfaces. Unknown languages deliberately fall back to German; every
+   * currently supported language has an explicit entry.
+   */
+  private static final Map<String, String> CLIENT_SAFE_HANDOVER_TEMPLATES =
+      Map.of(
+          "de",
+          "{{newAdvisor}} hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.",
+          "en",
+          "{{newAdvisor}} has taken over your case and will continue your counselling from now on.",
+          "fr",
+          "{{newAdvisor}} a repris votre dossier et poursuivra désormais votre accompagnement.",
+          "ru",
+          "{{newAdvisor}} принял(а) ваше дело и с этого момента продолжит консультирование.",
+          "tr",
+          "{{newAdvisor}} vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.",
+          "uk",
+          "{{newAdvisor}} перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.",
+          "ti",
+          "{{newAdvisor}} ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።");
+
+  /**
    * Default client-facing notification templates per reason and language (de/en/tr/uk). Source:
    * vault doc "Case Handover — System-Benachrichtigungen & Rechtstexte (Entwurf)"; tr/uk are
    * machine-drafted pending native review. {@code {{newAdvisor}}} is substituted at send time.
@@ -739,7 +762,7 @@ public class CaseHandoverService {
     Session session = request.getSession();
     Consultant requester = request.getRequesterConsultant();
     String requesterName = resolveConsultantName(requester);
-    String clientDescription = postGrantedChatSystemMessage(request, session, requesterName);
+    String clientDescription = postGrantedChatSystemMessage(session, requesterName);
     // #1010 task 1a: the explanation is counsellor-written free text that can reference case
     // content. It is no longer copied into the notification, which kept it in plaintext for good;
     // the handover-request API serves it on demand instead.
@@ -756,9 +779,7 @@ public class CaseHandoverService {
           "case.handover.granted",
           EventNotificationService.CATEGORY_SYSTEM,
           "New counsellor took over your case",
-          isBlank(clientDescription)
-              ? String.format("%s took over your case.", requesterName)
-              : clientDescription,
+          clientDescription,
           clientParams,
           buildAskerSessionActionPath(session),
           session.getId(),
@@ -786,11 +807,10 @@ public class CaseHandoverService {
    * Posts the designed in-chat system notification ("new counsellor took over your case") into the
    * session's Matrix room. Emission failures must never fail the handover itself.
    */
-  private String postGrantedChatSystemMessage(
-      CaseHandoverRequest request, Session session, String requesterName) {
+  private String postGrantedChatSystemMessage(Session session, String requesterName) {
     String description = null;
     try {
-      description = resolveClientNotificationDescription(request, requesterName);
+      description = resolveClientNotificationDescription(session, requesterName);
       matrixSessionSystemMessageService.postCaseHandoverGrantedMessage(
           session, requesterName, description);
     } catch (RuntimeException exception) {
@@ -802,24 +822,11 @@ public class CaseHandoverService {
     return description;
   }
 
-  private String resolveClientNotificationDescription(
-      CaseHandoverRequest request, String requesterName) {
-    var reasonCode = normalizeReasonCode(request.getReasonCode());
-    Map<String, String> templates =
-        caseHandoverReasonPolicyRepository
-            .findById(reasonCode)
-            .map(CaseHandoverReasonPolicy::getClientNotificationTemplates)
-            .filter(map -> map != null && !map.isEmpty())
-            .orElseGet(() -> DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get(reasonCode));
-    if (templates == null || templates.isEmpty()) {
-      return null;
-    }
-    var language = resolveSessionLanguage(request.getSession());
+  private String resolveClientNotificationDescription(Session session, String requesterName) {
+    var language = resolveSessionLanguage(session);
     var template =
-        templates.getOrDefault(
-            language,
-            templates.getOrDefault(
-                "de", templates.getOrDefault("en", templates.values().iterator().next())));
+        CLIENT_SAFE_HANDOVER_TEMPLATES.getOrDefault(
+            language, CLIENT_SAFE_HANDOVER_TEMPLATES.get("de"));
     return template.replace("{{newAdvisor}}", requesterName);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -63,28 +63,63 @@ public class CaseHandoverService {
   private static final String OUTCOME_ALREADY_ANSWERED = "ALREADY_ANSWERED";
   private static final String OUTCOME_NOT_REQUESTED = "NOT_REQUESTED";
 
+  private record ClientHandoverCopy(
+      String grantedTitle,
+      String grantedDescription,
+      String pendingTitle,
+      String pendingDescription) {}
+
   /**
-   * Client-safe handover text deliberately carries no reason-derived wording. The internal policy
-   * reason may describe illness, absence, emergencies, or staffing changes and therefore must stay
-   * on staff and audit surfaces. Unknown languages deliberately fall back to German; every
-   * currently supported language has an explicit entry.
+   * Built-in client-safe copy used until the tenant-scoped effective policy cache in
+   * ORISO-UserService#201 becomes the canonical source. No entry contains reason-derived wording;
+   * internal illness, absence, emergency, and staffing details stay on staff and audit surfaces.
+   * Unknown languages deliberately fall back to German, while every currently supported language
+   * has an explicit entry. fr/ru/tr/uk/ti copy requires native-speaker review before final release.
    */
-  private static final Map<String, String> CLIENT_SAFE_HANDOVER_TEMPLATES =
+  private static final Map<String, ClientHandoverCopy> CLIENT_SAFE_HANDOVER_COPY =
       Map.of(
           "de",
-          "{{newAdvisor}} hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.",
+          new ClientHandoverCopy(
+              "Neue Beratungsperson hat deinen Fall übernommen",
+              "{{newAdvisor}} hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.",
+              "Zugriffsanfrage einer Beratungsperson",
+              "{{newAdvisor}} bittet um Zugriff auf deinen Fall. Deine Zustimmung ist erforderlich."),
           "en",
-          "{{newAdvisor}} has taken over your case and will continue your counselling from now on.",
+          new ClientHandoverCopy(
+              "New counsellor took over your case",
+              "{{newAdvisor}} has taken over your case and will continue your counselling from now on.",
+              "Counsellor access request",
+              "{{newAdvisor}} requested access to your case. Your consent is required."),
           "fr",
-          "{{newAdvisor}} a repris votre dossier et poursuivra désormais votre accompagnement.",
+          new ClientHandoverCopy(
+              "Un nouveau conseiller ou une nouvelle conseillère a repris votre dossier",
+              "{{newAdvisor}} a repris votre dossier et poursuivra désormais votre accompagnement.",
+              "Demande d’accès d’un conseiller ou d’une conseillère",
+              "{{newAdvisor}} demande l’accès à votre dossier. Votre consentement est requis."),
           "ru",
-          "{{newAdvisor}} принял(а) ваше дело и с этого момента продолжит консультирование.",
+          new ClientHandoverCopy(
+              "Новый консультант принял ваше дело",
+              "{{newAdvisor}} принял(а) ваше дело и с этого момента продолжит консультирование.",
+              "Запрос консультанта на доступ",
+              "{{newAdvisor}} запросил(а) доступ к вашему делу. Требуется ваше согласие."),
           "tr",
-          "{{newAdvisor}} vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.",
+          new ClientHandoverCopy(
+              "Yeni bir danışman vakanızı devraldı",
+              "{{newAdvisor}} vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.",
+              "Danışman erişim talebi",
+              "{{newAdvisor}} vakanıza erişim istedi. Onayınız gerekiyor."),
           "uk",
-          "{{newAdvisor}} перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.",
+          new ClientHandoverCopy(
+              "Новий консультант перейняв вашу справу",
+              "{{newAdvisor}} перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.",
+              "Запит консультанта на доступ",
+              "{{newAdvisor}} запитує доступ до вашої справи. Потрібна ваша згода."),
           "ti",
-          "{{newAdvisor}} ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።");
+          new ClientHandoverCopy(
+              "ሓድሽ ኣማኻሪ ጉዳይካ ተረኪቡ",
+              "{{newAdvisor}} ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።",
+              "ናይ ኣማኻሪ ናይ ምእታው ሕቶ",
+              "{{newAdvisor}} ናብ ጉዳይካ ክኣቱ ሓቲቱ። ፍቓድካ የድሊ።"));
 
   /**
    * Default client-facing notification templates per reason and language (de/en/tr/uk). Source:
@@ -762,7 +797,9 @@ public class CaseHandoverService {
     Session session = request.getSession();
     Consultant requester = request.getRequesterConsultant();
     String requesterName = resolveConsultantName(requester);
-    String clientDescription = postGrantedChatSystemMessage(session, requesterName);
+    ClientHandoverCopy clientCopy = resolveClientHandoverCopy(session);
+    String clientDescription = renderClientCopy(clientCopy.grantedDescription(), requesterName);
+    postGrantedChatSystemMessage(session, requesterName, clientDescription);
     // #1010 task 1a: the explanation is counsellor-written free text that can reference case
     // content. It is no longer copied into the notification, which kept it in plaintext for good;
     // the handover-request API serves it on demand instead.
@@ -778,7 +815,7 @@ public class CaseHandoverService {
           session.getUser().getUserId(),
           "case.handover.granted",
           EventNotificationService.CATEGORY_SYSTEM,
-          "New counsellor took over your case",
+          clientCopy.grantedTitle(),
           clientDescription,
           clientParams,
           buildAskerSessionActionPath(session),
@@ -807,10 +844,9 @@ public class CaseHandoverService {
    * Posts the designed in-chat system notification ("new counsellor took over your case") into the
    * session's Matrix room. Emission failures must never fail the handover itself.
    */
-  private String postGrantedChatSystemMessage(Session session, String requesterName) {
-    String description = null;
+  private void postGrantedChatSystemMessage(
+      Session session, String requesterName, String description) {
     try {
-      description = resolveClientNotificationDescription(session, requesterName);
       matrixSessionSystemMessageService.postCaseHandoverGrantedMessage(
           session, requesterName, description);
     } catch (RuntimeException exception) {
@@ -819,14 +855,14 @@ public class CaseHandoverService {
           session.getId(),
           exception.getMessage());
     }
-    return description;
   }
 
-  private String resolveClientNotificationDescription(Session session, String requesterName) {
+  private ClientHandoverCopy resolveClientHandoverCopy(Session session) {
     var language = resolveSessionLanguage(session);
-    var template =
-        CLIENT_SAFE_HANDOVER_TEMPLATES.getOrDefault(
-            language, CLIENT_SAFE_HANDOVER_TEMPLATES.get("de"));
+    return CLIENT_SAFE_HANDOVER_COPY.getOrDefault(language, CLIENT_SAFE_HANDOVER_COPY.get("de"));
+  }
+
+  private String renderClientCopy(String template, String requesterName) {
     return template.replace("{{newAdvisor}}", requesterName);
   }
 
@@ -843,6 +879,7 @@ public class CaseHandoverService {
       return;
     }
     String requesterName = resolveConsultantName(request.getRequesterConsultant());
+    ClientHandoverCopy clientCopy = resolveClientHandoverCopy(session);
     // The request id remains so the advice seeker can answer the consent prompt. The configured
     // reason and counsellor-written explanation stay staff-only and are never copied into the
     // advice seeker's notification payload.
@@ -850,8 +887,8 @@ public class CaseHandoverService {
         session.getUser().getUserId(),
         "case.handover.consent.requested",
         EventNotificationService.CATEGORY_SYSTEM,
-        "Counsellor access request",
-        String.format("%s requested access to your case.", requesterName),
+        clientCopy.pendingTitle(),
+        renderClientCopy(clientCopy.pendingDescription(), requesterName),
         eventNotificationService.buildCaseHandoverParams(
             session, requesterName, null, null, request.getId()),
         buildAskerSessionActionPath(session) + "?caseHandoverRequestId=" + request.getId(),

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -382,7 +382,7 @@ public class CaseHandoverService {
     }
 
     if (request.getStatus() != Status.PENDING_CLIENT_CONSENT) {
-      return toStatus(request);
+      return toClientStatus(request);
     }
 
     LocalDateTime now = LocalDateTime.now();
@@ -392,7 +392,7 @@ public class CaseHandoverService {
         request.setStatus(Status.DENIED);
         request.setAuditOutcome(OUTCOME_ALREADY_ANSWERED);
         CaseHandoverRequest saved = caseHandoverRequestRepository.save(request);
-        return toStatus(saved);
+        return toClientStatus(saved);
       }
 
       request.setStatus(Status.GRANTED);
@@ -404,14 +404,14 @@ public class CaseHandoverService {
       sessionRepository.save(session);
       CaseHandoverRequest saved = caseHandoverRequestRepository.save(request);
       notifyGranted(saved);
-      return toStatus(saved);
+      return toClientStatus(saved);
     }
 
     request.setStatus(Status.CLIENT_CONSENT_DECLINED);
     request.setAuditOutcome(OUTCOME_CLIENT_CONSENT_DECLINED);
     CaseHandoverRequest saved = caseHandoverRequestRepository.save(request);
     notifyConsentDeclined(saved);
-    return toStatus(saved);
+    return toClientStatus(saved);
   }
 
   private Consultant retrieveCurrentConsultant() {
@@ -722,11 +722,24 @@ public class CaseHandoverService {
         .build();
   }
 
+  private CaseHandoverStatus toClientStatus(CaseHandoverRequest request) {
+    return CaseHandoverStatus.builder()
+        .requestId(request.getId())
+        .sessionId(request.getSession().getId())
+        .status(request.getStatus().name())
+        .canViewContent(request.getStatus() == Status.GRANTED)
+        .clientConsentRequired(Boolean.TRUE.equals(request.getClientConsentRequired()))
+        .auditOutcome(request.getAuditOutcome())
+        .createdAt(request.getCreatedAt())
+        .resolvedAt(request.getResolvedAt())
+        .build();
+  }
+
   private void notifyGranted(CaseHandoverRequest request) {
     Session session = request.getSession();
     Consultant requester = request.getRequesterConsultant();
     String requesterName = resolveConsultantName(requester);
-    postGrantedChatSystemMessage(request, session, requesterName);
+    String clientDescription = postGrantedChatSystemMessage(request, session, requesterName);
     // #1010 task 1a: the explanation is counsellor-written free text that can reference case
     // content. It is no longer copied into the notification, which kept it in plaintext for good;
     // the handover-request API serves it on demand instead.
@@ -735,14 +748,18 @@ public class CaseHandoverService {
             session, requesterName, request.getReasonCode(), request.getReasonLabel(), null);
 
     if (session.getUser() != null && session.getUser().getUserId() != null) {
+      String clientParams =
+          eventNotificationService.buildCaseHandoverParams(
+              session, requesterName, null, null, null);
       eventNotificationService.createEvent(
           session.getUser().getUserId(),
           "case.handover.granted",
           EventNotificationService.CATEGORY_SYSTEM,
           "New counsellor took over your case",
-          String.format(
-              "%s took over your case. Reason: %s", requesterName, request.getReasonLabel()),
-          params,
+          isBlank(clientDescription)
+              ? String.format("%s took over your case.", requesterName)
+              : clientDescription,
+          clientParams,
           buildAskerSessionActionPath(session),
           session.getId(),
           session.getTenantId());
@@ -769,18 +786,20 @@ public class CaseHandoverService {
    * Posts the designed in-chat system notification ("new counsellor took over your case") into the
    * session's Matrix room. Emission failures must never fail the handover itself.
    */
-  private void postGrantedChatSystemMessage(
+  private String postGrantedChatSystemMessage(
       CaseHandoverRequest request, Session session, String requesterName) {
+    String description = null;
     try {
-      var description = resolveClientNotificationDescription(request, requesterName);
+      description = resolveClientNotificationDescription(request, requesterName);
       matrixSessionSystemMessageService.postCaseHandoverGrantedMessage(
-          session, requesterName, request.getReasonLabel(), request.getExplanation(), description);
+          session, requesterName, description);
     } catch (RuntimeException exception) {
       log.warn(
           "Case-handover system message for session {} could not be posted: {}",
           session.getId(),
           exception.getMessage());
     }
+    return description;
   }
 
   private String resolveClientNotificationDescription(
@@ -817,22 +836,17 @@ public class CaseHandoverService {
       return;
     }
     String requesterName = resolveConsultantName(request.getRequesterConsultant());
-    // #1010 task 1a: no explanation free text in the stored notification — the client reads it
-    // from the handover request itself, which the action path and params already point at.
+    // The request id remains so the advice seeker can answer the consent prompt. The configured
+    // reason and counsellor-written explanation stay staff-only and are never copied into the
+    // advice seeker's notification payload.
     eventNotificationService.createEvent(
         session.getUser().getUserId(),
         "case.handover.consent.requested",
         EventNotificationService.CATEGORY_SYSTEM,
         "Counsellor access request",
-        String.format(
-            "%s requested access to your case. Reason: %s",
-            requesterName, request.getReasonLabel()),
+        String.format("%s requested access to your case.", requesterName),
         eventNotificationService.buildCaseHandoverParams(
-            session,
-            requesterName,
-            request.getReasonCode(),
-            request.getReasonLabel(),
-            request.getId()),
+            session, requesterName, null, null, request.getId()),
         buildAskerSessionActionPath(session) + "?caseHandoverRequestId=" + request.getId(),
         session.getId(),
         session.getTenantId());

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageService.java
@@ -71,16 +71,10 @@ public class MatrixSessionSystemMessageService {
    *
    * @param session the handed-over session (room + participants)
    * @param newAdvisorName display name of the consultant who took over
-   * @param reasonLabel the selected handover reason label
-   * @param explanation the free-text explanation given by the requester
    * @param description localized client-facing template text (nullable)
    */
   public void postCaseHandoverGrantedMessage(
-      Session session,
-      String newAdvisorName,
-      String reasonLabel,
-      String explanation,
-      String description) {
+      Session session, String newAdvisorName, String description) {
     if (session == null || session.getId() == null) {
       return;
     }
@@ -93,7 +87,7 @@ public class MatrixSessionSystemMessageService {
       return;
     }
 
-    var body = buildCaseHandoverGrantedBody(newAdvisorName, reasonLabel, explanation, description);
+    var body = buildCaseHandoverGrantedBody(newAdvisorName, description);
     if (body == null) {
       return;
     }
@@ -163,8 +157,7 @@ public class MatrixSessionSystemMessageService {
     return resolveMatrixCredentials(session);
   }
 
-  private String buildCaseHandoverGrantedBody(
-      String newAdvisorName, String reasonLabel, String explanation, String description) {
+  private String buildCaseHandoverGrantedBody(String newAdvisorName, String description) {
     var payload = new java.util.LinkedHashMap<String, String>();
     payload.put("type", CASE_HANDOVER_GRANTED_TYPE);
     if (isNotBlank(newAdvisorName)) {
@@ -172,12 +165,6 @@ public class MatrixSessionSystemMessageService {
     }
     if (isNotBlank(description)) {
       payload.put("description", description);
-    }
-    if (isNotBlank(reasonLabel)) {
-      payload.put("reasonLabel", reasonLabel);
-    }
-    if (isNotBlank(explanation)) {
-      payload.put("explanation", explanation);
     }
     try {
       return SYSTEM_NOTIFICATION_PREFIX + OBJECT_MAPPER.writeValueAsString(payload);

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
@@ -44,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -156,7 +156,7 @@ class CaseHandoverServiceTest {
   }
 
   @Test
-  void requestAccess_usesOnlyLocalizedClientTemplateForAskerNotification() {
+  void requestAccess_usesOnlyGenericLocalizedTextForAskerNotification() {
     when(eventNotificationService.buildCaseHandoverParams(
             eq(session), anyString(), isNull(), isNull(), isNull()))
         .thenReturn("{\"audience\":\"asker\"}");
@@ -170,7 +170,8 @@ class CaseHandoverServiceTest {
             eq("case.handover.granted"),
             eq(EventNotificationService.CATEGORY_SYSTEM),
             anyString(),
-            contains("erkrankt"),
+            eq(
+                "Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter."),
             eq("{\"audience\":\"asker\"}"),
             anyString(),
             eq(123L),
@@ -179,8 +180,15 @@ class CaseHandoverServiceTest {
 
   @Test
   void requestAccess_keepsPendingConsentReasonOutOfAskerNotification() {
+    when(caseHandoverRequestRepository.save(any(CaseHandoverRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              CaseHandoverRequest saved = invocation.getArgument(0);
+              saved.setId(88L);
+              return saved;
+            });
     when(eventNotificationService.buildCaseHandoverParams(
-            eq(session), anyString(), isNull(), isNull(), isNull()))
+            eq(session), anyString(), isNull(), isNull(), eq(88L)))
         .thenReturn("{\"audience\":\"asker\"}");
 
     caseHandoverService.requestAccess(
@@ -197,22 +205,51 @@ class CaseHandoverServiceTest {
             anyString(),
             eq(123L),
             eq(7L));
+    verify(eventNotificationService)
+        .buildCaseHandoverParams(eq(session), anyString(), isNull(), isNull(), eq(88L));
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"de", "en", "fr", "ru", "tr", "uk", "ti"})
-  void requestAccess_providesSafeClientDescriptionForEverySupportedLanguage(String language) {
+  @CsvSource({
+    "de, 'Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.'",
+    "en, 'Requesting Counsellor has taken over your case and will continue your counselling from now on.'",
+    "fr, 'Requesting Counsellor a repris votre dossier et poursuivra désormais votre accompagnement.'",
+    "ru, 'Requesting Counsellor принял(а) ваше дело и с этого момента продолжит консультирование.'",
+    "tr, 'Requesting Counsellor vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.'",
+    "uk, 'Requesting Counsellor перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.'",
+    "ti, 'Requesting Counsellor ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።'"
+  })
+  void requestAccess_providesSafeClientDescriptionForEverySupportedLanguage(
+      String language, String expectedDescription) {
     session.setLanguageCode(LanguageCode.getByCode(language));
     ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
 
     caseHandoverService.requestAccess(
-        123L, "OTHER_EMERGENCY", "Client disclosed sensitive information.");
+        123L, "COUNSELLOR_IS_ILL", "Client disclosed sensitive information.");
 
     verify(matrixSessionSystemMessageService)
         .postCaseHandoverGrantedMessage(eq(session), anyString(), description.capture());
-    assertFalse(description.getValue().isBlank());
-    assertFalse(description.getValue().contains("Other emergency"));
-    assertFalse(description.getValue().contains("Client disclosed sensitive information"));
+    assertEquals(expectedDescription, description.getValue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "COUNSELLOR_ON_HOLIDAY",
+        "OTHER_EMERGENCY",
+        "COUNSELLOR_IS_ILL",
+        "COUNSELLOR_LEFT"
+      })
+  void requestAccess_neverDerivesClientDescriptionFromInternalReason(String reasonCode) {
+    ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
+
+    caseHandoverService.requestAccess(123L, reasonCode, "Client disclosed sensitive information.");
+
+    verify(matrixSessionSystemMessageService)
+        .postCaseHandoverGrantedMessage(eq(session), anyString(), description.capture());
+    assertEquals(
+        "Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.",
+        description.getValue());
   }
 
   /** The reason stays — it is a configured label, not free text — and moves into params. */
@@ -456,6 +493,7 @@ class CaseHandoverServiceTest {
     assertTrue(status.isCanViewContent());
     assertNull(status.getReasonCode());
     assertNull(status.getReasonLabel());
+    assertNull(status.getPolicyAuthority());
     assertEquals(requester, session.getConsultant());
     assertEquals(CaseHandoverRequest.Status.GRANTED, request.getStatus());
     assertEquals("ACCESS_GRANTED", request.getAuditOutcome());
@@ -491,6 +529,9 @@ class CaseHandoverServiceTest {
 
     assertEquals("CLIENT_CONSENT_DECLINED", status.getStatus());
     assertFalse(status.isCanViewContent());
+    assertNull(status.getReasonCode());
+    assertNull(status.getReasonLabel());
+    assertNull(status.getPolicyAuthority());
     assertEquals(previous, session.getConsultant());
     assertEquals(CaseHandoverRequest.Status.CLIENT_CONSENT_DECLINED, request.getStatus());
     assertEquals("CLIENT_CONSENT_DECLINED", request.getAuditOutcome());
@@ -510,6 +551,9 @@ class CaseHandoverServiceTest {
     assertEquals("DENIED", status.getStatus());
     assertFalse(status.isCanViewContent());
     assertEquals("ALREADY_ANSWERED", status.getAuditOutcome());
+    assertNull(status.getReasonCode());
+    assertNull(status.getReasonLabel());
+    assertNull(status.getPolicyAuthority());
     assertEquals(other, session.getConsultant());
     assertEquals(CaseHandoverRequest.Status.DENIED, request.getStatus());
     assertEquals("ALREADY_ANSWERED", request.getAuditOutcome());

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -234,6 +234,9 @@ class CaseHandoverServiceTest {
       String language, String expectedTitle, String expectedDescription) {
     session.setLanguageCode(LanguageCode.getByCode(language));
     ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
+    when(eventNotificationService.buildCaseHandoverParams(
+            eq(session), anyString(), isNull(), isNull(), isNull()))
+        .thenReturn("{\"audience\":\"asker\"}");
 
     caseHandoverService.requestAccess(
         123L, "COUNSELLOR_IS_ILL", "Client disclosed sensitive information.");
@@ -248,7 +251,39 @@ class CaseHandoverServiceTest {
             eq(EventNotificationService.CATEGORY_SYSTEM),
             eq(expectedTitle),
             eq(expectedDescription),
-            isNull(),
+            eq("{\"audience\":\"asker\"}"),
+            anyString(),
+            eq(123L),
+            eq(7L));
+    verify(eventNotificationService)
+        .buildCaseHandoverParams(eq(session), anyString(), isNull(), isNull(), isNull());
+  }
+
+  @Test
+  void requestAccess_fallsBackToGermanClientCopyWhenLanguageIsMissing() {
+    session.setLanguageCode(null);
+    when(eventNotificationService.buildCaseHandoverParams(
+            eq(session), anyString(), isNull(), isNull(), isNull()))
+        .thenReturn("{\"audience\":\"asker\"}");
+
+    caseHandoverService.requestAccess(
+        123L, "COUNSELLOR_IS_ILL", "Client disclosed sensitive information.");
+
+    verify(matrixSessionSystemMessageService)
+        .postCaseHandoverGrantedMessage(
+            eq(session),
+            eq("Requesting Counsellor"),
+            eq(
+                "Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter."));
+    verify(eventNotificationService)
+        .createEvent(
+            eq("asker"),
+            eq("case.handover.granted"),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq("Neue Beratungsperson hat deinen Fall übernommen"),
+            eq(
+                "Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter."),
+            eq("{\"audience\":\"asker\"}"),
             anyString(),
             eq(123L),
             eq(7L));

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -41,6 +43,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -151,6 +155,66 @@ class CaseHandoverServiceTest {
         "the explanation label must be gone too, not just this sample's wording");
   }
 
+  @Test
+  void requestAccess_usesOnlyLocalizedClientTemplateForAskerNotification() {
+    when(eventNotificationService.buildCaseHandoverParams(
+            eq(session), anyString(), isNull(), isNull(), isNull()))
+        .thenReturn("{\"audience\":\"asker\"}");
+
+    caseHandoverService.requestAccess(
+        123L, "COUNSELLOR_IS_ILL", "Client disclosed sensitive information.");
+
+    verify(eventNotificationService)
+        .createEvent(
+            eq("asker"),
+            eq("case.handover.granted"),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            anyString(),
+            contains("erkrankt"),
+            eq("{\"audience\":\"asker\"}"),
+            anyString(),
+            eq(123L),
+            eq(7L));
+  }
+
+  @Test
+  void requestAccess_keepsPendingConsentReasonOutOfAskerNotification() {
+    when(eventNotificationService.buildCaseHandoverParams(
+            eq(session), anyString(), isNull(), isNull(), isNull()))
+        .thenReturn("{\"audience\":\"asker\"}");
+
+    caseHandoverService.requestAccess(
+        123L, "COUNSELLOR_ASKED_FOR_ADVICE", "Client disclosed sensitive information.");
+
+    verify(eventNotificationService)
+        .createEvent(
+            eq("asker"),
+            eq("case.handover.consent.requested"),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            anyString(),
+            eq("Requesting Counsellor requested access to your case."),
+            eq("{\"audience\":\"asker\"}"),
+            anyString(),
+            eq(123L),
+            eq(7L));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"de", "en", "fr", "ru", "tr", "uk", "ti"})
+  void requestAccess_providesSafeClientDescriptionForEverySupportedLanguage(String language) {
+    session.setLanguageCode(LanguageCode.getByCode(language));
+    ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
+
+    caseHandoverService.requestAccess(
+        123L, "OTHER_EMERGENCY", "Client disclosed sensitive information.");
+
+    verify(matrixSessionSystemMessageService)
+        .postCaseHandoverGrantedMessage(eq(session), anyString(), description.capture());
+    assertFalse(description.getValue().isBlank());
+    assertFalse(description.getValue().contains("Other emergency"));
+    assertFalse(description.getValue().contains("Client disclosed sensitive information"));
+  }
+
   /** The reason stays — it is a configured label, not free text — and moves into params. */
   @Test
   void requestAccess_carriesRequesterAndReasonAsParams() {
@@ -246,8 +310,6 @@ class CaseHandoverServiceTest {
         .postCaseHandoverGrantedMessage(
             org.mockito.ArgumentMatchers.eq(session),
             org.mockito.ArgumentMatchers.anyString(),
-            org.mockito.ArgumentMatchers.eq("Other emergency"),
-            org.mockito.ArgumentMatchers.eq("Colleague is unavailable."),
             org.mockito.ArgumentMatchers.contains("deinen Fall übernommen"));
   }
 
@@ -392,6 +454,8 @@ class CaseHandoverServiceTest {
 
     assertEquals("GRANTED", status.getStatus());
     assertTrue(status.isCanViewContent());
+    assertNull(status.getReasonCode());
+    assertNull(status.getReasonLabel());
     assertEquals(requester, session.getConsultant());
     assertEquals(CaseHandoverRequest.Status.GRANTED, request.getStatus());
     assertEquals("ACCESS_GRANTED", request.getAuditOutcome());
@@ -411,8 +475,6 @@ class CaseHandoverServiceTest {
         .postCaseHandoverGrantedMessage(
             org.mockito.ArgumentMatchers.eq(session),
             org.mockito.ArgumentMatchers.eq("Requesting Counsellor"),
-            org.mockito.ArgumentMatchers.eq("Counsellor asked for advice"),
-            org.mockito.ArgumentMatchers.eq("Need a second opinion."),
             description.capture());
     assertTrue(description.getValue().contains("hat deinen Fall übernommen"));
     assertFalse(description.getValue().contains("zeitweise mitlesen"));

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -178,8 +178,19 @@ class CaseHandoverServiceTest {
             eq(7L));
   }
 
-  @Test
-  void requestAccess_keepsPendingConsentReasonOutOfAskerNotification() {
+  @ParameterizedTest
+  @CsvSource({
+    "de, 'Zugriffsanfrage einer Beratungsperson', 'Requesting Counsellor bittet um Zugriff auf deinen Fall. Deine Zustimmung ist erforderlich.'",
+    "en, 'Counsellor access request', 'Requesting Counsellor requested access to your case. Your consent is required.'",
+    "fr, 'Demande d’accès d’un conseiller ou d’une conseillère', 'Requesting Counsellor demande l’accès à votre dossier. Votre consentement est requis.'",
+    "ru, 'Запрос консультанта на доступ', 'Requesting Counsellor запросил(а) доступ к вашему делу. Требуется ваше согласие.'",
+    "tr, 'Danışman erişim talebi', 'Requesting Counsellor vakanıza erişim istedi. Onayınız gerekiyor.'",
+    "uk, 'Запит консультанта на доступ', 'Requesting Counsellor запитує доступ до вашої справи. Потрібна ваша згода.'",
+    "ti, 'ናይ ኣማኻሪ ናይ ምእታው ሕቶ', 'Requesting Counsellor ናብ ጉዳይካ ክኣቱ ሓቲቱ። ፍቓድካ የድሊ።'"
+  })
+  void requestAccess_keepsPendingConsentReasonOutOfLocalizedAskerNotification(
+      String language, String expectedTitle, String expectedDescription) {
+    session.setLanguageCode(LanguageCode.getByCode(language));
     when(caseHandoverRequestRepository.save(any(CaseHandoverRequest.class)))
         .thenAnswer(
             invocation -> {
@@ -199,8 +210,8 @@ class CaseHandoverServiceTest {
             eq("asker"),
             eq("case.handover.consent.requested"),
             eq(EventNotificationService.CATEGORY_SYSTEM),
-            anyString(),
-            eq("Requesting Counsellor requested access to your case."),
+            eq(expectedTitle),
+            eq(expectedDescription),
             eq("{\"audience\":\"asker\"}"),
             anyString(),
             eq(123L),
@@ -211,16 +222,16 @@ class CaseHandoverServiceTest {
 
   @ParameterizedTest
   @CsvSource({
-    "de, 'Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.'",
-    "en, 'Requesting Counsellor has taken over your case and will continue your counselling from now on.'",
-    "fr, 'Requesting Counsellor a repris votre dossier et poursuivra désormais votre accompagnement.'",
-    "ru, 'Requesting Counsellor принял(а) ваше дело и с этого момента продолжит консультирование.'",
-    "tr, 'Requesting Counsellor vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.'",
-    "uk, 'Requesting Counsellor перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.'",
-    "ti, 'Requesting Counsellor ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።'"
+    "de, 'Neue Beratungsperson hat deinen Fall übernommen', 'Requesting Counsellor hat deinen Fall übernommen und führt deine Beratung ab jetzt weiter.'",
+    "en, 'New counsellor took over your case', 'Requesting Counsellor has taken over your case and will continue your counselling from now on.'",
+    "fr, 'Un nouveau conseiller ou une nouvelle conseillère a repris votre dossier', 'Requesting Counsellor a repris votre dossier et poursuivra désormais votre accompagnement.'",
+    "ru, 'Новый консультант принял ваше дело', 'Requesting Counsellor принял(а) ваше дело и с этого момента продолжит консультирование.'",
+    "tr, 'Yeni bir danışman vakanızı devraldı', 'Requesting Counsellor vakanızı devraldı ve bundan sonra danışmanlığınıza devam edecek.'",
+    "uk, 'Новий консультант перейняв вашу справу', 'Requesting Counsellor перейняв(-ла) вашу справу й відтепер продовжуватиме консультування.'",
+    "ti, 'ሓድሽ ኣማኻሪ ጉዳይካ ተረኪቡ', 'Requesting Counsellor ጉዳይካ ተረኪቡ ካብ ሕጂ ንደሓር ምኽሪ ክቕጽል እዩ።'"
   })
   void requestAccess_providesSafeClientDescriptionForEverySupportedLanguage(
-      String language, String expectedDescription) {
+      String language, String expectedTitle, String expectedDescription) {
     session.setLanguageCode(LanguageCode.getByCode(language));
     ArgumentCaptor<String> description = ArgumentCaptor.forClass(String.class);
 
@@ -230,6 +241,17 @@ class CaseHandoverServiceTest {
     verify(matrixSessionSystemMessageService)
         .postCaseHandoverGrantedMessage(eq(session), anyString(), description.capture());
     assertEquals(expectedDescription, description.getValue());
+    verify(eventNotificationService)
+        .createEvent(
+            eq("asker"),
+            eq("case.handover.granted"),
+            eq(EventNotificationService.CATEGORY_SYSTEM),
+            eq(expectedTitle),
+            eq(expectedDescription),
+            isNull(),
+            anyString(),
+            eq(123L),
+            eq(7L));
   }
 
   @ParameterizedTest

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrix/MatrixSessionSystemMessageServiceTest.java
@@ -334,6 +334,33 @@ class MatrixSessionSystemMessageServiceTest {
   }
 
   @Test
+  void postCaseHandoverGrantedMessage_shouldNotExposeInternalReasonOrExplanation() {
+    // The room is shared with the advice seeker. Staff-only handover metadata must never be
+    // serialized into this client-visible event; only the approved localized description belongs
+    // here.
+    var session = sessionWithUserMatrixId(USER_MATRIX_ID, "asker.username");
+    when(matrixSynapseService.loginAsUserAccessToken(USER_MATRIX_ID)).thenReturn(ACCESS_TOKEN);
+    when(matrixSynapseService.sendMessage(anyString(), anyString(), eq(ACCESS_TOKEN)))
+        .thenReturn(Map.of("event_id", "$evt"));
+
+    matrixSessionSystemMessageService.postCaseHandoverGrantedMessage(
+        session, "New Advisor", "Deine Beratung wird jetzt von New Advisor fortgefuehrt.");
+
+    var bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(matrixSynapseService)
+        .sendMessage(eq(MATRIX_ROOM_ID), bodyCaptor.capture(), eq(ACCESS_TOKEN));
+
+    assertThat(bodyCaptor.getValue())
+        .contains("\"type\":\"CASE_HANDOVER_GRANTED\"")
+        .contains("\"username\":\"New Advisor\"")
+        .contains("Deine Beratung wird jetzt von New Advisor fortgefuehrt.")
+        .doesNotContain("reasonLabel")
+        .doesNotContain("Counsellor is ill")
+        .doesNotContain("explanation")
+        .doesNotContain("Client disclosed sensitive information");
+  }
+
+  @Test
   void postUserLeftChatMessage_shouldNotSendMessage_whenAgencyCredentialsEmpty() {
     var session = sessionWithoutHumanMatrixIds();
     when(agencyMatrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))


### PR DESCRIPTION
## Summary
- remove internal handover reason and explanation fields from client-visible Matrix events
- sanitize pending-consent and granted notifications sent to advice seekers
- omit internal reason and policy authority from client consent responses while preserving staff notifications and audit data
- cover localized client-safe notification text for all supported languages

## Reviewer test plan
1. Run the focused Matrix and case-handover service tests with JDK 21.
2. Verify the client-visible Matrix event JSON contains neither `reasonLabel` nor `explanation`.
3. Verify pending and granted advice-seeker notifications omit reason codes and labels.
4. Verify the client consent response omits reason and policy authority.
5. Verify consultant-facing status and notification paths still retain the internal reason.

Closes #1051
Related: OpenResilienceInitiative/ORISO-Frontend#1131
Parent: OpenResilienceInitiative/ORISO-E2E#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client consent statuses now display only safe, user-facing information.
  * Handover notifications include the advisor’s name and localized, reason-free descriptions in seven languages, with German fallback.
  * Pending-consent notifications retain the request ID while excluding internal reason details.

* **Bug Fixes**
  * Removed internal reason codes, labels, policy details, and explanations from client-facing messages.
  * Improved consistency and privacy of handover notifications across supported languages.
  * Handover notifications remain reliable even if posting to the messaging system fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->