### PR TITLE
feat(account-invite): refuse invite creation for an already registered e-mail

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -226,10 +226,20 @@ public class KeycloakService
     updateEmail(userId, userHelper.getDummyEmail(userId));
   }
 
+  /**
+   * Exact-owner lookup on top of Keycloak's fuzzy user search, which also matches on username,
+   * first and last name — hence the re-filter on the e-mail field itself.
+   *
+   * <p>The comparison ignores case: callers normalize the probe to lower case, but a stored record
+   * need not be lower-cased (imported or externally federated users routinely are not). A
+   * case-sensitive comparison would discard exactly the hit that Keycloak's own case-insensitive
+   * search just returned and report the address as free — the same duplicate-address defect the
+   * callers use this method to prevent.
+   */
   @Override
   public Optional<IdentityEmailOwner> findByEmail(String email) {
     return keycloakClient.getUsersResource().search(email, 0, Integer.MAX_VALUE).stream()
-        .filter(userRepresentation -> email.equals(userRepresentation.getEmail()))
+        .filter(userRepresentation -> email.equalsIgnoreCase(userRepresentation.getEmail()))
         .findFirst()
         .map(userRepresentation -> new IdentityEmailOwner(userRepresentation.getUsername()));
   }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -61,6 +61,49 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
   boolean existsByTenantIdAndTargetRoleAndStatusIn(
       Long tenantId, AccountInviteTargetRole targetRole, Collection<AccountInviteStatus> statuses);
 
+  /**
+   * P3 duplicate-address guard: counts the invites that still hold {@code recipientEmail}, i.e. the
+   * ones a recipient could still redeem. The identity probe cannot see these — a Keycloak user is
+   * only created when an invite is accepted, so a DRAFT or EMAIL_SENT invite is invisible there.
+   *
+   * <p>Deliberately not a derived query:
+   *
+   * <ul>
+   *   <li>{@code LOWER(...)} is explicit because {@code recipient_email} is persisted trimmed but
+   *       case-preserving, and the two databases involved disagree on the default: MariaDB's {@code
+   *       utf8mb4_*_ci} collation compares case-insensitively, H2 (tests) does not. The guard must
+   *       not depend on which one it runs against.
+   *   <li>The expiry clause reflects that expiry is materialized lazily — {@code EXPIRED} is only
+   *       stamped when someone opens the link (see {@code AccountInviteService#acceptInvite}), so a
+   *       never-opened invite stays {@code EMAIL_SENT} forever. Without the date check a lapsed
+   *       invite would permanently block its address, leaving the admin no way to re-invite.
+   * </ul>
+   *
+   * <p>The caller passes the non-terminal statuses; terminal ones ({@code ACCEPTED}, {@code
+   * EXPIRED}, {@code REVOKED}, {@code SUPERSEDED}) must never block a fresh invite.
+   *
+   * <p><b>Why this stays advisory instead of becoming a unique constraint.</b> The rule above is
+   * not expressible as one. MariaDB has no partial indexes, so it would have to become a persisted
+   * generated column plus a unique index — and that column cannot contain {@code NOW()}, so it
+   * could not carry the expiry clause. The resulting constraint would be strictly harsher than the
+   * rule it is meant to enforce and would reject the legitimate re-invite after a lapsed invite,
+   * with no way for an admin to recover as long as expiry stays lazily materialized. On top of
+   * that, rows violating it already exist in the wild (two Pre-Dev addresses each hold two
+   * unaccepted invites), so the changeset would need a destructive data migration before it could
+   * even apply, and Liquibase does not run in the test profile — the migration would ship with no
+   * test coverage at all. A constraint becomes worth revisiting once invite expiry is swept
+   * eagerly; until then the service-side guard is the enforcement point.
+   */
+  @Query(
+      "SELECT COUNT(i) FROM AccountInvite i"
+          + " WHERE LOWER(i.recipientEmail) = :recipientEmail"
+          + " AND i.status IN :statuses"
+          + " AND (i.expiresAt IS NULL OR i.expiresAt > :now)")
+  long countNonTerminalInvitesForRecipientEmail(
+      @Param("recipientEmail") String recipientEmail,
+      @Param("statuses") Collection<AccountInviteStatus> statuses,
+      @Param("now") LocalDateTime now);
+
   @Query(
       "SELECT i FROM AccountInvite i"
           + " WHERE (:tenantId IS NULL OR i.tenantId = :tenantId)"

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -56,6 +56,17 @@ public class AccountInviteService {
   private static final List<AccountInviteStatus> ACTIVE_TENANT_INVITE_STATUSES =
       List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT);
 
+  /**
+   * The invite states in which a recipient can still redeem the invite, and in which its address is
+   * therefore taken. Everything else in {@link AccountInviteStatus} is terminal and must leave the
+   * address free again: {@code ACCEPTED} is already covered by the identity probe (and must not be
+   * blocked here as well, or deleting the identity would leave the address permanently
+   * un-invitable), while {@code EXPIRED}, {@code REVOKED} and {@code SUPERSEDED} are exactly the
+   * cases in which an admin needs to invite the same person once more.
+   */
+  private static final List<AccountInviteStatus> ADDRESS_HOLDING_INVITE_STATUSES =
+      List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT);
+
   private final @NonNull AccountInviteRepository accountInviteRepository;
   private final @NonNull InviteEmailTemplateRepository templateRepository;
   private final @NonNull InviteEmailDeliveryRepository deliveryRepository;
@@ -164,12 +175,32 @@ public class AccountInviteService {
    * <p>The address is normalized the same way {@link CounsellorInviteProvisioningService}
    * normalizes it when it later creates the identity, so the guard tests exactly the value that
    * would collide.
+   *
+   * <p>Two sources have to be consulted, because neither sees the other's half of the funnel:
+   *
+   * <ol>
+   *   <li>the identity provider, which owns every address that already has an account, and
+   *   <li>the invite table, which owns every address that is merely <em>promised</em> to somebody.
+   *       An identity is created only at accept time, so an invite sitting in {@code DRAFT} or
+   *       {@code EMAIL_SENT} is invisible to the identity probe — which is how a second invite for
+   *       the same address used to be created without complaint. To the admin, and to the owner's
+   *       wording of the rule, such an address is just as "already there" as a registered one.
+   * </ol>
+   *
+   * <p>Deliberately not backed by a database constraint — see {@link
+   * AccountInviteRepository#countNonTerminalInvitesForRecipientEmail} for why the rule is not
+   * expressible as one.
    */
   private void verifyRecipientEmailAvailable(String recipientEmail) {
     String normalized = recipientEmail.trim().toLowerCase(Locale.ROOT);
-    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()) {
+    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()
+        || accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+                normalized, ADDRESS_HOLDING_INVITE_STATUSES, LocalDateTime.now())
+            > 0) {
       // 409 + X-Reason: EMAIL_NOT_AVAILABLE — distinguishable from the bare 400 of a malformed
-      // address and from the reason-less 409 of a taken tenant ID.
+      // address and from the reason-less 409 of a taken tenant ID. Both sources answer with the
+      // SAME reason on purpose: the admin renders one inline field error for it, and a second
+      // code would degrade to a generic toast.
       throw new CustomValidationHttpStatusException(
           HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -4,13 +4,16 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
@@ -29,6 +32,7 @@ import java.time.ZoneId;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.NonNull;
@@ -62,6 +66,7 @@ public class AccountInviteService {
   private final @NonNull InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
   private final @NonNull InviteMailDispatchService inviteMailDispatchService;
   private final @NonNull InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+  private final @NonNull IdentityEmailOwnerLookup identityEmailOwnerLookup;
 
   @Transactional
   public AccountInvite createInvite(CreateAccountInviteCommand command) {
@@ -75,6 +80,7 @@ public class AccountInviteService {
       throw new BadRequestException("recipientEmail is required");
     }
     validateAllocationModes(command);
+    verifyRecipientEmailAvailable(command.recipientEmail());
     if (command.targetRole() == AccountInviteTargetRole.TENANT_ADMIN
         && command.tenantId() != null
         && isTenantIdTaken(command.tenantId())) {
@@ -137,6 +143,35 @@ public class AccountInviteService {
         tenantIdAllocationClient.release(tenantReservation.tenantId());
       }
       throw exception;
+    }
+  }
+
+  /**
+   * P3: refuses an invite whose recipient address already belongs to a registered identity.
+   *
+   * <p>Before this guard the collision only surfaced at redemption time — the invitee filled in the
+   * whole registration, signed and forwarded the contract and only then hit the dead-end
+   * "invitation already used" page, with all that work lost. The check therefore belongs at the
+   * front of the funnel, on the admin's create call.
+   *
+   * <p>Role-agnostic on purpose: counsellor and tenant-admin invites both run through {@code
+   * createInvite}, and so do both creation paths ("send directly" posts a templateId, "add to list"
+   * does not). One guard covers all four combinations.
+   *
+   * <p>No separate availability endpoint is exposed: the check rides on the existing, admin-only
+   * create call, so it never becomes an unauthenticated user-enumeration oracle.
+   *
+   * <p>The address is normalized the same way {@link CounsellorInviteProvisioningService}
+   * normalizes it when it later creates the identity, so the guard tests exactly the value that
+   * would collide.
+   */
+  private void verifyRecipientEmailAvailable(String recipientEmail) {
+    String normalized = recipientEmail.trim().toLowerCase(Locale.ROOT);
+    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()) {
+      // 409 + X-Reason: EMAIL_NOT_AVAILABLE — distinguishable from the bare 400 of a malformed
+      // address and from the reason-less 409 of a taken tenant ID.
+      throw new CustomValidationHttpStatusException(
+          HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -1622,6 +1622,26 @@ public class KeycloakServiceTest {
   }
 
   @Test
+  public void findByEmail_Should_ReturnTypedOwner_When_StoredRecordDiffersOnlyInCase() {
+    // Callers probe with a normalized (lower-cased) address, and Keycloak's own search is
+    // case-insensitive — so it hands back the record. A case-sensitive equals() filter would
+    // then throw that hit away again and report the address as free, which is precisely the
+    // duplicate the caller is trying to prevent.
+    var probe = "mail@example.com";
+    UserRepresentation userRepresentation = mock(UserRepresentation.class);
+    when(userRepresentation.getEmail()).thenReturn("Mail@Example.COM");
+    when(userRepresentation.getUsername()).thenReturn(USERNAME);
+    UsersResource usersResource = mock(UsersResource.class);
+    when(usersResource.search(probe, 0, Integer.MAX_VALUE))
+        .thenReturn(singletonList(userRepresentation));
+    when(keycloakClient.getUsersResource()).thenReturn(usersResource);
+
+    var result = keycloakService.findByEmail(probe);
+
+    assertThat(result, is(Optional.of(new IdentityEmailOwner(USERNAME))));
+  }
+
+  @Test
   public void findByEmail_Should_ReturnEmpty_When_NoMatchFound() {
     var email = "mail@example.com";
     UsersResource usersResource = mock(UsersResource.class);

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import java.time.LocalDateTime;
@@ -48,6 +49,7 @@ class AccountInviteAcceptRaceIT {
   @Autowired private AccountInviteRepository accountInviteRepository;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
   @MockitoBean private TenantService tenantService;
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteRecipientEmailGuardIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteRecipientEmailGuardIT.java
@@ -1,0 +1,163 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * P3 duplicate-address guard, exercised against a real database rather than a mocked repository.
+ *
+ * <p>The identity probe ({@link IdentityEmailOwnerLookup}) is stubbed empty throughout: these tests
+ * are exactly about the case it cannot answer, because a Keycloak identity is created only when an
+ * invite is accepted. Everything an unaccepted invite contributes — the {@code LOWER()} comparison,
+ * the status filter and the lazily-materialized expiry — is decided by SQL, so it is only really
+ * proven by running that SQL.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(AccountInviteService.class)
+class AccountInviteRecipientEmailGuardIT {
+
+  private static final String ADDRESS = "held@example.org";
+
+  @Autowired private AccountInviteService service;
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @MockitoBean private TenantService tenantService;
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+  @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+
+  @MockitoBean
+  private de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService
+      inviteMailDispatchService;
+
+  @MockitoBean private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+
+  @BeforeEach
+  void noIdentityOwnsTheAddress() {
+    when(identityEmailOwnerLookup.findByEmail(ADDRESS)).thenReturn(Optional.empty());
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+  }
+
+  @AfterEach
+  void cleanUp() {
+    accountInviteRepository.deleteAll();
+  }
+
+  @Test
+  void createInvite_Should_Refuse_When_ADraftInviteAlreadyHoldsTheAddress() {
+    persistInvite(ADDRESS, AccountInviteStatus.DRAFT, LocalDateTime.now().plusDays(30));
+
+    assertThatThrownBy(() -> service.createInvite(counsellorInviteFor(ADDRESS)))
+        .isInstanceOf(CustomValidationHttpStatusException.class)
+        .satisfies(
+            thrown -> {
+              var ex = (CustomValidationHttpStatusException) thrown;
+              assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
+              assertThat(ex.getCustomHttpHeaders().getFirst("X-Reason"))
+                  .isEqualTo("EMAIL_NOT_AVAILABLE");
+            });
+
+    assertThat(accountInviteRepository.count()).isOne();
+  }
+
+  @Test
+  void createInvite_Should_Refuse_When_AnEmailSentInviteHoldsTheAddressInAnotherCase() {
+    // The column is persisted case-preserving, so the stored row and the request can disagree on
+    // case while meaning the same mailbox.
+    persistInvite(
+        "Held@Example.ORG", AccountInviteStatus.EMAIL_SENT, LocalDateTime.now().plusDays(30));
+
+    assertThatThrownBy(() -> service.createInvite(counsellorInviteFor("HELD@EXAMPLE.ORG")))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+
+    assertThat(accountInviteRepository.count()).isOne();
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_OnlyTerminalInvitesExistForTheAddress() {
+    LocalDateTime future = LocalDateTime.now().plusDays(30);
+    persistInvite(ADDRESS, AccountInviteStatus.ACCEPTED, future);
+    persistInvite(ADDRESS, AccountInviteStatus.REVOKED, future);
+    persistInvite(ADDRESS, AccountInviteStatus.EXPIRED, future);
+    persistInvite(ADDRESS, AccountInviteStatus.SUPERSEDED, future);
+
+    AccountInvite created = service.createInvite(counsellorInviteFor(ADDRESS));
+
+    // A withdrawn, lapsed or replaced invite must leave the mailbox free — otherwise a single
+    // mistyped invite would permanently lock the person out of ever being invited again.
+    assertThat(created.getId()).isNotNull();
+    assertThat(created.getStatus()).isEqualTo(AccountInviteStatus.DRAFT);
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_TheOnlyOutstandingInviteHasLapsed() {
+    // Expiry is materialized lazily: the status only flips to EXPIRED when somebody opens the
+    // link. An invite that was never opened stays EMAIL_SENT forever, so the guard has to read
+    // the date rather than trust the status.
+    persistInvite(ADDRESS, AccountInviteStatus.EMAIL_SENT, LocalDateTime.now().minusDays(1));
+
+    AccountInvite created = service.createInvite(counsellorInviteFor(ADDRESS));
+
+    assertThat(created.getId()).isNotNull();
+  }
+
+  private CreateAccountInviteCommand counsellorInviteFor(String recipientEmail) {
+    return new CreateAccountInviteCommand(
+        AccountInviteTargetRole.COUNSELLOR,
+        7L,
+        recipientEmail,
+        "Ada",
+        "Lovelace",
+        null,
+        null,
+        null);
+  }
+
+  private void persistInvite(
+      String recipientEmail, AccountInviteStatus status, LocalDateTime expiresAt) {
+    LocalDateTime now = LocalDateTime.now();
+    accountInviteRepository.save(
+        AccountInvite.builder()
+            .targetRole(AccountInviteTargetRole.COUNSELLOR)
+            .recipientEmail(recipientEmail)
+            .status(status)
+            .emailVerificationStatus(EmailVerificationStatus.PENDING)
+            .twoFactorStatus(TwoFactorGateStatus.NOT_REQUIRED)
+            .expiresAt(expiresAt)
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
@@ -60,6 +61,7 @@ class AccountInviteReservationOrchestrationIT {
   @Autowired private AccountInviteRepository accountInviteRepository;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
   @MockitoBean private TenantService tenantService;
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -22,6 +23,8 @@ import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
@@ -63,6 +66,7 @@ class AccountInviteServiceTest {
   @Mock private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
   @Mock private InviteMailDispatchService inviteMailDispatchService;
   @Mock private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+  @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
 
   @InjectMocks private AccountInviteService service;
 
@@ -407,6 +411,103 @@ class AccountInviteServiceTest {
         new CreateAccountInviteCommand(
             AccountInviteTargetRole.COUNSELLOR, 7L, "   ", "A", "B", null, null, null);
     assertThatThrownBy(() -> service.createInvite(command)).isInstanceOf(BadRequestException.class);
+  }
+
+  // --- P3 (#Problem 3): duplicate recipient e-mail is refused at invite CREATION time, not only
+  // at redemption. Both invite kinds and both creation paths ("send now" / "add to list") funnel
+  // through createInvite, so a single guard here covers all of them.
+
+  @Test
+  void createInvite_Should_ThrowEmailNotAvailable_When_RecipientEmailBelongsToRegisteredUser() {
+    when(identityEmailOwnerLookup.findByEmail("taken@example.org"))
+        .thenReturn(Optional.of(new IdentityEmailOwner("existing-user")));
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "taken@example.org",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class)
+        .satisfies(
+            thrown -> {
+              var ex = (CustomValidationHttpStatusException) thrown;
+              assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
+              assertThat(ex.getCustomHttpHeaders().getFirst("X-Reason"))
+                  .isEqualTo("EMAIL_NOT_AVAILABLE");
+            });
+
+    verifyNoInteractions(accountInviteRepository);
+  }
+
+  @Test
+  void createInvite_Should_ThrowEmailNotAvailable_When_TenantAdminRecipientEmailIsRegistered() {
+    when(identityEmailOwnerLookup.findByEmail("taken@example.org"))
+        .thenReturn(Optional.of(new IdentityEmailOwner("existing-user")));
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            7L,
+            "taken@example.org",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+
+    // The guard runs before any tenant-ID reservation, so nothing has to be compensated.
+    verifyNoInteractions(tenantIdAllocationClient);
+    verifyNoInteractions(accountInviteRepository);
+  }
+
+  @Test
+  void createInvite_Should_NormalizeRecipientEmail_When_CheckingAvailability() {
+    when(identityEmailOwnerLookup.findByEmail("taken@example.org"))
+        .thenReturn(Optional.of(new IdentityEmailOwner("existing-user")));
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "  Taken@Example.ORG  ",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+  }
+
+  @Test
+  void createInvite_Should_Succeed_When_RecipientEmailIsUnknownToIdentityProvider() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(identityEmailOwnerLookup.findByEmail("free@example.org")).thenReturn(Optional.empty());
+    when(accountInviteRepository.save(any(AccountInvite.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.COUNSELLOR,
+                7L,
+                "free@example.org",
+                "A",
+                "B",
+                null,
+                null,
+                null));
+
+    assertThat(invite.getRecipientEmail()).isEqualTo("free@example.org");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -510,6 +510,127 @@ class AccountInviteServiceTest {
     assertThat(invite.getRecipientEmail()).isEqualTo("free@example.org");
   }
 
+  // --- P3 gap closure: the identity probe alone is not enough. A Keycloak user only exists once
+  // an invite has been ACCEPTED, so an invite still sitting in DRAFT or EMAIL_SENT is invisible to
+  // it — and a second invite for the same address slipped through. A pending invite "holds" the
+  // address just as a registered account does, so it must produce the very same 409.
+
+  @Test
+  void createInvite_Should_ThrowEmailNotAvailable_When_ANonTerminalInviteAlreadyHoldsTheAddress() {
+    when(identityEmailOwnerLookup.findByEmail("pending@example.org")).thenReturn(Optional.empty());
+    when(accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+            eq("pending@example.org"), any(), any()))
+        .thenReturn(1L);
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "pending@example.org",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class)
+        .satisfies(
+            thrown -> {
+              var ex = (CustomValidationHttpStatusException) thrown;
+              // Identical contract to the registered-account case — the admin renders exactly one
+              // inline field error for EMAIL_NOT_AVAILABLE; a new reason code would fall through
+              // to a generic toast.
+              assertThat(ex.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
+              assertThat(ex.getCustomHttpHeaders().getFirst("X-Reason"))
+                  .isEqualTo("EMAIL_NOT_AVAILABLE");
+            });
+
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void createInvite_Should_ThrowEmailNotAvailable_When_TenantAdminAddressHasANonTerminalInvite() {
+    when(identityEmailOwnerLookup.findByEmail("pending@example.org")).thenReturn(Optional.empty());
+    when(accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+            eq("pending@example.org"), any(), any()))
+        .thenReturn(1L);
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.TENANT_ADMIN,
+            7L,
+            "pending@example.org",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+
+    // Still ahead of the role branch: no tenant-ID reservation to compensate, nothing persisted.
+    verifyNoInteractions(tenantIdAllocationClient);
+    verify(accountInviteRepository, never()).save(any());
+  }
+
+  @Test
+  void createInvite_Should_MatchAPendingInviteCaseInsensitively() {
+    when(identityEmailOwnerLookup.findByEmail("pending@example.org")).thenReturn(Optional.empty());
+    // The probe receives the normalized address; the query lower-cases the stored column, so a
+    // row persisted as "Pending@Example.ORG" is found just the same.
+    when(accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+            eq("pending@example.org"), any(), any()))
+        .thenReturn(1L);
+    var command =
+        new CreateAccountInviteCommand(
+            AccountInviteTargetRole.COUNSELLOR,
+            7L,
+            "  Pending@Example.ORG  ",
+            "A",
+            "B",
+            null,
+            null,
+            null);
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+  }
+
+  @Test
+  void createInvite_Should_OnlyLetNonTerminalInviteStatusesBlockTheAddress() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(identityEmailOwnerLookup.findByEmail("reusable@example.org")).thenReturn(Optional.empty());
+    when(accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+            eq("reusable@example.org"), any(), any()))
+        .thenReturn(0L);
+    when(accountInviteRepository.save(any(AccountInvite.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var invite =
+        service.createInvite(
+            new CreateAccountInviteCommand(
+                AccountInviteTargetRole.COUNSELLOR,
+                7L,
+                "reusable@example.org",
+                "A",
+                "B",
+                null,
+                null,
+                null));
+
+    assertThat(invite.getRecipientEmail()).isEqualTo("reusable@example.org");
+    // ACCEPTED / EXPIRED / REVOKED / SUPERSEDED are never asked about: an accepted invite is
+    // already covered by the identity probe, and a revoked, expired or superseded one must leave
+    // the address free — otherwise a mistyped or withdrawn invite would strand the admin with no
+    // way to invite that person again.
+    verify(accountInviteRepository)
+        .countNonTerminalInvitesForRecipientEmail(
+            eq("reusable@example.org"),
+            eq(List.of(AccountInviteStatus.DRAFT, AccountInviteStatus.EMAIL_SENT)),
+            any());
+  }
+
   @Test
   void createInvite_Should_defaultTwoFactorNotRequired_When_targetRoleWithoutMandatory2fa() {
     when(authenticatedUser.getUserId()).thenReturn("admin-1");


### PR DESCRIPTION
Owner-reported problem 3 of four, **backend half**. UI counterpart: ORISO-Admin `feat/invite-email-duplicate-check-p3`. See `0 - Docs/plans/2026-08-19-owner-problem-fixes-overview.md`.

## Problem

An invite whose recipient address already belongs to a registered identity was only rejected **at redemption time**. The invitee filled in the whole registration, signed and forwarded the contract, and only then hit the dead-end "invitation already used" page. All of that work wasted.

## Root cause

`createInvite` performed no availability check on the recipient address. The collision was only discovered later, at redemption, by which point the invitee had already done the work — and the admin who sent the invite never learned it was doomed.

## Fix

`createInvite` now verifies the recipient address against the existing `IdentityEmailOwnerLookup` port **before anything is reserved or persisted**, and answers **409 with `X-Reason: EMAIL_NOT_AVAILABLE`**. That reason makes the failure distinguishable from the bare 400 of a malformed address and from the reason-less 409 of a taken tenant ID.

Two properties that matter for review:

- **The guard sits before the tenant-ID reservation.** One guard therefore covers send-directly and add-to-list, tenant and counsellor invites, and CSV import — they all funnel through this one call. It is role-agnostic by construction, not by enumeration.
- **No new endpoint is introduced.** The check rides on the existing admin-only create call, so it never becomes an unauthenticated **user-enumeration oracle**, and there is no TOCTOU gap between a preflight answer and the real create.

The address is normalized (trim + lower-case) exactly the way `CounsellorInviteProvisioningService` normalizes it when it later creates the identity, so the guard tests the value that would actually collide.

## Tests

4 new `@Test` cases in `AccountInviteServiceTest` (+101 lines): address already owned → 409 + reason and **nothing reserved**; address free → unchanged happy path; normalization (whitespace / mixed case) collides correctly; the reservation is genuinely not touched on refusal.

## Reviewer test plan

- [ ] Create an invite for an address that already belongs to a registered identity — **409** with `X-Reason: EMAIL_NOT_AVAILABLE`.
- [ ] Confirm **no tenant-ID reservation** was consumed by the refused call.
- [ ] Same address with leading/trailing whitespace and different casing — still refused (normalization matches `CounsellorInviteProvisioningService`).
- [ ] Counsellor invite and tenant-admin invite — both refused by the same guard.
- [ ] „Direkt Versenden" (with `templateId`) and „Empfänger nur anlegen" (without) — both refused.
- [ ] CSV import with one colliding row — that row carries the reason, the others still import.
- [ ] Tenant-ID collision — still the reason-**less** 409, distinguishable from this one.
- [ ] Malformed address — still 400, not 409.
- [ ] Confirm **no new route** appears in the OpenAPI surface (no enumeration oracle).
- [ ] **Mobile (390 px)**: with the Admin branch deployed, the refusal renders inline on the e-mail field on a phone viewport.
