### PR TITLE
docs(api): deprecate hard-coded messagesRead in session list DTOs

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2091,7 +2091,13 @@ components:
           example: 1539184948
         messagesRead:
           type: boolean
-          example: false
+          deprecated: true
+          description:
+            'Always true since the Matrix-native session list refactor: read
+            state is derived client-side from the Matrix room
+            (OpenResilienceInitiative/ORISO-Frontend#1147). Do not consume;
+            kept only for API compatibility until removal.'
+          example: true
         isTeamSession:
           type: boolean
           example: false
@@ -2339,7 +2345,13 @@ components:
           example: 1539184948
         messagesRead:
           type: boolean
-          example: false
+          deprecated: true
+          description:
+            'Always true since the Matrix-native session list refactor: read
+            state is derived client-side from the Matrix room
+            (OpenResilienceInitiative/ORISO-Frontend#1147). Do not consume;
+            kept only for API compatibility until removal.'
+          example: true
         matrixRoomId:
           type: string
           example: "!aBcDeF123:matrix.example"

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantChatEnricher.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantChatEnricher.java
@@ -26,6 +26,8 @@ public class ConsultantChatEnricher {
         consultantSessionResponseDTO -> {
           var chat = consultantSessionResponseDTO.getChat();
           chat.setSubscribed(joinedRoomIds.contains(chat.getMatrixRoomId()));
+          // messagesRead is deprecated in the API spec: always true, read state is derived
+          // client-side from the Matrix room (ORISO-Frontend#1147). Kept for compatibility.
           chat.setMessagesRead(true);
           if (chat.getStartDateWithTime() != null) {
             consultantSessionResponseDTO.setLatestMessage(

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionEnricher.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionEnricher.java
@@ -47,6 +47,8 @@ public class ConsultantSessionEnricher {
 
   private void enrichConsultantSession(ConsultantSessionResponseDTO consultantSessionResponseDTO) {
     var session = consultantSessionResponseDTO.getSession();
+    // messagesRead is deprecated in the API spec: always true, read state is derived
+    // client-side from the Matrix room (ORISO-Frontend#1147). Kept for compatibility.
     session.setMessagesRead(true);
     enrichSessionWithTopic(consultantSessionResponseDTO);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/UserSessionListService.java
@@ -133,6 +133,8 @@ public class UserSessionListService {
     sessions.forEach(
         sessionResponse -> {
           var session = sessionResponse.getSession();
+          // messagesRead is deprecated in the API spec: always true, read state is derived
+          // client-side from the Matrix room (ORISO-Frontend#1147). Kept for compatibility.
           session.setMessagesRead(true);
           if (sessionResponse.getLatestMessage() == null
               && session.getMessageDate() != null
@@ -149,6 +151,8 @@ public class UserSessionListService {
         sessionResponse -> {
           var chat = sessionResponse.getChat();
           chat.setSubscribed(joinedRoomIds.contains(chat.getMatrixRoomId()));
+          // messagesRead is deprecated in the API spec: always true, read state is derived
+          // client-side from the Matrix room (ORISO-Frontend#1147). Kept for compatibility.
           chat.setMessagesRead(true);
           if (sessionResponse.getLatestMessage() == null && chat.getStartDateWithTime() != null) {
             sessionResponse.setLatestMessage(Timestamp.valueOf(chat.getStartDateWithTime()));


### PR DESCRIPTION
## Problem

`messagesRead` in the session-list DTOs has been a hard-coded `true` at all four call sites (`ConsultantSessionEnricher`, `UserSessionListService` ×2, `ConsultantChatEnricher`) since the Matrix-native refactor (`344ac3ca`). The field carries no information, but the contract still presents it as authoritative room state.

## Change

Contract-only companion to OpenResilienceInitiative/ORISO-Frontend#1147 (frontend derives unread state from the Matrix client and stops reading this field):

- mark both `messagesRead` schema occurrences in `api/userservice.yaml` as `deprecated: true` with a description pointing at the client-side derivation
- annotate the four constant call sites with the same pointer

No behaviour change: the field is still serialized as `true`, so existing clients keep working. Actual removal is a breaking contract change and is deliberately **not** part of this PR.

## Why a separate PR

Contract changes must not ride along with behaviour changes. The frontend fix (ORISO-Frontend PR, see #1147) works with or without this PR; this one only stops the dead field from looking authoritative.

## Verification

- `./mvnw generate-sources` regenerates the API models cleanly with the deprecated flag (exit 0)
- additive spec change only (`deprecated` + `description` + example) — no shape/type change, so no consumer impact

## Reviewer test plan

- [ ] Confirm both YAML hunks only add `deprecated`/`description`/`example` and change no types
- [ ] Confirm the four Java hunks are comment-only
- [ ] Confirm no other consumer in this repo reads `getMessagesRead()` expecting real data
