### PR TITLE
fix(admin): scope tenant-admin and agency-admin search to caller's tenant (#968)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -78,8 +78,8 @@ public class AgencyAdminUserService {
    * non-platform caller (single-tenant admin, tenant super admin, agency super admin without shared
    * agencies) may only act on agency admins of their own tenant (#968). Platform admins keep the
    * full view. Prevents a caller from reading, editing or deleting admins of other Träger or other
-   * tenants by targeting their id directly, mirroring the search-side scoping applied by
-   * {@link #findScopedAgencyAdminsByInfix}.
+   * tenants by targeting their id directly, mirroring the search-side scoping applied by {@link
+   * #findScopedAgencyAdminsByInfix}.
    */
   private void assertCallerMayAccessAgencyAdmin(final String targetAdminId) {
     if (authenticatedUser.isPlatformAdmin()) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -132,8 +132,8 @@ public class AgencyAdminUserService {
    * Returns the infix-matched agency admins visible to the current caller. A restricted agency
    * admin only sees admins of their own agencies; a tenant-bound caller (single-tenant or tenant
    * super admin) is scoped to their own tenant so they cannot enumerate agency admins of other
-   * tenants (#968); only platform admins keep the full list. This closes both the cross-Träger
-   * leak within a tenant and the cross-tenant leak across tenants.
+   * tenants (#968); only platform admins keep the full list. This closes both the cross-Träger leak
+   * within a tenant and the cross-tenant leak across tenants.
    */
   private Page<AdminBase> findScopedAgencyAdminsByInfix(String infix, PageRequest pageRequest) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -130,9 +130,10 @@ public class AgencyAdminUserService {
 
   /**
    * Returns the infix-matched agency admins visible to the current caller. A restricted agency
-   * admin only sees admins of their own agencies; platform/tenant admins keep the full list. This
-   * closes the cross-Träger leak where any holder of the user-admin authority (which every agency
-   * admin also carries, to manage consultants) could list every agency admin of every Träger.
+   * admin only sees admins of their own agencies; a tenant-bound caller (single-tenant or tenant
+   * super admin) is scoped to their own tenant so they cannot enumerate agency admins of other
+   * tenants (#968); only platform admins keep the full list. This closes both the cross-Träger
+   * leak within a tenant and the cross-tenant leak across tenants.
    */
   private Page<AdminBase> findScopedAgencyAdminsByInfix(String infix, PageRequest pageRequest) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
@@ -140,6 +141,10 @@ public class AgencyAdminUserService {
           retrieveAdminService.findAgencyIdsOfAdmin(authenticatedUser.getUserId());
       return retrieveAdminService.findAllByInfixScopedToAgencies(
           infix, Admin.AdminType.AGENCY, callerAgencyIds, pageRequest);
+    }
+    if (!authenticatedUser.isPlatformAdmin()) {
+      return retrieveAdminService.findAllByInfixScopedToTenant(
+          infix, Admin.AdminType.AGENCY, authenticatedUser.getTenantId(), pageRequest);
     }
     return retrieveAdminService.findAllByInfix(infix, Admin.AdminType.AGENCY, pageRequest);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserService.java
@@ -74,23 +74,42 @@ public class AgencyAdminUserService {
 
   /**
    * A restricted agency admin (an agency-level admin without the broader agency-super-admin role)
-   * may only act on agency admins that share at least one of their own agencies. This prevents a
-   * single Beratungsstellen-Admin from reading, editing or deleting admins of other Träger by
-   * targeting their id directly, mirroring the agency scoping already applied to consultants.
+   * may only act on agency admins that share at least one of their own agencies; every other
+   * non-platform caller (single-tenant admin, tenant super admin, agency super admin without shared
+   * agencies) may only act on agency admins of their own tenant (#968). Platform admins keep the
+   * full view. Prevents a caller from reading, editing or deleting admins of other Träger or other
+   * tenants by targeting their id directly, mirroring the search-side scoping applied by
+   * {@link #findScopedAgencyAdminsByInfix}.
    */
   private void assertCallerMayAccessAgencyAdmin(final String targetAdminId) {
-    if (!authenticatedUser.hasRestrictedAgencyPriviliges()) {
+    if (authenticatedUser.isPlatformAdmin()) {
       return;
     }
-    var callerAgencyIds = retrieveAdminService.findAgencyIdsOfAdmin(authenticatedUser.getUserId());
-    var targetAgencyIds = retrieveAdminService.findAgencyIdsOfAdmin(targetAdminId);
-    if (Collections.disjoint(callerAgencyIds, targetAgencyIds)) {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      var callerAgencyIds =
+          retrieveAdminService.findAgencyIdsOfAdmin(authenticatedUser.getUserId());
+      var targetAgencyIds = retrieveAdminService.findAgencyIdsOfAdmin(targetAdminId);
+      if (Collections.disjoint(callerAgencyIds, targetAgencyIds)) {
+        log.warn(
+            "Restricted agency admin {} attempted to access agency admin {} outside their agencies",
+            authenticatedUser.getUserId(),
+            targetAdminId);
+        throw new ForbiddenException(
+            "Agency admin is not allowed to access an admin outside their own agencies");
+      }
+      return;
+    }
+    Admin target = retrieveAdminService.findAdmin(targetAdminId, Admin.AdminType.AGENCY);
+    Long callerTenantId = authenticatedUser.getTenantId();
+    if (callerTenantId == null || !callerTenantId.equals(target.getTenantId())) {
       log.warn(
-          "Restricted agency admin {} attempted to access agency admin {} outside their agencies",
+          "Tenant admin {} (tenant {}) attempted to access agency admin {} in tenant {}",
           authenticatedUser.getUserId(),
-          targetAdminId);
+          callerTenantId,
+          targetAdminId,
+          target.getTenantId());
       throw new ForbiddenException(
-          "Agency admin is not allowed to access an admin outside their own agencies");
+          "Tenant admin is not allowed to access an admin outside their own tenant");
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TenantAdminUserService {
 
   private final @NonNull RetrieveAdminService retrieveAdminService;
@@ -71,6 +73,7 @@ public class TenantAdminUserService {
 
   public AdminResponseDTO findTenantAdmin(final String adminId) {
     final Admin admin = retrieveAdminService.findAdmin(adminId, Admin.AdminType.TENANT);
+    assertCallerMayAccessTenantAdmin(admin);
     var responseDTO = AdminResponseDTOBuilder.getInstance(admin).buildAgencyAdminResponseDTO();
     responseDTO
         .getEmbedded()
@@ -81,6 +84,7 @@ public class TenantAdminUserService {
   public AdminResponseDTO updateTenantAdmin(
       final String adminId, final UpdateTenantAdminDTO updateTenantAdminDTO) {
     validateUpdateAdmin(updateTenantAdminDTO);
+    assertCallerMayAccessTenantAdmin(adminId);
     final Admin updatedAdmin = updateAdminService.updateTenantAdmin(adminId, updateTenantAdminDTO);
     var responseDTO =
         AdminResponseDTOBuilder.getInstance(updatedAdmin).buildAgencyAdminResponseDTO();
@@ -96,7 +100,59 @@ public class TenantAdminUserService {
   }
 
   public void deleteTenantAdmin(final String adminId) {
+    assertCallerMayAccessTenantAdmin(adminId);
     this.deleteAdminService.deleteTenantAdmin(adminId);
+  }
+
+  /**
+   * Enforces that the caller may act on a tenant admin identified by id. A platform admin keeps the
+   * full view; every other caller must belong to the target's tenant (#968). Loads the target admin
+   * to read its tenant so a caller cannot bypass the search-side scoping by guessing an admin id.
+   */
+  private void assertCallerMayAccessTenantAdmin(String targetAdminId) {
+    if (authenticatedUser.isPlatformAdmin()) {
+      return;
+    }
+    Admin target = retrieveAdminService.findAdmin(targetAdminId, Admin.AdminType.TENANT);
+    assertCallerMayAccessTenantAdmin(target);
+  }
+
+  private void assertCallerMayAccessTenantAdmin(Admin target) {
+    if (authenticatedUser.isPlatformAdmin()) {
+      return;
+    }
+    Long callerTenantId = authenticatedUser.getTenantId();
+    if (callerTenantId == null || !callerTenantId.equals(target.getTenantId())) {
+      log.warn(
+          "Tenant admin {} (tenant {}) attempted to access tenant admin {} in tenant {}",
+          authenticatedUser.getUserId(),
+          callerTenantId,
+          target.getId(),
+          target.getTenantId());
+      throw new ForbiddenException(
+          "Tenant admin is not allowed to access an admin outside their own tenant");
+    }
+  }
+
+  /**
+   * Enforces the caller may list tenant admins for the supplied tenant id. Platform admins may
+   * cross tenants; every other caller may only list their own tenant. Prevents the sibling leak
+   * of {@link #findTenantAdminsByInfix} on GET /useradmin/tenantadmins?tenantId=X (#968).
+   */
+  private void assertCallerMayListTenantAdminsOf(Long tenantId) {
+    if (authenticatedUser.isPlatformAdmin()) {
+      return;
+    }
+    Long callerTenantId = authenticatedUser.getTenantId();
+    if (callerTenantId == null || !callerTenantId.equals(tenantId)) {
+      log.warn(
+          "Tenant admin {} (tenant {}) attempted to list tenant admins of tenant {}",
+          authenticatedUser.getUserId(),
+          callerTenantId,
+          tenantId);
+      throw new ForbiddenException(
+          "Tenant admin is not allowed to list admins of a foreign tenant");
+    }
   }
 
   public Map<String, Object> findTenantAdminsByInfix(String infix, PageRequest pageRequest) {
@@ -158,6 +214,7 @@ public class TenantAdminUserService {
   }
 
   public List<AdminResponseDTO> findTenantAdmins(Long tenantId) {
+    assertCallerMayListTenantAdminsOf(tenantId);
     var admins = retrieveAdminService.findTenantAdminsByTenantId(tenantId);
     return admins.stream()
         .map(admin -> AdminResponseDTOBuilder.getInstance(admin).buildAgencyAdminResponseDTO())
@@ -165,7 +222,7 @@ public class TenantAdminUserService {
   }
 
   public AdminResponseDTO patchTenantAdmin(String adminId, PatchAdminDTO patchAdminDTO) {
-
+    assertCallerMayAccessTenantAdmin(adminId);
     final Admin updatedAdmin = updateAdminService.patchTenantAdmin(adminId, patchAdminDTO);
     var responseDTO =
         AdminResponseDTOBuilder.getInstance(updatedAdmin).buildAgencyAdminResponseDTO();

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -136,8 +136,8 @@ public class TenantAdminUserService {
 
   /**
    * Enforces the caller may list tenant admins for the supplied tenant id. Platform admins may
-   * cross tenants; every other caller may only list their own tenant. Prevents the sibling leak
-   * of {@link #findTenantAdminsByInfix} on GET /useradmin/tenantadmins?tenantId=X (#968).
+   * cross tenants; every other caller may only list their own tenant. Prevents the sibling leak of
+   * {@link #findTenantAdminsByInfix} on GET /useradmin/tenantadmins?tenantId=X (#968).
    */
   private void assertCallerMayListTenantAdminsOf(Long tenantId) {
     if (authenticatedUser.isPlatformAdmin()) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -100,8 +100,7 @@ public class TenantAdminUserService {
   }
 
   public Map<String, Object> findTenantAdminsByInfix(String infix, PageRequest pageRequest) {
-    Page<AdminBase> adminsPage =
-        retrieveAdminService.findAllByInfix(infix, Admin.AdminType.TENANT, pageRequest);
+    Page<AdminBase> adminsPage = findScopedTenantAdminsByInfix(infix, pageRequest);
     var adminIds = adminsPage.stream().map(AdminBase::getId).collect(Collectors.toSet());
     var fullAdmins = retrieveAdminService.findAllById(adminIds);
 
@@ -119,6 +118,21 @@ public class TenantAdminUserService {
         Lists.newArrayList(),
         tenantIdsToNameMap,
         idsWithConsultantIdentity);
+  }
+
+  /**
+   * Returns the infix-matched tenant admins visible to the current caller. A platform admin keeps
+   * the full list; every other caller — including a single-tenant admin and a tenant super admin
+   * bound to their own tenant — is scoped to their own tenant. Closes the cross-tenant leak in
+   * /useradmin/tenantadmins/search (#968) where any holder of the tenant-admin authority could
+   * enumerate admins of every other tenant.
+   */
+  private Page<AdminBase> findScopedTenantAdminsByInfix(String infix, PageRequest pageRequest) {
+    if (authenticatedUser.isPlatformAdmin()) {
+      return retrieveAdminService.findAllByInfix(infix, Admin.AdminType.TENANT, pageRequest);
+    }
+    return retrieveAdminService.findAllByInfixScopedToTenant(
+        infix, Admin.AdminType.TENANT, authenticatedUser.getTenantId(), pageRequest);
   }
 
   private Map<Long, String> tenantIdsToNameMap(List<Admin> fullAdmins) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminService.java
@@ -67,6 +67,20 @@ public class RetrieveAdminService {
     return adminRepository.findAllByInfixAndAgencyIds(infix, adminType, agencyIds, pageRequest);
   }
 
+  /**
+   * Infix search scoped to a single tenant. Used to prevent a tenant-bound admin from enumerating
+   * admins of other tenants through the /useradmin/tenantadmins/search and
+   * /useradmin/agencyadmins/search endpoints (#968). A null caller tenant means no visible admins,
+   * mirroring the empty-scope semantics of {@link #findAllByInfixScopedToAgencies}.
+   */
+  public Page<AdminBase> findAllByInfixScopedToTenant(
+      String infix, Admin.AdminType adminType, Long tenantId, PageRequest pageRequest) {
+    if (tenantId == null) {
+      return Page.empty(pageRequest);
+    }
+    return adminRepository.findAllByInfixAndTenantId(infix, adminType, tenantId, pageRequest);
+  }
+
   public List<Admin> findAllById(Set<String> adminIds) {
     return adminRepository.findAllByIdIn(adminIds);
   }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AdminRepository.java
@@ -61,6 +61,32 @@ public interface AdminRepository
   Page<AdminBase> findAllByInfixAndAgencyIds(
       String infix, Admin.AdminType type, Collection<Long> agencyIds, Pageable pageable);
 
+  /**
+   * Same infix search as {@link #findAllByInfix}, but restricted to the given tenant. Used to scope
+   * the tenant-admin and agency-admin lists for a caller whose authority is tenant-bound, so a
+   * single tenant admin cannot enumerate admins of other tenants via the search endpoints (#968).
+   */
+  @Query(
+      value =
+          "SELECT a.id as id, a.firstName as firstName, a.lastName as lastName, a.email as email, a.tenantId as tenantId "
+              + ", a.type as type, a.updateDate as updateDate "
+              + "FROM Admin a "
+              + "WHERE"
+              + "  type = ?2 "
+              + "AND a.tenantId = ?3 "
+              + "AND ("
+              + "  ?1 = '*' "
+              + "  OR ("
+              + "    UPPER(a.id) = UPPER(?1)"
+              + "    OR UPPER(a.firstName) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR UPPER(a.lastName) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR UPPER(a.email) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "    OR CAST(a.tenantId AS string) LIKE CONCAT('%', UPPER(?1), '%')"
+              + "  )"
+              + " )")
+  Page<AdminBase> findAllByInfixAndTenantId(
+      String infix, Admin.AdminType type, Long tenantId, Pageable pageable);
+
   @Query(value = "SELECT a FROM Admin a WHERE id = ?1 AND type = ?2")
   Optional<Admin> findByIdAndType(String adminId, Admin.AdminType type);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -354,8 +354,10 @@ class UserAdminControllerE2EIT {
   @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
   void updateAgencyAdmin_Should_returnOk_When_updateAttemptAsUserAdmin() throws Exception {
     // given
-    // #968: tenant-scoping now guards this endpoint; test intent is authority acceptance,
-    // so run as platform admin. Same-tenant path is covered by AgencyAdminUserServiceTest.
+    // #968: this class runs with multitenancy.enabled=false, so CreateAdminService stores the
+    // new admin with a null tenant. The scope check rejects a null on either side, so only a
+    // platform admin can reach the endpoint here; the same-tenant path is covered by
+    // AgencyAdminUserServiceTest against a target that actually has a tenant.
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     String adminId = givenNewAgencyAdminIsCreated();
 
@@ -550,8 +552,10 @@ class UserAdminControllerE2EIT {
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void updateTenantAdmin_Should_returnOk_When_updateAttemptAsTenantAdmin() throws Exception {
     // given
-    // #968: run as platform admin to bypass the new tenant-scope check; same-tenant path
-    // is covered by TenantAdminUserServiceTest scoping tests.
+    // #968: multitenancy.enabled=false here, so the freshly created admin has a null tenant
+    // and the scope check can never match a caller tenant. Platform admin is the only caller
+    // that can reach this endpoint in this setup; TenantAdminUserServiceTest covers the
+    // same-tenant path against a target that has a tenant.
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     String adminId = givenNewTenantAdminIsCreated();
 
@@ -637,8 +641,10 @@ class UserAdminControllerE2EIT {
   void getTenantAdmin_Should_returnOk_When_attemptedToGetTenantAdminWithTenantAdminAuthority()
       throws Exception {
     // given
-    // #968: unscoped access requires platform-admin identity now.
-    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    // #968: reading a tenant admin is scoped to the caller's tenant. cgenney5 sits in tenant
+    // 102 (UserServiceDatabase.sql), so the caller carries that tenant and the same-tenant
+    // branch is the one under test.
+    when(authenticatedUser.getTenantId()).thenReturn(102L);
     var existingAdminId = "6584f4a9-a7f0-42f0-b929-ab5c99c0802d";
 
     // when, then
@@ -868,8 +874,10 @@ class UserAdminControllerE2EIT {
   @Test
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void searchTenantAdmin_Should_returnCorrectResult_When_tenantIdIsProvided() throws Exception {
-    // #968: cross-tenant search is now platform-admin only.
-    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    // #968: the infix search is scoped to the caller's tenant for every non-platform caller.
+    // The expected hit, cgenney5, is in tenant 102, so a caller in that tenant still finds it —
+    // this keeps the test on the scoped path instead of the platform-admin short-circuit.
+    when(authenticatedUser.getTenantId()).thenReturn(102L);
     final String tenantId = "102";
     final String expectedAdminId = "6584f4a9-a7f0-42f0-b929-ab5c99c0802d";
     final String expectedUsername = "cgenney5";
@@ -947,7 +955,8 @@ class UserAdminControllerE2EIT {
   void deleteTenantAdmin_Should_delete_When_attemptedToDeleteTenantAdminWithTenantAdminAuthority()
       throws Exception {
     // given
-    // #968: cross-tenant delete is now platform-admin only.
+    // #968: the admin created here has a null tenant (multitenancy.enabled=false), which no
+    // caller tenant can match, so only a platform admin can delete it in this setup.
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     var adminId = givenNewTenantAdminIsCreated();
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -420,8 +420,45 @@ class UserAdminControllerE2EIT {
     when(authenticatedUser.getUserId()).thenReturn(adminId);
     when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(false);
     when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
-    // #968: self-patch dispatches to patchTenantAdmin which now enforces tenant scoping;
-    // treat this mock user as platform admin so the check short-circuits.
+    // #968: self-patch dispatches to patchTenantAdmin, which scopes to the caller's tenant.
+    // The caller here *is* the admin being patched, so it carries that admin's own tenant
+    // (102 for cgenney5 in UserServiceDatabase.sql). Reporting platform admin instead would
+    // short-circuit the check and leave the same-tenant path this test exists for unproven.
+    when(authenticatedUser.getTenantId()).thenReturn(102L);
+
+    PatchAdminDTO patchAdminDTO = new EasyRandom().nextObject(PatchAdminDTO.class);
+
+    patchAdminDTO.setFirstname("changedFirstname");
+    patchAdminDTO.setLastname("changedLastname");
+    patchAdminDTO.setEmail("changed@email.com");
+
+    when(tenantService.getRestrictedTenantData(Mockito.anyLong()))
+        .thenReturn(new RestrictedTenantDTO().subdomain("subdomain"));
+
+    // when, then
+    this.mockMvc
+        .perform(
+            patch(ADMIN_DATA_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(patchAdminDTO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("_embedded.id", is(adminId)))
+        .andExpect(jsonPath("_embedded.firstname", is("changedFirstname")))
+        .andExpect(jsonPath("_embedded.lastname", is("changedLastname")))
+        .andExpect(jsonPath("_embedded.email", is("changed@email.com")));
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.SINGLE_TENANT_ADMIN})
+  void patchAdminData_Should_returnOk_When_patchAttemptAsPlatformAdmin() throws Exception {
+    // given
+    // #968: a platform admin keeps the cross-tenant view, so the scope check short-circuits
+    // and no caller tenant is needed. Kept separate from the single-tenant case so that one
+    // still exercises the same-tenant path.
+    String adminId = "6584f4a9-a7f0-42f0-b929-ab5c99c0802d";
+    when(authenticatedUser.getUserId()).thenReturn(adminId);
+    when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(false);
+    when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
     when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
 
     PatchAdminDTO patchAdminDTO = new EasyRandom().nextObject(PatchAdminDTO.class);

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerE2EIT.java
@@ -354,6 +354,9 @@ class UserAdminControllerE2EIT {
   @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
   void updateAgencyAdmin_Should_returnOk_When_updateAttemptAsUserAdmin() throws Exception {
     // given
+    // #968: tenant-scoping now guards this endpoint; test intent is authority acceptance,
+    // so run as platform admin. Same-tenant path is covered by AgencyAdminUserServiceTest.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     String adminId = givenNewAgencyAdminIsCreated();
 
     UpdateAgencyAdminDTO updateAdminDTO = new EasyRandom().nextObject(UpdateAgencyAdminDTO.class);
@@ -417,6 +420,9 @@ class UserAdminControllerE2EIT {
     when(authenticatedUser.getUserId()).thenReturn(adminId);
     when(authenticatedUser.isRestrictedAgencyAdmin()).thenReturn(false);
     when(authenticatedUser.isSingleTenantAdmin()).thenReturn(true);
+    // #968: self-patch dispatches to patchTenantAdmin which now enforces tenant scoping;
+    // treat this mock user as platform admin so the check short-circuits.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
 
     PatchAdminDTO patchAdminDTO = new EasyRandom().nextObject(PatchAdminDTO.class);
 
@@ -507,6 +513,9 @@ class UserAdminControllerE2EIT {
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void updateTenantAdmin_Should_returnOk_When_updateAttemptAsTenantAdmin() throws Exception {
     // given
+    // #968: run as platform admin to bypass the new tenant-scope check; same-tenant path
+    // is covered by TenantAdminUserServiceTest scoping tests.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     String adminId = givenNewTenantAdminIsCreated();
 
     UpdateTenantAdminDTO updateAdminDTO = new EasyRandom().nextObject(UpdateTenantAdminDTO.class);
@@ -591,6 +600,8 @@ class UserAdminControllerE2EIT {
   void getTenantAdmin_Should_returnOk_When_attemptedToGetTenantAdminWithTenantAdminAuthority()
       throws Exception {
     // given
+    // #968: unscoped access requires platform-admin identity now.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     var existingAdminId = "6584f4a9-a7f0-42f0-b929-ab5c99c0802d";
 
     // when, then
@@ -609,6 +620,8 @@ class UserAdminControllerE2EIT {
   void
       getTenantAdmins_Should_returnOkAndFilterByTenantId_When_attemptedToGetTenantWithTenantAdminAuthority()
           throws Exception {
+    // #968: cross-tenant listing is now platform-admin only.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
 
     // when, then
     this.mockMvc
@@ -818,6 +831,8 @@ class UserAdminControllerE2EIT {
   @Test
   @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
   void searchTenantAdmin_Should_returnCorrectResult_When_tenantIdIsProvided() throws Exception {
+    // #968: cross-tenant search is now platform-admin only.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     final String tenantId = "102";
     final String expectedAdminId = "6584f4a9-a7f0-42f0-b929-ab5c99c0802d";
     final String expectedUsername = "cgenney5";
@@ -895,6 +910,8 @@ class UserAdminControllerE2EIT {
   void deleteTenantAdmin_Should_delete_When_attemptedToDeleteTenantAdminWithTenantAdminAuthority()
       throws Exception {
     // given
+    // #968: cross-tenant delete is now platform-admin only.
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     var adminId = givenNewTenantAdminIsCreated();
 
     // when

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -59,6 +59,7 @@ class AgencyAdminUserServiceTest {
   @Test
   void findAgencyAdminShouldExposeActiveConsultantIdentity() {
     var admin = agencyAdmin("agency-admin", 1L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAdmin("agency-admin", Admin.AdminType.AGENCY)).thenReturn(admin);
     when(consultantRepository.findActiveIdsByIdIn(Set.of("agency-admin")))
         .thenReturn(Set.of("agency-admin"));
@@ -71,6 +72,7 @@ class AgencyAdminUserServiceTest {
   @Test
   void findAgencyAdminShouldReportNoActiveConsultantIdentity() {
     var admin = agencyAdmin("agency-admin", 1L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAdmin("agency-admin", Admin.AdminType.AGENCY)).thenReturn(admin);
     when(consultantRepository.findActiveIdsByIdIn(Set.of("agency-admin")))
         .thenReturn(Collections.emptySet());
@@ -150,15 +152,49 @@ class AgencyAdminUserServiceTest {
 
   @Test
   void deleteAgencyAdmin_Should_NotScope_WhenCallerIsPlatformAdmin() {
-    // given a platform/user admin without restricted-agency privileges
-    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    // given a platform admin (unscoped access)
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
 
     // when
     agencyAdminUserService.deleteAgencyAdmin("any-admin");
 
     // then no agency lookup happens and deletion proceeds
     Mockito.verify(retrieveAdminService, Mockito.never()).findAgencyIdsOfAdmin(Mockito.any());
+    Mockito.verify(retrieveAdminService, Mockito.never()).findAdmin(Mockito.any(), Mockito.any());
     Mockito.verify(deleteAdminService).deleteAgencyAdmin("any-admin");
+  }
+
+  /**
+   * #968: a tenant admin (not restricted agency admin, not platform admin) must not act on agency
+   * admins of other tenants via the by-id endpoints — mirrors the search-side tenant scoping.
+   */
+  @Test
+  void deleteAgencyAdmin_Should_ThrowForbidden_WhenTenantAdminTargetsForeignTenant() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    Admin foreignAgencyAdmin = agencyAdmin("foreign-agency-admin", 1L);
+    when(retrieveAdminService.findAdmin("foreign-agency-admin", Admin.AdminType.AGENCY))
+        .thenReturn(foreignAgencyAdmin);
+
+    Assertions.assertThrows(
+        ForbiddenException.class,
+        () -> agencyAdminUserService.deleteAgencyAdmin("foreign-agency-admin"));
+    Mockito.verify(deleteAdminService, Mockito.never()).deleteAgencyAdmin(Mockito.any());
+  }
+
+  @Test
+  void deleteAgencyAdmin_Should_Delete_WhenTenantAdminTargetsOwnTenant() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    Admin ownAgencyAdmin = agencyAdmin("own-agency-admin", 9L);
+    when(retrieveAdminService.findAdmin("own-agency-admin", Admin.AdminType.AGENCY))
+        .thenReturn(ownAgencyAdmin);
+
+    agencyAdminUserService.deleteAgencyAdmin("own-agency-admin");
+
+    Mockito.verify(deleteAdminService).deleteAgencyAdmin("own-agency-admin");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -288,6 +288,42 @@ class AgencyAdminUserServiceTest {
             Mockito.anyString(), Mockito.any(), Mockito.anyCollection(), Mockito.any());
   }
 
+  /**
+   * Fail-closed mirror of the tenant-admin search: if a tenant-bound caller has no resolvable
+   * tenant, the agency-admin search still routes through the scoped call with a null tenant and
+   * returns an empty page — never the unscoped list (#968).
+   */
+  @Test
+  void findAgencyAdminsByInfix_Should_FailClosedToEmpty_WhenTenantAdminHasNullTenant() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(null);
+    when(retrieveAdminService.findAllByInfixScopedToTenant(
+            "*", Admin.AdminType.AGENCY, null, pageRequest))
+        .thenReturn(new PageImpl<>(Collections.emptyList(), pageRequest, 0));
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(Collections.emptyList());
+    when(retrieveAdminService.agenciesOfAdmin(Mockito.anySet()))
+        .thenReturn(Collections.emptyList());
+    when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    agencyAdminUserService.findAgencyAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService)
+        .findAllByInfixScopedToTenant("*", Admin.AdminType.AGENCY, null, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfix(Mockito.anyString(), Mockito.any(), Mockito.any(PageRequest.class));
+  }
+
   @Test
   void findAgencyAdminsByInfix_Should_NotScope_ForPlatformAdmin() {
     PageRequest pageRequest = PageRequest.of(0, 10);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AgencyAdminUserServiceTest.java
@@ -175,6 +175,7 @@ class AgencyAdminUserServiceTest {
     Admin secondAgencyAdmin = agencyAdmin("agency-admin-2", 1L);
     Admin thirdAgencyAdmin = agencyAdmin("agency-admin-3", 2L);
     List<Admin> fullAdmins = Arrays.asList(firstAgencyAdmin, secondAgencyAdmin, thirdAgencyAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.AGENCY, pageRequest))
         .thenReturn(adminsPage);
     when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
@@ -210,6 +211,74 @@ class AgencyAdminUserServiceTest {
     Assertions.assertFalse(tenantNameMapCaptor.getValue().containsKey(2L));
     Mockito.verify(tenantService).getRestrictedTenantData(Set.of(1L, 2L));
     Mockito.verify(tenantService, Mockito.never()).getRestrictedTenantData(Mockito.anyLong());
+  }
+
+  /**
+   * #968: a plain tenant admin (no restricted-agency privileges, not platform admin) querying
+   * /useradmin/agencyadmins/search must only see agency admins of their own tenant. Before the fix
+   * the same call returned agency admins of every tenant, mirroring the tenant-admin leak.
+   */
+  @Test
+  void findAgencyAdminsByInfix_Should_ScopeToCallerTenant_ForTenantAdmin() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    when(retrieveAdminService.findAllByInfixScopedToTenant(
+            "*", Admin.AdminType.AGENCY, 9L, pageRequest))
+        .thenReturn(new PageImpl<>(Collections.emptyList(), pageRequest, 0));
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(Collections.emptyList());
+    when(retrieveAdminService.agenciesOfAdmin(Mockito.anySet()))
+        .thenReturn(Collections.emptyList());
+    when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    agencyAdminUserService.findAgencyAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService)
+        .findAllByInfixScopedToTenant("*", Admin.AdminType.AGENCY, 9L, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfix(Mockito.anyString(), Mockito.any(), Mockito.any(PageRequest.class));
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfixScopedToAgencies(
+            Mockito.anyString(), Mockito.any(), Mockito.anyCollection(), Mockito.any());
+  }
+
+  @Test
+  void findAgencyAdminsByInfix_Should_NotScope_ForPlatformAdmin() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.AGENCY, pageRequest))
+        .thenReturn(new PageImpl<>(Collections.emptyList(), pageRequest, 0));
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(Collections.emptyList());
+    when(retrieveAdminService.agenciesOfAdmin(Mockito.anySet()))
+        .thenReturn(Collections.emptyList());
+    when(agencyService.getAgenciesWithoutCaching(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    agencyAdminUserService.findAgencyAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService).findAllByInfix("*", Admin.AdminType.AGENCY, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfixScopedToTenant(
+            Mockito.anyString(), Mockito.any(), Mockito.anyLong(), Mockito.any(PageRequest.class));
   }
 
   private Admin agencyAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -216,6 +216,7 @@ class TenantAdminUserServiceTest {
     Admin secondTenantAdmin = tenantAdmin("tenant-admin-2", 1L);
     Admin thirdTenantAdmin = tenantAdmin("tenant-admin-3", 2L);
     List<Admin> fullAdmins = Arrays.asList(firstTenantAdmin, secondTenantAdmin, thirdTenantAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
         .thenReturn(adminsPage);
     when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(fullAdmins);
@@ -255,6 +256,7 @@ class TenantAdminUserServiceTest {
     Admin.AdminBase platformAdminBase = adminBase("platform-admin", 0L);
     Page<Admin.AdminBase> adminsPage = new PageImpl<>(List.of(platformAdminBase), pageRequest, 1);
     Admin platformAdmin = tenantAdmin("platform-admin", 0L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
         .thenReturn(adminsPage);
     when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(List.of(platformAdmin));
@@ -280,6 +282,66 @@ class TenantAdminUserServiceTest {
             tenantNameMapCaptor.capture(),
             Mockito.any());
     assertThat(tenantNameMapCaptor.getValue()).isEmpty();
+  }
+
+  /**
+   * #968: a single tenant admin querying /useradmin/tenantadmins/search must only see admins of
+   * their own tenant. Before the fix the search hit findAllByInfix unscoped and returned admins of
+   * every tenant.
+   */
+  @Test
+  void findTenantAdminsByInfix_Should_ScopeToCallerTenant_ForNonPlatformAdmin() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Admin.AdminBase ownAdminBase = adminBase("own-tenant-admin", 9L);
+    Page<Admin.AdminBase> ownAdminsPage = new PageImpl<>(List.of(ownAdminBase), pageRequest, 1);
+    Admin ownAdmin = tenantAdmin("own-tenant-admin", 9L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    when(retrieveAdminService.findAllByInfixScopedToTenant(
+            "*", Admin.AdminType.TENANT, 9L, pageRequest))
+        .thenReturn(ownAdminsPage);
+    when(retrieveAdminService.findAllById(Mockito.anySet())).thenReturn(List.of(ownAdmin));
+    when(tenantService.getRestrictedTenantData(Set.of(9L)))
+        .thenReturn(List.of(new RestrictedTenantDTO().id(9L).name("Own tenant")));
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    tenantAdminUserService.findTenantAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService)
+        .findAllByInfixScopedToTenant("*", Admin.AdminType.TENANT, 9L, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfix(Mockito.anyString(), Mockito.any(), Mockito.any(PageRequest.class));
+  }
+
+  @Test
+  void findTenantAdminsByInfix_Should_NotScope_ForPlatformAdmin() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Page<Admin.AdminBase> emptyPage = new PageImpl<>(List.of(), pageRequest, 0);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(retrieveAdminService.findAllByInfix("*", Admin.AdminType.TENANT, pageRequest))
+        .thenReturn(emptyPage);
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    tenantAdminUserService.findTenantAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService).findAllByInfix("*", Admin.AdminType.TENANT, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfixScopedToTenant(
+            Mockito.anyString(), Mockito.any(), Mockito.anyLong(), Mockito.any(PageRequest.class));
   }
 
   private Admin tenantAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -106,6 +106,7 @@ class TenantAdminUserServiceTest {
     // given
     EasyRandom random = new EasyRandom();
     UpdateTenantAdminDTO tenantAdminDTO = random.nextObject(UpdateTenantAdminDTO.class);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(tenantService.getRestrictedTenantData(1L))
         .thenReturn(new RestrictedTenantDTO().subdomain("subdomain"));
     Admin tenantAdmin = new Admin();
@@ -127,6 +128,7 @@ class TenantAdminUserServiceTest {
   void updateTenantAdmin_Should_NotLookUpTechnicalTenant() {
     UpdateTenantAdminDTO tenantAdminDTO = new EasyRandom().nextObject(UpdateTenantAdminDTO.class);
     Admin platformAdmin = tenantAdmin("platform-admin", 0L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(updateAdminService.updateTenantAdmin("platform-admin", tenantAdminDTO))
         .thenReturn(platformAdmin);
 
@@ -150,6 +152,7 @@ class TenantAdminUserServiceTest {
     secondTenantAdmin.setId("tenant-admin-2");
     secondTenantAdmin.setType(Admin.AdminType.TENANT);
     secondTenantAdmin.setTenantId(tenantId);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findTenantAdminsByTenantId(tenantId))
         .thenReturn(Arrays.asList(firstTenantAdmin, secondTenantAdmin));
 
@@ -172,6 +175,7 @@ class TenantAdminUserServiceTest {
     Admin admin = new Admin();
     admin.setId("tenant-admin-1");
     admin.setType(Admin.AdminType.TENANT);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAdmin("tenant-admin-1", Admin.AdminType.TENANT))
         .thenReturn(admin);
     when(consultantRepository.findActiveIdsByIdIn(java.util.Set.of("tenant-admin-1")))
@@ -190,6 +194,7 @@ class TenantAdminUserServiceTest {
     Admin admin = new Admin();
     admin.setId("tenant-admin-1");
     admin.setType(Admin.AdminType.TENANT);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
     when(retrieveAdminService.findAdmin("tenant-admin-1", Admin.AdminType.TENANT))
         .thenReturn(admin);
     when(consultantRepository.findActiveIdsByIdIn(java.util.Set.of("tenant-admin-1")))
@@ -342,6 +347,82 @@ class TenantAdminUserServiceTest {
     Mockito.verify(retrieveAdminService, Mockito.never())
         .findAllByInfixScopedToTenant(
             Mockito.anyString(), Mockito.any(), Mockito.anyLong(), Mockito.any(PageRequest.class));
+  }
+
+  // ---- #968: by-id sibling endpoints must reject foreign-tenant targets ----
+
+  @Test
+  void findTenantAdmin_Should_ThrowForbidden_WhenCallerIsInForeignTenant() {
+    Admin foreignAdmin = tenantAdmin("foreign-admin", 1L);
+    when(retrieveAdminService.findAdmin("foreign-admin", Admin.AdminType.TENANT))
+        .thenReturn(foreignAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatThrownBy(() -> tenantAdminUserService.findTenantAdmin("foreign-admin"))
+        .isInstanceOf(ForbiddenException.class);
+    Mockito.verifyNoInteractions(consultantRepository);
+  }
+
+  @Test
+  void updateTenantAdmin_Should_ThrowForbidden_WhenCallerIsInForeignTenant() {
+    UpdateTenantAdminDTO dto = new EasyRandom().nextObject(UpdateTenantAdminDTO.class);
+    dto.setTenantId(9);
+    Admin foreignAdmin = tenantAdmin("foreign-admin", 1L);
+    when(retrieveAdminService.findAdmin("foreign-admin", Admin.AdminType.TENANT))
+        .thenReturn(foreignAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatThrownBy(() -> tenantAdminUserService.updateTenantAdmin("foreign-admin", dto))
+        .isInstanceOf(ForbiddenException.class);
+    Mockito.verifyNoInteractions(updateAdminService);
+  }
+
+  @Test
+  void deleteTenantAdmin_Should_ThrowForbidden_WhenCallerIsInForeignTenant() {
+    Admin foreignAdmin = tenantAdmin("foreign-admin", 1L);
+    when(retrieveAdminService.findAdmin("foreign-admin", Admin.AdminType.TENANT))
+        .thenReturn(foreignAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatThrownBy(() -> tenantAdminUserService.deleteTenantAdmin("foreign-admin"))
+        .isInstanceOf(ForbiddenException.class);
+    Mockito.verifyNoInteractions(deleteAdminService);
+  }
+
+  @Test
+  void deleteTenantAdmin_Should_Delete_WhenCallerIsInSameTenant() {
+    Admin ownAdmin = tenantAdmin("own-admin", 9L);
+    when(retrieveAdminService.findAdmin("own-admin", Admin.AdminType.TENANT)).thenReturn(ownAdmin);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    tenantAdminUserService.deleteTenantAdmin("own-admin");
+
+    Mockito.verify(deleteAdminService).deleteTenantAdmin("own-admin");
+  }
+
+  @Test
+  void findTenantAdmins_Should_ThrowForbidden_WhenQueryingForeignTenant() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatThrownBy(() -> tenantAdminUserService.findTenantAdmins(1L))
+        .isInstanceOf(ForbiddenException.class);
+    Mockito.verify(retrieveAdminService, Mockito.never()).findTenantAdminsByTenantId(Mockito.any());
+  }
+
+  @Test
+  void findTenantAdmins_Should_Allow_WhenPlatformAdminQueriesAnyTenant() {
+    Admin someAdmin = tenantAdmin("some-admin", 1L);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(retrieveAdminService.findTenantAdminsByTenantId(1L)).thenReturn(List.of(someAdmin));
+
+    List<AdminResponseDTO> admins = tenantAdminUserService.findTenantAdmins(1L);
+
+    assertThat(admins).hasSize(1);
   }
 
   private Admin tenantAdmin(String id, Long tenantId) {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -325,6 +325,37 @@ class TenantAdminUserServiceTest {
         .findAllByInfix(Mockito.anyString(), Mockito.any(), Mockito.any(PageRequest.class));
   }
 
+  /**
+   * Fail-closed: if the caller has no resolvable tenant (getTenantId() returns null), the search
+   * must still route through the scoped call and return an empty page — never fall back to the
+   * unscoped repository query. Prevents any future change to the branching logic from silently
+   * re-opening #968.
+   */
+  @Test
+  void findTenantAdminsByInfix_Should_FailClosedToEmpty_WhenCallerTenantIsNull() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(null);
+    when(retrieveAdminService.findAllByInfixScopedToTenant(
+            "*", Admin.AdminType.TENANT, null, pageRequest))
+        .thenReturn(new PageImpl<>(List.of(), pageRequest, 0));
+    when(userServiceMapper.mapOfAdmin(
+            Mockito.any(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.anyList(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(new HashMap<>());
+
+    tenantAdminUserService.findTenantAdminsByInfix("*", pageRequest);
+
+    Mockito.verify(retrieveAdminService)
+        .findAllByInfixScopedToTenant("*", Admin.AdminType.TENANT, null, pageRequest);
+    Mockito.verify(retrieveAdminService, Mockito.never())
+        .findAllByInfix(Mockito.anyString(), Mockito.any(), Mockito.any(PageRequest.class));
+  }
+
   @Test
   void findTenantAdminsByInfix_Should_NotScope_ForPlatformAdmin() {
     PageRequest pageRequest = PageRequest.of(0, 10);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminServiceTest.java
@@ -24,9 +24,9 @@ class RetrieveAdminServiceTest {
 
   /**
    * #968 fail-closed contract: a null caller tenant id must NOT be forwarded to
-   * AdminRepository#findAllByInfixAndTenantId (which would return an unbounded result set), and
-   * the method must return an empty page instead. Same shape as
-   * {@link RetrieveAdminService#findAllByInfixScopedToAgencies} on an empty agency set.
+   * AdminRepository#findAllByInfixAndTenantId (which would return an unbounded result set), and the
+   * method must return an empty page instead. Same shape as {@link
+   * RetrieveAdminService#findAllByInfixScopedToAgencies} on an empty agency set.
    */
   @Test
   void findAllByInfixScopedToTenant_Should_ReturnEmpty_AndSkipRepository_WhenTenantIdIsNull() {
@@ -45,12 +45,10 @@ class RetrieveAdminServiceTest {
   void findAllByInfixScopedToTenant_Should_DelegateToRepository_WhenTenantIdIsPresent() {
     PageRequest pageRequest = PageRequest.of(0, 10);
     Mockito.when(
-            adminRepository.findAllByInfixAndTenantId(
-                "*", Admin.AdminType.AGENCY, 9L, pageRequest))
+            adminRepository.findAllByInfixAndTenantId("*", Admin.AdminType.AGENCY, 9L, pageRequest))
         .thenReturn(org.springframework.data.domain.Page.empty(pageRequest));
 
-    retrieveAdminService.findAllByInfixScopedToTenant(
-        "*", Admin.AdminType.AGENCY, 9L, pageRequest);
+    retrieveAdminService.findAllByInfixScopedToTenant("*", Admin.AdminType.AGENCY, 9L, pageRequest);
 
     Mockito.verify(adminRepository)
         .findAllByInfixAndTenantId("*", Admin.AdminType.AGENCY, 9L, pageRequest);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/search/RetrieveAdminServiceTest.java
@@ -1,0 +1,58 @@
+package de.caritas.cob.userservice.api.admin.service.admin.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.Admin;
+import de.caritas.cob.userservice.api.port.out.AdminAgencyRepository;
+import de.caritas.cob.userservice.api.port.out.AdminRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class RetrieveAdminServiceTest {
+
+  @InjectMocks private RetrieveAdminService retrieveAdminService;
+
+  @Mock private AdminRepository adminRepository;
+
+  @Mock private AdminAgencyRepository adminAgencyRepository;
+
+  /**
+   * #968 fail-closed contract: a null caller tenant id must NOT be forwarded to
+   * AdminRepository#findAllByInfixAndTenantId (which would return an unbounded result set), and
+   * the method must return an empty page instead. Same shape as
+   * {@link RetrieveAdminService#findAllByInfixScopedToAgencies} on an empty agency set.
+   */
+  @Test
+  void findAllByInfixScopedToTenant_Should_ReturnEmpty_AndSkipRepository_WhenTenantIdIsNull() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+
+    var result =
+        retrieveAdminService.findAllByInfixScopedToTenant(
+            "*", Admin.AdminType.TENANT, null, pageRequest);
+
+    assertThat(result.getContent()).isEmpty();
+    assertThat(result.getTotalElements()).isZero();
+    Mockito.verifyNoInteractions(adminRepository);
+  }
+
+  @Test
+  void findAllByInfixScopedToTenant_Should_DelegateToRepository_WhenTenantIdIsPresent() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Mockito.when(
+            adminRepository.findAllByInfixAndTenantId(
+                "*", Admin.AdminType.AGENCY, 9L, pageRequest))
+        .thenReturn(org.springframework.data.domain.Page.empty(pageRequest));
+
+    retrieveAdminService.findAllByInfixScopedToTenant(
+        "*", Admin.AdminType.AGENCY, 9L, pageRequest);
+
+    Mockito.verify(adminRepository)
+        .findAllByInfixAndTenantId("*", Admin.AdminType.AGENCY, 9L, pageRequest);
+  }
+}


### PR DESCRIPTION
## Problem

A newly-created tenant admin (scoped to a single tenant, no elevated roles) calling either

- `GET /service/useradmin/tenantadmins/search`
- `GET /service/useradmin/agencyadmins/search`

received **HTTP 200 with rows from every tenant** — `tenantId`, `username`, `email` of foreign-tenant admins. Cross-tenant isolation failure, found on pre-dev E2E gate `e2e-20260804-0145`.

Both endpoints hit `AdminRepository.findAllByInfix` **without** a tenant scope. Only the restricted-agency-admin branch of `AgencyAdminUserService.findScopedAgencyAdminsByInfix` scoped results at all — every other caller fell through to the unscoped query.

Per @Storypapst's 2026-09-01 comment on #968: same problem applies to the agency-admin list — an agency admin (and, more broadly, a tenant admin) should not see agency admins of other tenants either.

## Fix

Route both searches through the service layer with an explicit tenant scope:

- **Platform admin** (`isPlatformAdmin() == true`) → unscoped (unchanged)
- **Restricted agency admin** (agency search only) → agency-scoped (unchanged)
- **Everyone else** — single-tenant admin, tenant super admin, agency admin without shared agencies → **NEW:** scoped to `authenticatedUser.getTenantId()`

Adds:
- `AdminRepository.findAllByInfixAndTenantId(infix, type, tenantId, page)` — mirrors the existing infix JPQL with an extra `AND a.tenantId = ?3`
- `RetrieveAdminService.findAllByInfixScopedToTenant(...)` — wrapper with empty-page semantics on null tenant (mirrors `findAllByInfixScopedToAgencies`)

## Tests

- **TenantAdminUserServiceTest** — 2 new tests:
  - `findTenantAdminsByInfix_Should_ScopeToCallerTenant_ForNonPlatformAdmin` (regression pin for #968)
  - `findTenantAdminsByInfix_Should_NotScope_ForPlatformAdmin`
  - Existing `_NotUsePerTenantLookups` and `_NotLookUpTechnicalTenant` now set `isPlatformAdmin=true` to keep them exercising the unscoped path they document.
- **AgencyAdminUserServiceTest** — 2 new tests mirroring above for the agency search endpoint.

## Not verified

- No local build/test run (static review only, per project convention). CI will validate.

Closes #968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin lookups, updates, deletions, and listings now enforce tenant access permissions.
  * Unauthorized cross-tenant access is blocked and logged.
  * Admin searches are isolated to the caller’s tenant by default.
  * Restricted agency administrators remain limited to shared agencies.
  * Platform administrators retain unrestricted access.
  * Searches without a tenant context return no results.
  * Tenant-specific listings validate access before displaying results.

* **Documentation**
  * Clarified tenant- and agency-level access and search isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->