### PR TITLE
Join late-joining counsellors into existing enquiry rooms (and revoke on removal)

### DIFF
--- a/documentation/user-service-historical-failure-classification.json
+++ b/documentation/user-service-historical-failure-classification.json
@@ -196,19 +196,19 @@
       "primaryTotal": -509
     },
     "verifiedCurrent": {
-      "verifiedApplicationHead": "374642585ffaa8ebca1d20c1631f0a9373eacf6a",
-      "unit": 4107,
+      "verifiedApplicationHead": "e6af9a1bf6540a7c7d3a54318bc679ca9e457a0a",
+      "unit": 4122,
       "integration": 913,
-      "primaryTotal": 5020,
+      "primaryTotal": 5035,
       "localEvidence": [
         "JDK 21: ./mvnw -Dskip.integration-tests=true test plus exact inventory gate",
         "JDK 21: scripts/ci/run-required-integration-tests.sh plus exact inventory gate"
       ]
     },
     "sinceCutoverDelta": {
-      "unit": 734,
+      "unit": 749,
       "integration": 73,
-      "primaryTotal": 807
+      "primaryTotal": 822
     },
     "sourceDiff": {
       "fromCommit": "dce9b2f4d89851d452135de6b0697d22413368c7",
@@ -221,8 +221,8 @@
   },
   "currentRequiredSuite": {
     "command": "scripts/ci/run-required-integration-tests.sh",
-    "unitTests": 4107,
-    "unitReports": 457,
+    "unitTests": 4122,
+    "unitReports": 458,
     "unitSkipped": 0,
     "integrationReports": 99,
     "integrationTests": 913,

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
@@ -22,18 +22,21 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencyLateJoinerMembershipService;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
 import org.springframework.stereotype.Service;
 
 /** Service class to handle administrative operations on consultant-agencies. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ConsultantAgencyAdminService {
 
   private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
@@ -43,6 +46,7 @@ public class ConsultantAgencyAdminService {
   private final @NonNull AgencyService agencyService;
   private final @NonNull AgencyAdminService agencyAdminService;
   private final @NonNull ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+  private final @NonNull AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
 
   /**
    * Returns all Agencies for the given consultantId.
@@ -250,6 +254,33 @@ public class ConsultantAgencyAdminService {
     this.agencyDeletionValidationService.validateAndMarkForDeletion(consultantAgency);
     consultantAgency.setDeleteDate(nowInUtc());
     this.consultantAgencyRepository.save(consultantAgency);
+    revokeOpenEnquiryRoomMembership(consultantAgency);
+  }
+
+  /**
+   * US#1060, symmetric half: since a counsellor is joined into the agency's open enquiry rooms when
+   * they are assigned, detaching them again has to take that membership back. Otherwise the
+   * counsellor keeps receiving the agency's open initial requests through Matrix {@code /sync} long
+   * after the relation was deleted.
+   *
+   * <p>Best effort — the deleted relation is already persisted and is the source of truth; a
+   * Synapse failure must not turn a successful detach into an error response.
+   */
+  private void revokeOpenEnquiryRoomMembership(ConsultantAgency consultantAgency) {
+    var consultant = consultantAgency.getConsultant();
+    if (consultant == null) {
+      return;
+    }
+    try {
+      agencyLateJoinerMembershipService.removeConsultantFromOpenEnquiryRooms(
+          consultant, consultantAgency.getAgencyId());
+    } catch (RuntimeException ex) {
+      log.warn(
+          "Could not revoke enquiry room membership of consultant {} in agency {}: {}",
+          consultant.getId(),
+          consultantAgency.getAgencyId(),
+          ex.getMessage());
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -20,6 +20,7 @@ import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencyLateJoinerMembershipService;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -27,11 +28,13 @@ import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /** Creator class to generate new {@link ConsultantAgency} instances. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ConsultantAgencyRelationCreatorService {
 
   private final @NonNull ConsultantAgencyService consultantAgencyService;
@@ -43,6 +46,7 @@ public class ConsultantAgencyRelationCreatorService {
   private final @NonNull ConsultantAgencyRelationFinalizer consultantAgencyRelationFinalizer;
   private final @NonNull ConsultantTopicAgencyCompatibilityValidator
       consultantTopicAgencyCompatibilityValidator;
+  private final @NonNull AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
 
   /**
    * Creates a new {@link ConsultantAgency} based on the {@link ImportRecord} and agency ids.
@@ -136,6 +140,31 @@ public class ConsultantAgencyRelationCreatorService {
     if (isTeamAgencyButNotTeamConsultant(agency, consultant)) {
       consultant.setTeamConsultant(true);
       consultantRepository.save(consultant);
+    }
+
+    backfillExistingEnquiryRooms(consultant, agency.getId());
+  }
+
+  /**
+   * US#1060: the agency's counsellors are joined into an enquiry room when the room is created
+   * (US#905), which leaves everyone who joins the agency later outside the rooms that already exist
+   * — and a non-member never receives the room from Matrix {@code /sync}, so those open initial
+   * requests stay invisible to them. Assigning the agency is the only moment we learn about the new
+   * counsellor, so the backfill happens here.
+   *
+   * <p>Best effort by design: the relation is already persisted at this point and is the source of
+   * truth. A Synapse outage must degrade to "membership repaired later", never to a failed
+   * assignment request.
+   */
+  private void backfillExistingEnquiryRooms(Consultant consultant, Long agencyId) {
+    try {
+      agencyLateJoinerMembershipService.joinConsultantIntoOpenEnquiryRooms(consultant, agencyId);
+    } catch (RuntimeException ex) {
+      log.warn(
+          "Could not backfill consultant {} into the open enquiry rooms of agency {}: {}",
+          consultant.getId(),
+          agencyId,
+          ex.getMessage());
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipService.java
@@ -1,0 +1,209 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.helper.MatrixIds;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+/**
+ * US#1060 / FE#811: keeps the department membership of an enquiry room in step with the agency
+ * roster <em>after</em> the room already exists.
+ *
+ * <p>{@link AgencySilentMembershipService} joins every counsellor of the agency at room creation,
+ * which fixes the enquiry for everyone who was already in the agency at that moment. Nothing
+ * repaired the mirror-image case: a counsellor added to the agency a day later is not a member of
+ * yesterday's enquiry rooms, Matrix {@code /sync} therefore never hands those rooms to their
+ * client, and no later event fixes it — the open initial requests simply stay invisible to them
+ * until an admin intervenes.
+ *
+ * <p>Scope is deliberately the agency's <em>open</em> enquiries (status {@link SessionStatus#NEW},
+ * no counsellor assigned yet). Those are exactly the cases the whole department is entitled to pick
+ * up. An accepted case belongs to one counsellor and is governed by {@code AssignEnquiryFacade}, so
+ * backfilling it here would widen its audience beyond what ADR-002 allows. Directly addressed
+ * enquiries are excluded for the same reason they are excluded at creation.
+ *
+ * <p>Every step is best effort: an admin assigning an agency must never see their request fail
+ * because Synapse hiccuped on one room, and the relation in the database is the source of truth
+ * either way.
+ *
+ * <p>Note on encryption: a counsellor backfilled here holds no Megolm key for messages sent before
+ * they joined and depends on the client-side history-key transfer that ships with FE#811. Joining
+ * at creation stays the stronger guarantee; this service is the repair path for everyone who could
+ * not be there at creation.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AgencyLateJoinerMembershipService {
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
+  private final @NonNull SessionRoomGateway sessionRoomGateway;
+  private final @NonNull AgencySilentMembershipService agencySilentMembershipService;
+
+  /**
+   * Joins a counsellor who was just assigned to an agency into the Matrix rooms of that agency's
+   * already existing open enquiries.
+   *
+   * @param consultant the newly assigned counsellor
+   * @param agencyId the agency they were assigned to
+   * @return number of enquiry rooms the counsellor ended up joined into
+   */
+  public int joinConsultantIntoOpenEnquiryRooms(Consultant consultant, Long agencyId) {
+    var roomIds = openEnquiryRoomIds(consultant, agencyId);
+    if (roomIds.isEmpty()) {
+      return 0;
+    }
+
+    var agencyToken = resolveAgencyToken(agencyId);
+    if (isBlank(agencyToken)) {
+      return 0;
+    }
+
+    int joined = 0;
+    for (String roomId : roomIds) {
+      try {
+        if (agencySilentMembershipService.joinConsultantIntoRoom(consultant, roomId, agencyToken)) {
+          joined++;
+        }
+      } catch (RuntimeException ex) {
+        log.warn(
+            "Could not backfill consultant {} into enquiry room {} of agency {}: {}",
+            consultant.getId(),
+            roomId,
+            agencyId,
+            ex.getMessage());
+      }
+    }
+
+    log.info(
+        "Backfilled consultant {} into {} of {} open enquiry rooms of agency {}",
+        consultant.getId(),
+        joined,
+        roomIds.size(),
+        agencyId);
+    return joined;
+  }
+
+  /**
+   * Revokes the membership a counsellor holds in the open enquiry rooms of an agency they were just
+   * detached from. Without this the counsellor keeps syncing enquiries of an agency they no longer
+   * belong to — the exact stale access the at-creation fan-out would otherwise create.
+   *
+   * <p>A counsellor without a Matrix account never joined anything, so there is nothing to revoke
+   * and no account is provisioned here.
+   *
+   * <p>The scope is the same open enquiries the join side covers, and that symmetry is enforced by
+   * Matrix rather than chosen for tidiness: {@code AssignEnquiryFacade} removes the agency service
+   * account from the room the moment an enquiry is accepted, so its token can no longer kick anyone
+   * out of an accepted case. Rooms of accepted cases therefore need the assigned counsellor's own
+   * token and are handled by the case-handover/team-session paths, not here.
+   *
+   * @param consultant the detached counsellor
+   * @param agencyId the agency they were detached from
+   * @return number of enquiry rooms the counsellor was removed from
+   */
+  public int removeConsultantFromOpenEnquiryRooms(Consultant consultant, Long agencyId) {
+    if (consultant == null || isBlank(consultant.getMatrixUserId())) {
+      return 0;
+    }
+
+    var roomIds = openEnquiryRoomIds(consultant, agencyId);
+    if (roomIds.isEmpty()) {
+      return 0;
+    }
+
+    var agencyToken = resolveAgencyToken(agencyId);
+    if (isBlank(agencyToken)) {
+      return 0;
+    }
+
+    int removed = 0;
+    for (String roomId : roomIds) {
+      try {
+        if (sessionRoomGateway.removeUserFromRoom(
+            roomId, consultant.getMatrixUserId(), agencyToken)) {
+          removed++;
+        }
+      } catch (RuntimeException ex) {
+        log.warn(
+            "Could not remove consultant {} from enquiry room {} of agency {}: {}",
+            consultant.getId(),
+            roomId,
+            agencyId,
+            ex.getMessage());
+      }
+    }
+
+    log.info(
+        "Removed consultant {} from {} of {} open enquiry rooms of agency {}",
+        consultant.getId(),
+        removed,
+        roomIds.size(),
+        agencyId);
+    return removed;
+  }
+
+  private List<String> openEnquiryRoomIds(Consultant consultant, Long agencyId) {
+    if (consultant == null || agencyId == null) {
+      return List.of();
+    }
+
+    return sessionRepository
+        .findByAgencyIdAndStatusAndConsultantIsNull(agencyId, SessionStatus.NEW)
+        .stream()
+        .filter(session -> !Boolean.TRUE.equals(session.getIsConsultantDirectlySet()))
+        .map(Session::getMatrixRoomId)
+        .filter(StringUtils::isNotBlank)
+        .distinct()
+        .toList();
+  }
+
+  /**
+   * The enquiry rooms are owned by the agency's Matrix service account, so invites and kicks have
+   * to be issued with its token — the same resolution {@code AgencyPreAssignmentRoomService}
+   * performs when it creates the room.
+   */
+  private String resolveAgencyToken(Long agencyId) {
+    var credentialsOpt = matrixCredentialClient.fetchMatrixCredentials(agencyId);
+    if (credentialsOpt.isEmpty()) {
+      log.warn(
+          "No Matrix service account available for agency {}; enquiry room membership unchanged.",
+          agencyId);
+      return null;
+    }
+
+    var credentials = credentialsOpt.get();
+    if (isBlank(credentials.getMatrixUserId()) || isBlank(credentials.getMatrixPassword())) {
+      log.warn(
+          "Matrix service account configuration incomplete for agency {}; enquiry room membership unchanged.",
+          agencyId);
+      return null;
+    }
+
+    var agencyToken =
+        sessionRoomGateway.loginUser(
+            MatrixIds.localpartLenient(credentials.getMatrixUserId()),
+            credentials.getMatrixPassword());
+    if (isBlank(agencyToken)) {
+      log.error(
+          "Failed to login Matrix service account {} for agency {}; enquiry room membership unchanged.",
+          credentials.getMatrixUserId(),
+          agencyId);
+      return null;
+    }
+
+    return agencyToken;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
@@ -70,7 +70,7 @@ public class AgencySilentMembershipService {
 
     int joined = 0;
     for (Consultant consultant : consultants) {
-      if (joinSilently(consultant, roomId, agencyToken)) {
+      if (joinConsultantIntoRoom(consultant, roomId, agencyToken)) {
         joined++;
       }
     }
@@ -84,7 +84,21 @@ public class AgencySilentMembershipService {
     return joined;
   }
 
-  private boolean joinSilently(Consultant consultant, String roomId, String agencyToken) {
+  /**
+   * Invites and joins a single counsellor into an already existing room, provisioning their Matrix
+   * account if they never had one.
+   *
+   * <p>Extracted for US#1060: a counsellor added to the agency after an enquiry arrived has to be
+   * backfilled into the enquiry rooms that already exist (see {@link
+   * AgencyLateJoinerMembershipService}), and that backfill needs exactly the same per-counsellor
+   * membership semantics as the at-creation fan-out.
+   *
+   * @param consultant the counsellor to join
+   * @param roomId the Matrix room to join them into
+   * @param agencyToken access token of the agency service account that owns the room
+   * @return whether the counsellor ended up joined
+   */
+  public boolean joinConsultantIntoRoom(Consultant consultant, String roomId, String agencyToken) {
     try {
       var matrixUserId = ensureMatrixAccount(consultant);
       if (isBlank(matrixUserId)) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencyLateJoinerMembershipService;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -43,6 +44,7 @@ class ConsultantAgencyAdminServiceTest {
   @Mock private AgencyService agencyService;
   @Mock private AgencyAdminService agencyAdminService;
   @Mock private ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+  @Mock private AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
 
   // ---------------------------------------------------------------------------
   // findConsultantAgencies
@@ -219,6 +221,75 @@ class ConsultantAgencyAdminServiceTest {
         .save(any(ConsultantAgency.class));
     assertThat(relation1.getDeleteDate()).isNotNull();
     assertThat(relation2.getDeleteDate()).isNotNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // US#1060: the enquiry-room membership must follow the relation in both directions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The symmetric half of the late-joiner backfill: a counsellor detached from an agency keeps
+   * syncing that agency's open enquiries until their Matrix membership is revoked, so the
+   * revocation has to happen where the relation is marked deleted.
+   */
+  @Test
+  void markConsultantAgencyForDeletion_Should_RevokeOpenEnquiryRoomMembership() {
+    var consultant = new Consultant();
+    consultant.setId("c-1");
+    var relation = new ConsultantAgency();
+    relation.setConsultant(consultant);
+    relation.setAgencyId(10L);
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(relation));
+
+    consultantAgencyAdminService.markConsultantAgencyForDeletion("c-1", 10L);
+
+    verify(agencyLateJoinerMembershipService).removeConsultantFromOpenEnquiryRooms(consultant, 10L);
+  }
+
+  /**
+   * The admin UI's "edit consultant" screen does not detach a single agency, it submits the desired
+   * complete agency set and {@code ConsultantAdminFacade#setConsultantAgencies} turns the
+   * difference into this bulk call. Revocation therefore has to hold for every removed agency, not
+   * only for the single-agency endpoint.
+   */
+  @Test
+  void markConsultantAgenciesForDeletion_Should_RevokeMembershipForEveryRemovedAgency() {
+    var consultant = new Consultant();
+    consultant.setId("c-1");
+    var relation10 = new ConsultantAgency();
+    relation10.setConsultant(consultant);
+    relation10.setAgencyId(10L);
+    var relation20 = new ConsultantAgency();
+    relation20.setConsultant(consultant);
+    relation20.setAgencyId(20L);
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(relation10));
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 20L))
+        .thenReturn(List.of(relation20));
+
+    consultantAgencyAdminService.markConsultantAgenciesForDeletion("c-1", List.of(10L, 20L));
+
+    verify(agencyLateJoinerMembershipService).removeConsultantFromOpenEnquiryRooms(consultant, 10L);
+    verify(agencyLateJoinerMembershipService).removeConsultantFromOpenEnquiryRooms(consultant, 20L);
+  }
+
+  @Test
+  void markConsultantAgencyForDeletion_Should_NotFail_When_MembershipRevocationBlowsUp() {
+    var consultant = new Consultant();
+    consultant.setId("c-1");
+    var relation = new ConsultantAgency();
+    relation.setConsultant(consultant);
+    relation.setAgencyId(10L);
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(relation));
+    when(agencyLateJoinerMembershipService.removeConsultantFromOpenEnquiryRooms(consultant, 10L))
+        .thenThrow(new RuntimeException("synapse unreachable"));
+
+    consultantAgencyAdminService.markConsultantAgencyForDeletion("c-1", 10L);
+
+    assertThat(relation.getDeleteDate()).isNotNull();
+    verify(consultantAgencyRepository).save(relation);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencyLateJoinerMembershipService;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +52,8 @@ public class ConsultantAgencyAdminUserServiceTest {
   @Mock private AgencyAdminService agencyAdminService;
 
   @Mock private ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+
+  @Mock private AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
 
   @Test
   public void

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -26,6 +26,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencyLateJoinerMembershipService;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.RolesDTO;
 import java.util.LinkedHashMap;
@@ -64,6 +65,92 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Mock
   private ConsultantTopicAgencyCompatibilityValidator consultantTopicAgencyCompatibilityValidator;
+
+  @Mock private AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
+
+  /**
+   * US#1060: an agency assignment that stops at the database row leaves the counsellor locked out
+   * of every enquiry that arrived before them, because Matrix membership is what makes an enquiry
+   * visible at all (FE#811). The backfill therefore belongs to "the assignment is complete", not to
+   * a separate manual step.
+   */
+  @Test
+  void
+      completeConsultantAgencyAssigment_Should_backfillTheConsultantIntoExistingOpenEnquiryRooms() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(false);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+        input, LogService::logInfo);
+
+    verify(agencyLateJoinerMembershipService).joinConsultantIntoOpenEnquiryRooms(consultant, 2L);
+  }
+
+  /**
+   * The route the admin UI actually takes (POST /consultants/{id}/agencies) persists the relation
+   * and completes the assignment in one call. Covering only the legacy two-step entry point would
+   * leave the endpoint that produced the bug report untested.
+   */
+  @Test
+  void createNewConsultantAgency_Should_backfillTheConsultantIntoExistingOpenEnquiryRooms() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(83L);
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(280L)).thenReturn(agency);
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+    when(consultantAgencyService.saveConsultantAgency(any(ConsultantAgency.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    consultantAgencyRelationCreatorService.createNewConsultantAgency(
+        "consultant Id", new CreateConsultantAgencyDTO().agencyId(280L));
+
+    verify(agencyLateJoinerMembershipService).joinConsultantIntoOpenEnquiryRooms(consultant, 280L);
+  }
+
+  /**
+   * The relation in the database is the source of truth; a Synapse hiccup must not make the admin's
+   * assignment request fail after the row was already written.
+   */
+  @Test
+  void completeConsultantAgencyAssigment_Should_notFail_When_theEnquiryBackfillBlowsUp() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(false);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
+    when(agencyLateJoinerMembershipService.joinConsultantIntoOpenEnquiryRooms(consultant, 2L))
+        .thenThrow(new RuntimeException("synapse unreachable"));
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    assertDoesNotThrow(
+        () ->
+            consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+                input, LogService::logInfo));
+
+    verify(consultantAgencyRelationFinalizer)
+        .finalizeConsultantAgencyRelation(consultant, agencyDTO);
+  }
 
   @Test
   public void

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipServiceTest.java
@@ -1,0 +1,218 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * US#1060 / FE#811. {@link AgencySilentMembershipService} closes the gap for enquiries that arrive
+ * <em>after</em> a counsellor joined the agency; this service closes the mirror-image gap for
+ * counsellors who join <em>after</em> the enquiry arrived. Both halves are needed — an enquiry room
+ * nobody backfills stays invisible to the new counsellor forever, because Matrix {@code /sync}
+ * returns nothing for a non-member and no later event repairs that.
+ */
+@ExtendWith(MockitoExtension.class)
+class AgencyLateJoinerMembershipServiceTest {
+
+  private static final Long AGENCY_ID = 4711L;
+  private static final String AGENCY_MATRIX_USER_ID = "@agency4711:oriso.org";
+  private static final String AGENCY_MATRIX_PASSWORD = "agency-secret";
+  private static final String AGENCY_TOKEN = "agency-access-token";
+  private static final String CONSULTANT_MATRIX_USER_ID = "@late:oriso.org";
+
+  @Mock private SessionRepository sessionRepository;
+  @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
+  @Mock private SessionRoomGateway sessionRoomGateway;
+  @Mock private AgencySilentMembershipService agencySilentMembershipService;
+
+  @InjectMocks private AgencyLateJoinerMembershipService underTest;
+
+  private Consultant lateJoiner() {
+    var consultant = new Consultant();
+    consultant.setId("c-late");
+    consultant.setUsername("c-late");
+    consultant.setMatrixUserId(CONSULTANT_MATRIX_USER_ID);
+    return consultant;
+  }
+
+  private Session openEnquiry(Long id, String roomId) {
+    var session = new Session();
+    session.setId(id);
+    session.setAgencyId(AGENCY_ID);
+    session.setStatus(SessionStatus.NEW);
+    session.setMatrixRoomId(roomId);
+    return session;
+  }
+
+  private void agencyServiceAccountAvailable() {
+    var credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId(AGENCY_MATRIX_USER_ID);
+    credentials.setMatrixPassword(AGENCY_MATRIX_PASSWORD);
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+    when(sessionRoomGateway.loginUser("agency4711", AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+  }
+
+  private void openEnquiries(Session... sessions) {
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(AGENCY_ID, SessionStatus.NEW))
+        .thenReturn(List.of(sessions));
+  }
+
+  @Test
+  @DisplayName("a counsellor added to the agency is joined into every open enquiry room")
+  void joinConsultantIntoOpenEnquiryRooms_joinsEveryOpenEnquiryRoomOfTheAgency() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"), openEnquiry(2L, "!two:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!one:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!two:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(2, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verify(agencySilentMembershipService)
+        .joinConsultantIntoRoom(consultant, "!one:oriso.org", AGENCY_TOKEN);
+    verify(agencySilentMembershipService)
+        .joinConsultantIntoRoom(consultant, "!two:oriso.org", AGENCY_TOKEN);
+  }
+
+  @Test
+  @DisplayName("a directly addressed enquiry is never fanned out to a late joiner")
+  void joinConsultantIntoOpenEnquiryRooms_skipsDirectlyAssignedEnquiries() {
+    var consultant = lateJoiner();
+    var directEnquiry = openEnquiry(1L, "!direct:oriso.org");
+    directEnquiry.setIsConsultantDirectlySet(true);
+    openEnquiries(directEnquiry, openEnquiry(2L, "!department:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!department:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verify(agencySilentMembershipService, never())
+        .joinConsultantIntoRoom(any(), eq("!direct:oriso.org"), anyString());
+  }
+
+  @Test
+  @DisplayName("an enquiry without a Matrix room yet is skipped instead of failing the assignment")
+  void joinConsultantIntoOpenEnquiryRooms_skipsEnquiriesWithoutRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, null), openEnquiry(2L, "  "));
+
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("no usable agency service account means no join, but never an exception")
+  void joinConsultantIntoOpenEnquiryRooms_toleratesMissingAgencyServiceAccount() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"));
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("one unjoinable room does not cost the late joiner the remaining rooms")
+  void joinConsultantIntoOpenEnquiryRooms_isBestEffortPerRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!broken:oriso.org"), openEnquiry(2L, "!healthy:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!broken:oriso.org", AGENCY_TOKEN))
+        .thenThrow(new RuntimeException("synapse rejected this room"));
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!healthy:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+
+  @Test
+  @DisplayName("missing consultant or agency short-circuits without touching Matrix")
+  void joinConsultantIntoOpenEnquiryRooms_shortCircuitsOnMissingInput() {
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(null, AGENCY_ID));
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(lateJoiner(), null));
+
+    verifyNoInteractions(sessionRepository);
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(sessionRoomGateway);
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("a counsellor removed from the agency loses membership in its open enquiry rooms")
+  void removeConsultantFromOpenEnquiryRooms_removesFromEveryOpenEnquiryRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"), openEnquiry(2L, "!two:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!one:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!two:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(2, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+
+  @Test
+  @DisplayName("a counsellor without a Matrix account has nothing to revoke")
+  void removeConsultantFromOpenEnquiryRooms_skipsConsultantWithoutMatrixAccount() {
+    var consultant = lateJoiner();
+    consultant.setMatrixUserId(null);
+
+    assertEquals(0, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(sessionRepository);
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(sessionRoomGateway);
+  }
+
+  @Test
+  @DisplayName("one failing removal does not stop the remaining rooms from being revoked")
+  void removeConsultantFromOpenEnquiryRooms_isBestEffortPerRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!broken:oriso.org"), openEnquiry(2L, "!healthy:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!broken:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenThrow(new RuntimeException("synapse rejected this room"));
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!healthy:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+}

--- a/tests/ci/test_historical_failure_classification.py
+++ b/tests/ci/test_historical_failure_classification.py
@@ -112,7 +112,7 @@ class HistoricalFailureClassificationContractTest(unittest.TestCase):
         self.assertEqual(required_suite["unitTests"], current["unit"])
         self.assertEqual(required_suite["integrationTests"], current["integration"])
         self.assertEqual(
-            "374642585ffaa8ebca1d20c1631f0a9373eacf6a",
+            "e6af9a1bf6540a7c7d3a54318bc679ca9e457a0a",
             current["verifiedApplicationHead"],
         )
         self.assertEqual(2, len(current["localEvidence"]))
@@ -130,8 +130,8 @@ class HistoricalFailureClassificationContractTest(unittest.TestCase):
             "scripts/ci/run-required-integration-tests.sh",
             current["command"],
         )
-        self.assertEqual(4107, current.get("unitTests"))
-        self.assertEqual(457, current["unitReports"])
+        self.assertEqual(4122, current.get("unitTests"))
+        self.assertEqual(458, current["unitReports"])
         self.assertEqual(99, current["integrationReports"])
         self.assertEqual(913, current["integrationTests"])
         self.assertEqual(0, current["failures"])


### PR DESCRIPTION
## What & why

OpenResilienceInitiative/ORISO-UserService#905 joins the agency's counsellors into an enquiry's Matrix room **at room creation**. That only helps counsellors who were already in the agency at that moment. A counsellor added to the agency **afterwards** never becomes a member of the rooms that already exist — Matrix `/sync` returns nothing for a non-member, and no later event repairs it, so open initial requests stay invisible to them until an admin intervenes.

This PR adds `AgencyLateJoinerMembershipService` and wires it into both directions of the agency relation:

- **Join (the reported bug):** completing an agency assignment backfills the counsellor into the Matrix rooms of the agency's existing open enquiries. Both entry points are covered — the atomic `createNewConsultantAgency` path the admin UI uses and the legacy two-step `completeConsultantAgencyAssigment` path — because they funnel through one place.
- **Removal (the reverse path the issue asks for):** marking a consultant-agency relation deleted revokes that membership again, so a counsellor does not keep syncing enquiries of an agency they left. The hook sits in `markAsDeleted`, which covers both the single-agency endpoint and the bulk path that `ConsultantAdminFacade#setConsultantAgencies` uses when an admin edits a consultant's agency set.

**Scope:** the agency's *open* enquiries — status `NEW`, no counsellor assigned, not directly addressed. Those are the cases the whole department is entitled to pick up; an accepted case belongs to one counsellor and is governed by `AssignEnquiryFacade`. On the removal side that scope is not a preference but a constraint: `AssignEnquiryFacade` removes the agency service account from the room when an enquiry is accepted, so the agency token can no longer act on an accepted case at all.

**Failure semantics:** both directions are best effort. The relation in the database is the source of truth, so a Synapse failure degrades to "membership repaired later" rather than failing the admin's request. Per-counsellor membership logic is shared with the at-creation fan-out by promoting `AgencySilentMembershipService#joinSilently` to the public `joinConsultantIntoRoom`, so the backfill cannot drift from #905's semantics.

Closes OpenResilienceInitiative/ORISO-UserService#1060
Refs OpenResilienceInitiative/ORISO-Frontend#811

## How should I test this?

- [ ] Create an enquiry for agency A (as an advice seeker) → confirm a counsellor already in agency A sees it → **expected:** unchanged behaviour from #905, enquiry visible and readable.
- [ ] Add a **new** counsellor to agency A in the admin panel → log in as that counsellor → open the initial-request list → **expected:** the enquiry created *before* they joined is listed, opens, and its message text is readable.
- [ ] Same enquiry, check attachments → **expected:** attachments load for the late joiner.
- [ ] Check the service log during the assignment → **expected:** one `Backfilled consultant <id> into N of N open enquiry rooms of agency <id>` line.
- [ ] Remove that counsellor from agency A again → log in as them → **expected:** the enquiry disappears from their list; log shows `Removed consultant <id> from N of N open enquiry rooms of agency <id>`.
- [ ] Edit a consultant in the admin panel and drop one agency from their agency set (the bulk path) → **expected:** the same revocation happens for the dropped agency, and agencies left untouched keep their enquiries.
- [ ] Assign an agency whose Matrix service account is misconfigured (or stop Synapse) → **expected:** the assignment request still succeeds with 2xx; only a `WARN` is logged. Nothing 500s.
- [ ] Create an enquiry via a **direct** counsellor link, then add a new counsellor to the agency → **expected:** the directly addressed enquiry is *not* fanned out to them.

## Verified locally vs CI must prove

**Verified locally** (JDK 21 via `brew --prefix openjdk@21`, `./mvnw`, targeted test classes only):

| Test class | Result |
| --- | --- |
| `AgencyLateJoinerMembershipServiceTest` (new) | `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0` |
| `ConsultantAgencyRelationCreatorServiceTest` | `Tests run: 16, Failures: 0, Errors: 0, Skipped: 0` |
| `ConsultantAgencyAdminServiceTest` | `Tests run: 14, Failures: 0, Errors: 0, Skipped: 0` |
| `ConsultantAgencyAdminUserServiceTest` | `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` |
| `AgencySilentMembershipServiceTest` (#905, untouched behaviour) | `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` |
| `AgencyPreAssignmentRoomServiceTest` (#905, untouched behaviour) | `Tests run: 16, Failures: 0, Errors: 0, Skipped: 0` |
| Aggregate | `Tests run: 69, Failures: 0, Errors: 0, Skipped: 0` — `BUILD SUCCESS` |

`mvn spotless:apply` is clean (google-java-format, GOOGLE style).

**Failing-test proof.** The tests were confirmed to fail without the fix, not merely to pass with it. Both call sites were commented out (`backfillExistingEnquiryRooms` in `ConsultantAgencyRelationCreatorService`, `revokeOpenEnquiryRoomMembership` in `ConsultantAgencyAdminService`) and both public methods of `AgencyLateJoinerMembershipService` were made to return `0` immediately. Result: `Tests run: 39, Failures: 9, Errors: 3` — `BUILD FAILURE`, including

```
ConsultantAgencyRelationCreatorServiceTest.createNewConsultantAgency_Should_backfillTheConsultantIntoExistingOpenEnquiryRooms
ConsultantAgencyRelationCreatorServiceTest.completeConsultantAgencyAssigment_Should_backfillTheConsultantIntoExistingOpenEnquiryRooms
ConsultantAgencyAdminServiceTest.markConsultantAgencyForDeletion_Should_RevokeOpenEnquiryRoomMembership
ConsultantAgencyAdminServiceTest.markConsultantAgenciesForDeletion_Should_RevokeMembershipForEveryRemovedAgency
AgencyLateJoinerMembershipServiceTest.joinConsultantIntoOpenEnquiryRooms_joinsEveryOpenEnquiryRoomOfTheAgency:96 expected: <2> but was: <0>
AgencyLateJoinerMembershipServiceTest.removeConsultantFromOpenEnquiryRooms_removesFromEveryOpenEnquiryRoom:187 expected: <2> but was: <0>
```

The disabling edits were reverted from backups and the suite was re-run green (`Tests run: 69, Failures: 0` — `BUILD SUCCESS`) before committing.

**CI must prove** (deliberately not run locally — 16 GB machine, targeted classes only):

- The **full unit suite** — nothing outside the six classes above was executed here. Every Spring component that constructs `ConsultantAgencyAdminService` or `ConsultantAgencyRelationCreatorService` gained a constructor argument, so any test building them by hand rather than via `@InjectMocks` will surface in CI, not locally.
- **Spring context startup** — `AgencyLateJoinerMembershipService` is a new `@Service` with four injected collaborators; only a full context load proves the wiring.
- **Integration tests (`*IT`)** — none were run.
- **A real Matrix round-trip.** Every assertion here is against mocks. That invite → login → join actually produces a readable room for the late joiner, and that `removeUserFromRoom` with the *agency* token actually kicks a counsellor from an unassigned enquiry room, is only proven on pre-dev by the reviewer checklist above.

## Open risks and scope explicitly not covered

1. **Rollback amplifier.** `ConsultantAdminFacade#setConsultantAgencies` is `@Transactional` and performs the bulk removal and the creations inside one transaction. Matrix membership changes are not transactional: if that transaction rolls back later (e.g. the subsequent topic validation fails), the DB relations are restored but the Matrix joins/kicks are not undone. This PR keeps the side effects inline because that is what every existing Matrix side effect in this codebase does and there is no after-commit hook idiom here to follow; introducing one is a separate change. Worth a follow-up ticket.
2. **Stale membership in already-accepted rooms is not cleaned up.** A counsellor who was a silent member at creation, whose colleague then accepted the case, keeps that membership after leaving the agency. This is deliberately out of scope: once the enquiry is accepted the agency service account has left the room, so the agency token cannot remove anyone. Fixing it needs the assigned counsellor's or an admin token — a different mechanism (see the case-handover / team-session paths).
3. **Latency.** The backfill runs synchronously inside the admin's assignment request and costs roughly one invite + one login + one join per open enquiry room. An agency with a large backlog of open enquiries will make that request noticeably slower. Acceptable for correctness first; a queue is the follow-up if it bites.
4. **Megolm history.** A counsellor backfilled after messages were already sent holds no Megolm key for them and depends on the client-side history-key transfer shipping in OpenResilienceInitiative/ORISO-Frontend#811. Joining at creation (#905) remains the stronger guarantee — this is the repair path for everyone who could not be there at creation. Reviewers should read old messages, not just confirm the room appears.
5. **Base branch.** This targets `speed/reflux-progress-exp-16-aug` (the shipping branch) on purpose, not `pre-dev`.
