### PR TITLE
Normalize admin e-mails independently of the JVM locale

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminController.java
@@ -45,6 +45,7 @@ import jakarta.validation.Valid;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,7 +123,7 @@ public class UserAdminController implements UseradminApi {
     de.caritas.cob.userservice.api.helper.PlainCredentialsHolder.set(
         createConsultantDTO.getUsername(), null);
 
-    createConsultantDTO.setEmail(createConsultantDTO.getEmail().toLowerCase());
+    createConsultantDTO.setEmail(createConsultantDTO.getEmail().toLowerCase(Locale.ROOT));
     var consultant = consultantAdminFacade.createNewConsultant(createConsultantDTO);
 
     return ResponseEntity.ok(consultant);
@@ -285,7 +286,7 @@ public class UserAdminController implements UseradminApi {
   private ConsultantAdminResponseDTO performUpdate(
       String consultantId, UpdateAdminConsultantDTO updateConsultantDTO) {
     if (updateConsultantDTO.getEmail() != null) {
-      updateConsultantDTO.setEmail(updateConsultantDTO.getEmail().toLowerCase());
+      updateConsultantDTO.setEmail(updateConsultantDTO.getEmail().toLowerCase(Locale.ROOT));
     }
     return consultantAdminFacade.updateConsultant(consultantId, updateConsultantDTO);
   }
@@ -394,7 +395,7 @@ public class UserAdminController implements UseradminApi {
 
   @Override
   public ResponseEntity<AdminResponseDTO> createTenantAdmin(CreateAdminDTO createAgencyAdminDTO) {
-    createAgencyAdminDTO.setEmail(createAgencyAdminDTO.getEmail().toLowerCase());
+    createAgencyAdminDTO.setEmail(createAgencyAdminDTO.getEmail().toLowerCase(Locale.ROOT));
     var admin = adminUserFacade.createNewTenantAdmin(createAgencyAdminDTO);
 
     return ResponseEntity.ok(admin);
@@ -402,6 +403,7 @@ public class UserAdminController implements UseradminApi {
 
   @Override
   public ResponseEntity<AdminResponseDTO> createAgencyAdmin(final CreateAdminDTO createAdminDTO) {
+    createAdminDTO.setEmail(createAdminDTO.getEmail().toLowerCase(Locale.ROOT));
     return ResponseEntity.ok(this.adminUserFacade.createNewAgencyAdmin(createAdminDTO));
   }
 
@@ -448,7 +450,7 @@ public class UserAdminController implements UseradminApi {
   @Override
   public ResponseEntity<AdminResponseDTO> updateAgencyAdmin(
       final String adminId, UpdateAgencyAdminDTO updateAgencyAdminDTO) {
-    updateAgencyAdminDTO.setEmail(updateAgencyAdminDTO.getEmail().toLowerCase());
+    updateAgencyAdminDTO.setEmail(updateAgencyAdminDTO.getEmail().toLowerCase(Locale.ROOT));
     var admin = adminUserFacade.updateAgencyAdmin(adminId, updateAgencyAdminDTO);
 
     return new ResponseEntity<>(admin, HttpStatus.OK);
@@ -457,7 +459,7 @@ public class UserAdminController implements UseradminApi {
   @Override
   public ResponseEntity<AdminResponseDTO> updateTenantAdmin(
       final String adminId, UpdateTenantAdminDTO updateTenantAdminDTO) {
-    updateTenantAdminDTO.setEmail(updateTenantAdminDTO.getEmail().toLowerCase());
+    updateTenantAdminDTO.setEmail(updateTenantAdminDTO.getEmail().toLowerCase(Locale.ROOT));
     var admin = adminUserFacade.updateTenantAdmin(adminId, updateTenantAdminDTO);
 
     return new ResponseEntity<>(admin, HttpStatus.OK);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerTest.java
@@ -46,7 +46,9 @@ import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,17 +93,17 @@ class UserAdminControllerTest {
   @Test
   void createTenantAdmin_emailIsLowercased_beforeDelegation() {
     // Business reason: admin account e-mails must be normalized to avoid duplicate identities by
-    // case.
+    // case, independently of the host JVM locale.
     var dto = new CreateAdminDTO();
-    dto.setEmail("UPPER@EXAMPLE.ORG");
+    dto.setEmail("IDENTITY@EXAMPLE.ORG");
     when(adminUserFacade.createNewTenantAdmin(any())).thenReturn(new AdminResponseDTO());
 
-    var response = controller.createTenantAdmin(dto);
+    var response = withTurkishDefaultLocale(() -> controller.createTenantAdmin(dto));
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     var captor = ArgumentCaptor.forClass(CreateAdminDTO.class);
     verify(adminUserFacade).createNewTenantAdmin(captor.capture());
-    assertEquals("upper@example.org", captor.getValue().getEmail());
+    assertEquals("identity@example.org", captor.getValue().getEmail());
   }
 
   @Test
@@ -190,17 +192,17 @@ class UserAdminControllerTest {
   @Test
   void createConsultant_emailIsLowercased_beforeDelegation() {
     var dto = new CreateConsultantDTO();
-    dto.setEmail("UPPER@EXAMPLE.ORG");
+    dto.setEmail("IDENTITY@EXAMPLE.ORG");
     dto.setUsername("user");
     when(consultantAdminFacade.createNewConsultant(any()))
         .thenReturn(new ConsultantAdminResponseDTO());
 
-    var response = controller.createConsultant(dto);
+    var response = withTurkishDefaultLocale(() -> controller.createConsultant(dto));
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     var captor = ArgumentCaptor.forClass(CreateConsultantDTO.class);
     verify(consultantAdminFacade).createNewConsultant(captor.capture());
-    assertEquals("upper@example.org", captor.getValue().getEmail());
+    assertEquals("identity@example.org", captor.getValue().getEmail());
   }
 
   @Test
@@ -291,16 +293,16 @@ class UserAdminControllerTest {
   @Test
   void updateConsultant_emailIsLowercased_beforeDelegation() {
     var dto = new UpdateAdminConsultantDTO();
-    dto.setEmail("CASE@EXAMPLE.ORG");
+    dto.setEmail("IDENTITY@EXAMPLE.ORG");
     when(consultantAdminFacade.updateConsultant(eq("c-1"), any()))
         .thenReturn(new ConsultantAdminResponseDTO());
 
-    var response = controller.updateConsultant("c-1", dto);
+    var response = withTurkishDefaultLocale(() -> controller.updateConsultant("c-1", dto));
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     var captor = ArgumentCaptor.forClass(UpdateAdminConsultantDTO.class);
     verify(consultantAdminFacade).updateConsultant(eq("c-1"), captor.capture());
-    assertEquals("case@example.org", captor.getValue().getEmail());
+    assertEquals("identity@example.org", captor.getValue().getEmail());
   }
 
   @Test
@@ -406,14 +408,17 @@ class UserAdminControllerTest {
   @Test
   void createAgencyAdmin_Should_delegate() {
     var dto = new CreateAdminDTO();
-    dto.setEmail("a@x.org");
+    dto.setEmail("IDENTITY@EXAMPLE.ORG");
     var expected = new AdminResponseDTO();
-    when(adminUserFacade.createNewAgencyAdmin(dto)).thenReturn(expected);
+    when(adminUserFacade.createNewAgencyAdmin(any())).thenReturn(expected);
 
-    var response = controller.createAgencyAdmin(dto);
+    var response = withTurkishDefaultLocale(() -> controller.createAgencyAdmin(dto));
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(expected, response.getBody());
+    var captor = ArgumentCaptor.forClass(CreateAdminDTO.class);
+    verify(adminUserFacade).createNewAgencyAdmin(captor.capture());
+    assertEquals("identity@example.org", captor.getValue().getEmail());
   }
 
   @Test
@@ -574,5 +579,15 @@ class UserAdminControllerTest {
     assertEquals(
         "jakarta.validation.Valid",
         askerPause.getParameters()[1].getAnnotations()[0].annotationType().getName());
+  }
+
+  private <T> T withTurkishDefaultLocale(Supplier<T> action) {
+    Locale originalLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      return action.get();
+    } finally {
+      Locale.setDefault(originalLocale);
+    }
   }
 }


### PR DESCRIPTION
## What

Deterministic, locale-independent e-mail normalization for every admin/consultant create and update endpoint in `UserAdminController`:

- The five existing `toLowerCase()` calls (create consultant, update consultant, create tenant admin, update agency admin, update tenant admin) now use `toLowerCase(Locale.ROOT)`. On a JVM with e.g. a Turkish default locale, plain `toLowerCase()` maps `I` to dotless `ı`, producing a different identity string for the same input.
- `createAgencyAdmin` gains the normalization it was missing entirely — agency-admin e-mails were stored exactly as typed.

## Why now (restore provenance)

This is a P2 restore from the speed-branch audit (2026-08-31, `0 - Docs/speed-branch-audit-2026-08-31.md`, UserService Group B). The fix originally shipped as `ba44b12be7aaa146847334110e711378e9e79c61` on `speed/reflux-progress-exp-16-aug` (2026-07-29, refs #916) and never reached `pre-dev`.

Verified on current `origin/pre-dev` (34f4ab4b) before restoring: all five call sites still use locale-dependent `toLowerCase()`, and `createAgencyAdmin` performs no normalization.

**Ported, not cherry-picked:** the original commit patched `UserAdminAccountControllerDelegate` / `UserAdminConsultantControllerDelegate`, which do not exist on `pre-dev` — the same change is applied to `UserAdminController` directly. The original's `tests/ci/test_module_boundaries.py` hunk is delegate-specific and intentionally not ported.

## Tests

- `UserAdminControllerTest`: the four e-mail tests now run under a forced `tr-TR` default locale (`withTurkishDefaultLocale`), and `createAgencyAdmin_Should_delegate` now asserts the normalized e-mail reaches the facade. 42/42 green on JDK 21.
- Mutation check: reverting `createTenantAdmin` to `toLowerCase()` and removing the `createAgencyAdmin` normalization makes exactly those tests fail (2 failures), then green again after restoring the fix.
- `spotless:check` green.

## Reviewer test plan

- [ ] `./mvnw test -Dtest=UserAdminControllerTest` is green on JDK 21
- [ ] Confirm every e-mail write path in `UserAdminController` uses `Locale.ROOT`
- [ ] Confirm `createAgencyAdmin` normalizes before delegating to the facade
- [ ] Judge whether normalization should also be asserted at the facade/service layer (out of scope here)

Refs #916
