### PR TITLE
fix: serve stored branding in emails

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/tenant/TenantService.java
@@ -52,6 +52,15 @@ public class TenantService {
         .getRestrictedTenantDataByTenantId(tenantId);
   }
 
+  /** Explicit platform-branding lookup; generic tenant operations still reject technical id 0. */
+  @Cacheable(cacheNames = CacheManagerConfig.TENANT_CACHE, key = "'platform-branding'")
+  public RestrictedTenantDTO getPlatformTenantData() {
+    log.info("Calling tenant service to get platform branding data");
+    return tenantServiceApiControllerFactory
+        .createControllerApi()
+        .getRestrictedTenantDataByTenantId(TenantContext.TECHNICAL_TENANT_ID);
+  }
+
   public List<RestrictedTenantDTO> getRestrictedTenantData(Set<Long> tenantIds) {
     var concreteTenantIds =
         tenantIds.stream()

--- a/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
@@ -22,9 +22,8 @@ import org.springframework.stereotype.Component;
  *   <li><b>Name</b> — tenant name → configured platform name.
  *   <li><b>Logo</b> — tenant {@code theming.logo} → tenant {@code theming.associationLogo} →
  *       configured platform logo → no image at all, in which case the layout renders the text
- *       wordmark. Only absolute {@code http(s)} URLs are accepted: the tenant theming fields may
- *       hold inline base64 images, and {@code data:} URIs are blocked by Gmail and Outlook, so a
- *       base64 logo deliberately degrades to the wordmark instead of producing a broken image.
+ *       wordmark. Stored inline images are exposed through TenantService's public HTTP asset
+ *       endpoint because mail clients block {@code data:} URIs.
  *   <li><b>Accent colour</b> — tenant {@code theming.primaryColor} → {@link
  *       EmailColors#PLATFORM_ACCENT_DARK}. Contrast-safe foregrounds are derived from it in {@link
  *       EmailBranding}, so a light theme colour never yields light-on-light text. See {@link
@@ -75,20 +74,38 @@ public class EmailBrandingResolver {
 
     return new EmailBranding(
         brandName,
-        resolveLogoUrl(theming),
+        resolveLogoUrl(tenant, theming),
         resolveAccentColor(theming),
         resolveFooterUrl(tenant, "/impressum"),
         resolveFooterUrl(tenant, "/datenschutz"));
   }
 
-  private String resolveLogoUrl(Theming theming) {
+  private String resolveLogoUrl(RestrictedTenantDTO tenant, Theming theming) {
     if (theming != null) {
       String tenantLogo = firstAbsoluteUrl(theming.getLogo(), theming.getAssociationLogo());
       if (tenantLogo != null) {
         return tenantLogo;
       }
+      if (!isBlank(theming.getLogo()) || !isBlank(theming.getAssociationLogo())) {
+        String baseUrl = resolveBrandingAssetBaseUrl(tenant);
+        if (!isBlank(baseUrl)) {
+          return baseUrl + "/service/tenant/public/branding/logo";
+        }
+      }
     }
     return firstAbsoluteUrl(platformLogoUrl);
+  }
+
+  private String resolveBrandingAssetBaseUrl(RestrictedTenantDTO tenant) {
+    if (tenant != null
+        && tenant.getId() != null
+        && !TenantContext.TECHNICAL_TENANT_ID.equals(tenant.getId())) {
+      String tenantBaseUrl = normalizeBaseUrl(tenantTemplateSupplier.getTenantBaseUrl(tenant));
+      if (!isBlank(tenantBaseUrl) && firstAbsoluteUrl(tenantBaseUrl) != null) {
+        return tenantBaseUrl;
+      }
+    }
+    return firstAbsoluteUrl(applicationBaseUrl);
   }
 
   /**
@@ -143,7 +160,7 @@ public class EmailBrandingResolver {
 
   private RestrictedTenantDTO loadTenantQuietly(Long tenantId) {
     if (tenantId == null || TenantContext.TECHNICAL_TENANT_ID.equals(tenantId)) {
-      return null;
+      return loadPlatformTenantQuietly();
     }
     try {
       return tenantService.getRestrictedTenantData(tenantId);
@@ -152,6 +169,17 @@ public class EmailBrandingResolver {
       log.debug(
           "No tenant branding available for tenantId {} ({}) — using platform branding",
           tenantId,
+          exception.getClass().getSimpleName());
+      return loadPlatformTenantQuietly();
+    }
+  }
+
+  private RestrictedTenantDTO loadPlatformTenantQuietly() {
+    try {
+      return tenantService.getPlatformTenantData();
+    } catch (RuntimeException exception) {
+      log.debug(
+          "No platform branding available ({}) — using configured fallbacks",
           exception.getClass().getSimpleName());
       return null;
     }

--- a/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
@@ -71,22 +70,33 @@ class EmailBrandingResolverTest {
         .isEqualTo("https://cdn.example.org/platform.png");
   }
 
-  /**
-   * Tenant theming may store an inline base64 image. {@code data:} URIs are blocked by Gmail and
-   * Outlook, so they must degrade to the wordmark rather than produce a broken image.
-   */
   @Test
-  void resolve_Should_ignoreBase64AndDataUriLogosAndFallBackToTheWordmark() {
-    givenNoTemplateAttributes();
+  void resolve_ShouldProxyStoredLogosThroughTheTenantsPublicBrandingEndpoint() {
     Theming base64Logo = new Theming();
     base64Logo.setLogo("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQ");
     base64Logo.setAssociationLogo("data:image/png;base64,iVBORw0KGgo=");
-    when(tenantService.getRestrictedTenantData(7L)).thenReturn(tenant("Nord", base64Logo));
+    RestrictedTenantDTO resolvedTenant = tenant("Nord", base64Logo);
+    when(tenantService.getRestrictedTenantData(7L)).thenReturn(resolvedTenant);
+    when(tenantTemplateSupplier.getTenantBaseUrl(resolvedTenant)).thenReturn("https://nord.org");
 
     EmailBranding branding = resolver("").resolve(7L);
 
-    assertThat(branding.logoUrl()).isNull();
-    assertThat(branding.hasLogo()).isFalse();
+    assertThat(branding.logoUrl())
+        .isEqualTo("https://nord.org/service/tenant/public/branding/logo");
+    assertThat(branding.hasLogo()).isTrue();
+  }
+
+  @Test
+  void resolve_ShouldUseThePlatformBrandingEndpointWhenNoTenantIsKnown() {
+    givenNoTemplateAttributes();
+    Theming platformTheming = new Theming();
+    platformTheming.setLogo("data:image/png;base64,iVBORw0KGgo=");
+    when(tenantService.getPlatformTenantData()).thenReturn(tenant("ORISO", platformTheming));
+
+    EmailBranding branding = resolver("").resolve(null);
+
+    assertThat(branding.logoUrl())
+        .isEqualTo("https://app.oriso.org/service/tenant/public/branding/logo");
   }
 
   // --- colour ---------------------------------------------------------------------------
@@ -160,12 +170,12 @@ class EmailBrandingResolverTest {
   }
 
   @Test
-  void resolve_Should_notCallTenantService_When_NoTenantIdIsKnown() {
+  void resolve_ShouldLoadPlatformBranding_When_NoTenantIdIsKnown() {
     givenNoTemplateAttributes();
 
     resolver("").resolve(null);
 
-    verifyNoInteractions(tenantService);
+    org.mockito.Mockito.verify(tenantService).getPlatformTenantData();
   }
 
   // --- footer ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- resolve platform branding when a mail has no concrete tenant
- fall back to platform branding when tenant branding lookup fails
- keep absolute logo URLs unchanged
- route stored data-URI or raw base64 logos through the public TenantService asset endpoint instead of embedding blocked data URIs

## Verification

- `EmailBrandingResolverTest` green
- full `./mvnw -q test` green
- `./mvnw -q spotless:check` green
- `git diff --check` green

## Dependency

The public logo endpoint is introduced by OpenResilienceInitiative/ORISO-TenantService#214.

Refs #914