### PR TITLE
fix(supervision): attach the standing supervisor when a case changes hands

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateService.java
@@ -251,6 +251,17 @@ public class ConsultantUpdateService {
               + assignedSupervisorId
               + " cannot be a standing supervisor (isSupervisor is false)");
     }
+    // A platform admin sees consultants across tenants, so nothing above stops a cross-tenant
+    // assignment. Storing one is worse than rejecting it: attachStandingSupervisorIfAssigned is
+    // best-effort and swallows the failure, so the case would run unsupervised while the admin
+    // board shows a supervisor. Objects.equals covers single-tenant deployments, where both ids
+    // are null.
+    if (!java.util.Objects.equals(consultant.getTenantId(), standingSupervisor.getTenantId())) {
+      throw new BadRequestException(
+          "Consultant "
+              + assignedSupervisorId
+              + " cannot be a standing supervisor (different tenant)");
+    }
     consultant.setAssignedSupervisorId(assignedSupervisorId);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/SessionSupervisorFacade.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -385,6 +386,26 @@ public class SessionSupervisorFacade {
    * @param sessionId the just-accepted session
    * @param acceptingConsultant the counsellor who accepted it (carries the standing assignment)
    */
+  /**
+   * Runs {@link #attachStandingSupervisorIfAssigned} inside a transaction of its own. For
+   * after-commit callers only.
+   *
+   * <p>During an {@code afterCommit} callback the just-committed transaction's resources are still
+   * bound to the thread. A repository write issued from there joins that transaction, which can no
+   * longer commit, so the {@code SessionSupervisor} row is silently lost — after {@code
+   * addSupervisor} has already provisioned Matrix access. {@code addSupervisor}'s own {@code
+   * &#64;Transactional} cannot save us either, because {@link #attachStandingSupervisorIfAssigned}
+   * self-invokes it and so never passes through the proxy.
+   *
+   * <p>REQUIRES_NEW on this externally proxied entry point gives the write a live transaction. The
+   * facade still swallows supervision failures, so this never undoes the caller's handover.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void attachStandingSupervisorInNewTransaction(
+      Long sessionId, Consultant acceptingConsultant) {
+    attachStandingSupervisorIfAssigned(sessionId, acceptingConsultant);
+  }
+
   public void attachStandingSupervisorIfAssigned(Long sessionId, Consultant acceptingConsultant) {
     String standingSupervisorId = acceptingConsultant.getAssignedSupervisorId();
     if (standingSupervisorId == null || standingSupervisorId.isBlank()) {

--- a/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignSessionFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/assignsession/AssignSessionFacade.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.facade.assignsession;
 
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
+import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -38,6 +39,13 @@ public class AssignSessionFacade {
   private final @NonNull HttpServletRequest httpServletRequest;
 
   /**
+   * ADR-008 "Supervision (auto-assigned)": a case that changes hands must pick up the NEW
+   * counsellor's standing supervisor. Until now only the enquiry-accept path did, so every
+   * reassignment silently left the case unsupervised.
+   */
+  private final @NonNull SessionSupervisorFacade sessionSupervisorFacade;
+
+  /**
    * Assigns the given {@link Session} session to the given {@link Consultant}. Removes consultants
    * from the Matrix room when they no longer have the right to view this session.
    *
@@ -56,6 +64,11 @@ public class AssignSessionFacade {
     if (!authenticatedUser.isAdviceSeeker()) {
       sendEmailForConsultantChange(session, consultantToAssign);
     }
+    // The case now belongs to consultantToAssign, so layer their standing supervision on top.
+    // Never throws (see the facade's contract): a supervision problem must degrade to "this case
+    // is unsupervised", never to "the reassignment failed". This method is not transactional, so
+    // the direct call is safe here — the handover paths need an after-commit hook instead.
+    sessionSupervisorFacade.attachStandingSupervisorIfAssigned(session.getId(), consultantToAssign);
 
     var event =
         new AssignSessionStatisticsEvent(

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -513,7 +513,10 @@ public class CaseHandoverService {
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            sessionSupervisorFacade.attachStandingSupervisorIfAssigned(sessionId, newOwner);
+            // Must be the REQUIRES_NEW entry point: at afterCommit the committed transaction's
+            // resources are still bound, so a write through the plain method would join a
+            // transaction that can no longer commit and the SessionSupervisor row would be lost.
+            sessionSupervisorFacade.attachStandingSupervisorInNewTransaction(sessionId, newOwner);
           }
         });
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -513,10 +513,24 @@ public class CaseHandoverService {
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            // Must be the REQUIRES_NEW entry point: at afterCommit the committed transaction's
-            // resources are still bound, so a write through the plain method would join a
-            // transaction that can no longer commit and the SessionSupervisor row would be lost.
-            sessionSupervisorFacade.attachStandingSupervisorInNewTransaction(sessionId, newOwner);
+            try {
+              // Must be the REQUIRES_NEW entry point: at afterCommit the committed transaction's
+              // resources are still bound, so a write through the plain method would join a
+              // transaction that can no longer commit and the SessionSupervisor row would be lost.
+              sessionSupervisorFacade.attachStandingSupervisorInNewTransaction(sessionId, newOwner);
+            } catch (RuntimeException supervisionFailure) {
+              // The catch has to sit OUTSIDE the proxied boundary. The facade swallows its own
+              // exceptions, but a swallowed persistence failure has already marked the new
+              // transaction rollback-only, so the commit the proxy attempts afterwards throws
+              // UnexpectedRollbackException — after this method returned. Escaping here would
+              // surface as a 500 on a handover that has already committed, which is exactly the
+              // guarantee this indirection exists to protect.
+              log.warn(
+                  "Standing supervisor attach failed after the handover of session {} committed;"
+                      + " the case stays unsupervised",
+                  sessionId,
+                  supervisionFailure);
+            }
           }
         });
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestExceptio
 import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.CaseHandoverReasonPolicy;
 import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
@@ -48,6 +49,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -238,6 +241,14 @@ public class CaseHandoverService {
               .build());
 
   private final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  /**
+   * ADR-008 "Supervision (auto-assigned)": a takeover hands the case to a new owner, so the new
+   * owner's standing supervisor must attach. Invoked after commit — see {@link
+   * #attachStandingSupervisorAfterCommit}.
+   */
+  private final @NonNull SessionSupervisorFacade sessionSupervisorFacade;
+
   private final @NonNull CaseHandoverReasonPolicyRepository caseHandoverReasonPolicyRepository;
   private final @NonNull SessionRepository sessionRepository;
   private final @NonNull ConsultantAgencyRepository consultantAgencyRepository;
@@ -418,6 +429,7 @@ public class CaseHandoverService {
       session.setConsultant(requester);
       session.setUpdateDate(now);
       sessionRepository.save(session);
+      attachStandingSupervisorAfterCommit(session.getId(), requester);
       notifyGranted(saved);
     } else {
       notifyPendingConsent(saved);
@@ -460,6 +472,7 @@ public class CaseHandoverService {
       session.setConsultant(request.getRequesterConsultant());
       session.setUpdateDate(now);
       sessionRepository.save(session);
+      attachStandingSupervisorAfterCommit(session.getId(), request.getRequesterConsultant());
       CaseHandoverRequest saved = caseHandoverRequestRepository.save(request);
       notifyGranted(saved);
       return toClientStatus(saved);
@@ -470,6 +483,39 @@ public class CaseHandoverService {
     CaseHandoverRequest saved = caseHandoverRequestRepository.save(request);
     notifyConsentDeclined(saved);
     return toClientStatus(saved);
+  }
+
+  /**
+   * ADR-008 "Supervision (auto-assigned)": attach the new owner's standing supervisor once the
+   * takeover has actually committed.
+   *
+   * <p>Deliberately NOT a direct call. {@code addSupervisor} is itself {@code @Transactional}, so
+   * called from inside this service's transaction it would join it — and any exception it raises
+   * (client opted out, that supervisor is already on the case, no Matrix user id) marks the shared
+   * transaction rollback-only. The facade swallowing the exception would not save us: the handover
+   * would still fail at commit with an UnexpectedRollbackException. Running after commit keeps the
+   * facade's contract intact — a supervision problem leaves the case unsupervised, it never undoes
+   * the handover.
+   *
+   * <p>Outside a transaction (unit tests, future non-transactional callers) it runs inline, which
+   * carries the same guarantee because the facade never throws.
+   *
+   * <p>The PREVIOUS counsellor's supervisor is deliberately left attached. ADR-008 leaves this
+   * open, and stripping oversight from a live case is not something a handover should do silently;
+   * removing a supervisor stays an explicit act.
+   */
+  private void attachStandingSupervisorAfterCommit(Long sessionId, Consultant newOwner) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      sessionSupervisorFacade.attachStandingSupervisorIfAssigned(sessionId, newOwner);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            sessionSupervisorFacade.attachStandingSupervisorIfAssigned(sessionId, newOwner);
+          }
+        });
   }
 
   private Consultant retrieveCurrentConsultant() {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
@@ -141,6 +141,29 @@ public class ConsultantUpdateServiceTest {
   }
 
   @Test
+  public void updateConsultant_Should_setStandingSupervisor_When_bothTenantIdsAreNull() {
+    // Single-tenant deployments leave tenant_id null on every consultant. The cross-tenant guard
+    // uses Objects.equals precisely so null == null still passes; a guard written with != would
+    // block every standing-supervisor assignment on those installations.
+    Consultant consultant = consultantWithId("counsellor-1");
+    consultant.setTenantId(null);
+    Consultant standingSupervisor = consultantWithId("supervisor-1");
+    standingSupervisor.setSupervisor(true);
+    standingSupervisor.setTenantId(null);
+    when(this.consultantService.getConsultant("counsellor-1")).thenReturn(Optional.of(consultant));
+    when(this.consultantService.getConsultant("supervisor-1"))
+        .thenReturn(Optional.of(standingSupervisor));
+    UpdateAdminConsultantDTO updateConsultant = updateDtoFor(consultant);
+    updateConsultant.setAssignedSupervisorId("supervisor-1");
+
+    this.consultantUpdateService.updateConsultant("counsellor-1", updateConsultant);
+
+    ArgumentCaptor<Consultant> saved = ArgumentCaptor.forClass(Consultant.class);
+    verify(this.consultantService).saveConsultant(saved.capture());
+    assertEquals("supervisor-1", saved.getValue().getAssignedSupervisorId());
+  }
+
+  @Test
   public void updateConsultant_Should_throwBadRequest_When_assigningSelfAsStandingSupervisor() {
     // Supervision is oversight BY A COLLEAGUE; supervising yourself is meaningless and would let a
     // counsellor silently self-approve their own oversight.

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/consultant/update/ConsultantUpdateServiceTest.java
@@ -81,6 +81,9 @@ public class ConsultantUpdateServiceTest {
     Consultant consultant = consultantWithId("counsellor-1");
     Consultant standingSupervisor = consultantWithId("supervisor-1");
     standingSupervisor.setSupervisor(true);
+    // EasyRandom gives each consultant a random tenant; the standing assignment is tenant-scoped.
+    consultant.setTenantId(1L);
+    standingSupervisor.setTenantId(1L);
     when(this.consultantService.getConsultant("counsellor-1")).thenReturn(Optional.of(consultant));
     when(this.consultantService.getConsultant("supervisor-1"))
         .thenReturn(Optional.of(standingSupervisor));
@@ -101,11 +104,35 @@ public class ConsultantUpdateServiceTest {
     Consultant consultant = consultantWithId("counsellor-1");
     Consultant notASupervisor = consultantWithId("colleague-1");
     notASupervisor.setSupervisor(false);
+    consultant.setTenantId(1L);
+    notASupervisor.setTenantId(1L);
     when(this.consultantService.getConsultant("counsellor-1")).thenReturn(Optional.of(consultant));
     when(this.consultantService.getConsultant("colleague-1"))
         .thenReturn(Optional.of(notASupervisor));
     UpdateAdminConsultantDTO updateConsultant = updateDtoFor(consultant);
     updateConsultant.setAssignedSupervisorId("colleague-1");
+
+    assertThrows(
+        BadRequestException.class,
+        () -> this.consultantUpdateService.updateConsultant("counsellor-1", updateConsultant));
+    verify(this.consultantService, Mockito.never()).saveConsultant(any());
+  }
+
+  @Test
+  public void updateConsultant_Should_throwBadRequest_When_standingSupervisorIsFromAnotherTenant() {
+    // A platform admin sees consultants across tenants, so nothing else here stops a cross-tenant
+    // assignment. Storing one is worse than rejecting it: the attach is best-effort and swallows
+    // its failure, so the case would run unsupervised while the admin board shows a supervisor.
+    Consultant consultant = consultantWithId("counsellor-1");
+    consultant.setTenantId(1L);
+    Consultant foreignSupervisor = consultantWithId("supervisor-2");
+    foreignSupervisor.setSupervisor(true);
+    foreignSupervisor.setTenantId(2L);
+    when(this.consultantService.getConsultant("counsellor-1")).thenReturn(Optional.of(consultant));
+    when(this.consultantService.getConsultant("supervisor-2"))
+        .thenReturn(Optional.of(foreignSupervisor));
+    UpdateAdminConsultantDTO updateConsultant = updateDtoFor(consultant);
+    updateConsultant.setAssignedSupervisorId("supervisor-2");
 
     assertThrows(
         BadRequestException.class,

--- a/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignSessionFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/assignsession/AssignSessionFacadeTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.facade.EmailNotificationFacade;
+import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
@@ -37,6 +38,7 @@ class AssignSessionFacadeTest {
   @Mock UnauthorizedMembersProvider unauthorizedMembersProvider;
   @Mock StatisticsService statisticsService;
   @Mock HttpServletRequest httpServletRequest;
+  @Mock SessionSupervisorFacade sessionSupervisorFacade;
   @Mock Session session;
   @Mock User user;
   @Mock Consultant consultantToAssign;
@@ -99,5 +101,17 @@ class AssignSessionFacadeTest {
 
     verify(statisticsService)
         .fireEvent(org.mockito.ArgumentMatchers.any(AssignSessionStatisticsEvent.class));
+  }
+
+  /**
+   * ADR-008 "Supervision (auto-assigned)": until now only the enquiry-accept path attached the
+   * standing supervisor, so a case that was reassigned to another counsellor silently lost
+   * oversight. The supervisor that attaches is the NEW owner's, not the previous one's.
+   */
+  @Test
+  void assignSession_attachesTheNewConsultantsStandingSupervisor() {
+    assignSessionFacade.assignSession(session, consultantToAssign, authenticatedConsultant);
+
+    verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(42L, consultantToAssign);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
@@ -628,6 +630,56 @@ class CaseHandoverServiceTest {
     caseHandoverService.resolveClientConsent(123L, 88L, true);
 
     verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(123L, requester);
+  }
+
+  /**
+   * The production path is transactional, so it takes the deferred branch, not the
+   * no-synchronization fallback the test above exercises. Assert the real one: nothing before the
+   * commit, then the REQUIRES_NEW entry point and never the plain method.
+   */
+  @Test
+  void resolveClientConsent_defersTheSupervisorAttachToANewTransaction_WhenClientApproves() {
+    CaseHandoverRequest request = pendingConsentRequest();
+    when(caseHandoverRequestRepository.findByIdAndSessionId(88L, 123L))
+        .thenReturn(Optional.of(request));
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      caseHandoverService.resolveClientConsent(123L, 88L, true);
+
+      verify(sessionSupervisorFacade, never())
+          .attachStandingSupervisorInNewTransaction(any(), any());
+
+      TransactionSynchronizationManager.getSynchronizations()
+          .forEach(synchronization -> synchronization.afterCommit());
+
+      verify(sessionSupervisorFacade).attachStandingSupervisorInNewTransaction(123L, requester);
+      verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  /**
+   * The facade swallows its own failures, but the REQUIRES_NEW commit happens after that catch
+   * returns, so a rollback-only transaction throws out of the proxy. The handover has already
+   * committed by then; letting it escape would 500 a successful takeover.
+   */
+  @Test
+  void requestAccess_swallowsASupervisorAttachFailureRaisedByTheNewTransactionsCommit() {
+    doThrow(new UnexpectedRollbackException("transaction rolled back"))
+        .when(sessionSupervisorFacade)
+        .attachStandingSupervisorInNewTransaction(any(), any());
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
+
+      TransactionSynchronizationManager.getSynchronizations()
+          .forEach(synchronization -> synchronization.afterCommit());
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    verify(sessionSupervisorFacade).attachStandingSupervisorInNewTransaction(123L, requester);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -18,6 +18,7 @@ import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
+import de.caritas.cob.userservice.api.facade.SessionSupervisorFacade;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.CaseHandoverReasonPolicy;
 import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
@@ -51,6 +52,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -66,6 +68,7 @@ class CaseHandoverServiceTest {
   @Mock private EventNotificationService eventNotificationService;
   @Mock private MatrixSynapseService matrixSynapseService;
   @Mock private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
+  @Mock private SessionSupervisorFacade sessionSupervisorFacade;
 
   private Consultant requester;
   private Consultant previous;
@@ -129,6 +132,53 @@ class CaseHandoverServiceTest {
     verify(sessionRepository).save(session);
     verify(eventNotificationService, atLeastOnce())
         .createEvent(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * ADR-008 "Supervision (auto-assigned)": a takeover hands the case to a new owner, so the new
+   * owner's standing supervisor has to attach. Before this, only the enquiry-accept path did, and a
+   * case that changed hands silently ran unsupervised.
+   */
+  @Test
+  void requestAccess_attachesTheNewOwnersStandingSupervisor_WhenGranted() {
+    caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
+
+    verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(123L, requester);
+  }
+
+  @Test
+  void requestAccess_doesNotAttachAStandingSupervisor_WhenTheHandoverIsNotGranted() {
+    when(caseHandoverReasonPolicyRepository.findByEnabledTrueOrderByDisplayOrderAscCodeAsc())
+        .thenReturn(
+            List.of(reasonPolicy("OTHER_EMERGENCY", "Other emergency", false, false, true, 30)));
+
+    caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Needs cover.");
+
+    verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
+  }
+
+  /**
+   * The attach must not run inside this service's transaction. {@code addSupervisor} is itself
+   * transactional, so an exception it raises there (client opted out, supervisor already on the
+   * case, no Matrix user id) would mark the shared transaction rollback-only and kill the handover
+   * at commit — even though the facade swallows it. Deferring to after-commit is the whole point,
+   * so assert the deferral, not just the call.
+   */
+  @Test
+  void requestAccess_defersTheSupervisorAttachUntilTheHandoverHasCommitted() {
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
+
+      verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
+
+      TransactionSynchronizationManager.getSynchronizations()
+          .forEach(synchronization -> synchronization.afterCommit());
+
+      verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(123L, requester);
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -163,19 +163,26 @@ class CaseHandoverServiceTest {
    * case, no Matrix user id) would mark the shared transaction rollback-only and kill the handover
    * at commit — even though the facade swallows it. Deferring to after-commit is the whole point,
    * so assert the deferral, not just the call.
+   *
+   * <p>It must also defer to the REQUIRES_NEW entry point, not the plain one: during afterCommit
+   * the committed transaction's resources are still bound to the thread, so a write through the
+   * plain method joins a transaction that can no longer commit and the SessionSupervisor row is
+   * lost after Matrix access has already been granted.
    */
   @Test
-  void requestAccess_defersTheSupervisorAttachUntilTheHandoverHasCommitted() {
+  void requestAccess_defersTheSupervisorAttachToANewTransactionAfterTheHandoverHasCommitted() {
     TransactionSynchronizationManager.initSynchronization();
     try {
       caseHandoverService.requestAccess(123L, "OTHER_EMERGENCY", "Colleague is unavailable.");
 
-      verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
+      verify(sessionSupervisorFacade, never())
+          .attachStandingSupervisorInNewTransaction(any(), any());
 
       TransactionSynchronizationManager.getSynchronizations()
           .forEach(synchronization -> synchronization.afterCommit());
 
-      verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(123L, requester);
+      verify(sessionSupervisorFacade).attachStandingSupervisorInNewTransaction(123L, requester);
+      verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }
@@ -605,6 +612,33 @@ class CaseHandoverServiceTest {
     assertEquals(CaseHandoverRequest.Status.GRANTED, request.getStatus());
     assertEquals("ACCESS_GRANTED", request.getAuditOutcome());
     verify(sessionRepository).save(session);
+  }
+
+  /**
+   * A client-approved handover transfers ownership just as a granted requestAccess does, so the new
+   * owner's standing supervisor has to attach on this path too. Without this test a regression on
+   * the resolveClientConsent branch passes the whole suite.
+   */
+  @Test
+  void resolveClientConsent_attachesTheNewOwnersStandingSupervisor_WhenClientApproves() {
+    CaseHandoverRequest request = pendingConsentRequest();
+    when(caseHandoverRequestRepository.findByIdAndSessionId(88L, 123L))
+        .thenReturn(Optional.of(request));
+
+    caseHandoverService.resolveClientConsent(123L, 88L, true);
+
+    verify(sessionSupervisorFacade).attachStandingSupervisorIfAssigned(123L, requester);
+  }
+
+  @Test
+  void resolveClientConsent_doesNotAttachAStandingSupervisor_WhenClientDeclines() {
+    CaseHandoverRequest request = pendingConsentRequest();
+    when(caseHandoverRequestRepository.findByIdAndSessionId(88L, 123L))
+        .thenReturn(Optional.of(request));
+
+    caseHandoverService.resolveClientConsent(123L, 88L, false);
+
+    verify(sessionSupervisorFacade, never()).attachStandingSupervisorIfAssigned(any(), any());
   }
 
   @Test


### PR DESCRIPTION
Part of OpenResilienceInitiative/ORISO-Admin#884 — the backend half. The admin-panel half is OpenResilienceInitiative/ORISO-Admin#885.

## What

Two things ADR-008 leaves broken.

**1. A case that changes hands lost its supervision.** `attachStandingSupervisorIfAssigned` was wired into the enquiry-accept path only, so reassignment and case-handover takeover ran on unsupervised. ADR-008 line 63 names this as an open follow-up. Covers all three remaining owner changes: `AssignSessionFacade.assignSession` and both `CaseHandoverService` grant paths.

**2. A standing supervisor from another tenant was accepted.** `applyStandingSupervisor` validated only existence, the `isSupervisor` capability and not-self. A platform admin sees consultants across tenants, so a foreign id could be stored — and that is worse than a rejection: the attach is best-effort and swallows its failure, so the case would run unsupervised while the admin board showed a supervisor. Configured, and silently doing nothing.

## The part worth a reviewer's attention

The handover paths could not simply call the facade. `addSupervisor` is itself `@Transactional`, so from inside `CaseHandoverService`'s transaction it joins it — and any exception it raises (client opted out, that supervisor is already on the case, no Matrix user id) marks the shared transaction rollback-only. The facade swallowing the exception does not help: the handover would still fail at commit with `UnexpectedRollbackException`.

The attach therefore runs **after commit**, which keeps the ADR-008 contract intact: a supervision problem leaves the case unsupervised, it never undoes the handover. `AssignSessionFacade` is not transactional, so the direct call there is safe — the asymmetry is deliberate and commented.

A test asserts the deferral itself, not just the call: it fails if the attach is made direct.

## Deliberate decisions

- **The previous counsellor's supervisor stays attached.** ADR-008 leaves this open, and stripping oversight from a live case should not be a silent side effect of a handover; removing a supervisor remains an explicit act.
- **`Objects.equals` for the tenant check**, so single-tenant deployments where both ids are null keep working.

## Verification

**local only.** `mvn test`: 4025 passed, 0 failures, on JDK 21. Every new guard was mutation-checked — reverting it makes its test fail:

| reverted | result |
|---|---|
| after-commit deferral → direct call | deferral test fails |
| tenant check removed | cross-tenant test fails |

No image was built or deployed, so there is no Pre-Dev proof of the runtime behaviour yet. That gap is real and worth naming: this whole issue exists because the standing-supervisor feature shipped in July and sat unusable for six weeks without anyone noticing. There is **no E2E coverage for supervision at all** — only `t1-aside-confidentiality.spec.ts` touches supervisor asides, and nothing asserts "counsellor accepts a case → the supervisor attaches". A journey in ORISO-E2E is the durable fix and would run green on the next image deploy; happy to build it if wanted before or after this merges.

### Reviewer test plan

- [ ] Give a counsellor a standing supervisor in the admin panel, have them accept a new enquiry → the supervisor appears on the case (unchanged behaviour, guard against regression)
- [ ] Reassign that case to a second counsellor who has a *different* standing supervisor → the second counsellor's supervisor is now on the case
- [ ] Take a case over through case handover → same, the taking counsellor's standing supervisor attaches
- [ ] Confirm the previous counsellor's supervisor is still on the case after a takeover — that is intended, not a leftover
- [ ] Have the advice seeker switch supervision off, then take the case over → the handover still completes and the case simply stays unsupervised; it must not fail
- [ ] As a platform admin, try to set a standing supervisor from a different tenant → rejected with 400, nothing stored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standing supervisors are automatically attached when sessions are reassigned or cases are successfully handed over.
  * Supervisor attachment occurs after successful handovers and does not block the underlying operation if it fails.
* **Bug Fixes**
  * Prevented assigning standing supervisors from a different tenant.
  * Invalid cross-tenant assignments are rejected without saving changes.
* **Tests**
  * Added coverage for tenant validation, reassignment, handover outcomes, and post-commit processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->