### PR TITLE
Stop Keycloak create-user errors sharing state, and report the actual response

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakService.java
@@ -384,14 +384,25 @@ public class KeycloakService
         }
         return new CreatedIdentity(createdUserId);
       }
-      handleCreateKeycloakUserError(response);
+      throw createUserFailure(user, response);
     }
-    throw new InternalServerErrorException(
-        String.format(
-            "Could not create Keycloak account for: %s %nKeycloak error: %s", user, keycloakError));
   }
 
-  private void handleCreateKeycloakUserError(Response response) {
+  /**
+   * Builds the failure for a non-201 Keycloak create-user response.
+   *
+   * <p>Returns the exception rather than throwing it, and rather than recording the detail in a
+   * field the caller reads afterwards. {@code keycloakError} is {@code @Value}-injected
+   * configuration on a singleton bean, so writing the current request's Keycloak response into it
+   * corrupted it for the life of the JVM and let concurrent failures read each other's detail -
+   * request A could be handed the raw Keycloak body belonging to request B, which carries B's
+   * username and e-mail. Nothing else needs the value to outlive the throw, so it does not.
+   *
+   * <p>The status and raw body go into the exception message as well as the log line: a 500 whose
+   * message is only the configured "unexpected Keycloak error" string is unactionable, and the
+   * message is what reaches the operator through the error report.
+   */
+  private RuntimeException createUserFailure(UserDTO user, Response response) {
     final int status = response.getStatus();
     String rawResponse = "";
 
@@ -406,21 +417,20 @@ public class KeycloakService
 
     if (errorMatchesMarker(combinedError, identityClientConfig.getErrorMessageDuplicatedEmail())
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("email"))) {
-      throw new CustomValidationHttpStatusException(EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      return new CustomValidationHttpStatusException(EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
 
     if (errorMatchesMarker(combinedError, identityClientConfig.getErrorMessageDuplicatedUsername())
         || (status == HttpStatus.CONFLICT.value() && combinedError.contains("username"))) {
-      throw new CustomValidationHttpStatusException(USERNAME_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      return new CustomValidationHttpStatusException(USERNAME_NOT_AVAILABLE, HttpStatus.CONFLICT);
     }
 
-    // Preserve prior behavior but include status/raw details to avoid opaque 500s.
-    keycloakError =
-        !rawResponse.isBlank()
-            ? String.format("Keycloak create-user failed with status %s: %s", status, rawResponse)
-            : String.format("Keycloak create-user failed with status %s", status);
-
     log.warn("Keycloak create-user failed. status={}, rawResponse={}", status, rawResponse);
+
+    return new InternalServerErrorException(
+        String.format(
+            "%s: could not create Keycloak account for %s. Keycloak responded with status %s: %s",
+            keycloakError, user, status, rawResponse.isBlank() ? "<empty body>" : rawResponse));
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/keycloak/KeycloakServiceTest.java
@@ -7,6 +7,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import ch.qos.logback.classic.Level;
@@ -684,6 +686,67 @@ public class KeycloakServiceTest {
       assertThat(
           e.getCustomHttpHeaders().get("X-Reason").get(0), is(USERNAME_NOT_AVAILABLE.name()));
     }
+  }
+
+  @Test
+  public void createUser_Should_leaveTheInjectedErrorTemplateIntact_When_keycloakFails() {
+    // keycloakError is @Value-injected configuration on a singleton. Recording the current
+    // request's Keycloak response in it destroyed the configured value for the life of the JVM and
+    // let concurrent failures read one another's detail.
+    var configuredTemplate = "An unexpected Keycloak error occurred";
+    setField(keycloakService, "keycloakError", configuredTemplate);
+    givenADuplicatedEmailErrorMessage();
+    givenADuplicatedUserErrorMessage();
+    givenAFailingCreateUserResponse(500, "realm temporarily unavailable");
+
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> this.keycloakService.createUser(new EasyRandom().nextObject(UserDTO.class)));
+
+    assertThat(getField(keycloakService, "keycloakError"), is(configuredTemplate));
+  }
+
+  @Test
+  public void createUser_Should_carryKeycloakStatusAndBody_When_errorIsUnknown() {
+    setField(keycloakService, "keycloakError", "An unexpected Keycloak error occurred");
+    givenADuplicatedEmailErrorMessage();
+    givenADuplicatedUserErrorMessage();
+    givenAFailingCreateUserResponse(503, "realm temporarily unavailable");
+
+    var exception =
+        assertThrows(
+            InternalServerErrorException.class,
+            () -> this.keycloakService.createUser(new EasyRandom().nextObject(UserDTO.class)));
+
+    // Without these an operator sees only the configured string and cannot tell a misconfigured
+    // realm from an unreachable one.
+    assertThat(exception.getMessage(), containsString("503"));
+    assertThat(exception.getMessage(), containsString("realm temporarily unavailable"));
+  }
+
+  @Test
+  public void createUser_Should_reportAnEmptyKeycloakBody_When_errorIsUnknownAndBodyIsBlank() {
+    setField(keycloakService, "keycloakError", "An unexpected Keycloak error occurred");
+    givenADuplicatedEmailErrorMessage();
+    givenADuplicatedUserErrorMessage();
+    givenAFailingCreateUserResponse(500, "");
+
+    var exception =
+        assertThrows(
+            InternalServerErrorException.class,
+            () -> this.keycloakService.createUser(new EasyRandom().nextObject(UserDTO.class)));
+
+    assertThat(exception.getMessage(), containsString("500"));
+    assertThat(exception.getMessage(), containsString("<empty body>"));
+  }
+
+  private void givenAFailingCreateUserResponse(int status, String body) {
+    UsersResource failingUsersResource = mock(UsersResource.class);
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(status);
+    when(response.readEntity(String.class)).thenReturn(body);
+    when(failingUsersResource.create(any())).thenReturn(response);
+    when(keycloakClient.getUsersResource()).thenReturn(failingUsersResource);
   }
 
   @Test


### PR DESCRIPTION
## What & why

Creating a counsellor fails, and this is everything UserService records about it:

```
InternalServerErrorException: An unexpected Keycloak error occurred
  at KeycloakService.createUser(KeycloakService.java:398)
  at CreateConsultantSaga.createKeycloakUser(CreateConsultantSaga.java:407)
  ...
, An unexpected Keycloak error occurred, No Cause
```

That message is `api.error.keycloakError` from `messages.properties` — the `@Value`-injected template, nothing more. The Keycloak status and response body are absent, so an operator cannot distinguish a misconfigured realm from an unreachable one, from a rejected password policy, from a required-action failure. `No Cause` confirms nothing was chained.

**The trace also rules things out.** It reaches `createKeycloakUser`, so the tenant, licence and topic/agency validation all passed, and it is not a duplicate e-mail or username — those return `409 CONFLICT` with an `X-Reason` well before this point.

## The state bug behind the missing detail

`handleCreateKeycloakUserError` recorded the detail by **assigning to the injected field** and returning, leaving the caller to read it back after the try-with-resources had closed:

```java
keycloakError = String.format("Keycloak create-user failed with status %s: %s", status, rawResponse);
```

`keycloakError` is `@Value`-injected configuration on a singleton `@Service`. So:

- **The configured template is destroyed by the first failure** and never restored. For the rest of the JVM's life its value depends on request history rather than on configuration.
- **Concurrent failures read each other's detail.** Two requests interleave between the write and the read, and request A can be handed the raw Keycloak body belonging to request B — which carries B's username and e-mail.

Build and return the exception from one place instead. Nothing needs the detail to outlive the throw, so it no longer leaves the method. Status and body now go into the **exception message** as well as the log line, because the message is what reaches the operator through the error report.

Duplicate-email and duplicate-username detection is untouched and still answers `409 CONFLICT` with its `X-Reason`.

## This does not fix the underlying Keycloak rejection

It makes the rejection legible. Why Keycloak refused this create is still unknown, because the deployed build discarded it — see below.

## Note on the deployed environment

The frame is `KeycloakService.java:398` and the message is the bare template. On current `dev`, that throw site already formats `"Could not create Keycloak account for: %s %nKeycloak error: %s"` and there is a `log.warn` carrying `status` and `rawResponse`. Neither appears in the trace, so **dev.oriso.org is running an image older than `dev` HEAD**. Redeploying dev alone would already surface the Keycloak status and body; this PR makes that detail correct under concurrency and keeps it in the exception message rather than in shared state.

## How should I test this?

- [ ] Create a counsellor with an e-mail that already exists → **expected:** `409` with `X-Reason: EMAIL_NOT_AVAILABLE`, unchanged.
- [ ] Same for a duplicate username → **expected:** `409` with `X-Reason: USERNAME_NOT_AVAILABLE`, unchanged.
- [ ] Point the service at a Keycloak that rejects the create for any other reason → **expected:** the log and the exception message both name the status and the response body, where previously both said only "An unexpected Keycloak error occurred".
- [ ] Happy path → **expected:** unchanged.

## Verified locally

JDK 21 (`brew --prefix openjdk@21`), `./mvnw`.

| Check | Result |
| --- | --- |
| `KeycloakServiceTest` | `Tests run: 107, Failures: 0, Errors: 0, Skipped: 0` |
| Full unit suite (`-Dskip.integration-tests=true`) | `Tests run: 3816, Failures: 2` — both unrelated, see below |
| `mvn spotless:apply` | clean |

**Failing-test proof.** Reverting only the main-source change:

```
Tests run: 107, Failures: 2
createUser_Should_leaveTheInjectedErrorTemplateIntact_When_keycloakFails
  AssertionError: Expected: is "An unexpected Keycloak error occurred"
```

That test reads the field back after a failed create, which pins the config against being overwritten. The other two assert the status and body reach the message, including the blank-body case.

**The 2 full-suite failures are unrelated.** Both are `MatrixOnlyRuntimeConfigurationContractTest`, which scans `src/main/resources/application-local.properties` — an **untracked** file present only on the local machine and absent in CI. This branch touches two files, neither of them configuration.

## CI must prove

- **Integration tests (`*IT`)** — none run locally.
- **Spring context startup** — no wiring changed; `keycloakError` is still injected exactly as before, only no longer written to.

## Related

- OpenResilienceInitiative/ORISO-UserService#1072 — a separate latent `NullPointerException` in the licence check on the same endpoint. This trace shows it is **not** the cause of the reported failure; that PR stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
