### PR TITLE
refactor(draft): write the invisible-whitespace class with Unicode escapes

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/draft/DraftContent.java
@@ -30,7 +30,7 @@ public final class DraftContent {
       Pattern.compile("&(nbsp|#0*160|#x0*a0|#0*8203|#x0*200b);", Pattern.CASE_INSENSITIVE);
 
   /** Non-breaking space and zero-width space — invisible, and therefore not content. */
-  private static final Pattern INVISIBLE_WHITESPACE = Pattern.compile("[ ​]");
+  private static final Pattern INVISIBLE_WHITESPACE = Pattern.compile("[\\u00a0\\u200b]");
 
   private DraftContent() {}
 


### PR DESCRIPTION
Copilot follow-up from the #1075 review (the last remaining finding there): `DraftContent.INVISIBLE_WHITESPACE` embedded the NBSP and zero-width-space characters literally inside the regex character class — invisible in diffs and editors, and easy to corrupt via copy/paste. The class now uses `\u00a0`/`\u200b` escapes; behaviour is unchanged.

Verified locally on JDK 21: `DraftContentTest` + `EmptyDraftRowsMigrationTest` 32/32 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified the representation of invisible whitespace characters using Unicode escape sequences without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->