### PR TITLE
docs(assign-enquiry): refresh reused-room comment for post-#905/#1074 model (#925 AC#4)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -268,17 +268,19 @@ public class AssignEnquiryFacade {
                 consultant.getUsername(),
                 existingRoomId);
 
-            // Remove the agency service account from the reused room. The room now retains the
-            // accepting consultant, the advice seeker, and the department's other counsellors as
-            // silent members (ADR-002 §1, seeded by #905 and reconciled on late-joiners by #1074).
-            // The agency service account was only needed for pre-assignment provisioning.
+            // Remove the agency service account from the reused room. The room now retains two
+            // foreground members - the accepting consultant and the advice seeker - and the
+            // department's other counsellors as silent members (ADR-002 §1, seeded by #905 and
+            // reconciled on late-joiners by #1074). The agency service account was only needed
+            // for pre-assignment provisioning.
             boolean agencyRemoved =
                 sessionRoomGateway.removeUserFromRoom(
                     existingRoomId, agencyCredentials.getMatrixUserId(), agencyToken);
             if (agencyRemoved) {
               log.info(
-                  "Removed agency service account {} from room {} (accepting consultant, advice"
-                      + " seeker and the department's other counsellors remain as silent members)",
+                  "Removed agency service account {} from room {} (foreground: accepting"
+                      + " consultant and advice seeker; silent: the department's other"
+                      + " counsellors)",
                   agencyCredentials.getMatrixUserId(),
                   existingRoomId);
             } else {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -268,13 +268,17 @@ public class AssignEnquiryFacade {
                 consultant.getUsername(),
                 existingRoomId);
 
-            // Remove agency service account from room (now only consultant + user remain)
+            // Remove the agency service account from the reused room. The room now retains the
+            // accepting consultant, the advice seeker, and the department's other counsellors as
+            // silent members (ADR-002 §1, seeded by #905 and reconciled on late-joiners by #1074).
+            // The agency service account was only needed for pre-assignment provisioning.
             boolean agencyRemoved =
                 sessionRoomGateway.removeUserFromRoom(
                     existingRoomId, agencyCredentials.getMatrixUserId(), agencyToken);
             if (agencyRemoved) {
               log.info(
-                  "Removed agency service account {} from room {} (only consultant + user remain)",
+                  "Removed agency service account {} from room {} (department counsellors remain"
+                      + " as silent members)",
                   agencyCredentials.getMatrixUserId(),
                   existingRoomId);
             } else {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignEnquiryFacade.java
@@ -277,8 +277,8 @@ public class AssignEnquiryFacade {
                     existingRoomId, agencyCredentials.getMatrixUserId(), agencyToken);
             if (agencyRemoved) {
               log.info(
-                  "Removed agency service account {} from room {} (department counsellors remain"
-                      + " as silent members)",
+                  "Removed agency service account {} from room {} (accepting consultant, advice"
+                      + " seeker and the department's other counsellors remain as silent members)",
                   agencyCredentials.getMatrixUserId(),
                   existingRoomId);
             } else {


### PR DESCRIPTION
Addresses acceptance criterion #4 on #925 — https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/925

## What
Rewrite the comment and one log line in `AssignEnquiryFacade` (line 271 area) so both describe the current room model correctly.

Before:
> Remove agency service account from room (now only consultant + user remain)

After:
> Remove the agency service account from the reused room. The room now retains the accepting consultant, the advice seeker, and the department's other counsellors as silent members (ADR-002 §1, seeded by #905 and reconciled on late-joiners by #1074). The agency service account was only needed for pre-assignment provisioning.

## Why
The old comment described the pre-#905 Rocket.Chat flow. After #905 (permanent department membership) and #1074 (late-joiner reconciliation), the room retains the department's counsellors as silent members after the removal. The old wording made the file misleading for anyone reading the reuse branch.

## Scope
Comment + one log message only. No behaviour change. Zero test impact. Does not close #925 — criteria #1 (FE hide/mute silent members) and #3 (direct-enquiry handover decision) remain open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified status messaging for reused consultation rooms.
  * Confirmed that the accepting consultant, advice seeker, and other department counsellors remain silent members.
  * Confirmed that existing room membership behavior and access remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->