### PR TITLE
Loud SMTP resolution failures for invite mail dispatch (#1006 P2)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -234,18 +234,18 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
   @ExceptionHandler({SmtpSendException.class})
   public ResponseEntity<Object> handleSmtpSendFailure(
       final SmtpSendException ex, final WebRequest request) {
-    log.error("SMTP send failed", ex);
+    // The detailed diagnosis (field names, remedies, causes) belongs here in the server log only.
+    log.error("SMTP send failed ({})", ex.getCategory(), ex);
 
-    // #1006: the body carries the specific failure reason (never secret values — the SMTP
-    // services guarantee their messages are credential-free) so the Admin UI can show the
-    // operator what is actually wrong instead of a generic send failure.
-    var body = new java.util.LinkedHashMap<String, Object>();
-    body.put("reason", "SMTP_SEND_FAILED");
-    if (ex.getMessage() != null) {
-      body.put("message", ex.getMessage());
-    }
-
-    return handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.BAD_GATEWAY, request);
+    // #1006: per the repository error contract the body stays information-poor — it carries the
+    // stable reason plus a coarse category so the Admin UI can distinguish "credentials missing"
+    // from "SMTP disabled" without leaking deployment properties or service topology.
+    return handleExceptionInternal(
+        ex,
+        Map.of("reason", "SMTP_SEND_FAILED", "detail", ex.getCategory().name()),
+        new HttpHeaders(),
+        HttpStatus.BAD_GATEWAY,
+        request);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandler.java
@@ -236,12 +236,16 @@ public class ApiResponseEntityExceptionHandler extends ResponseEntityExceptionHa
       final SmtpSendException ex, final WebRequest request) {
     log.error("SMTP send failed", ex);
 
-    return handleExceptionInternal(
-        ex,
-        Map.of("reason", "SMTP_SEND_FAILED"),
-        new HttpHeaders(),
-        HttpStatus.BAD_GATEWAY,
-        request);
+    // #1006: the body carries the specific failure reason (never secret values — the SMTP
+    // services guarantee their messages are credential-free) so the Admin UI can show the
+    // operator what is actually wrong instead of a generic send failure.
+    var body = new java.util.LinkedHashMap<String, Object>();
+    body.put("reason", "SMTP_SEND_FAILED");
+    if (ex.getMessage() != null) {
+      body.put("message", ex.getMessage());
+    }
+
+    return handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.BAD_GATEWAY, request);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
@@ -5,16 +5,48 @@ package de.caritas.cob.userservice.api.exception;
  * configuration required to do so is unavailable). Mirrors the strict contract established in
  * ConsultingTypeService (TEN-INV-U5): callers must never report success — and never persist a SENT
  * state — when this is thrown. Mapped to 502 Bad Gateway.
+ *
+ * <p>#1006: each instance carries a coarse {@link Category}. Only the category reaches the API
+ * response body (information-poor per the repository error contract); the detailed message stays in
+ * the server log.
  */
 public class SmtpSendException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
+  /** Coarse, client-safe failure category — the only diagnostic detail the 502 body carries. */
+  public enum Category {
+    /** The settings source (ConsultingTypeService) is unreachable, erroring, or empty. */
+    SMTP_SETTINGS_UNAVAILABLE,
+    /** SMTP is switched off or the connection configuration is incomplete/invalid. */
+    SMTP_DISABLED_OR_INCOMPLETE,
+    /** No usable SMTP credentials could be resolved. */
+    SMTP_CREDENTIALS_MISSING,
+    /** The SMTP server rejected or never confirmed the handover. */
+    SMTP_TRANSPORT_FAILED
+  }
+
+  private final Category category;
+
   public SmtpSendException(String message) {
-    super(message);
+    this(Category.SMTP_TRANSPORT_FAILED, message);
   }
 
   public SmtpSendException(String message, Throwable cause) {
+    this(Category.SMTP_TRANSPORT_FAILED, message, cause);
+  }
+
+  public SmtpSendException(Category category, String message) {
+    super(message);
+    this.category = category;
+  }
+
+  public SmtpSendException(Category category, String message, Throwable cause) {
     super(message, cause);
+    this.category = category;
+  }
+
+  public Category getCategory() {
+    return category;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
@@ -12,7 +12,6 @@ import de.caritas.cob.userservice.api.service.email.layout.BrandedEmailRequest;
 import de.caritas.cob.userservice.api.service.email.layout.EmailBranding;
 import de.caritas.cob.userservice.api.service.email.layout.EmailBrandingResolver;
 import java.util.Map;
-import java.util.Optional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -104,13 +103,7 @@ public class InviteMailDispatchService {
       String primaryActionUrl,
       Long tenantId,
       String language) {
-    InviteSmtpSettings smtp =
-        resolveGlobalSmtpSettings()
-            .orElseThrow(
-                () ->
-                    new SmtpSendException(
-                        "Global SMTP settings are unavailable or incomplete — invite mail not"
-                            + " sent"));
+    InviteSmtpSettings smtp = resolveGlobalSmtpSettings();
     BrandedEmail mail =
         renderBrandedMail(subject, bodyContent, primaryActionUrl, tenantId, language);
     return inviteMailTransport.send(smtp, recipient, subject, mail.html(), mail.plainText());
@@ -132,56 +125,86 @@ public class InviteMailDispatchService {
         branding, new BrandedEmailRequest(subject, bodyContent, primaryActionUrl, null, language));
   }
 
+  /**
+   * Resolves the global SMTP settings or throws an {@link SmtpSendException} whose message names
+   * the exact defect (#1006, "loud failure"): unreachable settings endpoint, the disabled toggle or
+   * missing field by name, or missing credentials with both remedies. The message travels to the
+   * Admin UI via the SMTP exception handler, so it must never contain secret values.
+   */
   @SuppressWarnings("unchecked")
-  private Optional<InviteSmtpSettings> resolveGlobalSmtpSettings() {
+  private InviteSmtpSettings resolveGlobalSmtpSettings() {
     if (isBlank(consultingTypeServiceApiUrl)) {
-      log.warn("Invite mail dispatch: 'consulting.type.service.api.url' is not configured");
-      return Optional.empty();
+      throw new SmtpSendException(
+          "Invite mail not sent: 'consulting.type.service.api.url' is not configured on"
+              + " UserService, so the global SMTP settings cannot be resolved");
     }
+    String settingsUrl = normalizeBaseUrl(consultingTypeServiceApiUrl) + "/settings";
+
+    Map<String, Object> settingsResponse;
     try {
-      String settingsUrl = normalizeBaseUrl(consultingTypeServiceApiUrl) + "/settings";
-      Map<String, Object> settingsResponse = restTemplate.getForObject(settingsUrl, Map.class);
-      if (settingsResponse == null || settingsResponse.isEmpty()) {
-        return Optional.empty();
-      }
-
-      boolean systemEmailsEnabled =
-          asBooleanSettingValue(
-              settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
-      boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
-      String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
-      Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
-      boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
-      String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
-
-      if (!systemEmailsEnabled || !smtpEnabled || isBlank(host) || port == null || isBlank(from)) {
-        log.warn("Invite mail dispatch: global SMTP settings are incomplete or disabled");
-        return Optional.empty();
-      }
-
-      // The public /settings payload deliberately omits the SMTP username and password since the
-      // CTS-C01 credential-leak fix, so they can never be read from there.
-      String username = configuredSmtpUsername;
-      String password = configuredSmtpPassword;
-      if (isBlank(username) || isBlank(password)) {
-        var credentials = applicationSettingsService.getGlobalSmtpCredentials();
-        if (credentials.isEmpty()) {
-          log.warn(
-              "Invite mail not sent: no SMTP credentials available. Set SMTP_USER and"
-                  + " SMTP_PASSWORD on UserService or send with a super-admin token.");
-          return Optional.empty();
-        }
-        username = credentials.get().getGlobalSmtpUsername();
-        password = credentials.get().getGlobalSmtpPassword();
-      }
-
-      return Optional.of(new InviteSmtpSettings(host, port, secure, username, password, from));
+      settingsResponse = restTemplate.getForObject(settingsUrl, Map.class);
     } catch (Exception exception) {
-      log.warn(
-          "Invite mail dispatch: could not resolve global SMTP settings ({})",
-          exception.getClass().getSimpleName());
-      return Optional.empty();
+      throw new SmtpSendException(
+          "Invite mail not sent: the ConsultingTypeService /settings endpoint could not be reached"
+              + " ("
+              + exception.getClass().getSimpleName()
+              + ")",
+          exception);
     }
+    if (settingsResponse == null || settingsResponse.isEmpty()) {
+      throw new SmtpSendException(
+          "Invite mail not sent: the ConsultingTypeService /settings endpoint returned an empty"
+              + " payload");
+    }
+
+    boolean systemEmailsEnabled =
+        asBooleanSettingValue(settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
+    boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
+    String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
+    Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
+    boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
+    String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
+
+    var problems = new java.util.ArrayList<String>();
+    if (!systemEmailsEnabled) {
+      problems.add("globalFeatureSystemNotificationEmailsEnabled is disabled");
+    }
+    if (!smtpEnabled) {
+      problems.add("globalSmtpEnabled is disabled");
+    }
+    if (isBlank(host)) {
+      problems.add("globalSmtpHost is missing");
+    }
+    if (port == null) {
+      problems.add("globalSmtpPort is missing or not a number");
+    }
+    if (isBlank(from)) {
+      problems.add("globalSmtpFrom is missing");
+    }
+    if (!problems.isEmpty()) {
+      throw new SmtpSendException(
+          "Invite mail not sent: the global SMTP configuration is unusable — "
+              + String.join(", ", problems));
+    }
+
+    // The public /settings payload deliberately omits the SMTP username and password since the
+    // CTS-C01 credential-leak fix, so they can never be read from there.
+    String username = configuredSmtpUsername;
+    String password = configuredSmtpPassword;
+    if (isBlank(username) || isBlank(password)) {
+      var credentials = applicationSettingsService.getGlobalSmtpCredentials();
+      if (credentials.isEmpty()) {
+        throw new SmtpSendException(
+            "Invite mail not sent: no SMTP credentials available — set SMTP_USER and SMTP_PASSWORD"
+                + " on the UserService deployment (the supported configuration), or the request"
+                + " must carry a platform-admin token for the guarded credentials endpoint (see"
+                + " the UserService log for the credential lookup outcome)");
+      }
+      username = credentials.get().getGlobalSmtpUsername();
+      password = credentials.get().getGlobalSmtpPassword();
+    }
+
+    return new InviteSmtpSettings(host, port, secure, username, password, from);
   }
 
   private boolean asBooleanSettingValue(Object raw) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
@@ -181,8 +181,7 @@ public class InviteMailDispatchService {
         asBooleanSettingValue(settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
     Boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
     String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
-    boolean secure =
-        Boolean.TRUE.equals(asBooleanSettingValue(settingsResponse.get("globalSmtpSecure")));
+    Boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
     String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
 
     var problems = new java.util.ArrayList<String>();
@@ -196,6 +195,10 @@ public class InviteMailDispatchService {
       problems.add("globalSmtpEnabled is missing or not a boolean");
     } else if (!smtpEnabled) {
       problems.add("globalSmtpEnabled is disabled");
+    }
+    // Review 3893323639: an absent/malformed secure toggle must not silently select STARTTLS.
+    if (secure == null) {
+      problems.add("globalSmtpSecure is missing or not a boolean");
     }
     if (isBlank(host)) {
       problems.add("globalSmtpHost is missing");

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
@@ -127,14 +127,16 @@ public class InviteMailDispatchService {
 
   /**
    * Resolves the global SMTP settings or throws an {@link SmtpSendException} whose message names
-   * the exact defect (#1006, "loud failure"): unreachable settings endpoint, the disabled toggle or
-   * missing field by name, or missing credentials with both remedies. The message travels to the
-   * Admin UI via the SMTP exception handler, so it must never contain secret values.
+   * the exact defect (#1006, "loud failure"): unreachable or erroring settings endpoint, the
+   * disabled/missing toggle or missing field by name, an invalid port, or missing credentials with
+   * both remedies. The detailed message goes to the server log only; the API response carries just
+   * the coarse {@link SmtpSendException.Category}. Messages must never contain secret values.
    */
   @SuppressWarnings("unchecked")
   private InviteSmtpSettings resolveGlobalSmtpSettings() {
     if (isBlank(consultingTypeServiceApiUrl)) {
       throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE,
           "Invite mail not sent: 'consulting.type.service.api.url' is not configured on"
               + " UserService, so the global SMTP settings cannot be resolved");
     }
@@ -143,46 +145,68 @@ public class InviteMailDispatchService {
     Map<String, Object> settingsResponse;
     try {
       settingsResponse = restTemplate.getForObject(settingsUrl, Map.class);
-    } catch (Exception exception) {
+    } catch (org.springframework.web.client.RestClientResponseException exception) {
+      // Review 3893231991: an HTTP error means the endpoint WAS reached — say so, with the status.
       throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE,
+          "Invite mail not sent: the ConsultingTypeService /settings endpoint responded with HTTP "
+              + exception.getStatusCode().value(),
+          exception);
+    } catch (org.springframework.web.client.ResourceAccessException exception) {
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE,
           "Invite mail not sent: the ConsultingTypeService /settings endpoint could not be reached"
               + " ("
+              + exception.getClass().getSimpleName()
+              + ")",
+          exception);
+    } catch (Exception exception) {
+      // Conversion or other unexpected failures get their own case instead of "unreachable".
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE,
+          "Invite mail not sent: the ConsultingTypeService /settings response could not be"
+              + " processed ("
               + exception.getClass().getSimpleName()
               + ")",
           exception);
     }
     if (settingsResponse == null || settingsResponse.isEmpty()) {
       throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE,
           "Invite mail not sent: the ConsultingTypeService /settings endpoint returned an empty"
               + " payload");
     }
 
-    boolean systemEmailsEnabled =
+    Boolean systemEmailsEnabled =
         asBooleanSettingValue(settingsResponse.get("globalFeatureSystemNotificationEmailsEnabled"));
-    boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
+    Boolean smtpEnabled = asBooleanSettingValue(settingsResponse.get("globalSmtpEnabled"));
     String host = asStringSettingValue(settingsResponse.get("globalSmtpHost"));
-    Integer port = asIntSettingValue(settingsResponse.get("globalSmtpPort"));
-    boolean secure = asBooleanSettingValue(settingsResponse.get("globalSmtpSecure"));
+    boolean secure =
+        Boolean.TRUE.equals(asBooleanSettingValue(settingsResponse.get("globalSmtpSecure")));
     String from = asStringSettingValue(settingsResponse.get("globalSmtpFrom"));
 
     var problems = new java.util.ArrayList<String>();
-    if (!systemEmailsEnabled) {
+    // Review 3893223709: an absent or malformed toggle must not masquerade as "disabled".
+    if (systemEmailsEnabled == null) {
+      problems.add("globalFeatureSystemNotificationEmailsEnabled is missing or not a boolean");
+    } else if (!systemEmailsEnabled) {
       problems.add("globalFeatureSystemNotificationEmailsEnabled is disabled");
     }
-    if (!smtpEnabled) {
+    if (smtpEnabled == null) {
+      problems.add("globalSmtpEnabled is missing or not a boolean");
+    } else if (!smtpEnabled) {
       problems.add("globalSmtpEnabled is disabled");
     }
     if (isBlank(host)) {
       problems.add("globalSmtpHost is missing");
     }
-    if (port == null) {
-      problems.add("globalSmtpPort is missing or not a number");
-    }
+    Integer port = resolvePort(settingsResponse.get("globalSmtpPort"), problems);
     if (isBlank(from)) {
       problems.add("globalSmtpFrom is missing");
     }
     if (!problems.isEmpty()) {
       throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_DISABLED_OR_INCOMPLETE,
           "Invite mail not sent: the global SMTP configuration is unusable — "
               + String.join(", ", problems));
     }
@@ -195,6 +219,7 @@ public class InviteMailDispatchService {
       var credentials = applicationSettingsService.getGlobalSmtpCredentials();
       if (credentials.isEmpty()) {
         throw new SmtpSendException(
+            SmtpSendException.Category.SMTP_CREDENTIALS_MISSING,
             "Invite mail not sent: no SMTP credentials available — set SMTP_USER and SMTP_PASSWORD"
                 + " on the UserService deployment (the supported configuration), or the request"
                 + " must carry a platform-admin token for the guarded credentials endpoint (see"
@@ -207,15 +232,24 @@ public class InviteMailDispatchService {
     return new InviteSmtpSettings(host, port, secure, username, password, from);
   }
 
-  private boolean asBooleanSettingValue(Object raw) {
+  /**
+   * Review 3893223709: nullable on purpose — {@code null} means "missing or not a boolean", which
+   * must not be conflated with an explicit {@code false}.
+   */
+  private Boolean asBooleanSettingValue(Object raw) {
     Object value = unwrapSettingValue(raw);
     if (value instanceof Boolean bool) {
       return bool;
     }
     if (value instanceof String string) {
-      return "true".equalsIgnoreCase(string);
+      if ("true".equalsIgnoreCase(string.trim())) {
+        return Boolean.TRUE;
+      }
+      if ("false".equalsIgnoreCase(string.trim())) {
+        return Boolean.FALSE;
+      }
     }
-    return false;
+    return null;
   }
 
   private String asStringSettingValue(Object raw) {
@@ -223,18 +257,34 @@ public class InviteMailDispatchService {
     return nonNull(value) ? String.valueOf(value).trim() : null;
   }
 
-  private Integer asIntSettingValue(Object raw) {
+  /**
+   * Review 3893223709: validates the port as an integral TCP port in 1..65535 instead of letting 0,
+   * negative, out-of-range or fractional values fail later in transport. Adds the field-specific
+   * problem and returns {@code null} when the value is unusable.
+   */
+  private Integer resolvePort(Object raw, java.util.List<String> problems) {
     Object value = unwrapSettingValue(raw);
     if (value instanceof Number number) {
-      return number.intValue();
+      double asDouble = number.doubleValue();
+      if (asDouble == Math.rint(asDouble) && asDouble >= 1 && asDouble <= 65535) {
+        return (int) asDouble;
+      }
+      problems.add("globalSmtpPort is not a valid TCP port (1-65535)");
+      return null;
     }
     if (value instanceof String string && isNotBlank(string)) {
       try {
-        return Integer.parseInt(string.trim());
-      } catch (NumberFormatException exception) {
+        int parsed = Integer.parseInt(string.trim());
+        if (parsed >= 1 && parsed <= 65535) {
+          return parsed;
+        }
+        problems.add("globalSmtpPort is not a valid TCP port (1-65535)");
         return null;
+      } catch (NumberFormatException exception) {
+        // falls through to the "missing or not a number" problem below
       }
     }
+    problems.add("globalSmtpPort is missing or not a number");
     return null;
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
@@ -68,11 +68,13 @@ public class ApplicationSettingsService {
           ex instanceof RestClientResponseException responseException
               ? String.valueOf(responseException.getStatusCode())
               : "no response";
+      // Review 3893332413: attach the exception itself so root cause (TLS vs DNS vs
+      // connection) and stack trace reach the log — context fields stay secret-free.
       log.warn(
-          "Global SMTP credentials lookup at ConsultingTypeService failed ({}, status: {}): {}",
+          "Global SMTP credentials lookup at ConsultingTypeService failed ({}, status: {})",
           ex.getClass().getSimpleName(),
           status,
-          ex.getMessage());
+          ex);
       return Optional.empty();
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsService.java
@@ -13,12 +13,15 @@ import de.caritas.cob.userservice.applicationsettingsservice.generated.web.model
 import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 
 /** Service class to communicate with the ConsultingTypeService. */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ApplicationSettingsService {
@@ -49,10 +52,27 @@ public class ApplicationSettingsService {
       if (credentials == null
           || isBlank(credentials.getGlobalSmtpUsername())
           || isBlank(credentials.getGlobalSmtpPassword())) {
+        // #1006: log the configuration state, never the credential values themselves.
+        log.warn(
+            "Global SMTP credentials lookup at ConsultingTypeService returned no usable"
+                + " credentials (username or password missing/blank)");
         return Optional.empty();
       }
       return Optional.of(credentials);
     } catch (RestClientException ex) {
+      // #1006: this used to be swallowed silently, making "invite mail not sent"
+      // undiagnosable. The lookup stays best-effort, but status and cause must reach the log.
+      // A 403 here typically means the current request's token lacks the platform-admin role
+      // required by the guarded credentials endpoint.
+      String status =
+          ex instanceof RestClientResponseException responseException
+              ? String.valueOf(responseException.getStatusCode())
+              : "no response";
+      log.warn(
+          "Global SMTP credentials lookup at ConsultingTypeService failed ({}, status: {}): {}",
+          ex.getClass().getSimpleName(),
+          status,
+          ex.getMessage());
       return Optional.empty();
     }
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -67,8 +67,27 @@ class ApiResponseEntityExceptionHandlerTest {
     assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
     var body = assertInstanceOf(Map.class, response.getBody());
     assertEquals("SMTP_SEND_FAILED", body.get("reason"));
-    // #1006: the specific failure reason must reach the Admin UI, not just the server log.
-    assertEquals("handover failed", body.get("message"));
+    // Review 3893231984 / AGENTS.md error contract: the body carries only a stable coarse
+    // category — the detailed diagnosis (field names, remedies, causes) stays in the server log.
+    assertEquals("SMTP_TRANSPORT_FAILED", body.get("detail"));
+    assertNull(body.get("message"));
+    org.junit.jupiter.api.Assertions.assertFalse(body.toString().contains("handover failed"));
+  }
+
+  @Test
+  void handleSmtpSendFailure_carriesTheCoarseCategoryOfTheFailure() {
+    // #1006: the Admin UI companion surfaces the detail field, so it must follow the category.
+    var ex =
+        new de.caritas.cob.userservice.api.exception.SmtpSendException(
+            de.caritas.cob.userservice.api.exception.SmtpSendException.Category
+                .SMTP_CREDENTIALS_MISSING,
+            "no SMTP credentials available — set SMTP_USER and SMTP_PASSWORD");
+    var response = handler.handleSmtpSendFailure(ex, request);
+
+    var body = assertInstanceOf(Map.class, response.getBody());
+    assertEquals("SMTP_SEND_FAILED", body.get("reason"));
+    assertEquals("SMTP_CREDENTIALS_MISSING", body.get("detail"));
+    org.junit.jupiter.api.Assertions.assertFalse(body.toString().contains("SMTP_USER"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/ApiResponseEntityExceptionHandlerTest.java
@@ -67,6 +67,8 @@ class ApiResponseEntityExceptionHandlerTest {
     assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
     var body = assertInstanceOf(Map.class, response.getBody());
     assertEquals("SMTP_SEND_FAILED", body.get("reason"));
+    // #1006: the specific failure reason must reach the Admin UI, not just the server log.
+    assertEquals("handover failed", body.get("message"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
@@ -213,6 +213,40 @@ class InviteMailDispatchServiceTest {
   }
 
   /**
+   * Review 3893323639: the secure toggle gets the same strict nullable treatment — an absent value
+   * must not silently pick STARTTLS over implicit TLS.
+   */
+  @Test
+  void send_Should_reportToggleMissing_When_SecureToggleIsAbsent() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.remove("globalSmtpSecure");
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpSecure is missing or not a boolean");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** Review 3893323639: a malformed secure toggle is a config defect, not "false". */
+  @Test
+  void send_Should_reportToggleMalformed_When_SecureToggleIsNotABoolean() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.put("globalSmtpSecure", Map.of("value", "sometimes"));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpSecure is missing or not a boolean")
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_DISABLED_OR_INCOMPLETE));
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /**
    * Review 3893223709: 0, negative, out-of-range and fractional ports must fail here with a
    * field-specific message, not later in transport.
    */

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
@@ -161,7 +161,88 @@ class InviteMailDispatchServiceTest {
 
     assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
         .isInstanceOf(SmtpSendException.class)
-        .hasMessageContaining("globalSmtpEnabled");
+        .hasMessageContaining("globalSmtpEnabled is disabled")
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_DISABLED_OR_INCOMPLETE));
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** Review 3893223709: an absent toggle must not be reported as "disabled". */
+  @Test
+  void send_Should_reportToggleMissing_When_SmtpEnabledIsAbsent() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.remove("globalSmtpEnabled");
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpEnabled is missing or not a boolean")
+        .hasMessageNotContaining("globalSmtpEnabled is disabled");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** Review 3893223709: a malformed toggle must not be reported as "disabled" either. */
+  @Test
+  void send_Should_reportToggleMalformed_When_SmtpEnabledIsNotABoolean() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.put("globalSmtpEnabled", Map.of("value", "banana"));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpEnabled is missing or not a boolean")
+        .hasMessageNotContaining("globalSmtpEnabled is disabled");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** Review 3893223709: same nullable-boolean rule for the system-emails feature toggle. */
+  @Test
+  void send_Should_reportToggleMissing_When_SystemEmailsToggleIsAbsent() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.remove("globalFeatureSystemNotificationEmailsEnabled");
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining(
+            "globalFeatureSystemNotificationEmailsEnabled is missing or not a boolean");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /**
+   * Review 3893223709: 0, negative, out-of-range and fractional ports must fail here with a
+   * field-specific message, not later in transport.
+   */
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.MethodSource("invalidPorts")
+  void send_Should_rejectInvalidPort_When_PortIsNotAValidTcpPort(Object invalidPort) {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.put("globalSmtpPort", Map.of("value", invalidPort));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpPort is not a valid TCP port (1-65535)");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  static java.util.stream.Stream<Object> invalidPorts() {
+    return java.util.stream.Stream.of(0, -25, 70000, 587.5d, "0", "-25", "70000");
+  }
+
+  /** Review 3893223709: an absent port keeps its distinct "missing" diagnosis. */
+  @Test
+  void send_Should_reportPortMissing_When_PortIsAbsent() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.remove("globalSmtpPort");
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpPort is missing or not a number");
     verifyNoInteractions(inviteMailTransport);
   }
 
@@ -203,7 +284,35 @@ class InviteMailDispatchServiceTest {
         .isInstanceOf(SmtpSendException.class)
         .hasMessageContaining("could not be reached")
         .hasMessageContaining("ResourceAccessException")
-        .hasCauseInstanceOf(org.springframework.web.client.ResourceAccessException.class);
+        .hasCauseInstanceOf(org.springframework.web.client.ResourceAccessException.class)
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE));
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /**
+   * Review 3893231991: an HTTP error means the endpoint WAS reached — the diagnosis must carry the
+   * status code, not claim unreachability.
+   */
+  @Test
+  void send_Should_reportHttpStatus_When_SettingsEndpointRespondsWithError() {
+    when(restTemplate.getForObject(anyString(), any()))
+        .thenThrow(
+            org.springframework.web.client.HttpClientErrorException.create(
+                org.springframework.http.HttpStatus.FORBIDDEN, "Forbidden", null, null, null));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("responded with HTTP 403")
+        .hasMessageNotContaining("could not be reached")
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_SETTINGS_UNAVAILABLE));
     verifyNoInteractions(inviteMailTransport);
   }
 
@@ -275,7 +384,12 @@ class InviteMailDispatchServiceTest {
         .isInstanceOf(SmtpSendException.class)
         .hasMessageContaining("SMTP_USER")
         .hasMessageContaining("SMTP_PASSWORD")
-        .hasMessageContaining("platform-admin");
+        .hasMessageContaining("platform-admin")
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_CREDENTIALS_MISSING));
     verifyNoInteractions(inviteMailTransport);
   }
 
@@ -288,6 +402,12 @@ class InviteMailDispatchServiceTest {
 
     assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
         .isInstanceOf(SmtpSendException.class)
-        .hasMessageContaining("handover failed");
+        .hasMessageContaining("handover failed")
+        // Review 3893231984: transport failures keep the default coarse category.
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            e ->
+                assertThat(e.getCategory())
+                    .isEqualTo(SmtpSendException.Category.SMTP_TRANSPORT_FAILED));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
@@ -150,6 +150,7 @@ class InviteMailDispatchServiceTest {
         .doesNotContain("f8e71c");
   }
 
+  /** #1006: a disabled toggle must be named, not folded into a generic "incomplete" failure. */
   @Test
   void send_Should_throwSmtpSendException_When_SmtpDisabled() {
     when(restTemplate.getForObject(anyString(), any()))
@@ -159,18 +160,82 @@ class InviteMailDispatchServiceTest {
                 "globalSmtpEnabled", Map.of("value", false)));
 
     assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
-        .isInstanceOf(SmtpSendException.class);
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpEnabled");
     verifyNoInteractions(inviteMailTransport);
   }
 
+  /** #1006: only the offending flag is reported when everything else is configured. */
+  @Test
+  void send_Should_nameTheDisabledFlag_When_SystemNotificationEmailsDisabled() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.put("globalFeatureSystemNotificationEmailsEnabled", Map.of("value", false));
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalFeatureSystemNotificationEmailsEnabled")
+        .hasMessageNotContaining("globalSmtpHost");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** #1006: a missing connection field is named so the operator knows what to configure. */
+  @Test
+  void send_Should_nameTheMissingField_When_SmtpHostIsMissing() {
+    var payload = new java.util.HashMap<>(completeSettingsPayload());
+    payload.remove("globalSmtpHost");
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(payload);
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("globalSmtpHost")
+        .hasMessageNotContaining("globalSmtpFrom");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** #1006: an unreachable settings endpoint is distinguished from bad configuration. */
   @Test
   void send_Should_throwSmtpSendException_When_SettingsEndpointUnreachable() {
     when(restTemplate.getForObject(anyString(), any()))
         .thenThrow(new org.springframework.web.client.ResourceAccessException("down"));
 
     assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
-        .isInstanceOf(SmtpSendException.class);
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("could not be reached")
+        .hasMessageContaining("ResourceAccessException")
+        .hasCauseInstanceOf(org.springframework.web.client.ResourceAccessException.class);
     verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** #1006: an empty payload is its own diagnosis, not a generic failure. */
+  @Test
+  void send_Should_sayPayloadEmpty_When_SettingsEndpointReturnsNothing() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(Map.of());
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("empty");
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  /** #1006: a missing base URL is a deployment defect and must be named as such. */
+  @Test
+  void send_Should_nameTheMissingProperty_When_ConsultingTypeServiceUrlNotConfigured() {
+    var serviceWithoutUrl =
+        new InviteMailDispatchService(
+            restTemplate,
+            applicationSettingsService,
+            inviteMailTransport,
+            emailBrandingResolver,
+            renderer,
+            "",
+            "u",
+            "p");
+
+    assertThatThrownBy(() -> serviceWithoutUrl.send("to@example.org", "s", "b"))
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("consulting.type.service.api.url");
+    verifyNoInteractions(inviteMailTransport, restTemplate);
   }
 
   @Test
@@ -196,13 +261,21 @@ class InviteMailDispatchServiceTest {
             anyString());
   }
 
+  /**
+   * #1006: the credentials failure must tell the operator both ways out — set the deployment secret
+   * (the supported configuration) or send with a platform-admin token. Never a generic "unavailable
+   * or incomplete".
+   */
   @Test
   void send_Should_throwSmtpSendException_When_NoCredentialsAnywhere() {
     when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
     when(applicationSettingsService.getGlobalSmtpCredentials()).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service("", "").send("to@example.org", "s", "b"))
-        .isInstanceOf(SmtpSendException.class);
+        .isInstanceOf(SmtpSendException.class)
+        .hasMessageContaining("SMTP_USER")
+        .hasMessageContaining("SMTP_PASSWORD")
+        .hasMessageContaining("platform-admin");
     verifyNoInteractions(inviteMailTransport);
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsServiceTest.java
@@ -217,6 +217,10 @@ class ApplicationSettingsServiceTest {
                     assertThat(event.getFormattedMessage())
                         .contains("SMTP credentials")
                         .contains("403");
+                    // Review 3893332413: the exception itself (root cause + stack trace) must
+                    // reach the log, not just its message.
+                    assertThat(event.getThrowableProxy()).isNotNull();
+                    assertThat(event.getThrowableProxy().getClassName()).contains("Forbidden");
                   });
         });
   }
@@ -235,6 +239,9 @@ class ApplicationSettingsServiceTest {
                     assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.WARN);
                     assertThat(event.getFormattedMessage())
                         .contains("SMTP credentials")
+                        .contains("RestClientException");
+                    assertThat(event.getThrowableProxy()).isNotNull();
+                    assertThat(event.getThrowableProxy().getClassName())
                         .contains("RestClientException");
                   });
         });

--- a/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/consultingtype/ApplicationSettingsServiceTest.java
@@ -199,6 +199,90 @@ class ApplicationSettingsServiceTest {
     assertThat(applicationSettingsService.getGlobalSmtpCredentials()).isEmpty();
   }
 
+  // #1006: a swallowed RestClientException made "invite mail not sent" undiagnosable. The
+  // degradation stays (best-effort), but status and cause must reach the log at WARN.
+  @Test
+  void getGlobalSmtpCredentials_httpClientErrorException_logsWarnWithStatusAndContext() {
+    withCapturedLogs(
+        appender -> {
+          controllerApi.smtpException =
+              HttpClientErrorException.create(HttpStatus.FORBIDDEN, "Forbidden", null, null, null);
+
+          assertThat(applicationSettingsService.getGlobalSmtpCredentials()).isEmpty();
+
+          assertThat(appender.list)
+              .anySatisfy(
+                  event -> {
+                    assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.WARN);
+                    assertThat(event.getFormattedMessage())
+                        .contains("SMTP credentials")
+                        .contains("403");
+                  });
+        });
+  }
+
+  @Test
+  void getGlobalSmtpCredentials_restClientExceptionWithoutResponse_logsWarnWithExceptionType() {
+    withCapturedLogs(
+        appender -> {
+          controllerApi.smtpException = new RestClientException("settings unreachable");
+
+          assertThat(applicationSettingsService.getGlobalSmtpCredentials()).isEmpty();
+
+          assertThat(appender.list)
+              .anySatisfy(
+                  event -> {
+                    assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.WARN);
+                    assertThat(event.getFormattedMessage())
+                        .contains("SMTP credentials")
+                        .contains("RestClientException");
+                  });
+        });
+  }
+
+  // #1006: blank credentials from the endpoint are a configuration state worth a WARN — but the
+  // credential values themselves must never be logged.
+  @Test
+  void getGlobalSmtpCredentials_blankPassword_logsWarnWithoutCredentialValues() {
+    withCapturedLogs(
+        appender -> {
+          controllerApi.smtpResult =
+              new ApplicationSettingsSmtpCredentialsDTO()
+                  .globalSmtpUsername("smtp-account-name")
+                  .globalSmtpPassword("");
+
+          assertThat(applicationSettingsService.getGlobalSmtpCredentials()).isEmpty();
+
+          assertThat(appender.list)
+              .anySatisfy(
+                  event -> {
+                    assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.WARN);
+                    assertThat(event.getFormattedMessage()).contains("SMTP credentials");
+                  });
+          assertThat(appender.list)
+              .noneSatisfy(
+                  event -> assertThat(event.getFormattedMessage()).contains("smtp-account-name"));
+        });
+  }
+
+  private void withCapturedLogs(
+      java.util.function.Consumer<
+              ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>>
+          test) {
+    var logger =
+        (ch.qos.logback.classic.Logger)
+            org.slf4j.LoggerFactory.getLogger(ApplicationSettingsService.class);
+    var appender =
+        new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      test.accept(appender);
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
   // Sensitive SMTP credentials must always be fetched fresh, never from cache.
   @Test
   void getGlobalSmtpCredentials_calledTwice_callsApiTwice() {


### PR DESCRIPTION
Part of #1006 (the loud-failure item from the 2026-08-31 scope update). This PR does **not** touch the secret-owner design — that decision is proposed separately on the issue and remains with the client.

## Why

When an invite mail cannot be sent, every resolution failure today collapses into the generic *"Global SMTP settings are unavailable or incomplete"*, and the guarded credentials lookup swallows its `RestClientException` entirely. In practice that means: an admin without the platform-admin role gets a failure on a correctly configured platform, and neither the admin nor the operator can tell which of five different defects they are looking at.

## What

- `InviteMailDispatchService.resolveGlobalSmtpSettings` now throws `SmtpSendException` with the **specific** reason instead of degrading to `Optional.empty`:
  - ConsultingTypeService `/settings` endpoint unreachable (exception type as context, original exception as cause),
  - empty settings payload,
  - disabled toggle or missing field **by name** (`globalSmtpEnabled`, `globalFeatureSystemNotificationEmailsEnabled`, `globalSmtpHost`, `globalSmtpPort`, `globalSmtpFrom`),
  - `consulting.type.service.api.url` not configured,
  - no credentials available — the message names both remedies: set the `SMTP_USER`/`SMTP_PASSWORD` deployment secret (the supported configuration per #1006), or send with a platform-admin token for the guarded endpoint.
- `ApplicationSettingsService.getGlobalSmtpCredentials` no longer swallows `RestClientException` silently: it logs exception type, HTTP status and cause at WARN (a 403 here is the tell-tale for a missing platform-admin role), and warns when the endpoint returns blank credentials.
- The `SmtpSendException` handler keeps the `502` body information-poor per the repo error contract (review 3893231984): next to `reason: SMTP_SEND_FAILED` it carries only a stable coarse `detail` category — `SMTP_SETTINGS_UNAVAILABLE`, `SMTP_DISABLED_OR_INCOMPLETE`, `SMTP_CREDENTIALS_MISSING`, or `SMTP_TRANSPORT_FAILED` — never the raw message. The detailed diagnosis (field names, remedies, causes) goes to the server log. Note for the Admin-UI companion (ORISO-Admin PR #893): the UI surfaces whatever the body carries, so this category granularity is what admins will see.
- Review follow-ups: toggles parse as nullable booleans (absent/malformed reports "missing or not a boolean", not "disabled"); the port is validated as an integral TCP port 1..65535 with its own diagnostic; HTTP-status responses from `/settings` are reported as `responded with HTTP <status>` and distinguished from connection failures and conversion errors.
- **No secret values ever appear in exception messages or logs** (pinned by test). Happy path unchanged. The same silent pattern in `PasswordResetService` / `MagicLinkLoginService` / `GlobalSmtpTestEmailService` is deliberately left for the design decision on #1006 — they each carry a private copy of the resolution logic, and aligning them is part of the redesign, not this hotfix.

## Verification

- TDD: 11 new assertions in round 1 plus 16 in the review-fix round, each written first and confirmed failing, then the implementation.
- `InviteMailDispatchServiceTest` (24), `ApplicationSettingsServiceTest` (18), `ApiResponseEntityExceptionHandlerTest` (14): **56/56 green** (JDK 21, `testing` H2 profile conventions untouched).
- Mutation check (both rounds): implementation reverted via `git stash` → exactly the new assertions fail (11 in round 1; 16 in the review-fix round), every pre-existing test stays green → restored. No dead assertions.
- Spotless applied.

### Reviewer test plan

- [ ] Remove `SMTP_USER`/`SMTP_PASSWORD` from the UserService deployment and send an invite as a non-super-admin → the 502 body names the missing credentials and both remedies, instead of the generic failure; the UserService log shows the 403 from the credentials endpoint at WARN.
- [ ] Disable `globalSmtpEnabled` in the admin settings and send an invite → the error names `globalSmtpEnabled`, not "incomplete".
- [ ] Clear `globalSmtpHost` and send an invite → the error names `globalSmtpHost` only.
- [ ] Stop/blackhole ConsultingTypeService and send an invite → the error says the `/settings` endpoint could not be reached.
- [ ] With everything configured, send an invite → mail arrives exactly as before (happy path unchanged), and no credential value appears in any log line or API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Note: the full local unit suite was also run to completion: **4062 tests, 0 failures, 0 errors, 0 skipped — BUILD SUCCESS** (JDK 21).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMTP error handling with clear, client-safe categories for missing, invalid, disabled, unavailable, or failed email settings.
  * Prevented exception messages and credential configuration values from appearing in API responses.
  * Added validation for SMTP enablement flags and TCP port values.
  * Added warnings for unavailable or incomplete SMTP credentials while preserving fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->