### PR TITLE
feat(invite): serialize the DPA state and write the signature back to the invite

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -192,7 +192,7 @@ public class AccountInviteController {
                     request.formalLanguage,
                     request.acceptedByUserId));
     AccountInviteResponseDTO response =
-        AccountInviteResponseDTO.from(
+        AccountInviteResponseDTO.fromPublic(
             invite, latestDeliveryStatus(invite), accountInviteService.calculateAccessGate(invite));
     response.phase =
         invite.getTwoFactorStatus() == TwoFactorGateStatus.PENDING_SETUP
@@ -205,7 +205,7 @@ public class AccountInviteController {
   public ResponseEntity<AccountInviteResponseDTO> getInvite(@PathVariable String token) {
     AccountInvite invite = accountInviteService.requireActiveInvite(token);
     return ResponseEntity.ok(
-        AccountInviteResponseDTO.from(
+        AccountInviteResponseDTO.fromPublic(
             invite,
             latestDeliveryStatus(invite),
             accountInviteService.calculateAccessGate(invite)));
@@ -480,6 +480,22 @@ public class AccountInviteController {
               result.invite() == null ? null : AccountAccessGateStatus.BLOCKED_INVITE);
       dto.rawToken = result.rawToken();
       dto.acceptUrl = result.acceptUrl();
+      return dto;
+    }
+
+    /**
+     * View for the public token endpoints, which answer to whoever holds the raw invite link. The
+     * DPA progress state is Admin invite-board material (ORISO-Admin#896) and stays out of the
+     * anonymous responses - the wizard has its own resolve contract for what the invitee needs.
+     */
+    static AccountInviteResponseDTO fromPublic(
+        AccountInvite invite,
+        InviteEmailDeliveryStatus deliveryStatus,
+        AccountAccessGateStatus accessGateStatus) {
+      AccountInviteResponseDTO dto = from(invite, deliveryStatus, accessGateStatus);
+      dto.dpaForwardedAt = null;
+      dto.dpaForwardCount = null;
+      dto.dpaSignedAt = null;
       return dto;
     }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
@@ -487,12 +488,17 @@ public class AccountInviteController {
      * View for the public token endpoints, which answer to whoever holds the raw invite link. The
      * DPA progress state is Admin invite-board material (ORISO-Admin#896) and stays out of the
      * anonymous responses - the wizard has its own resolve contract for what the invitee needs.
+     * Nulling the fields is not enough: the service configures no global NON_NULL inclusion, so a
+     * null still emits the JSON key - the public shape must not carry the keys at all, hence the
+     * {@code PublicAccountInviteResponseDTO} subtype whose serialization drops them.
      */
     static AccountInviteResponseDTO fromPublic(
         AccountInvite invite,
         InviteEmailDeliveryStatus deliveryStatus,
         AccountAccessGateStatus accessGateStatus) {
-      AccountInviteResponseDTO dto = from(invite, deliveryStatus, accessGateStatus);
+      PublicAccountInviteResponseDTO dto =
+          fill(new PublicAccountInviteResponseDTO(), invite, deliveryStatus, accessGateStatus);
+      // Kept null at the Java level too, so no code path can read admin state off a public view.
       dto.dpaForwardedAt = null;
       dto.dpaForwardCount = null;
       dto.dpaSignedAt = null;
@@ -503,7 +509,14 @@ public class AccountInviteController {
         AccountInvite invite,
         InviteEmailDeliveryStatus deliveryStatus,
         AccountAccessGateStatus accessGateStatus) {
-      AccountInviteResponseDTO dto = new AccountInviteResponseDTO();
+      return fill(new AccountInviteResponseDTO(), invite, deliveryStatus, accessGateStatus);
+    }
+
+    private static <T extends AccountInviteResponseDTO> T fill(
+        T dto,
+        AccountInvite invite,
+        InviteEmailDeliveryStatus deliveryStatus,
+        AccountAccessGateStatus accessGateStatus) {
       dto.id = invite.getId();
       dto.targetRole = invite.getTargetRole() == null ? null : invite.getTargetRole().name();
       dto.tenantId = invite.getTenantId();
@@ -538,6 +551,15 @@ public class AccountInviteController {
       return dto;
     }
   }
+
+  /**
+   * Wire shape of the public token endpoints: identical to {@link AccountInviteResponseDTO} minus
+   * the Admin progress-board DPA state - the keys are ABSENT, not null, so the anonymous payload
+   * does not even advertise that vocabulary (ORISO-Admin#896). Admin endpoints keep the full shape
+   * with {@code dpaSignedAt} present-as-null until signed.
+   */
+  @JsonIgnoreProperties({"dpaForwardedAt", "dpaForwardCount", "dpaSignedAt"})
+  public static class PublicAccountInviteResponseDTO extends AccountInviteResponseDTO {}
 
   public static class PagedAccountInviteResponseDTO {
     public List<AccountInviteResponseDTO> content;

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -454,6 +454,18 @@ public class AccountInviteController {
     public String acceptUrl;
 
     /**
+     * DPA contract state for the Admin invite progress board (ORISO-Admin#896, epic #725). The
+     * frontend consumes these optional fields by exactly these names: {@code dpaForwardedAt} proves
+     * the "Vertragsunterlagen weitergeleitet" phase, {@code dpaSignedAt} the final "Vertrag
+     * unterschrieben" phase — without it the board must not claim completion. {@code
+     * dpaForwardCount} accompanies them so the board can tell a first forward from a re-forward.
+     */
+    public LocalDateTime dpaForwardedAt;
+
+    public Integer dpaForwardCount;
+    public LocalDateTime dpaSignedAt;
+
+    /**
      * Only set by the public accept endpoint (ORISO-Admin#569 resume contract): {@code
      * PENDING_2FA_ACTIVATION} while the mandatory 2FA activation is open (link resumable), {@code
      * COMPLETED} once every account gate is satisfied. {@code null} on admin-facing endpoints.
@@ -504,6 +516,9 @@ public class AccountInviteController {
       dto.twoFactorWaivedAt = invite.getTwoFactorWaivedAt();
       dto.twoFactorWaiverReason = invite.getTwoFactorWaiverReason();
       dto.createDate = invite.getCreateDate();
+      dto.dpaForwardedAt = invite.getDpaForwardedAt();
+      dto.dpaForwardCount = invite.getDpaForwardCount();
+      dto.dpaSignedAt = invite.getDpaSignedAt();
       return dto;
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -123,6 +123,16 @@ public class AccountInvite {
   @Builder.Default
   private int dpaForwardCount = 0;
 
+  /**
+   * When the tenant's data processing agreement was signed, written back to the invite so the Admin
+   * invite progress board can prove its final "Vertrag unterschrieben" phase (ORISO-Admin#896, epic
+   * #725). Stamped by the DPA_SIGNED_NOTICE chain for forwarded signatures and by the onboarding
+   * registration for an own acceptance; the authoritative record stays TenantService's {@code
+   * tenant_dpa_signature} — this is the invite-side mirror, never cleared, never regressed.
+   */
+  @Column(name = "dpa_signed_at", columnDefinition = "datetime")
+  private LocalDateTime dpaSignedAt;
+
   @Column(name = "accepted_at", columnDefinition = "datetime")
   private LocalDateTime acceptedAt;
 

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -126,4 +126,19 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
   Optional<AccountInvite>
       findFirstByTenantIdAndTargetRoleAndDpaForwardedAtIsNotNullOrderByDpaForwardedAtDesc(
           Long tenantId, AccountInviteTargetRole targetRole);
+
+  /**
+   * Writes the tenant's DPA signature timestamp back to its invites so the Admin invite progress
+   * board can prove the final "Vertrag unterschrieben" phase (ORISO-Admin#896, epic #725).
+   * Idempotent by construction: only rows whose {@code dpa_signed_at} is still null are touched, so
+   * repeated signature notices can never regress or overwrite an existing timestamp.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE AccountInvite i SET i.dpaSignedAt = :signedAt WHERE i.tenantId = :tenantId"
+          + " AND i.targetRole = :targetRole AND i.dpaSignedAt IS NULL")
+  int markDpaSigned(
+      @Param("tenantId") Long tenantId,
+      @Param("targetRole") AccountInviteTargetRole targetRole,
+      @Param("signedAt") LocalDateTime signedAt);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
@@ -247,6 +247,15 @@ public class TenantAdminOnboardingService {
               .orElseThrow(() -> new NotFoundException("Account invite not found"));
       claimedInvite.setAcceptedByUserId(admin.getId());
       claimedInvite.setTotpPendingSecret(otpInfo.secret());
+      if (command.dpaAccepted()) {
+        // The own acceptance IS the signature (recorded below as the tenant's U9 admin
+        // signature), so stamp it on the invite: the Admin invite progress board proves its
+        // final "Vertrag unterschrieben" phase from dpa_signed_at (ORISO-Admin#896, epic #725).
+        // Rollback-safe: a tenant-creation failure below rolls this write back with the rest of
+        // the transaction. A forwarded DPA stays pending here - only the DPA_SIGNED_NOTICE chain
+        // may stamp it once TenantService verified the external signature actually landed.
+        claimedInvite.setDpaSignedAt(now);
+      }
       claimedInvite.setUpdateDate(now);
       accountInviteRepository.save(claimedInvite);
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeService.java
@@ -223,6 +223,12 @@ public class DpaSignedNoticeService {
       return;
     }
     var signature = forwardedSignature.get();
+    // Before anything that can bail out (recipient resolution, the ledger claim): the verified
+    // signature must reach the invite row either way, because the Admin invite progress board
+    // proves its final "Vertrag unterschrieben" phase from the invite's dpa_signed_at
+    // (ORISO-Admin#896, epic #725). Idempotent end to end - the repository update only fills a
+    // still-null timestamp, so a repeated hint can never regress or overwrite it.
+    recordSignatureOnInvites(tenantId, signature);
     Optional<Recipient> recipient = resolveRecipient(tenantId, signature);
     if (recipient.isEmpty()) {
       log.warn(
@@ -235,6 +241,27 @@ public class DpaSignedNoticeService {
       return;
     }
     sendNotice(tenantId, signature, recipient.get(), claim.get());
+  }
+
+  /**
+   * Writes the verified signature timestamp back to the tenant's onboarding invites (own
+   * transaction: the surrounding dispatch is deliberately transaction-free, and the stamp must
+   * survive a later mail failure). Falls back to the processing time when the upstream timestamp
+   * does not parse - a wrong-but-present stamp is better for the board than a phase that never
+   * completes.
+   */
+  private void recordSignatureOnInvites(Long tenantId, DpaSignatureDTO signature) {
+    LocalDateTime signedAt =
+        Optional.ofNullable(parseDateTime(signature.getSignedAt())).orElseGet(LocalDateTime::now);
+    Integer stamped =
+        requiresNewTransaction.execute(
+            tx ->
+                accountInviteRepository.markDpaSigned(
+                    tenantId, AccountInviteTargetRole.TENANT_ADMIN, signedAt));
+    if (stamped != null && stamped > 0) {
+      log.info(
+          "DPA signature for tenant {} written back to {} onboarding invite(s)", tenantId, stamped);
+    }
   }
 
   private Optional<DpaSignatureDTO> findLatestForwardedSignature(Long tenantId) {

--- a/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/0089_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/0089_changeSet.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+  <changeSet id="0089_account_invite_dpa_signed_at" author="oriso">
+    <sqlFile
+      path="db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"/>
+    <rollback>
+      <sqlFile
+        path="db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at-rollback.sql"
+        relativeToChangelogFile="false"
+        splitStatements="true"
+        stripComments="true"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at-rollback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account_invite DROP COLUMN IF EXISTS dpa_signed_at;

--- a/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at.sql
+++ b/src/main/resources/db/changelog/changeset/0089_account_invite_dpa_signed_at/account-invite-dpa-signed-at.sql
@@ -1,0 +1,8 @@
+-- ORISO-Admin#896 (epic #725): the Admin invite progress board proves its final
+-- "Vertrag unterschrieben" phase from the invite row. The authoritative signature record stays
+-- TenantService's tenant_dpa_signature; this column is the invite-side write-back, stamped by the
+-- DPA_SIGNED_NOTICE chain (forwarded signatures, ORISO-UserService#1005) and by the onboarding
+-- registration (own acceptance). Nullable on purpose: null means "not signed yet", and the
+-- write-back only ever fills a null - it never overwrites or clears.
+ALTER TABLE account_invite
+  ADD COLUMN IF NOT EXISTS dpa_signed_at DATETIME NULL AFTER dpa_forward_count;

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -163,6 +163,8 @@
        that already ran it under an earlier path converge without harm. -->
   <include
     file="db/changelog/changeset/0088_support_room_repair/0088_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0089_account_invite_dpa_signed_at/0089_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -498,6 +499,86 @@ class AccountInviteControllerTest {
     assertEquals(LocalDateTime.parse("2026-08-20T10:00:00"), dto.dpaForwardedAt);
     assertEquals(2, dto.dpaForwardCount);
     assertEquals(LocalDateTime.parse("2026-08-21T09:30:00"), dto.dpaSignedAt);
+  }
+
+  private static AccountInvite sampleInviteWithDpaState() {
+    var invite = sampleInvite();
+    invite.setDpaForwardedAt(LocalDateTime.parse("2026-08-20T10:00:00"));
+    invite.setDpaForwardCount(2);
+    invite.setDpaSignedAt(LocalDateTime.parse("2026-08-21T09:30:00"));
+    return invite;
+  }
+
+  /**
+   * The public token endpoints answer to whoever holds the raw invite link - the DPA progress state
+   * is Admin invite-board material (ORISO-Admin#896) and must not ride along there.
+   */
+  @Test
+  void getInvite_publicTokenEndpoint_doesNotExposeTheAdminDpaState() {
+    var invite = sampleInviteWithDpaState();
+    when(accountInviteService.requireActiveInvite("token-details")).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_INVITE);
+
+    var response = controller.getInvite("token-details");
+
+    assertNull(response.getBody().dpaForwardedAt);
+    assertNull(response.getBody().dpaForwardCount);
+    assertNull(response.getBody().dpaSignedAt);
+  }
+
+  @Test
+  void acceptInvite_publicTokenEndpoint_doesNotExposeTheAdminDpaState() {
+    var invite = sampleInviteWithDpaState();
+    when(counsellorInviteProvisioningService.acceptInvite("token-2", null)).thenReturn(invite);
+    when(accountInviteService.calculateAccessGate(invite))
+        .thenReturn(AccountAccessGateStatus.BLOCKED_INVITE);
+
+    var response = controller.acceptInvite("token-2", null);
+
+    assertNull(response.getBody().dpaForwardedAt);
+    assertNull(response.getBody().dpaForwardCount);
+    assertNull(response.getBody().dpaSignedAt);
+  }
+
+  /**
+   * Wire contract for the Admin invite progress board (ORISO-Admin#896): the board consumes the
+   * JSON properties {@code dpaForwardedAt}, {@code dpaForwardCount}, {@code dpaSignedAt} by exactly
+   * these names. Serialized through a Jackson 3 mapper like the one the HTTP layer uses (Spring
+   * Boot 4 JacksonJsonHttpMessageConverter) - reading Java fields alone could not catch a renamed
+   * or re-annotated property.
+   */
+  @Test
+  void responseDto_wireContract_serializesTheDpaPropertiesByName() {
+    var dto =
+        AccountInviteController.AccountInviteResponseDTO.from(
+            sampleInviteWithDpaState(), null, null);
+
+    var json = tools.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto);
+    var tree = tools.jackson.databind.json.JsonMapper.builder().build().readTree(json);
+
+    assertEquals("2026-08-20T10:00:00", tree.path("dpaForwardedAt").asString());
+    assertEquals(2, tree.path("dpaForwardCount").asInt());
+    assertEquals("2026-08-21T09:30:00", tree.path("dpaSignedAt").asString());
+  }
+
+  @Test
+  void responseDto_wireContract_notYetSignedSerializesAsExplicitNull() {
+    // #896 renders the phase open until dpaSignedAt arrives; the property is present-as-null
+    // (Jackson default inclusion), not absent - pinned so the shape cannot drift silently
+    var invite = sampleInviteWithDpaState();
+    invite.setDpaSignedAt(null);
+
+    var dto = AccountInviteController.AccountInviteResponseDTO.from(invite, null, null);
+    var tree =
+        tools.jackson.databind.json.JsonMapper.builder()
+            .build()
+            .readTree(
+                tools.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto));
+
+    assertEquals(true, tree.has("dpaSignedAt"), "dpaSignedAt must stay present in the payload");
+    assertEquals(true, tree.get("dpaSignedAt").isNull(), "not signed yet must serialize as null");
+    assertEquals("2026-08-20T10:00:00", tree.path("dpaForwardedAt").asString());
   }
 
   private static AccountInvite sampleInvite() {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -2,7 +2,6 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -514,7 +513,10 @@ class AccountInviteControllerTest {
    * is Admin invite-board material (ORISO-Admin#896) and must not ride along there.
    */
   @Test
-  void getInvite_publicTokenEndpoint_doesNotExposeTheAdminDpaState() {
+  void getInvite_publicTokenEndpoint_omitsTheAdminDpaKeysFromTheWire() {
+    // Nulling the fields is not enough: without a global NON_NULL inclusion (this service
+    // configures none) a null still emits the JSON key. The public shape must not carry the keys
+    // at all - the payload itself must not advertise the Admin board's DPA vocabulary.
     var invite = sampleInviteWithDpaState();
     when(accountInviteService.requireActiveInvite("token-details")).thenReturn(invite);
     when(accountInviteService.calculateAccessGate(invite))
@@ -522,13 +524,17 @@ class AccountInviteControllerTest {
 
     var response = controller.getInvite("token-details");
 
-    assertNull(response.getBody().dpaForwardedAt);
-    assertNull(response.getBody().dpaForwardCount);
-    assertNull(response.getBody().dpaSignedAt);
+    var mapper = tools.jackson.databind.json.JsonMapper.builder().build();
+    var tree = mapper.readTree(mapper.writeValueAsString(response.getBody()));
+    assertEquals(false, tree.has("dpaForwardedAt"), "public payload must not carry the key");
+    assertEquals(false, tree.has("dpaForwardCount"), "public payload must not carry the key");
+    assertEquals(false, tree.has("dpaSignedAt"), "public payload must not carry the key");
+    // the invitee-facing content is unaffected
+    assertEquals("invitee@example.org", tree.path("recipientEmail").asString());
   }
 
   @Test
-  void acceptInvite_publicTokenEndpoint_doesNotExposeTheAdminDpaState() {
+  void acceptInvite_publicTokenEndpoint_omitsTheAdminDpaKeysFromTheWire() {
     var invite = sampleInviteWithDpaState();
     when(counsellorInviteProvisioningService.acceptInvite("token-2", null)).thenReturn(invite);
     when(accountInviteService.calculateAccessGate(invite))
@@ -536,9 +542,13 @@ class AccountInviteControllerTest {
 
     var response = controller.acceptInvite("token-2", null);
 
-    assertNull(response.getBody().dpaForwardedAt);
-    assertNull(response.getBody().dpaForwardCount);
-    assertNull(response.getBody().dpaSignedAt);
+    var mapper = tools.jackson.databind.json.JsonMapper.builder().build();
+    var tree = mapper.readTree(mapper.writeValueAsString(response.getBody()));
+    assertEquals(false, tree.has("dpaForwardedAt"), "public payload must not carry the key");
+    assertEquals(false, tree.has("dpaForwardCount"), "public payload must not carry the key");
+    assertEquals(false, tree.has("dpaSignedAt"), "public payload must not carry the key");
+    // the resume contract's own field stays
+    assertEquals(true, tree.has("phase"));
   }
 
   /**

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -480,6 +480,26 @@ class AccountInviteControllerTest {
     assertNotNull(annotation);
   }
 
+  /**
+   * Contract for the Admin invite progress board (ORISO-Admin#896, epic #725): the entity has
+   * stored the DPA forward state since the #722/#1090 chain and now the signature write-back, but
+   * the response DTO used to drop all of it — the board could never prove its "Vertragsunterlagen
+   * weitergeleitet" and final "Vertrag unterschrieben" phases.
+   */
+  @Test
+  void responseDto_serializesTheDpaStateForTheInviteProgressBoard() {
+    var invite = sampleInvite();
+    invite.setDpaForwardedAt(LocalDateTime.parse("2026-08-20T10:00:00"));
+    invite.setDpaForwardCount(2);
+    invite.setDpaSignedAt(LocalDateTime.parse("2026-08-21T09:30:00"));
+
+    var dto = AccountInviteController.AccountInviteResponseDTO.from(invite, null, null);
+
+    assertEquals(LocalDateTime.parse("2026-08-20T10:00:00"), dto.dpaForwardedAt);
+    assertEquals(2, dto.dpaForwardCount);
+    assertEquals(LocalDateTime.parse("2026-08-21T09:30:00"), dto.dpaSignedAt);
+  }
+
   private static AccountInvite sampleInvite() {
     return AccountInvite.builder()
         .id(10L)

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepositoryIT.java
@@ -1,0 +1,87 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import de.caritas.cob.userservice.api.config.JpaAuditingConfiguration;
+import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * DPA signed write-back semantics (ORISO-Admin#896, epic #725): {@code markDpaSigned} is the only
+ * writer of {@code dpa_signed_at} for forwarded signatures, and its idempotency lives in the query
+ * itself ({@code dpa_signed_at IS NULL} guard) — which only a real database can prove.
+ */
+@DataJpaTest
+@ActiveProfiles("testing")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaAuditingConfiguration.class)
+class AccountInviteRepositoryIT {
+
+  private static final LocalDateTime SIGNED_AT =
+      LocalDateTime.of(2026, 8, 14, 9, 15).truncatedTo(ChronoUnit.SECONDS);
+
+  @Autowired private AccountInviteRepository accountInviteRepository;
+
+  @AfterEach
+  void reset() {
+    accountInviteRepository.deleteAll();
+  }
+
+  @Test
+  void markDpaSigned_stampsOnlyTheTenantAdminInvitesOfTheTenant() {
+    var target = persistedInvite(42L, AccountInviteTargetRole.TENANT_ADMIN, null);
+    var otherTenant = persistedInvite(43L, AccountInviteTargetRole.TENANT_ADMIN, null);
+    var counsellor = persistedInvite(42L, AccountInviteTargetRole.COUNSELLOR, null);
+
+    int stamped =
+        accountInviteRepository.markDpaSigned(42L, AccountInviteTargetRole.TENANT_ADMIN, SIGNED_AT);
+
+    assertEquals(1, stamped);
+    assertEquals(SIGNED_AT, reload(target).getDpaSignedAt());
+    assertNull(reload(otherTenant).getDpaSignedAt());
+    assertNull(reload(counsellor).getDpaSignedAt());
+  }
+
+  @Test
+  void markDpaSigned_neverRegressesAnExistingTimestamp() {
+    // a repeated signature notice must not move an already-stamped invite — the guard is in the
+    // query, not in the caller
+    var alreadyStamped =
+        persistedInvite(42L, AccountInviteTargetRole.TENANT_ADMIN, SIGNED_AT.minusDays(1));
+
+    int stamped =
+        accountInviteRepository.markDpaSigned(42L, AccountInviteTargetRole.TENANT_ADMIN, SIGNED_AT);
+
+    assertEquals(0, stamped);
+    assertEquals(SIGNED_AT.minusDays(1), reload(alreadyStamped).getDpaSignedAt());
+  }
+
+  private AccountInvite reload(AccountInvite invite) {
+    return accountInviteRepository.findById(invite.getId()).orElseThrow();
+  }
+
+  private AccountInvite persistedInvite(
+      Long tenantId, AccountInviteTargetRole targetRole, LocalDateTime dpaSignedAt) {
+    return accountInviteRepository.save(
+        AccountInvite.builder()
+            .targetRole(targetRole)
+            .tenantId(tenantId)
+            .recipientEmail("invitee@example.org")
+            .tokenHash(UUID.randomUUID().toString())
+            .expiresAt(LocalDateTime.now().plusDays(10))
+            .dpaSignedAt(dpaSignedAt)
+            .createDate(LocalDateTime.now())
+            .build());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingServiceTest.java
@@ -482,6 +482,53 @@ class TenantAdminOnboardingServiceTest {
     verify(tenantCreationClient, never()).createTenant(any());
   }
 
+  /**
+   * ORISO-Admin#896 (epic #725): the invite progress board proves its final "Vertrag
+   * unterschrieben" phase from the invite's {@code dpaSignedAt}. An own acceptance at registration
+   * IS the signature (recorded as the tenant's U9 admin signature), so the registration must stamp
+   * the invite — otherwise every self-signed tenant waits for a signature forever.
+   */
+  @Test
+  void registerTenantAdmin_ownDpaAcceptance_stampsTheSignatureOnTheInvite() {
+    AccountInvite invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    givenPublishedOperatorDpa();
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    when(createAdminService.createNewTenantAdmin(any())).thenReturn(onboardedAdmin());
+    when(identitySecondFactor.getOtpCredential(anyString()))
+        .thenReturn(new IdentityOtpCredential(null, "TOTPSECRET", null, null));
+    when(tenantCreationClient.createTenant(any()))
+        .thenReturn(new MultilingualTenantDTO().id(RESERVED_TENANT_ID));
+
+    service.registerTenantAdmin(RAW_TOKEN, validCommand());
+
+    assertNotNull(
+        invite.getDpaSignedAt(),
+        "an own DPA acceptance is the signature and must be stamped on the invite");
+  }
+
+  @Test
+  void registerTenantAdmin_dpaForwardedEarlier_doesNotStampTheSignature() {
+    // The forwarded signature is pending with an external signer — only the DPA_SIGNED_NOTICE
+    // chain may stamp it once TenantService has verified the signature actually landed.
+    var invite = tenantAdminInvite(AccountInviteStatus.EMAIL_SENT);
+    invite.setDpaForwardedAt(LocalDateTime.now().minusMinutes(5));
+    when(accountInviteRepository.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.claimForAcceptance(eq(7L), isNull(), any())).thenReturn(1);
+    when(accountInviteRepository.findById(7L)).thenReturn(Optional.of(invite));
+    when(createAdminService.createNewTenantAdmin(any(CreateAdminDTO.class)))
+        .thenReturn(onboardedAdmin());
+    when(identitySecondFactor.getOtpCredential(anyString()))
+        .thenReturn(new IdentityOtpCredential(null, "TOTPSECRET", "QRBASE64", null));
+    when(tenantCreationClient.createTenant(any()))
+        .thenReturn(new MultilingualTenantDTO().id(RESERVED_TENANT_ID));
+
+    service.registerTenantAdmin(RAW_TOKEN, commandWithoutAcceptance());
+
+    assertNull(invite.getDpaSignedAt(), "a pending forwarded signature must not be pre-stamped");
+  }
+
   @Test
   void registerTenantAdmin_dpaForwardedEarlier_createsTenantWithoutAcceptance() {
     // given an invite that forwarded the DPA in wizard step 1

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeServiceTest.java
@@ -396,4 +396,66 @@ class DpaSignedNoticeServiceTest {
     assertEquals(DPA_VERSION, claim.getDpaVersion());
     assertEquals("toni@example.org", claim.getRecipientEmail());
   }
+
+  // --- DPA signed write-back to the invite (ORISO-Admin#896, epic #725) ---
+
+  @Test
+  void onSignatureHint_writesTheSignatureTimestampBackToTheTenantAdminInvites() {
+    // The Admin invite progress board proves its final "Vertrag unterschrieben" phase from the
+    // invite's dpaSignedAt — the verified signature must reach the invite row, not only the mail.
+    givenSignatures(forwardedSignature("kc-admin-1"));
+    when(adminRepository.findById("kc-admin-1")).thenReturn(Optional.of(forwardingAdmin()));
+
+    service.onSignatureHint(TENANT_ID);
+
+    verify(accountInviteRepository)
+        .markDpaSigned(
+            TENANT_ID,
+            AccountInviteTargetRole.TENANT_ADMIN,
+            java.time.LocalDateTime.parse("2026-08-14T09:15:00"));
+  }
+
+  @Test
+  void onSignatureHint_duplicateNotice_stillWritesTheSignatureBackButSendsNoSecondMail() {
+    // Repeated hints must stay idempotent end to end: the ledger dedupes the mail, and the
+    // write-back only fills a still-null dpa_signed_at (guarded in the repository query), so a
+    // duplicate can never regress the invite state — but it must also not skip the write-back,
+    // because the first hint may have raced a deploy after claiming and before stamping.
+    givenSignatures(forwardedSignature("kc-admin-1"));
+    when(adminRepository.findById("kc-admin-1")).thenReturn(Optional.of(forwardingAdmin()));
+    when(noticeRepository.save(any(DpaSignedNotice.class)))
+        .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+    service.onSignatureHint(TENANT_ID);
+
+    verify(accountInviteRepository)
+        .markDpaSigned(
+            eq(TENANT_ID),
+            eq(AccountInviteTargetRole.TENANT_ADMIN),
+            any(java.time.LocalDateTime.class));
+    verify(inviteMailDispatchService, never())
+        .send(anyString(), anyString(), anyString(), any(), anyLong(), anyString());
+  }
+
+  @Test
+  void onSignatureHint_unresolvableRecipient_stillWritesTheSignatureBack() {
+    // No resolvable notice recipient (admin gone, no forwarding invite) must not lose the
+    // signature on the board: the write-back anchors on the verified signature alone.
+    givenSignatures(forwardedSignature("kc-admin-1"));
+    when(adminRepository.findById("kc-admin-1")).thenReturn(Optional.empty());
+    when(accountInviteRepository
+            .findFirstByTenantIdAndTargetRoleAndDpaForwardedAtIsNotNullOrderByDpaForwardedAtDesc(
+                TENANT_ID, AccountInviteTargetRole.TENANT_ADMIN))
+        .thenReturn(Optional.empty());
+
+    service.onSignatureHint(TENANT_ID);
+
+    verify(accountInviteRepository)
+        .markDpaSigned(
+            eq(TENANT_ID),
+            eq(AccountInviteTargetRole.TENANT_ADMIN),
+            any(java.time.LocalDateTime.class));
+    verify(inviteMailDispatchService, never())
+        .send(anyString(), anyString(), anyString(), any(), anyLong(), anyString());
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/DpaSignedNoticeServiceTest.java
@@ -276,6 +276,9 @@ class DpaSignedNoticeServiceTest {
 
     verify(inviteMailDispatchService, never()).send(any(), any(), any(), any(), any(), any());
     verify(noticeRepository, never()).save(any());
+    // the notice chain must only ever stamp verified FORWARDED_EXTERNAL signatures - the
+    // self-sign path stamps its own invite at registration
+    verify(accountInviteRepository, never()).markDpaSigned(any(), any(), any());
   }
 
   @Test
@@ -286,6 +289,9 @@ class DpaSignedNoticeServiceTest {
     service.onSignatureHint(TENANT_ID);
 
     verify(inviteMailDispatchService, never()).send(any(), any(), any(), any(), any(), any());
+    // a pending forward is NOT a signature: a reordering that stamps before the SIGNED filter
+    // would mark unsigned DPAs as signed on the Admin board
+    verify(accountInviteRepository, never()).markDpaSigned(any(), any(), any());
   }
 
   @Test
@@ -296,6 +302,7 @@ class DpaSignedNoticeServiceTest {
     service.onSignatureHint(TENANT_ID);
 
     verify(inviteMailDispatchService, never()).send(any(), any(), any(), any(), any(), any());
+    verify(accountInviteRepository, never()).markDpaSigned(any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## What

Closes the backend contract gap that Admin PR OpenResilienceInitiative/ORISO-Admin#896 documented: the invite progress board renders a "Vertragsunterlagen weitergeleitet" phase and the final "Vertrag unterschrieben" phase from two optional DTO fields the backend never served. Field names mirror #896's frontend contract exactly (`dpaForwardedAt`, `dpaSignedAt`), documented on the DTO.

1. **Serialize the existing forward state** — `AccountInvite` has stored `dpa_forwarded_at` / `dpa_forward_count` since the #722/#1090 forward chain, but `AccountInviteResponseDTO` dropped them. Now serialized (plus `dpaForwardCount`, so the board can tell a first forward from a re-forward). The DTO is handwritten (no OpenAPI spec involved), so no api yaml change.
2. **Signed write-back** — new nullable `account_invite.dpa_signed_at` column. The authoritative record stays TenantService's `tenant_dpa_signature`; this is the invite-side mirror:
   - **Forwarded signatures**: the `DPA_SIGNED_NOTICE` chain (#1005) stamps the invite as soon as the verified signature is read back from TenantService — before recipient resolution and the exactly-once ledger claim, so an unresolvable recipient or a duplicate hint still stamps. Idempotency lives in the repository query itself (`dpa_signed_at IS NULL` guard): repeated notices can never regress or overwrite the timestamp.
   - **Own acceptance at registration** IS the signature (recorded as the tenant's U9 admin signature), so `registerTenantAdmin` stamps the invite in the same transaction (rollback-safe with tenant creation). A forwarded-pending registration deliberately does NOT stamp — only the notice chain may, once TenantService verified the external signature landed. This half is a deliberate completeness addition beyond the notice chain: without it every self-signed tenant would wait for a signature forever on the board.

## Liquibase — changeset numbering

**`0089_account_invite_dpa_signed_at`** — pre-dev has 0086/0087/0088 taken. Multiple restore/feature PRs are in flight in parallel worktrees; **if another in-flight PR also claims 0089, renumber at merge.** DDL is idempotent (`ADD COLUMN IF NOT EXISTS` / rollback `DROP COLUMN IF EXISTS`), matching the 0087 pattern.

## Verification

- TDD red-first: 5 new unit tests written first and confirmed failing (DTO serialization; notice-chain write-back incl. duplicate-notice and unresolvable-recipient idempotency; own-acceptance stamp) plus a forwarded-registration guard test.
- New `AccountInviteRepositoryIT` (H2/@DataJpaTest) proves the query-level idempotency: stamps only the tenant's TENANT_ADMIN invites, never regresses an existing timestamp.
- Mutation check: DTO mapping, notice write-back call, registration stamp, and the `IS NULL` guard each knocked out → exactly the guarding tests fail (6), everything else green; restored → all green.
- Green on JDK 21: `DpaSignedNoticeServiceTest` 20/20, `TenantAdminOnboardingServiceTest` 56/56, `AccountInviteControllerTest` 29/29, `AccountInviteRepositoryIT` 2/2 (107 total, 0 skipped).
- **`DatabaseChangelogDriftIT` run against a fresh MariaDB 11.0.6**: changeset 0089 applies from scratch and Hibernate validates the full entity schema (`dpa_signed_at datetime NULL` confirmed in the resulting table).
- `spotless:apply` clean.

## Reviewer test plan

- [ ] Run `./mvnw -Dskip.integration-tests=true -Dtest=DpaSignedNoticeServiceTest,TenantAdminOnboardingServiceTest,AccountInviteControllerTest,AccountInviteRepositoryIT test` on JDK 21 → 107/107 green.
- [ ] Forward the DPA from the onboarding wizard, then sign it via the public link → the invite row's stepper reaches "Vertrag unterschrieben" without any frontend change (the board lights up from `dpaSignedAt` alone, per #896).
- [ ] Register a tenant admin accepting the DPA directly → the row completes immediately.
- [ ] Trigger the signature hint twice → the invite's `dpa_signed_at` keeps its first value, no second notice mail.
- [ ] Invite list/response payloads now carry `dpaForwardedAt`, `dpaForwardCount`, `dpaSignedAt`.

Part of OpenResilienceInitiative/ORISO-Admin#725. References OpenResilienceInitiative/ORISO-UserService#1005 and OpenResilienceInitiative/ORISO-Admin#896 (no closing keywords intended).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Invite progress now includes DPA forwarding time, forwarding count, and signing time.
  - DPA signatures are recorded during administrator onboarding or after confirmation by an external signer.
  - Forwarded DPAs remain pending until the external signing process is completed.

- **Bug Fixes**
  - Existing signature timestamps are preserved during duplicate or repeated notifications.
  - DPA status updates reliably even when notification delivery cannot be completed.
  - Public invite responses no longer expose administrator-only DPA progress details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->