### PR TITLE
The layout owns the invite action link, the body must not carry it

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -30,6 +30,7 @@ import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -508,7 +509,7 @@ public class AccountInviteService {
     // the public Admin route, everyone else accepts on the public App route.
     String acceptUrl = inviteAcceptUrlBuilder.buildAcceptUrl(invite.getTargetRole(), rawToken);
     String subject = render(template.getSubject(), invite, acceptUrl);
-    String body = render(template.getBody(), invite, acceptUrl);
+    String body = renderBody(template.getBody(), invite, acceptUrl);
 
     InviteMailSendReceipt receipt;
     try {
@@ -654,6 +655,49 @@ public class AccountInviteService {
       return 20;
     }
     return Math.min(size, 100);
+  }
+
+  /** The action-link token standing alone on its own line, including that line's break. */
+  private static final Pattern ACTION_LINK_TOKEN_LINE =
+      Pattern.compile("(?m)^[ \\t]*\\{\\{inviteLink\\}\\}[ \\t]*(\\r?\\n)?");
+
+  /** A run of three or more line breaks, left behind when a token line is lifted out. */
+  private static final Pattern BLANK_LINE_RUN = Pattern.compile("(\\r?\\n){3,}");
+
+  /** The action-link token sitting inside a sentence, with the space in front of it. */
+  private static final Pattern ACTION_LINK_TOKEN_INLINE =
+      Pattern.compile("[ \\t]*\\{\\{inviteLink\\}\\}");
+
+  /**
+   * Renders a template <em>body</em>. Same substitution as {@link #render}, minus the action link.
+   *
+   * <p>The branded layout renders the invite link itself — as a CTA button and, underneath it, a
+   * visible copy-paste line carrying the plain URL (in the HTML part and in the text/plain
+   * alternative alike). A body that <em>also</em> inlined {@code {{inviteLink}}} therefore produced
+   * the same URL twice in the received mail, which is what the annotated screenshots show. The
+   * layout owns the action link; the body must not carry it.
+   *
+   * <p>Enforcing it here rather than in the composer is deliberate: the send path and the Admin
+   * preview share this code, so an author cannot compose a mail whose link is duplicated, and
+   * templates saved before this rule existed — including the shipped default — are repaired on
+   * render instead of needing a migration.
+   *
+   * <p>Removal is line-aware. A token alone on its line takes the line with it, so the sentence
+   * that introduced it runs straight into the button. A token inside a sentence takes the space in
+   * front of it, leaving the author's own wording otherwise untouched: {@code "Hier: {{inviteLink}}
+   * — viel Erfolg"} becomes {@code "Hier: — viel Erfolg"}. The dangling colon is the author's text
+   * and is not invented away.
+   */
+  public static String renderBody(String value, AccountInvite invite, String acceptUrl) {
+    if (value == null) {
+      return "";
+    }
+    String withoutActionLink = ACTION_LINK_TOKEN_LINE.matcher(value).replaceAll("");
+    withoutActionLink = ACTION_LINK_TOKEN_INLINE.matcher(withoutActionLink).replaceAll("");
+    // Lifting a line out of "text\n\n{{inviteLink}}\n\ntext" would otherwise leave a
+    // triple break — a visible hole exactly where the link used to be.
+    withoutActionLink = BLANK_LINE_RUN.matcher(withoutActionLink).replaceAll("\n\n");
+    return render(withoutActionLink, invite, acceptUrl);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailPreviewService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailPreviewService.java
@@ -33,9 +33,9 @@ public class InviteEmailPreviewService {
   /** Obvious non-token: a preview must never render something that looks like a live link. */
   static final String SAMPLE_TOKEN = "SAMPLE-PREVIEW-TOKEN";
 
-  static final String SAMPLE_EMAIL = "erika.musterfrau@example.org";
-  static final String SAMPLE_FIRST_NAME = "Erika";
-  static final String SAMPLE_LAST_NAME = "Musterfrau";
+  static final String SAMPLE_EMAIL = "maren.muster@example.org";
+  static final String SAMPLE_FIRST_NAME = "Maren";
+  static final String SAMPLE_LAST_NAME = "Muster";
   static final String SAMPLE_SUBJECT = "Ihre Einladung zu ORISO";
   static final String SAMPLE_BODY =
       """
@@ -85,7 +85,7 @@ public class InviteEmailPreviewService {
     String acceptUrl = inviteAcceptUrlBuilder.buildAcceptUrl(targetRoleFor(kind), SAMPLE_TOKEN);
 
     String renderedSubject = AccountInviteService.render(subject, sampleInvite, acceptUrl);
-    String renderedBody = AccountInviteService.render(body, sampleInvite, acceptUrl);
+    String renderedBody = AccountInviteService.renderBody(body, sampleInvite, acceptUrl);
 
     BrandedEmail mail =
         inviteMailDispatchService.renderBrandedMail(

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -112,7 +112,8 @@ class AccountInviteServiceTest {
         ArgumentCaptor.forClass(InviteEmailDelivery.class);
     verify(deliveryRepository).save(deliveryCaptor.capture());
     assertThat(deliveryCaptor.getValue().getSubjectSnapshot()).isEqualTo("Welcome Ada");
-    assertThat(deliveryCaptor.getValue().getBodySnapshot()).contains(result.rawToken());
+    // The action link reaches the recipient through the layout CTA, not the body.
+    assertThat(deliveryCaptor.getValue().getBodySnapshot()).doesNotContain(result.rawToken());
     assertThat(deliveryCaptor.getValue().getRecipientSnapshot()).isEqualTo("owner@example.org");
     assertThat(deliveryCaptor.getValue().getStatus()).isEqualTo(InviteEmailDeliveryStatus.SENT);
   }
@@ -1100,7 +1101,66 @@ class AccountInviteServiceTest {
         .buildAcceptUrl(AccountInviteTargetRole.COUNSELLOR, result.rawToken());
     assertThat(result.acceptUrl())
         .isEqualTo("https://app.oriso.org/account-invite/" + result.rawToken());
-    assertThat(result.delivery().getBodySnapshot()).isEqualTo("Link: " + result.acceptUrl());
+    // The body no longer carries the link: the branded layout renders it as a button
+    // plus a visible copy-paste line, so a body that also inlined it produced the same
+    // URL twice in the received mail.
+    assertThat(result.delivery().getBodySnapshot()).isEqualTo("Link:");
+    assertThat(result.delivery().getBodySnapshot()).doesNotContain(result.acceptUrl());
+  }
+
+  @Test
+  void sendInvite_Should_dropTheActionLinkLine_soTheLayoutRendersTheLinkExactlyOnce() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .recipientEmail("a@example.org")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder()
+            .id(20L)
+            .subject("s")
+            .body("Bitte schliessen Sie die Einrichtung ab:\n\n{{inviteLink}}\n\nViele Gruesse")
+            .build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
+
+    var result = service.sendInvite(new SendInviteCommand(1L, 20L));
+
+    // The whole line goes, not just the token, so the sentence runs straight into the
+    // CTA button instead of leaving a hole where the raw URL used to be.
+    assertThat(result.delivery().getBodySnapshot())
+        .isEqualTo("Bitte schliessen Sie die Einrichtung ab:\n\nViele Gruesse");
+    assertThat(result.delivery().getBodySnapshot()).doesNotContain(result.acceptUrl());
+  }
+
+  @Test
+  void sendInvite_Should_stillHandTheActionUrlToTheLayout_soTheCtaSurvives() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .recipientEmail("a@example.org")
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .status(AccountInviteStatus.DRAFT)
+            .build();
+    InviteEmailTemplate template =
+        InviteEmailTemplate.builder().id(20L).subject("s").body("{{inviteLink}}").build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    givenSuccessfulDispatch();
+
+    var result = service.sendInvite(new SendInviteCommand(1L, 20L));
+
+    // Removing the token from the body must not remove the link from the mail: the
+    // dispatcher still receives the accept URL as the primary action.
+    verify(inviteMailDispatchService)
+        .send(any(), any(), any(), eq(result.acceptUrl()), any(), any());
   }
 
   @Test
@@ -1129,7 +1189,40 @@ class AccountInviteServiceTest {
 
     assertThat(result.acceptUrl())
         .isEqualTo("https://app.oriso.org/admin/tenant-onboarding/" + result.rawToken());
-    assertThat(result.delivery().getBodySnapshot()).contains("/admin/tenant-onboarding/");
+    // Body-only assertion inverted with the duplicate-link fix: the URL reaches the
+    // recipient through the layout's CTA, not through the authored body.
+    assertThat(result.delivery().getBodySnapshot()).doesNotContain("/admin/tenant-onboarding/");
+  }
+
+  @Test
+  void renderBody_Should_defineExactlyWhatHappensToAnInlineActionLinkToken() {
+    AccountInvite invite =
+        AccountInvite.builder().id(1L).recipientEmail("a@example.org").firstName("Ada").build();
+
+    // Alone on its line: the line goes with it, so the introducing sentence runs
+    // straight into the CTA button.
+    assertThat(
+            AccountInviteService.renderBody(
+                "Hallo {{firstName}},\n\n{{inviteLink}}\n\nViele Gruesse", invite, "https://x/t"))
+        .isEqualTo("Hallo Ada,\n\nViele Gruesse");
+
+    // Inside a sentence: the token and the space before it go; the author's own
+    // wording is left alone, dangling colon and all. We remove a link, we do not
+    // rewrite prose.
+    assertThat(
+            AccountInviteService.renderBody(
+                "Hier: {{inviteLink}} — viel Erfolg", invite, "https://x/t"))
+        .isEqualTo("Hier: — viel Erfolg");
+
+    // A body that never used the token is untouched.
+    assertThat(AccountInviteService.renderBody("Hallo {{firstName}}", invite, "https://x/t"))
+        .isEqualTo("Hallo Ada");
+
+    // Whatever the shape, the URL never reaches the body.
+    assertThat(
+            AccountInviteService.renderBody(
+                "a {{inviteLink}} b\n{{inviteLink}}\n", invite, "https://x/t"))
+        .doesNotContain("https://x/t");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailPreviewServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/InviteEmailPreviewServiceTest.java
@@ -89,7 +89,7 @@ class InviteEmailPreviewServiceTest {
   @Test
   void preview_Should_renderExactlyWhatTheDispatcherBuilds() {
     String subject = "Ihre Einladung";
-    String body = "Hallo Erika Musterfrau,\n\nbitte richten Sie Ihr Konto ein.";
+    String body = "Hallo Maren Muster,\n\nbitte richten Sie Ihr Konto ein.";
 
     InviteEmailPreview preview =
         previewService.preview(
@@ -142,7 +142,7 @@ class InviteEmailPreviewServiceTest {
         previewService.preview(new PreviewCommand(null, null, null, null, null));
 
     assertThat(preview.subject()).isEqualTo(InviteEmailPreviewService.SAMPLE_SUBJECT);
-    assertThat(preview.html()).contains("Erika").contains("Musterfrau");
+    assertThat(preview.html()).contains("Maren").contains("Muster");
     assertThat(preview.kind()).isEqualTo(InviteEmailTemplateKind.TENANT_INVITE);
   }
 
@@ -163,10 +163,10 @@ class InviteEmailPreviewServiceTest {
     InviteEmailPreview preview =
         previewService.preview(new PreviewCommand(5L, null, null, null, null));
 
-    assertThat(preview.subject()).isEqualTo("Willkommen Erika");
+    assertThat(preview.subject()).isEqualTo("Willkommen Maren");
     assertThat(preview.templateName()).isEqualTo("Counsellor DE");
     assertThat(preview.html())
-        .contains("Erika Musterfrau")
+        .contains("Maren Muster")
         .doesNotContain("{{inviteLink}}")
         .contains(preview.sampleAcceptUrl());
   }


### PR DESCRIPTION
## Why

A received invite mail showed the action link twice: once as raw text, because the authored body substituted `{{inviteLink}}`, and once as the real CTA, because the branded layout renders the action link itself — a button plus a visible copy-paste line, in the HTML part and in the `text/plain` alternative alike (`email/layout/cta.html`, `cta.txt`).

The shipped default body contains that token (`InviteEmailPreviewService.SAMPLE_BODY`), so this was the normal case, not an edge case. The Admin preview showed it too, since `InviteEmailPreviewService` and `InviteMailDispatchService` share this renderer.

## What

**One rule instead of a special case: the layout owns the action link; the body must not carry it.**

- New `AccountInviteService.renderBody(...)`, used by the send path (`AccountInviteService:512`) and by the preview endpoint (`InviteEmailPreviewService:88`). It strips `{{inviteLink}}` before substitution.
- Removal is line-aware and precisely defined:
  - token alone on its line → the whole line goes, and the leftover blank-line run collapses, so the sentence that introduced it runs straight into the button;
  - token inside a sentence → the token and the space in front of it go. `"Hier: {{inviteLink}} — viel Erfolg"` becomes `"Hier: — viel Erfolg"`. The dangling colon is the author's own text and is **not** invented away. This is asserted, not left to whatever the regex happens to do.
- D4: sample identity `Lisa`/`Beispiel` → `Maren`/`Muster` (`SAMPLE_FIRST_NAME`, `SAMPLE_LAST_NAME`, `SAMPLE_EMAIL`).

### Why in the renderer rather than in the composer

- Send path and preview share it, so an author cannot compose a mail whose link is duplicated, and cannot see one state while the recipient gets another.
- Templates saved before the rule existed are repaired on render. **Nobody is blocked from saving an existing template and no migration is needed** — an earlier draft of this change added an Admin-side save block, and it was removed for exactly that reason: a structural strip makes a stored token harmless, so blocking the save would only have cost an author their edit.
- Legacy bodies that emitted the URL as raw text now get the real button instead. That is the separately filed **E3** („Button fehlt in aktueller version" — the mail literally read `Button https://…`), fixed as a side effect.

### What an author does instead

Nothing. The layout always renders the button **and** a visible copy-paste line carrying the plain URL, in the HTML part and the `text/plain` alternative both (`cta.txt` is `{{ACTION_LABEL}}:\n{{ACTION_URL}}`). The inline token was never doing work the layout does not already do — including for plain-text readers, which was the one case where removing it could have cost something real.

## Blast radius (verified, not assumed)

- `renderBrandedMail` has exactly two callers.
- `inviteLink` appears in exactly two places in `src/main`.
- `DPA_FORWARD` mails go through a different dispatcher (`dpaSigningEmailDispatchService`) and never relied on the body token.

## Verification

Red → green, and proven by mutation rather than asserted:

```
green:     Tests run: 93, Failures: 0, Errors: 0, Skipped: 0   BUILD SUCCESS
           (AccountInviteServiceTest 86 + InviteEmailPreviewServiceTest 7)

mutation:  renderBody() -> render() on the send path
           Tests run: 86, Failures: 4, Errors: 0
             sendInvite_Should_SetEmailSentAndPersistSnapshot_When_TemplateExists:116
             sendInvite_Should_dropTheActionLinkLine_soTheLayoutRendersTheLinkExactlyOnce:1137
             sendInvite_Should_renderAllPlaceholders_FromRoleBasedAcceptUrl:1107
             sendInvite_Should_requestTenantAdminAcceptUrlForTenantAdminRole:1194
```

Three existing tests asserted that the body snapshot **carried** the accept URL. They were documenting the defect; they now assert its absence, and one new test pins that the dispatcher still receives the accept URL as its primary action, so removing the token from the body did not remove the link from the mail.

## Note for the reviewer

`POST|GET /useradmin/invite-email-templates/preview` is **absent from the checked-in OpenAPI spec** under `api/`. Not introduced here and not blocking, but worth a follow-up if that spec is meant to be authoritative.

## Related

Pairs with ORISO-Admin `fix/tenant-invites-surface-2026-08-18`, which removes `{{inviteLink}}` from the Admin token picker and points the composer preview at this renderer (finding E2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
