### PR TITLE
Join late-joining counsellors into existing enquiry rooms (and revoke on removal)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminService.java
@@ -22,18 +22,22 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.ConsultantLeftAgencyEvent;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /** Service class to handle administrative operations on consultant-agencies. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ConsultantAgencyAdminService {
 
   private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
@@ -43,6 +47,7 @@ public class ConsultantAgencyAdminService {
   private final @NonNull AgencyService agencyService;
   private final @NonNull AgencyAdminService agencyAdminService;
   private final @NonNull ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+  private final @NonNull ApplicationEventPublisher eventPublisher;
 
   /**
    * Returns all Agencies for the given consultantId.
@@ -258,6 +263,33 @@ public class ConsultantAgencyAdminService {
     this.agencyDeletionValidationService.validateAndMarkForDeletion(consultantAgency);
     consultantAgency.setDeleteDate(nowInUtc());
     this.consultantAgencyRepository.save(consultantAgency);
+    announceDetachedAgency(consultantAgency);
+  }
+
+  /**
+   * US#1060, symmetric half: a counsellor is joined into the agency's open enquiry rooms when they
+   * are assigned, so detaching them again has to take that membership back. Otherwise they keep
+   * receiving the agency's open initial requests through Matrix {@code /sync} long after the
+   * relation was deleted.
+   *
+   * <p>Announced rather than performed here, and only once the deletion is persisted: the bulk path
+   * behind {@code ConsultantAdminFacade#setConsultantAgencies} applies removals inside a
+   * transaction that a later rejected assignment can still roll back. Revoking Matrix membership
+   * inline would lock the counsellor out of enquiries the database still says are theirs. See
+   * {@code AgencyMembershipSyncListener}.
+   */
+  private void announceDetachedAgency(ConsultantAgency consultantAgency) {
+    var consultant = consultantAgency.getConsultant();
+    if (consultant == null) {
+      log.warn(
+          "Consultant agency relation {} has no consultant; enquiry room membership of agency {}"
+              + " not revoked",
+          consultantAgency.getId(),
+          consultantAgency.getAgencyId());
+      return;
+    }
+    eventPublisher.publishEvent(
+        new ConsultantLeftAgencyEvent(consultant.getId(), consultantAgency.getAgencyId()));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorService.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantImportService.ImportRecord;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.ConsultantJoinedAgencyEvent;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /** Creator class to generate new {@link ConsultantAgency} instances. */
@@ -45,6 +47,7 @@ public class ConsultantAgencyRelationCreatorService {
   private final @NonNull ConsultantAgencyRelationFinalizer consultantAgencyRelationFinalizer;
   private final @NonNull ConsultantTopicAgencyCompatibilityValidator
       consultantTopicAgencyCompatibilityValidator;
+  private final @NonNull ApplicationEventPublisher eventPublisher;
 
   /**
    * Creates a new {@link ConsultantAgency} based on the {@link ImportRecord} and agency ids.
@@ -139,6 +142,14 @@ public class ConsultantAgencyRelationCreatorService {
       consultant.setTeamConsultant(true);
       consultantRepository.save(consultant);
     }
+
+    // US#1060: an agency assignment that stops at the database row leaves the counsellor locked
+    // out of every enquiry that arrived before them — Matrix membership is what makes an enquiry
+    // visible at all (FE#811). Announced rather than performed here: the membership fan-out has to
+    // wait for the commit, or a later rejected agency would roll the row back around a Matrix join
+    // that already happened. See AgencyMembershipSyncListener.
+    eventPublisher.publishEvent(
+        new ConsultantJoinedAgencyEvent(consultant.getId(), agency.getId()));
   }
 
   private void ensureConsultingTypeRoles(ConsultantAgencyCreationInput input, AgencyDTO agency) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipService.java
@@ -1,0 +1,223 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.caritas.cob.userservice.api.helper.MatrixIds;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+/**
+ * US#1060 / FE#811: keeps the department membership of an enquiry room in step with the agency
+ * roster <em>after</em> the room already exists.
+ *
+ * <p>{@link AgencySilentMembershipService} joins every counsellor of the agency at room creation,
+ * which fixes the enquiry for everyone who was already in the agency at that moment. Nothing
+ * repaired the mirror-image case: a counsellor added to the agency a day later is not a member of
+ * yesterday's enquiry rooms, Matrix {@code /sync} therefore never hands those rooms to their
+ * client, and no later event fixes it — the open initial requests simply stay invisible to them
+ * until an admin intervenes.
+ *
+ * <p>Scope is deliberately the agency's <em>open</em> enquiries (status {@link SessionStatus#NEW}
+ * or {@link SessionStatus#INITIAL}, no counsellor assigned yet). Those are exactly the cases the
+ * whole department is entitled to pick up. An accepted case belongs to one counsellor and is
+ * governed by {@code AssignEnquiryFacade}, so backfilling it here would widen its audience beyond
+ * what ADR-002 allows. Directly addressed enquiries are excluded for the same reason they are
+ * excluded at creation.
+ *
+ * <p>Every step is best effort: an admin assigning an agency must never see their request fail
+ * because Synapse hiccuped on one room, and the relation in the database is the source of truth
+ * either way.
+ *
+ * <p>Note on encryption: a counsellor backfilled here holds no Megolm key for messages sent before
+ * they joined and depends on the client-side history-key transfer that ships with FE#811. Joining
+ * at creation stays the stronger guarantee; this service is the repair path for everyone who could
+ * not be there at creation.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AgencyLateJoinerMembershipService {
+
+  /**
+   * What counts as an open enquiry, mirroring {@code ConsultantAgencyDeletionValidationService}:
+   * {@code NEW} is an enquiry waiting to be picked up, {@code INITIAL} one whose room exists but
+   * whose first message is still unwritten. Backfilling an {@code INITIAL} enquiry is the better of
+   * the two outcomes, not merely extra coverage — the late joiner is then already a member when the
+   * asker sends, so the Megolm session reaches their device and they read plaintext instead of
+   * depending on a client-side history-key transfer.
+   */
+  private static final List<SessionStatus> OPEN_ENQUIRY_STATES =
+      List.of(SessionStatus.NEW, SessionStatus.INITIAL);
+
+  private final @NonNull SessionRepository sessionRepository;
+  private final @NonNull AgencyMatrixCredentialClient matrixCredentialClient;
+  private final @NonNull SessionRoomGateway sessionRoomGateway;
+  private final @NonNull AgencySilentMembershipService agencySilentMembershipService;
+
+  /**
+   * Joins a counsellor who was just assigned to an agency into the Matrix rooms of that agency's
+   * already existing open enquiries.
+   *
+   * @param consultant the newly assigned counsellor
+   * @param agencyId the agency they were assigned to
+   * @return number of enquiry rooms the counsellor ended up joined into
+   */
+  public int joinConsultantIntoOpenEnquiryRooms(Consultant consultant, Long agencyId) {
+    var roomIds = openEnquiryRoomIds(consultant, agencyId);
+    if (roomIds.isEmpty()) {
+      return 0;
+    }
+
+    var agencyToken = resolveAgencyToken(agencyId);
+    if (isBlank(agencyToken)) {
+      return 0;
+    }
+
+    int joined = 0;
+    for (String roomId : roomIds) {
+      try {
+        if (agencySilentMembershipService.joinConsultantIntoRoom(consultant, roomId, agencyToken)) {
+          joined++;
+        }
+      } catch (RuntimeException ex) {
+        log.warn(
+            "Could not backfill consultant {} into enquiry room {} of agency {}: {}",
+            consultant.getId(),
+            roomId,
+            agencyId,
+            ex.getMessage());
+      }
+    }
+
+    log.info(
+        "Backfilled consultant {} into {} of {} open enquiry rooms of agency {}",
+        consultant.getId(),
+        joined,
+        roomIds.size(),
+        agencyId);
+    return joined;
+  }
+
+  /**
+   * Revokes the membership a counsellor holds in the open enquiry rooms of an agency they were just
+   * detached from. Without this the counsellor keeps syncing enquiries of an agency they no longer
+   * belong to — the exact stale access the at-creation fan-out would otherwise create.
+   *
+   * <p>A counsellor without a Matrix account never joined anything, so there is nothing to revoke
+   * and no account is provisioned here.
+   *
+   * <p>The scope is the same open enquiries the join side covers, and that symmetry is enforced by
+   * Matrix rather than chosen for tidiness: {@code AssignEnquiryFacade} removes the agency service
+   * account from the room the moment an enquiry is accepted, so its token can no longer kick anyone
+   * out of an accepted case. Rooms of accepted cases therefore need the assigned counsellor's own
+   * token and are handled by the case-handover/team-session paths, not here.
+   *
+   * @param consultant the detached counsellor
+   * @param agencyId the agency they were detached from
+   * @return number of enquiry rooms the counsellor was removed from
+   */
+  public int removeConsultantFromOpenEnquiryRooms(Consultant consultant, Long agencyId) {
+    if (consultant == null || isBlank(consultant.getMatrixUserId())) {
+      return 0;
+    }
+
+    var roomIds = openEnquiryRoomIds(consultant, agencyId);
+    if (roomIds.isEmpty()) {
+      return 0;
+    }
+
+    var agencyToken = resolveAgencyToken(agencyId);
+    if (isBlank(agencyToken)) {
+      return 0;
+    }
+
+    int removed = 0;
+    for (String roomId : roomIds) {
+      try {
+        if (sessionRoomGateway.removeUserFromRoom(
+            roomId, consultant.getMatrixUserId(), agencyToken)) {
+          removed++;
+        }
+      } catch (RuntimeException ex) {
+        log.warn(
+            "Could not remove consultant {} from enquiry room {} of agency {}: {}",
+            consultant.getId(),
+            roomId,
+            agencyId,
+            ex.getMessage());
+      }
+    }
+
+    log.info(
+        "Removed consultant {} from {} of {} open enquiry rooms of agency {}",
+        consultant.getId(),
+        removed,
+        roomIds.size(),
+        agencyId);
+    return removed;
+  }
+
+  private List<String> openEnquiryRoomIds(Consultant consultant, Long agencyId) {
+    if (consultant == null || agencyId == null) {
+      return List.of();
+    }
+
+    return OPEN_ENQUIRY_STATES.stream()
+        .map(
+            status ->
+                sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(agencyId, status))
+        .flatMap(List::stream)
+        .filter(session -> !Boolean.TRUE.equals(session.getIsConsultantDirectlySet()))
+        .map(Session::getMatrixRoomId)
+        .filter(StringUtils::isNotBlank)
+        .distinct()
+        .toList();
+  }
+
+  /**
+   * The enquiry rooms are owned by the agency's Matrix service account, so invites and kicks have
+   * to be issued with its token — the same resolution {@code AgencyPreAssignmentRoomService}
+   * performs when it creates the room.
+   */
+  private String resolveAgencyToken(Long agencyId) {
+    var credentialsOpt = matrixCredentialClient.fetchMatrixCredentials(agencyId);
+    if (credentialsOpt.isEmpty()) {
+      log.warn(
+          "No Matrix service account available for agency {}; enquiry room membership unchanged.",
+          agencyId);
+      return null;
+    }
+
+    var credentials = credentialsOpt.get();
+    if (isBlank(credentials.getMatrixUserId()) || isBlank(credentials.getMatrixPassword())) {
+      log.warn(
+          "Matrix service account configuration incomplete for agency {}; enquiry room membership unchanged.",
+          agencyId);
+      return null;
+    }
+
+    var agencyToken =
+        sessionRoomGateway.loginUser(
+            MatrixIds.localpartLenient(credentials.getMatrixUserId()),
+            credentials.getMatrixPassword());
+    if (isBlank(agencyToken)) {
+      log.error(
+          "Failed to login Matrix service account {} for agency {}; enquiry room membership unchanged.",
+          credentials.getMatrixUserId(),
+          agencyId);
+      return null;
+    }
+
+    return agencyToken;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyMembershipSyncListener.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencyMembershipSyncListener.java
@@ -1,0 +1,103 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import java.util.function.ToIntFunction;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * US#1060: keeps the Matrix membership of an agency's open enquiry rooms in step with its roster,
+ * strictly <em>after</em> the roster change is committed.
+ *
+ * <p>Why after the commit and not inline. {@code ConsultantAdminFacade#setConsultantAgencies} is
+ * transactional and applies removals before creations, one agency at a time. An inline fan-out
+ * would push the first agency's membership into Matrix and then, if a later agency is rejected,
+ * roll the database back around it. Matrix has no transaction to join, so the counsellor would stay
+ * a member of the enquiry rooms of an agency they were never given — a confidentiality bug, and the
+ * mirror-image lockout on the removal side. Publishing an event and acting on {@link
+ * TransactionPhase#AFTER_COMMIT} makes that outcome structurally impossible.
+ *
+ * <p>{@code fallbackExecution = true} is load-bearing rather than decorative: the POST endpoint
+ * ({@code ConsultantAdminFacade#createNewConsultantAgency}) and the CSV import are not
+ * transactional at all, and without the fallback the listener would silently never run on those
+ * paths.
+ *
+ * <p>Nothing escapes this listener. {@code CreateConsultantSaga#assignAgenciesOrRollback} deletes
+ * the freshly created consultant on any {@link RuntimeException}, so a Synapse hiccup here would
+ * otherwise cost an admin the consultant they just created. The relation in the database is the
+ * source of truth; a failed fan-out degrades to "membership repaired later".
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AgencyMembershipSyncListener {
+
+  private final @NonNull ConsultantRepository consultantRepository;
+  private final @NonNull AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
+
+  /**
+   * Kill switch for bulk operations. The CSV import creates relations row by row and agency by
+   * agency, so a large import multiplies the per-relation fan-out by every open enquiry of every
+   * agency involved. Operations can switch the fan-out off for that window and repair membership
+   * afterwards rather than have one request hammer Synapse.
+   */
+  @Value("${matrix.membership.lateJoiner.enabled:true}")
+  private boolean lateJoinerMembershipEnabled;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onConsultantJoinedAgency(ConsultantJoinedAgencyEvent event) {
+    syncMembership(
+        event.consultantId(),
+        event.agencyId(),
+        consultant ->
+            agencyLateJoinerMembershipService.joinConsultantIntoOpenEnquiryRooms(
+                consultant, event.agencyId()));
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+  public void onConsultantLeftAgency(ConsultantLeftAgencyEvent event) {
+    syncMembership(
+        event.consultantId(),
+        event.agencyId(),
+        consultant ->
+            agencyLateJoinerMembershipService.removeConsultantFromOpenEnquiryRooms(
+                consultant, event.agencyId()));
+  }
+
+  private void syncMembership(
+      String consultantId, Long agencyId, ToIntFunction<Consultant> membershipChange) {
+    if (!lateJoinerMembershipEnabled) {
+      log.debug(
+          "Late joiner membership is disabled; enquiry rooms of agency {} left untouched for"
+              + " consultant {}",
+          agencyId,
+          consultantId);
+      return;
+    }
+
+    try {
+      consultantRepository
+          .findByIdAndDeleteDateIsNull(consultantId)
+          .ifPresentOrElse(
+              membershipChange::applyAsInt,
+              () ->
+                  log.warn(
+                      "Consultant {} no longer exists; enquiry room membership of agency {} not"
+                          + " synchronised",
+                      consultantId,
+                      agencyId));
+    } catch (RuntimeException ex) {
+      log.warn(
+          "Could not synchronise enquiry room membership of consultant {} in agency {}: {}",
+          consultantId,
+          agencyId,
+          ex.getMessage());
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
@@ -70,7 +70,7 @@ public class AgencySilentMembershipService {
 
     int joined = 0;
     for (Consultant consultant : consultants) {
-      if (joinSilently(consultant, roomId, agencyToken)) {
+      if (joinConsultantIntoRoom(consultant, roomId, agencyToken)) {
         joined++;
       }
     }
@@ -84,7 +84,21 @@ public class AgencySilentMembershipService {
     return joined;
   }
 
-  private boolean joinSilently(Consultant consultant, String roomId, String agencyToken) {
+  /**
+   * Invites and joins a single counsellor into an already existing room, provisioning their Matrix
+   * account if they never had one.
+   *
+   * <p>Extracted for US#1060: a counsellor added to the agency after an enquiry arrived has to be
+   * backfilled into the enquiry rooms that already exist (see {@link
+   * AgencyLateJoinerMembershipService}), and that backfill needs exactly the same per-counsellor
+   * membership semantics as the at-creation fan-out.
+   *
+   * @param consultant the counsellor to join
+   * @param roomId the Matrix room to join them into
+   * @param agencyToken access token of the agency service account that owns the room
+   * @return whether the counsellor ended up joined
+   */
+  public boolean joinConsultantIntoRoom(Consultant consultant, String roomId, String agencyToken) {
     try {
       var matrixUserId = ensureMatrixAccount(consultant);
       if (isBlank(matrixUserId)) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/ConsultantJoinedAgencyEvent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/ConsultantJoinedAgencyEvent.java
@@ -1,0 +1,14 @@
+package de.caritas.cob.userservice.api.service.session;
+
+/**
+ * US#1060: a consultant-agency relation was created and committed.
+ *
+ * <p>Carries ids rather than the {@code Consultant} entity on purpose. The membership fan-out runs
+ * after the transaction commits, when the persistence context is gone and the entity is detached —
+ * and the fan-out may persist a lazily provisioned Matrix account, so it needs a managed instance
+ * it reads itself.
+ *
+ * @param consultantId the consultant that joined the agency
+ * @param agencyId the agency they joined
+ */
+public record ConsultantJoinedAgencyEvent(String consultantId, Long agencyId) {}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/ConsultantLeftAgencyEvent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/ConsultantLeftAgencyEvent.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.userservice.api.service.session;
+
+/**
+ * US#1060: a consultant-agency relation was marked deleted and committed. See {@link
+ * ConsultantJoinedAgencyEvent} for why this carries ids instead of the entity.
+ *
+ * @param consultantId the consultant that left the agency
+ * @param agencyId the agency they left
+ */
+public record ConsultantLeftAgencyEvent(String consultantId, Long agencyId) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -360,6 +360,10 @@ matrix.adminPassword=${MATRIX_ADMIN_PASSWORD:}
 # Derive consultant live-chat availability from real-time Matrix presence.
 matrix.presenceEnabled=${MATRIX_PRESENCE_ENABLED:true}
 matrix.encryptionEnabled=${MATRIX_ENCRYPTION_ENABLED:false}
+# US#1060 kill switch: backfilling a newly assigned counsellor into the agency's open enquiry
+# rooms costs Synapse calls per room, which a bulk CSV import multiplies by every row. Turn off
+# for an import window and repair membership afterwards.
+matrix.membership.lateJoiner.enabled=${MATRIX_LATE_JOINER_MEMBERSHIP_ENABLED:true}
 # A consultant counts as available only if their last Matrix activity is within this window (ms).
 # Avoids counting consultants who closed the app but linger as "online"/"unavailable" in Synapse.
 matrix.presenceActiveThresholdMs=${MATRIX_PRESENCE_ACTIVE_THRESHOLD_MS:300000}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminServiceTest.java
@@ -3,8 +3,10 @@ package de.caritas.cob.userservice.api.admin.service.agency;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
@@ -19,6 +21,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.ConsultantLeftAgencyEvent;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -29,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -43,6 +47,7 @@ class ConsultantAgencyAdminServiceTest {
   @Mock private AgencyService agencyService;
   @Mock private AgencyAdminService agencyAdminService;
   @Mock private ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   // ---------------------------------------------------------------------------
   // findConsultantAgencies
@@ -251,6 +256,71 @@ class ConsultantAgencyAdminServiceTest {
         .save(any(ConsultantAgency.class));
     assertThat(relation1.getDeleteDate()).isNotNull();
     assertThat(relation2.getDeleteDate()).isNotNull();
+  }
+
+  /**
+   * US#1060, the symmetric half: because a counsellor is joined into the agency's open enquiry
+   * rooms when they are assigned, detaching them has to take that membership back — otherwise they
+   * keep receiving the agency's open initial requests through Matrix {@code /sync} long after the
+   * relation was deleted. Announced only once the deletion is persisted.
+   */
+  @Test
+  void markConsultantAgencyForDeletion_Should_publishTheLeftAgencyEvent_afterMarkingItDeleted() {
+    var relation = detachableRelation("c-1", 10L);
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(relation));
+
+    consultantAgencyAdminService.markConsultantAgencyForDeletion("c-1", 10L);
+
+    var inOrder = inOrder(consultantAgencyRepository, eventPublisher);
+    inOrder.verify(consultantAgencyRepository).save(relation);
+    inOrder.verify(eventPublisher).publishEvent(new ConsultantLeftAgencyEvent("c-1", 10L));
+  }
+
+  /**
+   * A refused detach (last counsellor of an active agency) leaves the relation intact, so revoking
+   * the counsellor's room membership would lock them out of enquiries they still own.
+   */
+  @Test
+  void markConsultantAgencyForDeletion_Should_notPublish_When_theDeletionIsRejected() {
+    var relation = detachableRelation("c-1", 10L);
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(relation));
+    org.mockito.Mockito.doThrow(
+            new CustomValidationHttpStatusException(
+                de.caritas.cob.userservice.api.exception.httpresponses.customheader
+                    .HttpStatusExceptionReason
+                    .CONSULTANT_IS_THE_LAST_OF_AGENCY_AND_AGENCY_IS_STILL_ACTIVE))
+        .when(agencyDeletionValidationService)
+        .validateAndMarkForDeletion(relation);
+
+    assertThrows(
+        CustomValidationHttpStatusException.class,
+        () -> consultantAgencyAdminService.markConsultantAgencyForDeletion("c-1", 10L));
+
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  void markConsultantAgenciesForDeletion_Should_publishOneEventPerAgency() {
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 10L))
+        .thenReturn(List.of(detachableRelation("c-1", 10L)));
+    when(consultantAgencyRepository.findByConsultantIdAndAgencyIdAndDeleteDateIsNull("c-1", 20L))
+        .thenReturn(List.of(detachableRelation("c-1", 20L)));
+
+    consultantAgencyAdminService.markConsultantAgenciesForDeletion("c-1", List.of(10L, 20L));
+
+    verify(eventPublisher).publishEvent(new ConsultantLeftAgencyEvent("c-1", 10L));
+    verify(eventPublisher).publishEvent(new ConsultantLeftAgencyEvent("c-1", 20L));
+  }
+
+  private ConsultantAgency detachableRelation(String consultantId, Long agencyId) {
+    var consultant = new Consultant();
+    consultant.setId(consultantId);
+    var relation = new ConsultantAgency();
+    relation.setConsultant(consultant);
+    relation.setAgencyId(agencyId);
+    return relation;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/agency/ConsultantAgencyAdminUserServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsultantAgencyAdminUserServiceTest {
@@ -51,6 +52,8 @@ public class ConsultantAgencyAdminUserServiceTest {
   @Mock private AgencyAdminService agencyAdminService;
 
   @Mock private ConsultantAgencyDeletionValidationService agencyDeletionValidationService;
+
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @Test
   public void

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyLateJoinerMembershipIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyLateJoinerMembershipIT.java
@@ -1,0 +1,239 @@
+package de.caritas.cob.userservice.api.admin.service.consultant.create.agencyrelation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.util.Lists;
+import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.UserServiceApplication;
+import de.caritas.cob.userservice.api.adapters.keycloak.KeycloakService;
+import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.CreateConsultantAgencyDTO;
+import de.caritas.cob.userservice.api.admin.facade.ConsultantAdminFacade;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.RegistrationType;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.model.UserAgency;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.UserRepository;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import java.util.List;
+import java.util.Optional;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * US#1060 acceptance: a counsellor added to an agency <em>after</em> an enquiry already arrived
+ * must end up a member of that enquiry's Matrix room.
+ *
+ * <p>US#905 joins the agency's counsellors into the room at room creation, which only ever helps
+ * counsellors who were already in the agency at that moment. Matrix {@code /sync} hands a room to
+ * members only, so for everybody who joined the agency later the open initial requests simply do
+ * not exist — no error, no empty state, nothing to act on.
+ *
+ * <p>This test drives the two real admin entry points end to end rather than the fan-out service,
+ * so it fails on a missing <em>wiring</em> just as loudly as on a missing service. The PUT path
+ * ({@code setConsultantAgencies}) is the one the admin panel actually calls and is transactional;
+ * the POST path ({@code createNewConsultantAgency}) is not, which is exactly why the membership
+ * hook must survive both.
+ *
+ * <p>This class must not be {@code @Transactional}: the hook runs after the assignment is
+ * committed, and a test-managed transaction that never commits would silently swallow it.
+ */
+@SpringBootTest(classes = UserServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+class ConsultantAgencyLateJoinerMembershipIT {
+
+  private static final Long AGENCY_ID = 91015L;
+  private static final Long OTHER_AGENCY_ID = 91016L;
+  private static final Long UNKNOWN_AGENCY_ID = 91099L;
+  private static final String ENQUIRY_ROOM_ID = "!existing-enquiry:oriso.org";
+  private static final String OTHER_AGENCY_ROOM_ID = "!other-agency-enquiry:oriso.org";
+  private static final String CONSULTANT_MATRIX_USER_ID = "@late.joiner:oriso.org";
+  private static final String AGENCY_TOKEN = "agency-service-account-token";
+  private static final String CONSULTANT_TOKEN = "late-joiner-token";
+  private static final String ROLE_SET_KEY = "valid-role-set";
+
+  private final EasyRandom easyRandom = new EasyRandom();
+
+  @Autowired private ConsultantAdminFacade consultantAdminFacade;
+
+  @Autowired private ConsultantRepository consultantRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private UserAgencyRepository userAgencyRepository;
+
+  @Autowired private SessionRepository sessionRepository;
+
+  @MockitoBean private AgencyService agencyService;
+
+  @MockitoBean private KeycloakService keycloakService;
+
+  @MockitoBean private ConsultingTypeManager consultingTypeManager;
+
+  @MockitoBean private AgencyMatrixCredentialClient matrixCredentialClient;
+
+  @MockitoBean private SessionRoomGateway sessionRoomGateway;
+
+  @BeforeEach
+  void setUp() {
+    givenAgencyExists(AGENCY_ID);
+    givenAgencyExists(OTHER_AGENCY_ID);
+    givenConsultingTypeSettings();
+    givenAgencyServiceAccount();
+    when(sessionRoomGateway.loginAsUser(CONSULTANT_MATRIX_USER_ID)).thenReturn(CONSULTANT_TOKEN);
+    when(sessionRoomGateway.joinRoom(anyString(), eq(CONSULTANT_TOKEN))).thenReturn(true);
+  }
+
+  @Test
+  @DisplayName("a counsellor added after the enquiry arrived is joined into its existing room")
+  void addingAConsultantToAnAgencyWithAnExistingOpenEnquiry_joinsThemIntoThatRoom() {
+    var consultant = givenConsultantWithoutAgency();
+    givenOpenEnquiry(AGENCY_ID, ENQUIRY_ROOM_ID);
+
+    consultantAdminFacade.createNewConsultantAgency(consultant.getId(), agencyRelation(AGENCY_ID));
+
+    verify(sessionRoomGateway).joinRoom(ENQUIRY_ROOM_ID, CONSULTANT_TOKEN);
+  }
+
+  @Test
+  @DisplayName("the admin panel's agency editor joins the counsellor into the new agency's rooms")
+  void replacingAConsultantsAgencies_joinsThemIntoTheNewAgencysOpenEnquiryRooms() {
+    var consultant = givenConsultantWithoutAgency();
+    givenOpenEnquiry(AGENCY_ID, ENQUIRY_ROOM_ID);
+
+    consultantAdminFacade.setConsultantAgencies(
+        consultant.getId(), List.of(agencyRelation(AGENCY_ID)));
+
+    verify(sessionRoomGateway).joinRoom(ENQUIRY_ROOM_ID, CONSULTANT_TOKEN);
+  }
+
+  @Test
+  @DisplayName("the backfill stays inside the assigned agency and never leaks another one's rooms")
+  void addingAConsultantToAnAgency_leavesOtherAgenciesEnquiryRoomsAlone() {
+    var consultant = givenConsultantWithoutAgency();
+    givenOpenEnquiry(AGENCY_ID, ENQUIRY_ROOM_ID);
+    givenOpenEnquiry(OTHER_AGENCY_ID, OTHER_AGENCY_ROOM_ID);
+
+    consultantAdminFacade.createNewConsultantAgency(consultant.getId(), agencyRelation(AGENCY_ID));
+
+    verify(sessionRoomGateway).joinRoom(ENQUIRY_ROOM_ID, CONSULTANT_TOKEN);
+    verify(sessionRoomGateway, never()).joinRoom(eq(OTHER_AGENCY_ROOM_ID), anyString());
+  }
+
+  @Test
+  @DisplayName("a rolled-back agency edit must not leave the counsellor inside the Matrix room")
+  void replacingAgencies_joinsNoRoom_When_aLaterAssignmentInTheSameTransactionFails() {
+    var consultant = givenConsultantWithoutAgency();
+    givenOpenEnquiry(AGENCY_ID, ENQUIRY_ROOM_ID);
+    when(agencyService.getAgency(UNKNOWN_AGENCY_ID)).thenReturn(null);
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAdminFacade.setConsultantAgencies(
+                consultant.getId(),
+                List.of(agencyRelation(AGENCY_ID), agencyRelation(UNKNOWN_AGENCY_ID))));
+
+    verifyNoInteractions(sessionRoomGateway);
+  }
+
+  private CreateConsultantAgencyDTO agencyRelation(Long agencyId) {
+    var relation = new CreateConsultantAgencyDTO();
+    relation.setAgencyId(agencyId);
+    relation.setRoleSetKey(ROLE_SET_KEY);
+    return relation;
+  }
+
+  private void givenAgencyExists(Long agencyId) {
+    var agency = new AgencyDTO();
+    agency.setId(agencyId);
+    agency.setTeamAgency(false);
+    agency.setConsultingType(0);
+    when(agencyService.getAgency(agencyId)).thenReturn(agency);
+    when(agencyService.getAgenciesWithoutCaching(List.of(agencyId))).thenReturn(List.of(agency));
+  }
+
+  private void givenConsultingTypeSettings() {
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(easyRandom.nextObject(ExtendedConsultingTypeResponseDTO.class));
+  }
+
+  private void givenAgencyServiceAccount() {
+    var credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId("@agency:oriso.org");
+    credentials.setMatrixPassword("agency-password");
+    when(matrixCredentialClient.fetchMatrixCredentials(any())).thenReturn(Optional.of(credentials));
+    when(sessionRoomGateway.loginUser("agency", "agency-password")).thenReturn(AGENCY_TOKEN);
+  }
+
+  private Consultant givenConsultantWithoutAgency() {
+    var consultant = easyRandom.nextObject(Consultant.class);
+    consultant.setConsultantAgencies(null);
+    consultant.setSessions(null);
+    consultant.setConsultantMobileTokens(null);
+    consultant.setConsultantTopics(null);
+    consultant.setTenantId(null);
+    consultant.setMatrixUserId(CONSULTANT_MATRIX_USER_ID);
+    consultant.setDeleteDate(null);
+    consultant.setLanguages(null);
+    consultant.setAppointments(null);
+    return consultantRepository.save(consultant);
+  }
+
+  private void givenOpenEnquiry(Long agencyId, String matrixRoomId) {
+    var user = easyRandom.nextObject(User.class);
+    user.setSessions(null);
+    user.setUserMobileTokens(null);
+    user.setUserAgencies(null);
+    userRepository.save(user);
+
+    var userAgency = new UserAgency();
+    userAgency.setAgencyId(agencyId);
+    userAgency.setUser(user);
+    userAgencyRepository.save(userAgency);
+
+    var session = new Session();
+    session.setStatus(SessionStatus.NEW);
+    session.setRegistrationType(RegistrationType.REGISTERED);
+    session.setPostcode("12345");
+    session.setConsultant(null);
+    session.setUser(user);
+    session.setAgencyId(agencyId);
+    session.setMatrixRoomId(matrixRoomId);
+    session.setLanguageCode(LanguageCode.de);
+    session.setTeamSession(true);
+    session.setSessionTopics(Lists.newArrayList());
+    session.setIsConsultantDirectlySet(false);
+    sessionRepository.save(session);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/create/agencyrelation/ConsultantAgencyRelationCreatorServiceTest.java
@@ -8,8 +8,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
@@ -27,6 +29,7 @@ import de.caritas.cob.userservice.api.port.out.IdentityRoleUpdater;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.ConsultantJoinedAgencyEvent;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.userservice.consultingtypeservice.generated.web.model.RolesDTO;
 import java.util.LinkedHashMap;
@@ -40,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsultantAgencyRelationCreatorServiceTest {
@@ -66,6 +70,94 @@ public class ConsultantAgencyRelationCreatorServiceTest {
 
   @Mock
   private ConsultantTopicAgencyCompatibilityValidator consultantTopicAgencyCompatibilityValidator;
+
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  /**
+   * US#1060: an agency assignment that stops at the database row leaves the counsellor locked out
+   * of every enquiry that arrived before them, because Matrix membership is what makes an enquiry
+   * visible at all (FE#811). Announcing the completed assignment therefore belongs to "the
+   * assignment is done", not to a separate manual step.
+   */
+  @Test
+  void completeConsultantAgencyAssigment_Should_publishTheJoinedAgencyEvent() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agencyDTO = new AgencyDTO().id(2L).teamAgency(false);
+
+    when(consultantRepository.findByIdAndDeleteDateIsNull(anyString()))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(eq(2L))).thenReturn(agencyDTO);
+
+    var input =
+        new CreateConsultantAgencyDTOInputAdapter(
+            "consultant Id", new CreateConsultantAgencyDTO().agencyId(2L));
+
+    consultantAgencyRelationCreatorService.completeConsultantAgencyAssigment(
+        input, LogService::logInfo);
+
+    verify(eventPublisher).publishEvent(new ConsultantJoinedAgencyEvent("consultant Id", 2L));
+  }
+
+  /**
+   * The route the admin UI actually takes (POST /consultants/{id}/agencies) persists the relation
+   * and completes the assignment in one call. The event has to come after the relation is
+   * finalized: a listener that fires earlier could act on a relation the finalizer has not yet made
+   * real.
+   */
+  @Test
+  void createNewConsultantAgency_Should_publishTheJoinedAgencyEvent_afterTheRelationIsFinalized() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(83L);
+    consultant.setStatus(ConsultantStatus.CREATED);
+    var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(280L)).thenReturn(agency);
+    when(consultingTypeManager.getConsultingTypeSettings(0))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+    when(consultantAgencyService.saveConsultantAgency(any(ConsultantAgency.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    consultantAgencyRelationCreatorService.createNewConsultantAgency(
+        "consultant Id", new CreateConsultantAgencyDTO().agencyId(280L));
+
+    var inOrder = inOrder(consultantAgencyRelationFinalizer, eventPublisher);
+    inOrder
+        .verify(consultantAgencyRelationFinalizer)
+        .finalizeConsultantAgencyRelation(eq(consultant), any(ConsultantAgency.class));
+    inOrder
+        .verify(eventPublisher)
+        .publishEvent(new ConsultantJoinedAgencyEvent("consultant Id", 280L));
+  }
+
+  /**
+   * A rejected assignment never became a relation, so nothing may be announced. Otherwise a
+   * counsellor would be joined into the enquiry rooms of an agency they were refused.
+   */
+  @Test
+  void createNewConsultantAgency_Should_notPublish_When_theRelationIsRejected() {
+    var consultant = new Consultant();
+    consultant.setId("consultant Id");
+    consultant.setTenantId(83L);
+    var agency = new AgencyDTO().id(280L).consultingType(0).teamAgency(false);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("consultant Id"))
+        .thenReturn(Optional.of(consultant));
+    when(agencyService.getAgency(280L)).thenReturn(agency);
+    doThrow(new BadRequestException("topics do not match the requested agency"))
+        .when(consultantTopicAgencyCompatibilityValidator)
+        .validateCurrentTopicsAgainstAssignedAndAdditionalAgencies(any(), any(), any());
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            consultantAgencyRelationCreatorService.createNewConsultantAgency(
+                "consultant Id", new CreateConsultantAgencyDTO().agencyId(280L)));
+
+    verifyNoInteractions(eventPublisher);
+  }
 
   @Test
   public void

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyLateJoinerMembershipServiceTest.java
@@ -1,0 +1,258 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.model.Session.SessionStatus;
+import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import de.caritas.cob.userservice.api.service.agency.AgencyMatrixCredentialClient;
+import de.caritas.cob.userservice.api.service.agency.dto.AgencyMatrixCredentialsDTO;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * US#1060 / FE#811. {@link AgencySilentMembershipService} closes the gap for enquiries that arrive
+ * <em>after</em> a counsellor joined the agency; this service closes the mirror-image gap for
+ * counsellors who join <em>after</em> the enquiry arrived. Both halves are needed — an enquiry room
+ * nobody backfills stays invisible to the new counsellor forever, because Matrix {@code /sync}
+ * returns nothing for a non-member and no later event repairs that.
+ */
+@ExtendWith(MockitoExtension.class)
+class AgencyLateJoinerMembershipServiceTest {
+
+  private static final Long AGENCY_ID = 4711L;
+  private static final String AGENCY_MATRIX_USER_ID = "@agency4711:oriso.org";
+  private static final String AGENCY_MATRIX_PASSWORD = "agency-secret";
+  private static final String AGENCY_TOKEN = "agency-access-token";
+  private static final String CONSULTANT_MATRIX_USER_ID = "@late:oriso.org";
+
+  @Mock private SessionRepository sessionRepository;
+  @Mock private AgencyMatrixCredentialClient matrixCredentialClient;
+  @Mock private SessionRoomGateway sessionRoomGateway;
+  @Mock private AgencySilentMembershipService agencySilentMembershipService;
+
+  @InjectMocks private AgencyLateJoinerMembershipService underTest;
+
+  private Consultant lateJoiner() {
+    var consultant = new Consultant();
+    consultant.setId("c-late");
+    consultant.setUsername("c-late");
+    consultant.setMatrixUserId(CONSULTANT_MATRIX_USER_ID);
+    return consultant;
+  }
+
+  private Session openEnquiry(Long id, String roomId) {
+    var session = new Session();
+    session.setId(id);
+    session.setAgencyId(AGENCY_ID);
+    session.setStatus(SessionStatus.NEW);
+    session.setMatrixRoomId(roomId);
+    return session;
+  }
+
+  private void agencyServiceAccountAvailable() {
+    var credentials = new AgencyMatrixCredentialsDTO();
+    credentials.setMatrixUserId(AGENCY_MATRIX_USER_ID);
+    credentials.setMatrixPassword(AGENCY_MATRIX_PASSWORD);
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID))
+        .thenReturn(Optional.of(credentials));
+    when(sessionRoomGateway.loginUser("agency4711", AGENCY_MATRIX_PASSWORD))
+        .thenReturn(AGENCY_TOKEN);
+  }
+
+  /** The service consults both open-enquiry queues, so every fixture has to answer for both. */
+  private void openEnquiries(Session... sessions) {
+    givenEnquiriesWithStatus(SessionStatus.NEW, sessions);
+    givenEnquiriesWithStatus(SessionStatus.INITIAL);
+  }
+
+  private void enquiriesAwaitingTheirFirstMessage(Session... sessions) {
+    givenEnquiriesWithStatus(SessionStatus.NEW);
+    givenEnquiriesWithStatus(SessionStatus.INITIAL, sessions);
+  }
+
+  private void givenEnquiriesWithStatus(SessionStatus status, Session... sessions) {
+    when(sessionRepository.findByAgencyIdAndStatusAndConsultantIsNull(AGENCY_ID, status))
+        .thenReturn(List.of(sessions));
+  }
+
+  @Test
+  @DisplayName("a counsellor added to the agency is joined into every open enquiry room")
+  void joinConsultantIntoOpenEnquiryRooms_joinsEveryOpenEnquiryRoomOfTheAgency() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"), openEnquiry(2L, "!two:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!one:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!two:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(2, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verify(agencySilentMembershipService)
+        .joinConsultantIntoRoom(consultant, "!one:oriso.org", AGENCY_TOKEN);
+    verify(agencySilentMembershipService)
+        .joinConsultantIntoRoom(consultant, "!two:oriso.org", AGENCY_TOKEN);
+  }
+
+  @Test
+  @DisplayName("an enquiry still awaiting its first message is backfilled as well")
+  void joinConsultantIntoOpenEnquiryRooms_alsoCoversEnquiriesAwaitingTheirFirstMessage() {
+    var consultant = lateJoiner();
+    var awaitingFirstMessage = openEnquiry(3L, "!awaiting:oriso.org");
+    awaitingFirstMessage.setStatus(SessionStatus.INITIAL);
+    enquiriesAwaitingTheirFirstMessage(awaitingFirstMessage);
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!awaiting:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verify(agencySilentMembershipService)
+        .joinConsultantIntoRoom(consultant, "!awaiting:oriso.org", AGENCY_TOKEN);
+  }
+
+  @Test
+  @DisplayName("a directly addressed enquiry is never fanned out to a late joiner")
+  void joinConsultantIntoOpenEnquiryRooms_skipsDirectlyAssignedEnquiries() {
+    var consultant = lateJoiner();
+    var directEnquiry = openEnquiry(1L, "!direct:oriso.org");
+    directEnquiry.setIsConsultantDirectlySet(true);
+    openEnquiries(directEnquiry, openEnquiry(2L, "!department:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!department:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verify(agencySilentMembershipService, never())
+        .joinConsultantIntoRoom(any(), eq("!direct:oriso.org"), anyString());
+  }
+
+  @Test
+  @DisplayName("an enquiry without a Matrix room yet is skipped instead of failing the assignment")
+  void joinConsultantIntoOpenEnquiryRooms_skipsEnquiriesWithoutRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, null), openEnquiry(2L, "  "));
+
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("no usable agency service account means no join, but never an exception")
+  void joinConsultantIntoOpenEnquiryRooms_toleratesMissingAgencyServiceAccount() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"));
+    when(matrixCredentialClient.fetchMatrixCredentials(AGENCY_ID)).thenReturn(Optional.empty());
+
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("one unjoinable room does not cost the late joiner the remaining rooms")
+  void joinConsultantIntoOpenEnquiryRooms_isBestEffortPerRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!broken:oriso.org"), openEnquiry(2L, "!healthy:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!broken:oriso.org", AGENCY_TOKEN))
+        .thenThrow(new RuntimeException("synapse rejected this room"));
+    when(agencySilentMembershipService.joinConsultantIntoRoom(
+            consultant, "!healthy:oriso.org", AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+
+  @Test
+  @DisplayName("missing consultant or agency short-circuits without touching Matrix")
+  void joinConsultantIntoOpenEnquiryRooms_shortCircuitsOnMissingInput() {
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(null, AGENCY_ID));
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(lateJoiner(), null));
+
+    verifyNoInteractions(sessionRepository);
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(sessionRoomGateway);
+    verifyNoInteractions(agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("an agency without a single open enquiry room never reaches out to Matrix at all")
+  void joinConsultantIntoOpenEnquiryRooms_neverTouchesMatrix_When_theAgencyHasNoOpenEnquiryRoom() {
+    var consultant = lateJoiner();
+    openEnquiries();
+
+    assertEquals(0, underTest.joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(matrixCredentialClient, sessionRoomGateway, agencySilentMembershipService);
+  }
+
+  @Test
+  @DisplayName("a counsellor removed from the agency loses membership in its open enquiry rooms")
+  void removeConsultantFromOpenEnquiryRooms_removesFromEveryOpenEnquiryRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!one:oriso.org"), openEnquiry(2L, "!two:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!one:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!two:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(2, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+
+  @Test
+  @DisplayName("a counsellor without a Matrix account has nothing to revoke")
+  void removeConsultantFromOpenEnquiryRooms_skipsConsultantWithoutMatrixAccount() {
+    var consultant = lateJoiner();
+    consultant.setMatrixUserId(null);
+
+    assertEquals(0, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+
+    verifyNoInteractions(sessionRepository);
+    verifyNoInteractions(matrixCredentialClient);
+    verifyNoInteractions(sessionRoomGateway);
+  }
+
+  @Test
+  @DisplayName("one failing removal does not stop the remaining rooms from being revoked")
+  void removeConsultantFromOpenEnquiryRooms_isBestEffortPerRoom() {
+    var consultant = lateJoiner();
+    openEnquiries(openEnquiry(1L, "!broken:oriso.org"), openEnquiry(2L, "!healthy:oriso.org"));
+    agencyServiceAccountAvailable();
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!broken:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenThrow(new RuntimeException("synapse rejected this room"));
+    when(sessionRoomGateway.removeUserFromRoom(
+            "!healthy:oriso.org", CONSULTANT_MATRIX_USER_ID, AGENCY_TOKEN))
+        .thenReturn(true);
+
+    assertEquals(1, underTest.removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyMembershipSyncListenerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/AgencyMembershipSyncListenerTest.java
@@ -1,0 +1,139 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * US#1060: the membership fan-out must never ride along inside the caller's transaction.
+ *
+ * <p>{@code ConsultantAdminFacade#setConsultantAgencies} is transactional and applies removals
+ * before creations. A synchronous fan-out would push the first agency's membership into Matrix and
+ * then, if a later agency is rejected, roll the database back around it — leaving the counsellor a
+ * member of the enquiry rooms of an agency they were never given. Matrix has no transaction to
+ * join, so the only correct moment is after the commit that made the relation real.
+ *
+ * <p>The second reason for the listener is blast radius: {@code
+ * CreateConsultantSaga#assignAgenciesOrRollback} deletes the freshly created consultant on any
+ * {@link RuntimeException}. A Synapse hiccup must therefore never escape this listener.
+ */
+@ExtendWith(MockitoExtension.class)
+class AgencyMembershipSyncListenerTest {
+
+  private static final String CONSULTANT_ID = "c-late";
+  private static final Long AGENCY_ID = 4711L;
+
+  @Mock private ConsultantRepository consultantRepository;
+  @Mock private AgencyLateJoinerMembershipService agencyLateJoinerMembershipService;
+
+  @InjectMocks private AgencyMembershipSyncListener underTest;
+
+  private final Consultant consultant = new Consultant();
+
+  @BeforeEach
+  void setUp() {
+    consultant.setId(CONSULTANT_ID);
+    ReflectionTestUtils.setField(underTest, "lateJoinerMembershipEnabled", true);
+  }
+
+  @Test
+  @DisplayName("a committed agency assignment backfills the counsellor into the open enquiries")
+  void onConsultantJoinedAgency_resolvesTheConsultantAndJoinsTheOpenEnquiries() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultant));
+
+    underTest.onConsultantJoinedAgency(new ConsultantJoinedAgencyEvent(CONSULTANT_ID, AGENCY_ID));
+
+    verify(agencyLateJoinerMembershipService)
+        .joinConsultantIntoOpenEnquiryRooms(consultant, AGENCY_ID);
+  }
+
+  @Test
+  @DisplayName("a Matrix failure must never roll back the consultant CreateConsultantSaga created")
+  void onConsultantJoinedAgency_neverThrows_When_theFanOutBlowsUp() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultant));
+    doThrow(new RuntimeException("synapse is down"))
+        .when(agencyLateJoinerMembershipService)
+        .joinConsultantIntoOpenEnquiryRooms(any(), anyLong());
+
+    assertDoesNotThrow(
+        () ->
+            underTest.onConsultantJoinedAgency(
+                new ConsultantJoinedAgencyEvent(CONSULTANT_ID, AGENCY_ID)));
+  }
+
+  @Test
+  @DisplayName("a consultant deleted between commit and fan-out is simply skipped")
+  void onConsultantJoinedAgency_doesNothing_When_theConsultantWasDeletedMeanwhile() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.empty());
+
+    underTest.onConsultantJoinedAgency(new ConsultantJoinedAgencyEvent(CONSULTANT_ID, AGENCY_ID));
+
+    verifyNoInteractions(agencyLateJoinerMembershipService);
+  }
+
+  @Test
+  @DisplayName("operations can switch the fan-out off for a bulk import window")
+  void onConsultantJoinedAgency_doesNothing_When_theLateJoinerHookIsDisabled() {
+    ReflectionTestUtils.setField(underTest, "lateJoinerMembershipEnabled", false);
+
+    underTest.onConsultantJoinedAgency(new ConsultantJoinedAgencyEvent(CONSULTANT_ID, AGENCY_ID));
+
+    verifyNoInteractions(consultantRepository, agencyLateJoinerMembershipService);
+  }
+
+  @Test
+  @DisplayName("a committed agency removal revokes the counsellor's open enquiry membership")
+  void onConsultantLeftAgency_resolvesTheConsultantAndRevokesTheOpenEnquiries() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultant));
+
+    underTest.onConsultantLeftAgency(new ConsultantLeftAgencyEvent(CONSULTANT_ID, AGENCY_ID));
+
+    verify(agencyLateJoinerMembershipService)
+        .removeConsultantFromOpenEnquiryRooms(consultant, AGENCY_ID);
+  }
+
+  @Test
+  @DisplayName("a failing revocation must not turn a successful detach into an error response")
+  void onConsultantLeftAgency_neverThrows_When_theRevocationBlowsUp() {
+    when(consultantRepository.findByIdAndDeleteDateIsNull(CONSULTANT_ID))
+        .thenReturn(Optional.of(consultant));
+    doThrow(new RuntimeException("synapse is down"))
+        .when(agencyLateJoinerMembershipService)
+        .removeConsultantFromOpenEnquiryRooms(any(), anyLong());
+
+    assertDoesNotThrow(
+        () ->
+            underTest.onConsultantLeftAgency(
+                new ConsultantLeftAgencyEvent(CONSULTANT_ID, AGENCY_ID)));
+  }
+
+  @Test
+  @DisplayName("the kill switch stops the revocation half as well")
+  void onConsultantLeftAgency_doesNothing_When_theLateJoinerHookIsDisabled() {
+    ReflectionTestUtils.setField(underTest, "lateJoinerMembershipEnabled", false);
+
+    underTest.onConsultantLeftAgency(new ConsultantLeftAgencyEvent(CONSULTANT_ID, AGENCY_ID));
+
+    verifyNoInteractions(consultantRepository, agencyLateJoinerMembershipService);
+  }
+}


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-UserService#1060
Refs OpenResilienceInitiative/ORISO-Frontend#811

## Why this exists twice

PR OpenResilienceInitiative/ORISO-UserService#1063 already implemented this issue — but its base was `speed/reflux-progress-exp-16-aug`, not `pre-dev`. That branch is stuck behind a red openapi consumer check, so the fix never reached `pre-dev` and the bug is still live there:

```
git ls-tree -r --name-only origin/pre-dev | grep -i latejoiner   → empty
```

This PR brings the work onto `pre-dev` and closes four gaps #1063 left open (integration test, rollback leak, `INITIAL` enquiries, bulk-import fan-out).

## Problem

US#905 joins the agency's counsellors into an enquiry's Matrix room **at room creation**. That only helps counsellors who were already in the agency at that moment. A counsellor added afterwards never becomes a member of the rooms that already exist — Matrix `/sync` returns nothing for a non-member, and no later event repairs it. The agency's open initial requests simply stay invisible to them: no error, no empty state, nothing to act on.

## Change

`AgencyLateJoinerMembershipService` closes both halves:

- **Join (the reported bug):** completing an agency assignment backfills the counsellor into the Matrix rooms of the agency's existing open enquiries.
- **Revoke (the reverse path the issue asks for):** marking a consultant-agency relation deleted takes that membership back, so a counsellor does not keep syncing enquiries of an agency they left. The hook sits in `markAsDeleted`, which covers both the single-agency endpoint and the bulk path behind `ConsultantAdminFacade#setConsultantAgencies`.

Per-counsellor membership logic is shared with the at-creation fan-out by promoting `AgencySilentMembershipService#joinSilently` to the public `joinConsultantIntoRoom`, so the backfill cannot drift from #905's semantics.

**Scope:** open enquiries — status `NEW` or `INITIAL`, no counsellor assigned, not directly addressed. Those are the cases the whole department is entitled to pick up. `INITIAL` is more than extra coverage: a counsellor backfilled before the first message is a member when the asker sends, so the Megolm session reaches their device and they read plaintext instead of depending on the client-side history-key transfer. On the removal side the scope is a constraint rather than a preference — `AssignEnquiryFacade` removes the agency service account from the room when an enquiry is accepted, so its token can no longer act on an accepted case.

## The rollback leak #1063 left open

`ConsultantAdminFacade#setConsultantAgencies` is `@Transactional` and applies removals before creations, one agency at a time. #1063 called the fan-out inline. If a later agency is rejected, the first agency's Matrix join has **already happened** and the database rolls back around it — the counsellor ends up a member of the enquiry rooms of an agency they were never given. The mirror case on the removal side locks them out of enquiries the database still says are theirs.

Fixed by publishing `ConsultantJoinedAgencyEvent` / `ConsultantLeftAgencyEvent` and acting on them in `AgencyMembershipSyncListener` with `@TransactionalEventListener(AFTER_COMMIT, fallbackExecution = true)`. `fallbackExecution` is load-bearing, not decorative: the POST endpoint and the CSV import are not transactional at all, and without it the listener would silently never run on those paths.

This is verified, not asserted. Temporarily downgrading the listener to a plain synchronous `@EventListener` (exactly #1063's semantics) makes the guard test fail:

```
[ERROR] ConsultantAgencyLateJoinerMembershipIT
        .replacingAgencies_joinsNoRoom_When_aLaterAssignmentInTheSameTransactionFails
No interactions wanted here
```

Restoring `AFTER_COMMIT` makes it pass.

## Failure semantics

Both directions are best effort. The relation in the database is the source of truth, so a Synapse failure degrades to "membership repaired later" rather than failing the admin's request. Nothing escapes the listener — `CreateConsultantSaga#assignAgenciesOrRollback` deletes the freshly created consultant on any `RuntimeException`, so an unhandled Matrix error there would cost an admin the consultant they just created.

## Bulk import

`ConsultantImportService` creates relations row by row and agency by agency, and the fan-out costs Synapse calls per open enquiry room. A large import multiplies that out. `matrix.membership.lateJoiner.enabled` (`MATRIX_LATE_JOINER_MEMBERSHIP_ENABLED`, default `true`) lets operations switch the fan-out off for an import window; membership is repaired on the next assignment. No Helm change is needed for the default.

The service also queries and filters sessions **before** touching the agency service or Matrix, and returns early when the agency has no open enquiry room. That ordering is what keeps the six existing consultant-agency ITs from making real outbound calls.

## Tests

Written test-first; every test was watched failing before the code that makes it pass existed on this branch.

- `ConsultantAgencyLateJoinerMembershipIT` (new, 4 tests) — drives the real admin entry points end to end. Before the fix, on clean `pre-dev`:
  ```
  Wanted but not invoked:
  matrixSessionRoomGateway.joinRoom("!existing-enquiry:oriso.org", "late-joiner-token");
  Actually, there were zero interactions with this mock.
  ```
  Covers the POST path (no outer transaction → exercises `fallbackExecution`), the PUT path the admin panel actually calls (real `AFTER_COMMIT`), agency isolation, and the rollback guard.
- `AgencyLateJoinerMembershipServiceTest` (new, 11) — join and revoke fan-out, directly-addressed exclusion, rooms-less enquiries, missing agency service account, per-room best effort, `INITIAL` coverage, and the "never touches Matrix when there is nothing to do" guard.
- `AgencyMembershipSyncListenerTest` (new, 7) — resolution by id, never-throws in both directions, consultant deleted between commit and fan-out, kill switch.
- `ConsultantAgencyRelationCreatorServiceTest` (+3) — publishes on both the atomic and the legacy two-step path, ordered after the finalizer, and stays silent when the relation is rejected.
- `ConsultantAgencyAdminServiceTest` (+3) — publishes after the relation is persisted as deleted, stays silent when the deletion is refused, one event per agency in the bulk path.

Verification run locally (JDK 21):

```
./mvnw -B test                                    → 4020 tests, 0 failures
./mvnw -B -Dskip.unit-tests=true -Dtest=…IT …     → 40 tests, 0 failures
python3 scripts/ci/check-no-test-quarantine.py    → OK
python3 -m unittest discover -s tests/ci          → 97 tests, OK
```

`AgencyPreAssignmentRoomService` and its 16 tests are deliberately **not** touched — that is the evidence for the issue's second acceptance criterion ("existing at-creation behavior from #905 unchanged").

## Known limits (deliberate, recorded on the issue)

- **Megolm.** For messages sent *before* the backfill the backend can deliver membership and ciphertext, not plaintext. Reading those depends on the client-side history-key transfer from ORISO-Frontend#811. Enquiries backfilled while still `INITIAL` do not have this problem at all.
- **Revoke scope.** Only open enquiries. A counsellor who leaves an agency keeps membership in rooms of enquiries that were already accepted, because the agency service account has left those rooms and its token cannot kick anyone out of them.

## How should I test this?

- [ ] Create an enquiry for agency A as an advice seeker → confirm a counsellor already in agency A sees it → **expected:** unchanged behaviour from #905, enquiry visible and readable.
- [ ] Add a **new** counsellor to agency A in the admin panel → log in as that counsellor → open the initial-request list → **expected:** the enquiry created *before* they joined is listed and opens.
- [ ] Same enquiry, check attachments → **expected:** attachments load. If the message text stays unreadable, that is the Megolm limit above, not this hook — check the Synapse membership dump to confirm the join itself succeeded.
- [ ] Remove that counsellor from agency A again → **expected:** the enquiry disappears from their list.
- [ ] Service log during the assignment → **expected:** one `Backfilled consultant … into N of M open enquiry rooms of agency …` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
