### PR TITLE
fix(security): pin amqp-client to 5.33.1 to clear three HIGH CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,15 @@
 		<!-- Spring Boot 4.0.7 still manages HttpCore 5.3.6; 5.4.3 fixes
 		     CVE-2026-54399 and is compatible with the managed HttpClient 5.5.2. -->
 		<httpcore5.version>5.4.3</httpcore5.version>
+		<!-- Spring Boot 4.0.7 under-pins the RabbitMQ Java client at 5.27.1 (via
+		     spring-boot-starter-amqp -> spring-rabbit 4.0.4). 5.33.1 is the lowest
+		     version that clears all three HIGH findings of the image CVE gate:
+		     CVE-2026-63337 (unvalidated Class.forName in JSON-RPC, fixed 5.33.0),
+		     CVE-2026-69219 (oversized LongString/bytes in ValueReader, fixed 5.33.1)
+		     and CVE-2026-69220 (unbounded recursion in ValueReader, fixed 5.33.1).
+		     Boot 4.1.0 still manages only 5.30.0, so upgrading Boot does not remove
+		     the need for this override. Drop it once the Boot BOM manages >= 5.33.1. -->
+		<rabbit-amqp-client.version>5.33.1</rabbit-amqp-client.version>
 		<springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 		<lombok.version>1.18.42</lombok.version>


### PR DESCRIPTION
The image CVE gate ("Reject fixable high or critical image vulnerabilities") started failing on `com.rabbitmq:amqp-client` 5.27.1.

This is **not a regression from a feature branch**: the same Trivy step passed on `pre-dev` on 2026-08-18 (run `32171095881`) and the dependency has not changed since. A vulnerability-database refresh surfaced it, so a rebuild of `pre-dev` today would fail identically.

## Where the version comes from

`amqp-client` is not pinned in our `pom.xml`. It is transitive and BOM-managed:

```
$ ./mvnw -o dependency:tree -Dincludes=com.rabbitmq:amqp-client
[INFO] \- org.springframework.boot:spring-boot-starter-amqp:jar:4.0.7:compile
[INFO]    \- org.springframework.boot:spring-boot-amqp:jar:4.0.7:compile
[INFO]       \- org.springframework.amqp:spring-rabbit:jar:4.0.4:compile
[INFO]          \- com.rabbitmq:amqp-client:jar:5.27.1:compile
```

## Why an override and not a Boot upgrade

| Spring Boot BOM | `rabbit-amqp-client.version` | clears all three CVEs? |
| --- | --- | --- |
| 4.0.7 (current, latest 4.0.x) | 5.27.1 | no |
| 4.1.0 (next minor) | 5.30.0 | no |

Boot under-pins this dependency in every currently released line, so **no Boot upgrade fixes it**. A 4.0 -> 4.1 minor upgrade would be a much larger change and would still leave the gate red. The explicit override is the smaller *and* the only working fix.

## Why 5.33.1

Fixed versions as reported by the gate:

| CVE | Severity | Title | Fixed in |
| --- | --- | --- | --- |
| CVE-2026-63337 | HIGH | Unvalidated `Class.forName` in JSON-RPC | 5.33.0 |
| CVE-2026-69219 | HIGH | Oversized LongString/bytes in `ValueReader` | 5.33.1 |
| CVE-2026-69220 | HIGH | Unbounded recursion in `ValueReader` | 5.33.1 |

5.33.1 is the lowest version that clears all three.

## How it is applied

Via the Boot BOM property, matching the existing `netty.version`, `httpcore5.version` and `log4j.version` CVE overrides in this pom, with a comment naming the three CVEs and the fact that the Boot BOM under-pins it, so a future Boot upgrade can remove the override deliberately rather than by accident.

Verified locally:

```
[INFO]          \- com.rabbitmq:amqp-client:jar:5.33.1:compile
```

A minor bump within the 5.x line should be source- and binary-compatible with `spring-rabbit` 4.0.4; the integration tests and the MariaDB contract check in CI are the real verification.

The same commit is cherry-picked onto `speed/owner-fixes-2026-08-19` so the hand-over image can go green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)