### PR TITLE
fix(registration): reject enquiries for topics an agency does not serve

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
@@ -211,16 +211,19 @@ public class CreateSessionFacade {
    * exactly what agency search prevents by only listing agencies for the selected topic. Reject the
    * pairing here as well (ORISO-Frontend#1143).
    *
-   * <p>A registration without a main topic keeps working, and so does one where the agency lookup
-   * degraded to an unverified stub: a {@code null} topic list means "topics unknown", not "topics
-   * empty", and failing closed on missing data would take registration down with the agency
-   * service.
+   * <p>Only a known, non-empty topic list is treated as an authority. An absent or empty list means
+   * "this agency reports no topics", which is not the same statement as "this agency serves no
+   * topics": the agency lookup can degrade to an unverified stub, and a deployment that does not
+   * run topics in registration populates nothing. Enforcing on that would fail closed on missing
+   * data and take registration down with it, while adding no protection - agency search already
+   * inner-joins {@code agency_topic}, so an agency without topic rows cannot be offered to an
+   * advice seeker in the first place.
    */
   private void verifyAgencyServesMainTopic(UserDTO userDTO, AgencyDTO agencyDTO) {
     var mainTopicId = userDTO.getMainTopicId();
     var agencyTopicIds = agencyDTO.getTopicIds();
 
-    if (isNull(mainTopicId) || isNull(agencyTopicIds)) {
+    if (isNull(mainTopicId) || isNull(agencyTopicIds) || agencyTopicIds.isEmpty()) {
       return;
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateSessionFacade.java
@@ -74,6 +74,7 @@ public class CreateSessionFacade {
     }
 
     var agencyDTO = obtainVerifiedAgency(userDTO, extendedConsultingTypeResponseDTO);
+    verifyAgencyServesMainTopic(userDTO, agencyDTO);
 
     if (validationConstraints.contains(
         NewSessionValidationConstraint.ONE_SESSION_PER_TOPIC_ID_AND_AGENCY_ID)) {
@@ -201,6 +202,37 @@ public class CreateSessionFacade {
     }
 
     return agencyDTO;
+  }
+
+  /**
+   * The agency id and the main topic id reach us as two independent request fields, so a client can
+   * pair a topic with an agency that never offered it. Registration then puts the advice seeker's
+   * disclosure in front of a counselling centre that is not responsible for the subject, which is
+   * exactly what agency search prevents by only listing agencies for the selected topic. Reject the
+   * pairing here as well (ORISO-Frontend#1143).
+   *
+   * <p>A registration without a main topic keeps working, and so does one where the agency lookup
+   * degraded to an unverified stub: a {@code null} topic list means "topics unknown", not "topics
+   * empty", and failing closed on missing data would take registration down with the agency
+   * service.
+   */
+  private void verifyAgencyServesMainTopic(UserDTO userDTO, AgencyDTO agencyDTO) {
+    var mainTopicId = userDTO.getMainTopicId();
+    var agencyTopicIds = agencyDTO.getTopicIds();
+
+    if (isNull(mainTopicId) || isNull(agencyTopicIds)) {
+      return;
+    }
+
+    if (!agencyTopicIds.contains(mainTopicId)) {
+      log.warn(
+          "Rejected enquiry for agency {} with topic {}; the agency serves topics {}.",
+          agencyDTO.getId(),
+          mainTopicId,
+          agencyTopicIds);
+      throw new BadRequestException(
+          String.format("Agency %s does not serve topic %s", agencyDTO.getId(), mainTopicId));
+    }
   }
 
   private void checkIfAlreadyRegisteredToTopicAndSameAgency(

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateSessionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateSessionFacadeTest.java
@@ -3,8 +3,11 @@ package de.caritas.cob.userservice.api.facade;
 import static de.caritas.cob.userservice.api.testHelper.ExceptionConstants.INTERNAL_SERVER_ERROR_EXCEPTION;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_DTO_U25;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_ID;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_NAME;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.CITY;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.CONSULTING_TYPE_SETTINGS_SUCHT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.MESSAGE;
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.POSTCODE;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.SESSION_LIST;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.SESSION_WITHOUT_CONSULTANT;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.USER;
@@ -75,6 +78,9 @@ class CreateSessionFacadeTest {
   @Mock private AgencyPreAssignmentRoomService agencyPreAssignmentRoomService;
 
   @Mock private DirectSessionMatrixRoomService directSessionMatrixRoomService;
+
+  private static final Long TOPIC_ID_SERVED_BY_AGENCY = 3L;
+  private static final Long MAIN_TOPIC_ID_NOT_SERVED_BY_AGENCY = 1L;
 
   List<NewSessionValidationConstraint> validationConstraints =
       Lists.newArrayList(NewSessionValidationConstraint.ONE_SESSION_PER_CONSULTING_TYPE);
@@ -277,5 +283,106 @@ class CreateSessionFacadeTest {
 
     assertThat(result.getStatus(), is(HttpStatus.CREATED));
     assertThat(result.getSessionId(), is(session.getId()));
+  }
+
+  /**
+   * ORISO-Frontend#1143: an advice seeker must not be able to open an enquiry at a counselling
+   * centre that does not serve the selected topic. The agency id and the main topic id arrive as
+   * two independent request fields, so the pairing has to be verified server side.
+   */
+  @Test
+  void
+      createUserSession_Should_ThrowBadRequestAndNotPersistSession_When_AgencyDoesNotServeMainTopic() {
+    var userDto = userDtoWithMainTopic(MAIN_TOPIC_ID_NOT_SERVED_BY_AGENCY);
+    when(agencyVerifier.getVerifiedAgency(AGENCY_ID, 0))
+        .thenReturn(agencyServingTopics(TOPIC_ID_SERVED_BY_AGENCY));
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            createSessionFacade.createUserSession(
+                userDto, USER, CONSULTING_TYPE_SETTINGS_SUCHT, validationConstraints));
+
+    verify(sessionService, never()).initializeSession(any(), any(), any(Boolean.class));
+    verify(sessionService, never()).saveSession(any());
+  }
+
+  @Test
+  void createUserSession_Should_CreateSession_When_AgencyServesMainTopic() {
+    var userDto = userDtoWithMainTopic(TOPIC_ID_SERVED_BY_AGENCY);
+    when(agencyVerifier.getVerifiedAgency(AGENCY_ID, 0))
+        .thenReturn(
+            agencyServingTopics(TOPIC_ID_SERVED_BY_AGENCY, MAIN_TOPIC_ID_NOT_SERVED_BY_AGENCY));
+    when(sessionService.initializeSession(any(), any(), any(Boolean.class)))
+        .thenReturn(SESSION_WITHOUT_CONSULTANT);
+
+    var result =
+        createSessionFacade.createUserSession(
+            userDto, USER, CONSULTING_TYPE_SETTINGS_SUCHT, validationConstraints);
+
+    assertEquals(SESSION_WITHOUT_CONSULTANT.getId(), result);
+  }
+
+  @Test
+  void createUserSession_Should_CreateSession_When_RegistrationCarriesNoMainTopic() {
+    when(agencyVerifier.getVerifiedAgency(AGENCY_ID, 0))
+        .thenReturn(agencyServingTopics(TOPIC_ID_SERVED_BY_AGENCY));
+    when(sessionService.initializeSession(any(), any(), any(Boolean.class)))
+        .thenReturn(SESSION_WITHOUT_CONSULTANT);
+
+    var result =
+        createSessionFacade.createUserSession(
+            userDtoWithMainTopic(null),
+            USER,
+            CONSULTING_TYPE_SETTINGS_SUCHT,
+            validationConstraints);
+
+    assertEquals(SESSION_WITHOUT_CONSULTANT.getId(), result);
+  }
+
+  /**
+   * The agency lookup can degrade to an unverified stub (see obtainVerifiedAgency); that stub knows
+   * no topics. Registration must keep working there instead of failing closed on missing data.
+   */
+  @Test
+  void createUserSession_Should_CreateSession_When_AgencyTopicsAreUnknown() {
+    var agencyWithoutTopics = agencyServingTopics();
+    agencyWithoutTopics.setTopicIds(null);
+    when(agencyVerifier.getVerifiedAgency(AGENCY_ID, 0)).thenReturn(agencyWithoutTopics);
+    when(sessionService.initializeSession(any(), any(), any(Boolean.class)))
+        .thenReturn(SESSION_WITHOUT_CONSULTANT);
+
+    var result =
+        createSessionFacade.createUserSession(
+            userDtoWithMainTopic(MAIN_TOPIC_ID_NOT_SERVED_BY_AGENCY),
+            USER,
+            CONSULTING_TYPE_SETTINGS_SUCHT,
+            validationConstraints);
+
+    assertEquals(SESSION_WITHOUT_CONSULTANT.getId(), result);
+  }
+
+  private static UserDTO userDtoWithMainTopic(Long mainTopicId) {
+    var userDto = new UserDTO();
+    userDto.setUsername(USER_DTO_SUCHT.getUsername());
+    userDto.setPostcode(USER_DTO_SUCHT.getPostcode());
+    userDto.setAgencyId(AGENCY_ID);
+    userDto.setPassword(USER_DTO_SUCHT.getPassword());
+    userDto.setTermsAccepted("true");
+    userDto.setConsultingType("0");
+    userDto.setMainTopicId(mainTopicId);
+    return userDto;
+  }
+
+  private static AgencyDTO agencyServingTopics(Long... topicIds) {
+    return new AgencyDTO()
+        .id(AGENCY_ID)
+        .name(AGENCY_NAME)
+        .postcode(POSTCODE)
+        .city(CITY)
+        .teamAgency(false)
+        .offline(false)
+        .consultingType(0)
+        .topicIds(Lists.newArrayList(topicIds));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateSessionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateSessionFacadeTest.java
@@ -362,6 +362,28 @@ class CreateSessionFacadeTest {
     assertEquals(SESSION_WITHOUT_CONSULTANT.getId(), result);
   }
 
+  /**
+   * An empty topic list is the agency reporting nothing, not the agency declaring that it serves
+   * nothing - a deployment without topics in registration and the degraded lookup both look like
+   * this. Agency search inner-joins agency_topic, so an agency without topic rows can never be
+   * offered to an advice seeker anyway; rejecting here would only break registration.
+   */
+  @Test
+  void createUserSession_Should_CreateSession_When_AgencyReportsNoTopics() {
+    when(agencyVerifier.getVerifiedAgency(AGENCY_ID, 0)).thenReturn(agencyServingTopics());
+    when(sessionService.initializeSession(any(), any(), any(Boolean.class)))
+        .thenReturn(SESSION_WITHOUT_CONSULTANT);
+
+    var result =
+        createSessionFacade.createUserSession(
+            userDtoWithMainTopic(MAIN_TOPIC_ID_NOT_SERVED_BY_AGENCY),
+            USER,
+            CONSULTING_TYPE_SETTINGS_SUCHT,
+            validationConstraints);
+
+    assertEquals(SESSION_WITHOUT_CONSULTANT.getId(), result);
+  }
+
   private static UserDTO userDtoWithMainTopic(Long mainTopicId) {
     var userDto = new UserDTO();
     userDto.setUsername(USER_DTO_SUCHT.getUsername());


### PR DESCRIPTION
## Problem

`ORISO-Frontend#1143` (P0): a counselling centre receives requests for topics it is not configured for.

Agency search already does the right thing. `AgencyRepository.SELECT_WITH_TOPICS` joins `agency_topic` and filters on `at.topic_id = :topicId`, so `GET /service/agencies` and `GET /service/agencies/by-tenant` only ever list agencies that serve the selected topic. Verified live on Pre-Dev: agency `1` serves only topic `3`, and `?postcode=21212&topicId=1` returns `[]`.

The write path has no matching check. `agencyId` and `mainTopicId` arrive as two independent fields on `POST /users/askers/new` and `POST /users/askers/session/new`, and nothing compares them:

- `UserRegistrationControllerDelegate.validateUserHasChosenTopicIfTopicsFeatureIsEnabled` only checks that a topic is *present*.
- `AgencyVerifier.getVerifiedAgency` holds the `AgencyDTO` including `topicIds`, but only validates the *consulting type*.
- `SessionService.initializeSession` writes `agency_id` and `main_topic_id` onto the session row independently.

The session then reaches consultants purely by agency: `SessionService.retrieveRegisteredSessions` calls `findByAgencyIdInAndConsultantIsNullAndStatusAndRegistrationTypeOrderByCreateDateDesc(...)` with no topic predicate. So a mismatched pairing puts an advice seeker's disclosure in front of a counselling centre that is not responsible for the subject — a data-protection problem, not only a routing bug.

## Change

Verify the pairing in `CreateSessionFacade.createUserSession`, the single choke point both registered-enquiry endpoints pass through (`CreateUserFacade` and `UserRegistrationControllerDelegate.registerNewSession` both reach it via `CreateNewSessionFacade`). Anonymous conversations are unaffected — they carry no `agencyId` at all.

Enforced only against a **known, non-empty** topic list. `createDirectUserSession` (asker directed at a named consultant) is left alone.

## The seven integration tests that turned red — fixtures or guard?

Worth recording, because it changed the shape of the fix.

The first version of the guard also rejected an **empty** topic list, and seven `UserControllerE2EIT` registration cases went red. The guard's own log line named the cause:

```
Rejected enquiry for agency 5106534569952410475 with topic 0; the agency serves topics [].
```

`TestAgencyControllerApi.getAgenciesByIds` builds the agency with `easyRandom.nextObject(AgencyResponseDTO.class)` and never populates `topicIds`. The stub therefore **reports no topics**, which is not the same statement as **declaring that it serves none**. The fixtures are underspecified about topics, not wrong about the flow.

So: **the guard was too broad, and the fixtures were left untouched.**

Five of the seven are named `registerUserWithoutConsultingId…`, which reads like a special shape but is not — `givenAUserDTO()` delegates to `givenAUserDTO(null)`, so "without consulting id" means *without a **consultant** id*: the ordinary agency-routed registration, exactly the path this guard exists to protect. The cases that do pass a consultant id stayed green throughout, because they run through `createDirectUserSession`. The naming points at the mainstream path, not at an exemption, so editing those fixtures to a matching pair would have papered over a real over-reach.

Empty is now treated like absent, for reasons that hold outside the tests too:

- `obtainVerifiedAgency`'s 401/403 fallback builds an unverified stub with no topics; failing closed there would take registration down with the agency service.
- A deployment that does not run topics in registration populates nothing either.
- It costs no protection: agency search inner-joins `agency_topic`, so a topic-less agency can never be offered to an advice seeker in the first place.

The reported defect — an agency configured for one topic receiving an enquiry for another — is still rejected, because that list is non-empty and does not contain the topic.

## Test plan

- [ ] `./mvnw verify` — **unit 3983/3983 and integration 895/895 green** (verified locally; the integration phase needs Redis on `localhost:6379`, otherwise ~22 unrelated `AvailabilityStore Live-chat availability store operation failed` errors appear).
- [ ] `./mvnw -Dtest=CreateSessionFacadeTest test` — 15 tests green.
- [ ] Mutation check: comment out the `verifyAgencyServesMainTopic(...)` call; `createUserSession_Should_ThrowBadRequestAndNotPersistSession_When_AgencyDoesNotServeMainTopic` must fail with "Expected BadRequestException to be thrown, but nothing was thrown".
- [ ] On Pre-Dev after deploy: pick an agency serving only topic 3 and `POST /service/users/askers/session/new` with `mainTopicId: 1` — expect `400`, and no new row in `userservice.session`.
- [ ] Regression: a normal registration where the agency does serve the chosen topic still yields `201` and an enquiry in that agency's consultant list.

Pairs with the frontend change in OpenResilienceInitiative/ORISO-Frontend#1145, which stops the client from producing the mismatched pairing in the first place.

Closes OpenResilienceInitiative/ORISO-Frontend#1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)