### PR TITLE
fix: wire the orphaned draft-cleanup changeset and normalize the Magic-Link dummy check

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
@@ -106,8 +106,12 @@ public class IdentityConfig implements IdentityClientConfig, IdentityPolicy {
    */
   @Override
   public boolean isProfileEmailUsableForMagicLink(String email) {
-    return StringUtils.hasText(email)
-        && emailDummySuffix != null
-        && !email.endsWith(emailDummySuffix);
+    if (!StringUtils.hasText(email) || emailDummySuffix == null) {
+      return false;
+    }
+    // Compare on the normalized form: a dummy address must stay unusable even when it
+    // arrives with surrounding whitespace or different casing.
+    String normalized = email.trim().toLowerCase(java.util.Locale.ROOT);
+    return !normalized.endsWith(emailDummySuffix.trim().toLowerCase(java.util.Locale.ROOT));
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/IdentityConfig.java
@@ -110,8 +110,9 @@ public class IdentityConfig implements IdentityClientConfig, IdentityPolicy {
       return false;
     }
     // Compare on the normalized form: a dummy address must stay unusable even when it
-    // arrives with surrounding whitespace or different casing.
-    String normalized = email.trim().toLowerCase(java.util.Locale.ROOT);
-    return !normalized.endsWith(emailDummySuffix.trim().toLowerCase(java.util.Locale.ROOT));
+    // arrives with surrounding whitespace or different casing. strip() (not trim())
+    // also removes Unicode whitespace such as \u2003, which hasText() accepts.
+    String normalized = email.strip().toLowerCase(java.util.Locale.ROOT);
+    return !normalized.endsWith(emailDummySuffix.strip().toLowerCase(java.util.Locale.ROOT));
   }
 }

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -146,6 +146,12 @@
     file="db/changelog/changeset/0084_event_notification_explanation_backfill/0084_changeSet.xml" />
   <include
     file="db/changelog/changeset/0085_consultant_internal_display_name/0085_changeSet.xml" />
+  <!-- 0083_empty_draft_rows shipped without this include (found via PR #1075 review),
+       so it never ran anywhere. Appended here so already-migrated environments pick it
+       up in their next run; it only deletes zero-content draft rows and has no ordering
+       dependency on 0084/0085. -->
+  <include
+    file="db/changelog/changeset/0083_empty_draft_rows/0083_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
@@ -60,6 +60,18 @@ class IdentityConfigTest {
   }
 
   @Test
+  void isProfileEmailUsableForMagicLinkShouldRejectDummyAddressesRegardlessOfCaseAndWhitespace() {
+    givenAValidIdentityConfig();
+    identityConfig.setEmailDummySuffix("@dummy.oriso.org");
+
+    // A dummy address must stay unusable even when it arrives un-normalized.
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org "));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("  u123@dummy.oriso.org"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@DUMMY.ORISO.ORG"));
+    assertTrue(identityConfig.isProfileEmailUsableForMagicLink(" real.user@example.org "));
+  }
+
+  @Test
   void isConsultantDisplayNameAllowedShouldReadTheConfiguredFlagNullSafely() {
     givenAValidIdentityConfig();
 

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
@@ -83,6 +83,33 @@ class IdentityConfigTest {
   }
 
   @Test
+  void isProfileEmailUsableForMagicLinkShouldRejectDummyAddressesWithUnicodeWhitespace() {
+    givenAValidIdentityConfig();
+    identityConfig.setEmailDummySuffix("@dummy.oriso.org");
+
+    // hasText() accepts Unicode whitespace, so normalization must strip it too.
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org\u2003"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("\u00a0u123@dummy.oriso.org"));
+  }
+
+  @Test
+  void isProfileEmailUsableForMagicLinkShouldStayLocaleIndependent_WhenDefaultLocaleIsTurkish() {
+    givenAValidIdentityConfig();
+    identityConfig.setEmailDummySuffix("@DUMMY.orIso.org");
+
+    // Turkish lowercasing maps I to a dotless i; Locale.ROOT must keep the
+    // comparison stable regardless of the JVM default locale.
+    java.util.Locale previous = java.util.Locale.getDefault();
+    java.util.Locale.setDefault(java.util.Locale.forLanguageTag("tr-TR"));
+    try {
+      assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org"));
+      assertTrue(identityConfig.isProfileEmailUsableForMagicLink("real.user@example.org"));
+    } finally {
+      java.util.Locale.setDefault(previous);
+    }
+  }
+
+  @Test
   void isProfileEmailUsableForMagicLinkShouldRejectEverything_WhenNoDummySuffixIsConfigured() {
     givenAValidIdentityConfig();
     // Without a configured suffix the dummy rule cannot be evaluated: fail closed.

--- a/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/auth/IdentityConfigTest.java
@@ -68,7 +68,27 @@ class IdentityConfigTest {
     assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org "));
     assertFalse(identityConfig.isProfileEmailUsableForMagicLink("  u123@dummy.oriso.org"));
     assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@DUMMY.ORISO.ORG"));
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("  u123@Dummy.Oriso.Org  "));
     assertTrue(identityConfig.isProfileEmailUsableForMagicLink(" real.user@example.org "));
+  }
+
+  @Test
+  void isProfileEmailUsableForMagicLinkShouldNormalizeTheConfiguredSuffixItself() {
+    givenAValidIdentityConfig();
+    // The configured side must be normalized too, not only the submitted address.
+    identityConfig.setEmailDummySuffix(" @DUMMY.oriso.org ");
+
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("u123@dummy.oriso.org"));
+    assertTrue(identityConfig.isProfileEmailUsableForMagicLink("real.user@example.org"));
+  }
+
+  @Test
+  void isProfileEmailUsableForMagicLinkShouldRejectEverything_WhenNoDummySuffixIsConfigured() {
+    givenAValidIdentityConfig();
+    // Without a configured suffix the dummy rule cannot be evaluated: fail closed.
+    identityConfig.setEmailDummySuffix(null);
+
+    assertFalse(identityConfig.isProfileEmailUsableForMagicLink("real.user@example.org"));
   }
 
   @Test


### PR DESCRIPTION
Two findings from the Copilot review of the dev-sync PR #1075, both confirmed on pre-dev:

**Orphaned Liquibase changeset.** `db/changelog/changeset/0083_empty_draft_rows/0083_changeSet.xml` (the #983 cleanup of zero-content draft rows) was never included in `userservice-master.xml`, so it has never run in any deployment — the bad rows DraftMessageService now prevents are still in place everywhere. The include is appended after 0085 so environments that already migrated past 0083 pick it up on their next run; the delete has no ordering dependency on 0084/0085.

**Un-normalized dummy-address check.** `IdentityConfig.isProfileEmailUsableForMagicLink` compared the raw input against the dummy suffix, so a dummy address with surrounding whitespace or different casing would have counted as usable and could enable Magic Link for a dummy e-mail. The check now trims and lower-cases both sides. Covered by a new `IdentityConfigTest` case.

Verified locally on JDK 21: `IdentityConfigTest` (8/8) plus the changelog contract tests (`RocketChatAdapterRemovedContractTest`, `ConversationTypeLiquibaseContractTest`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved magic-link email validation for leading/trailing whitespace, Unicode whitespace, and letter-case differences.
  - Prevented blank, missing, or improperly formatted dummy email addresses from being treated as valid.
  - Ensured valid email addresses remain usable when surrounded by whitespace.
  - Improved handling when dummy email configuration is unavailable by failing safely.
  - Added database cleanup to remove empty draft entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->