### PR TITLE
fix: load consultant agencies explicitly to avoid LazyInitializationException

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
@@ -201,9 +201,17 @@ public class ConsultantAgencyAdminService {
   }
 
   private boolean noOtherTeamAgency(Consultant consultant, Long agencyId) {
-    return consultant.getConsultantAgencies().stream()
+    // Deliberately query the repository instead of navigating consultant.getConsultantAgencies():
+    // this method runs outside of an open Hibernate session (changeAgencyType() is not
+    // @Transactional, and spring.jpa.open-in-view is disabled), so the lazy collection on a
+    // consultant loaded by an earlier, already-closed repository call would raise a
+    // LazyInitializationException. A fresh, explicit query is self-contained and always eager.
+    // Same pattern as ChatService's explicit ChatAgencyRepository lookups (see #288).
+    return consultantAgencyRepository
+        .findByConsultantIdAndDeleteDateIsNull(consultant.getId())
+        .stream()
+        .filter(consultantAgency -> !agencyId.equals(consultantAgency.getAgencyId()))
         .map(this::toAgencyDto)
-        .filter(agencyDTO -> !agencyId.equals(agencyDTO.getId()))
         .noneMatch(AgencyDTO::getTeamAgency);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/facade/ConsultantAdminFacadeIT.java
@@ -4,13 +4,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.agencyadminserivce.generated.web.model.AgencyAdminResponseDTO;
 import de.caritas.cob.userservice.agencyserivce.generated.ApiClient;
+import de.caritas.cob.userservice.agencyserivce.generated.web.AgencyControllerApi;
+import de.caritas.cob.userservice.agencyserivce.generated.web.model.AgencyResponseDTO;
 import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyTypeDTO.AgencyTypeEnum;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantFilter;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.Sort;
@@ -21,6 +26,7 @@ import de.caritas.cob.userservice.api.config.apiclient.AgencyServiceApiControlle
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
+import de.caritas.cob.userservice.api.model.ConsultantAgencyStatus;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
@@ -31,6 +37,7 @@ import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -46,6 +53,7 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestClientException;
 
 @SpringBootTest(classes = UserServiceApplication.class)
 @TestPropertySource(properties = "spring.profiles.active=testing")
@@ -312,5 +320,105 @@ class ConsultantAdminFacadeIT {
 
     consultantAdminFacade.filterAgencyListForCreation(consultantId, newList);
     assertThat(newList.size(), is(1));
+  }
+
+  // ---------------------------------------------------------------------------
+  // changeAgencyType (regression test for #1069)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reproduces the original bug behind issue #1069: converting a team agency to a default (single)
+   * agency used to raise a {@code LazyInitializationException}. {@link
+   * de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade#changeAgencyType} is
+   * deliberately NOT annotated {@code @Transactional} (matching production), and this test class
+   * has no class-level {@code @Transactional} either, so — just like on a real request, since
+   * {@code spring.jpa.open-in-view=false} — every repository call below opens and closes its own
+   * Hibernate session. Before the fix, {@code noOtherTeamAgency()} touched a lazy collection on a
+   * consultant loaded by an already-closed prior repository call and blew up with a 500.
+   */
+  @Test
+  void
+      changeAgencyType_Should_notThrowLazyInitializationException_When_ConvertingTeamAgencyToDefaultAgency() {
+    var consultantId = UUID.randomUUID().toString();
+    givenConsultantWithoutAgency(consultantId);
+    var consultant = consultantRepository.findById(consultantId).orElseThrow();
+    consultant.setTeamConsultant(true);
+    consultantRepository.save(consultant);
+
+    var convertedAgencyId = 5551L;
+    var otherTeamAgencyId = 5552L;
+
+    consultantAgencyRepository.saveAll(
+        List.of(
+            ConsultantAgency.builder()
+                .consultant(consultant)
+                .agencyId(convertedAgencyId)
+                .status(ConsultantAgencyStatus.IN_PROGRESS)
+                .build(),
+            ConsultantAgency.builder()
+                .consultant(consultant)
+                .agencyId(otherTeamAgencyId)
+                .status(ConsultantAgencyStatus.IN_PROGRESS)
+                .build()));
+
+    when(agencyServiceApiControllerFactory.createControllerApi())
+        .thenReturn(
+            new TeamAwareAgencyControllerApi(new ApiClient(), Map.of(otherTeamAgencyId, true)));
+
+    var agencyTypeDTO = new AgencyTypeDTO().agencyType(AgencyTypeEnum.DEFAULT_AGENCY);
+
+    assertDoesNotThrow(
+        () -> consultantAdminFacade.changeAgencyType(convertedAgencyId, agencyTypeDTO));
+
+    var reloadedConsultant = consultantRepository.findById(consultantId).orElseThrow();
+    // The consultant still has agency 5552, which IS a team agency, so the team-consultant flag
+    // must be kept.
+    assertThat(reloadedConsultant.isTeamConsultant(), is(true));
+  }
+
+  @Test
+  void changeAgencyType_Should_RemoveTeamConsultantFlag_When_ConvertedAgencyWasTheOnlyTeamAgency() {
+    var consultantId = UUID.randomUUID().toString();
+    givenConsultantWithoutAgency(consultantId);
+    var consultant = consultantRepository.findById(consultantId).orElseThrow();
+    consultant.setTeamConsultant(true);
+    consultantRepository.save(consultant);
+
+    var convertedAgencyId = 5561L;
+    consultantAgencyRepository.save(
+        ConsultantAgency.builder()
+            .consultant(consultant)
+            .agencyId(convertedAgencyId)
+            .status(ConsultantAgencyStatus.IN_PROGRESS)
+            .build());
+
+    var agencyTypeDTO = new AgencyTypeDTO().agencyType(AgencyTypeEnum.DEFAULT_AGENCY);
+
+    assertDoesNotThrow(
+        () -> consultantAdminFacade.changeAgencyType(convertedAgencyId, agencyTypeDTO));
+
+    var reloadedConsultant = consultantRepository.findById(consultantId).orElseThrow();
+    assertThat(reloadedConsultant.isTeamConsultant(), is(false));
+  }
+
+  /** Test double returning a deterministic {@code teamAgency} flag per agency id. */
+  private static final class TeamAwareAgencyControllerApi extends AgencyControllerApi {
+
+    private final Map<Long, Boolean> teamAgencyById;
+
+    private TeamAwareAgencyControllerApi(ApiClient apiClient, Map<Long, Boolean> teamAgencyById) {
+      super(apiClient);
+      this.teamAgencyById = teamAgencyById;
+    }
+
+    @Override
+    public List<AgencyResponseDTO> getAgenciesByIds(List<Long> agencyIds)
+        throws RestClientException {
+      return agencyIds.stream()
+          .map(
+              id ->
+                  new AgencyResponseDTO().id(id).teamAgency(teamAgencyById.getOrDefault(id, false)))
+          .collect(Collectors.toList());
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
@@ -146,31 +146,63 @@ class ConsultantAgencyAdminServiceTest {
 
   @Test
   void removeConsultantsFromTeamSessionsByAgencyId_Should_RemoveTeamFlag_When_NoOtherTeamAgency() {
-    var teamAgency = new AgencyDTO();
-    teamAgency.setId(10L);
-    teamAgency.setTeamAgency(true);
-
     var consultantAgency = new ConsultantAgency();
     consultantAgency.setAgencyId(10L);
 
     var consultant = new Consultant();
+    consultant.setId("c-1");
     consultant.setTeamConsultant(true);
-    consultant.setConsultantAgencies(new java.util.HashSet<>(Set.of(consultantAgency)));
+    // Deliberately NOT populating consultant.consultantAgencies here: production code must no
+    // longer touch that lazy collection (it reproduces LazyInitializationException outside an
+    // open Hibernate session — see #1069). noOtherTeamAgency() must instead go through
+    // consultantAgencyRepository, which is what this test stubs below.
 
     when(sessionRepository.findByAgencyIdAndStatusAndTeamSessionIsTrue(
             10L, SessionStatus.IN_PROGRESS))
         .thenReturn(List.of());
     when(consultantRepository.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(List.of(10L)))
         .thenReturn(List.of(consultant));
-    // The only agency is 10L (the one being removed), so no other team agency remains
-    // noOtherTeamAgency filters out agencyId == 10L, leaving nothing — noneMatch returns true
-    // agencyService.getAgency is never called because the stream filters it out
-    when(agencyService.getAgency(10L)).thenReturn(teamAgency);
+    when(consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull("c-1"))
+        .thenReturn(List.of(consultantAgency));
+    // The only agency is 10L (the one being removed), so no other team agency remains.
+    // noOtherTeamAgency filters out agencyId == 10L, leaving nothing — noneMatch returns true.
+    // agencyService.getAgency is never called because the stream filters it out.
 
     consultantAgencyAdminService.removeConsultantsFromTeamSessionsByAgencyId(10L);
 
     assertThat(consultant.isTeamConsultant()).isFalse();
     verify(consultantRepository).save(consultant);
+  }
+
+  @Test
+  void
+      removeConsultantsFromTeamSessionsByAgencyId_Should_KeepTeamFlag_When_ConsultantHasOtherTeamAgency() {
+    var convertedAgencyRelation = new ConsultantAgency();
+    convertedAgencyRelation.setAgencyId(10L);
+    var otherAgencyRelation = new ConsultantAgency();
+    otherAgencyRelation.setAgencyId(20L);
+
+    var otherTeamAgency = new AgencyDTO();
+    otherTeamAgency.setId(20L);
+    otherTeamAgency.setTeamAgency(true);
+
+    var consultant = new Consultant();
+    consultant.setId("c-1");
+    consultant.setTeamConsultant(true);
+
+    when(sessionRepository.findByAgencyIdAndStatusAndTeamSessionIsTrue(
+            10L, SessionStatus.IN_PROGRESS))
+        .thenReturn(List.of());
+    when(consultantRepository.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(List.of(10L)))
+        .thenReturn(List.of(consultant));
+    when(consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull("c-1"))
+        .thenReturn(List.of(convertedAgencyRelation, otherAgencyRelation));
+    when(agencyService.getAgency(20L)).thenReturn(otherTeamAgency);
+
+    consultantAgencyAdminService.removeConsultantsFromTeamSessionsByAgencyId(10L);
+
+    assertThat(consultant.isTeamConsultant()).isTrue();
+    verify(consultantRepository, never()).save(consultant);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
@@ -108,6 +108,11 @@ public class ConsultantAgencyAdminUserServiceTest {
         .thenReturn(singletonList(session));
     when(this.consultantRepository.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(anyList()))
         .thenReturn(consultants);
+    // noOtherTeamAgency() now queries consultantAgencyRepository directly (not the lazy
+    // consultant.getConsultantAgencies() collection, see #1069) — give every consultant a second,
+    // non-team agency relation so agencyService.getAgency() is actually exercised.
+    when(this.consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull(any()))
+        .thenAnswer(invocation -> singleOtherAgencyRelation());
     when(this.agencyService.getAgency(any())).thenReturn(agencyDTO);
 
     this.consultantAgencyAdminService.removeConsultantsFromTeamSessionsByAgencyId(1L);
@@ -131,10 +136,23 @@ public class ConsultantAgencyAdminUserServiceTest {
           when(this.consultantRepository.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(
                   anyList()))
               .thenReturn(consultants);
+          when(this.consultantAgencyRepository.findByConsultantIdAndDeleteDateIsNull(any()))
+              .thenAnswer(invocation -> singleOtherAgencyRelation());
           when(this.agencyService.getAgency(any())).thenThrow(new InternalServerErrorException(""));
 
           this.consultantAgencyAdminService.removeConsultantsFromTeamSessionsByAgencyId(1L);
         });
+  }
+
+  /**
+   * A single {@link ConsultantAgency} relation to an agency other than the one (id 1L) being
+   * converted, so that noOtherTeamAgency()'s filter does not discard it and agencyService is
+   * actually invoked.
+   */
+  private static List<ConsultantAgency> singleOtherAgencyRelation() {
+    var otherRelation = new ConsultantAgency();
+    otherRelation.setAgencyId(2L);
+    return singletonList(otherRelation);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #1069.

Converting a team agency to a default (single) agency in the Admin Panel returned HTTP 500. Root cause: `ConsultantAdminFacade#changeAgencyType()` is intentionally not `@Transactional`, and `spring.jpa.open-in-view` is disabled for this service, so each repository call opens and closes its own Hibernate session. `ConsultantAgencyAdminService#noOtherTeamAgency()` was navigating `consultant.getConsultantAgencies()` — a lazy `@OneToMany` collection — on a `Consultant` entity that had already been loaded (and detached) by an earlier, separately-scoped repository call. Touching that lazy collection afterwards threw `LazyInitializationException`, which surfaced to the caller as a 500.

## Fix

`noOtherTeamAgency()` now queries `ConsultantAgencyRepository#findByConsultantIdAndDeleteDateIsNull` directly instead of touching the lazy association — a fresh, self-contained query that doesn't depend on session lifetime. This mirrors the explicit-repository-fetch pattern already used in `ChatService` for the same class of bug (#288, "load chat agencies explicitly to avoid LazyInitializationException").

No `@Transactional` was added to `changeAgencyType()`/`removeConsultantsFromTeamSessionsByAgencyId()` — avoiding the lazy touch entirely is more consistent with this codebase's existing convention and keeps each repository call independently scoped.

## Testing

- Added `ConsultantAdminFacadeIT#changeAgencyType_Should_notThrowLazyInitializationException_When_ConvertingTeamAgencyToDefaultAgency` and `..._Should_RemoveTeamConsultantFlag_When_ConvertedAgencyWasTheOnlyTeamAgency` — full Spring context, no class-level `@Transactional`, so these reproduce the real session-boundary conditions. Verified both fail with the exact original `LazyInitializationException: Cannot lazily initialize collection of role 'Consultant.consultantAgencies'` against the pre-fix code, and pass against the fix.
- Extended `ConsultantAgencyAdminServiceTest` with a case proving the team flag is *kept* when another team agency still exists (previously untested branch).
- Updated `ConsultantAgencyAdminUserServiceTest` stubs that relied on the old lazy-collection path.
- `mvn test -Dtest=ConsultantAgencyAdminServiceTest,ConsultantAdminFacadeIT,ConsultantAdminFacadeTest,ConsultantAgencyAdminUserServiceIT,ConsultantAgencyAdminUserServiceTest,ConsultantAgencyAdminUserServiceTenantAwareIT` — 81/81 green.
- `mvn spotless:check` — clean.

## Related

Unblocks ORISO-Admin#832 ("fix: add team/single agency toggle to agency settings") — Shazia's CHANGES_REQUESTED review asked for this backend fix to land alongside the toggle so both conversion directions (team↔single) work end to end.