### PR TITLE
fix(admin): reject cross-tenant admin creation from tenant-scoped callers

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidator.java
@@ -1,0 +1,66 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Ownership rule for the admin-creating endpoints (<code>POST /useradmin/tenantadmins</code> and
+ * <code>POST /useradmin/agencyadmins</code>).
+ *
+ * <p>Both endpoints take the target tenant from the request body. Role checks alone do not bound
+ * that value: every tenant admin holds {@code tenant-admin}, so a role-only guard such as {@link
+ * AuthenticatedUser#isTenantSuperAdmin()} lets a tenant-scoped caller attribute a new admin account
+ * to a tenant they do not own. Nothing downstream repairs it — the Hibernate tenant filter is
+ * read-only, the tenant interceptor only backfills a missing tenant id, and there is no constraint
+ * on {@code admin.tenant_id}. This is the write-side counterpart of the read-side scoping in {@code
+ * AgencyAdminUserService.findScopedAgencyAdminsByInfix}.
+ *
+ * <p>The caller's own tenant is taken from the authenticated principal, i.e. the {@code tenantId}
+ * claim of the Keycloak access token. With multitenancy enabled that claim is also what {@code
+ * TenantResolverService} resolves the request context from, so a tenant-scoped caller can neither
+ * omit nor influence it.
+ */
+@Slf4j
+public final class AdminTenantOwnershipValidator {
+
+  static final String CROSS_TENANT_MESSAGE =
+      "Admin accounts can only be created for the tenant of the calling admin";
+
+  private AdminTenantOwnershipValidator() {}
+
+  /**
+   * Rejects a create-admin request that attributes the new admin to a tenant the caller does not
+   * own.
+   *
+   * @param authenticatedUser the calling admin
+   * @param requestedTenantId the tenant id taken from the create-admin request body
+   * @throws ForbiddenException if the caller is bound to a tenant and asks for a different one
+   */
+  public static void assertCallerMayCreateAdminForTenant(
+      AuthenticatedUser authenticatedUser, Integer requestedTenantId) {
+    if (requestedTenantId == null) {
+      // Whether a tenant id is required at all is decided per endpoint; there is no tenant to own.
+      return;
+    }
+    if (authenticatedUser.isPlatformAdmin()) {
+      // Platform admins legitimately administer every tenant, including the technical tenant 0.
+      return;
+    }
+    Long callerTenantId = authenticatedUser.getTenantId();
+    if (callerTenantId == null || TenantContext.TECHNICAL_TENANT_ID.equals(callerTenantId)) {
+      // No tenant-bound caller: either a single-tenant deployment or the platform/technical
+      // context, neither of which can cross a tenant boundary that exists.
+      return;
+    }
+    if (!callerTenantId.equals(Long.valueOf(requestedTenantId))) {
+      log.warn(
+          "Admin {} of tenant {} attempted to create an admin account for tenant {}",
+          authenticatedUser.getUserId(),
+          callerTenantId,
+          requestedTenantId);
+      throw new ForbiddenException(CROSS_TENANT_MESSAGE);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidator.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidator.java
@@ -21,6 +21,14 @@ import lombok.extern.slf4j.Slf4j;
  * claim of the Keycloak access token. With multitenancy enabled that claim is also what {@code
  * TenantResolverService} resolves the request context from, so a tenant-scoped caller can neither
  * omit nor influence it.
+ *
+ * <p>The check bounds callers that <em>belong to</em> a tenant. It deliberately does not turn the
+ * platform context (caller tenant {@code 0}) into a tenant-bound caller: tenant 0 is the technical
+ * tenant nobody belongs to, and provisioning a tenant's admins from it is established, test-covered
+ * behaviour ({@code CreateAdminServiceIT}, {@code UserAdminControllerE2EIT}). Narrowing that
+ * exemption further — so that a tenant-0 principal without the full platform-admin role combination
+ * is also bounded — is a separate, behaviour-changing decision that would have to update those
+ * tests; it is not needed to close the tenant-scoped bypass this class exists for.
  */
 @Slf4j
 public final class AdminTenantOwnershipValidator {
@@ -50,8 +58,14 @@ public final class AdminTenantOwnershipValidator {
     }
     Long callerTenantId = authenticatedUser.getTenantId();
     if (callerTenantId == null || TenantContext.TECHNICAL_TENANT_ID.equals(callerTenantId)) {
-      // No tenant-bound caller: either a single-tenant deployment or the platform/technical
-      // context, neither of which can cross a tenant boundary that exists.
+      // No tenant-bound caller, so there is no tenant boundary to cross:
+      // - null: a single-tenant deployment. With multitenancy enabled the tenant resolver
+      //   rejects a request whose principal carries no resolvable tenant, so a tenant-scoped
+      //   caller never reaches this branch.
+      // - 0: the platform/technical context. Tenant 0 is not a tenant one can belong to; the
+      //   whole codebase treats it as "no concrete tenant" (TenantContext#TECHNICAL_TENANT_ID,
+      //   HttpTenantFilter#resolveSubdomain), and provisioning a tenant's first admin from that
+      //   context is an established, test-covered operation.
       return;
     }
     if (!callerTenantId.equals(Long.valueOf(requestedTenantId))) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserService.java
@@ -54,6 +54,8 @@ public class TenantAdminUserService {
 
   private void validateCreateAdmin(CreateAdminDTO createTenantAdminDTO) {
     validateTenantId(createTenantAdminDTO.getTenantId());
+    AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+        authenticatedUser, createTenantAdminDTO.getTenantId());
   }
 
   private void validateUpdateAdmin(UpdateTenantAdminDTO updateTenantAdminDTO) {

--- a/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminService.java
@@ -7,6 +7,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 import com.google.common.collect.Lists;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
+import de.caritas.cob.userservice.api.admin.service.admin.AdminTenantOwnershipValidator;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
@@ -79,6 +80,10 @@ public class CreateAdminService {
   private void setTenantIdForMultiTenancy(CreateAdminDTO createAdminDTO) {
     if (authenticatedUser.isTenantSuperAdmin()) {
       notNull(createAdminDTO.getTenantId());
+      // The tenant-admin role alone does not bound the tenant id: without this check any
+      // tenant-scoped admin could attribute the new agency admin to a foreign tenant.
+      AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+          authenticatedUser, createAdminDTO.getTenantId());
     } else {
       createAdminDTO.setTenantId(TenantContext.getCurrentTenant().intValue());
     }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserAdminControllerMultiTenancyTrueE2EIT.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static de.caritas.cob.userservice.api.adapters.web.controller.UserAdminControllerIT.AGENCY_ADMIN_PATH;
+import static de.caritas.cob.userservice.api.adapters.web.controller.UserAdminControllerIT.TENANT_ADMIN_PATH;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -169,6 +170,123 @@ class UserAdminControllerMultiTenancyTrueE2EIT {
                 .content(objectMapper.writeValueAsString(createAdminDTO)))
         .andExpect(status().isInternalServerError())
         .andReturn();
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void createNewAgencyAdmin_Should_returnForbidden_When_tenantAdminTargetsForeignTenant()
+      throws Exception {
+    // given a tenant admin of tenant 95 posting an agency admin for tenant 7
+    CreateAdminDTO createAdminDTO = new EasyRandom().nextObject(CreateAdminDTO.class);
+    createAdminDTO.setEmail("agencyadmin@email.com");
+    createAdminDTO.setTenantId(7);
+    givenTenant();
+    givenTenantSuperAdmin();
+    givenCallerBelongsToTenant(95L);
+
+    // when, then
+    this.mockMvc
+        .perform(
+            post(AGENCY_ADMIN_PATH)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createAdminDTO)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.USER_ADMIN})
+  void createNewAgencyAdmin_Should_returnOk_When_tenantAdminTargetsOwnTenant() throws Exception {
+    // given
+    CreateAdminDTO createAdminDTO = new EasyRandom().nextObject(CreateAdminDTO.class);
+    createAdminDTO.setEmail("agencyadmin@email.com");
+    createAdminDTO.setTenantId(95);
+    givenTenant();
+    givenTenantSuperAdmin();
+    givenCallerBelongsToTenant(95L);
+
+    // when, then
+    this.mockMvc
+        .perform(
+            post(AGENCY_ADMIN_PATH)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createAdminDTO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("_embedded.tenantId", is("95")));
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void createNewTenantAdmin_Should_returnForbidden_When_tenantAdminTargetsForeignTenant()
+      throws Exception {
+    // given a tenant admin of tenant 95 posting a tenant admin for tenant 7
+    CreateAdminDTO createAdminDTO = new EasyRandom().nextObject(CreateAdminDTO.class);
+    createAdminDTO.setEmail("tenantadmin@email.com");
+    createAdminDTO.setTenantId(7);
+    givenTenant();
+    givenCallerBelongsToTenant(95L);
+
+    // when, then
+    this.mockMvc
+        .perform(
+            post(TENANT_ADMIN_PATH)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createAdminDTO)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void createNewTenantAdmin_Should_returnOk_When_tenantAdminTargetsOwnTenant() throws Exception {
+    // given
+    CreateAdminDTO createAdminDTO = new EasyRandom().nextObject(CreateAdminDTO.class);
+    createAdminDTO.setEmail("tenantadmin@email.com");
+    createAdminDTO.setTenantId(95);
+    givenTenant();
+    givenCallerBelongsToTenant(95L);
+
+    // when, then
+    this.mockMvc
+        .perform(
+            post(TENANT_ADMIN_PATH)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createAdminDTO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("_embedded.tenantId", is("95")));
+  }
+
+  @Test
+  @WithMockUser(authorities = {AuthorityValue.TENANT_ADMIN})
+  void createNewTenantAdmin_Should_returnOk_When_platformAdminCreatesPlatformAdmin()
+      throws Exception {
+    // given
+    CreateAdminDTO createAdminDTO = new EasyRandom().nextObject(CreateAdminDTO.class);
+    createAdminDTO.setEmail("platformadmin@email.com");
+    createAdminDTO.setTenantId(0);
+    givenTenant();
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+
+    // when, then
+    this.mockMvc
+        .perform(
+            post(TENANT_ADMIN_PATH)
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createAdminDTO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("_embedded.tenantId", is("0")));
+  }
+
+  private void givenCallerBelongsToTenant(Long tenantId) {
+    when(authenticatedUser.getTenantId()).thenReturn(tenantId);
   }
 
   private void givenTenantSuperAdmin() {

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidatorTest.java
@@ -66,6 +66,11 @@ class AdminTenantOwnershipValidatorTest {
         .doesNotThrowAnyException();
   }
 
+  /**
+   * Tenant 0 is the technical tenant nobody belongs to, so a caller in that context is not bounded
+   * by this check — provisioning a tenant's admins from the platform context is established
+   * behaviour (see {@code CreateAdminServiceIT}, {@code UserAdminControllerE2EIT}).
+   */
   @Test
   void assertCallerMayCreateAdminForTenant_Should_Pass_When_CallerRunsInTechnicalTenantContext() {
     when(authenticatedUser.isPlatformAdmin()).thenReturn(false);

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidatorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/AdminTenantOwnershipValidatorTest.java
@@ -1,0 +1,101 @@
+package de.caritas.cob.userservice.api.admin.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTenantOwnershipValidatorTest {
+
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @Test
+  void
+      assertCallerMayCreateAdminForTenant_Should_Throw_When_TenantScopedCallerTargetsOtherTenant() {
+    lenient().when(authenticatedUser.getUserId()).thenReturn("caller-id");
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatThrownBy(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 7))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessage(AdminTenantOwnershipValidator.CROSS_TENANT_MESSAGE);
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_TenantScopedCallerTargetsOwnTenant() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 9))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_CallerIsPlatformAdmin() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 7))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_CallerIsPlatformAdminCreatingTenant0() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 0))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_CallerRunsInTechnicalTenantContext() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(0L);
+
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 7))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_CallerHasNoTenant() {
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(null);
+
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, 7))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void assertCallerMayCreateAdminForTenant_Should_Pass_When_NoTenantIdWasRequested() {
+    assertThatCode(
+            () ->
+                AdminTenantOwnershipValidator.assertCallerMayCreateAdminForTenant(
+                    authenticatedUser, null))
+        .doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/TenantAdminUserServiceTest.java
@@ -102,6 +102,56 @@ class TenantAdminUserServiceTest {
   }
 
   @Test
+  void createNewTenantAdmin_Should_RejectForeignTenantId_WhenCallerIsTenantScoped() {
+    // given a tenant admin of tenant 9 trying to create an admin record for tenant 7
+    CreateAdminDTO createAdminDTO = new CreateAdminDTO();
+    createAdminDTO.setTenantId(7);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    // when, then
+    assertThatThrownBy(() -> tenantAdminUserService.createNewTenantAdmin(createAdminDTO))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessage("Admin accounts can only be created for the tenant of the calling admin");
+    Mockito.verifyNoInteractions(createAdminService);
+  }
+
+  @Test
+  void createNewTenantAdmin_Should_AllowOwnTenantId_WhenCallerIsTenantScoped() {
+    // given
+    CreateAdminDTO createAdminDTO = new CreateAdminDTO();
+    createAdminDTO.setTenantId(9);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    when(createAdminService.createNewTenantAdmin(createAdminDTO))
+        .thenReturn(tenantAdmin("tenant-admin-9", 9L));
+
+    // when
+    AdminResponseDTO response = tenantAdminUserService.createNewTenantAdmin(createAdminDTO);
+
+    // then
+    Mockito.verify(createAdminService).createNewTenantAdmin(createAdminDTO);
+    assertThat(response.getEmbedded().getTenantId()).isEqualTo("9");
+  }
+
+  @Test
+  void createNewTenantAdmin_Should_AllowForeignTenantId_WhenCallerIsPlatformAdmin() {
+    // given
+    CreateAdminDTO createAdminDTO = new CreateAdminDTO();
+    createAdminDTO.setTenantId(7);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    when(createAdminService.createNewTenantAdmin(createAdminDTO))
+        .thenReturn(tenantAdmin("tenant-admin-7", 7L));
+
+    // when
+    AdminResponseDTO response = tenantAdminUserService.createNewTenantAdmin(createAdminDTO);
+
+    // then
+    Mockito.verify(createAdminService).createNewTenantAdmin(createAdminDTO);
+    assertThat(response.getEmbedded().getTenantId()).isEqualTo("7");
+  }
+
+  @Test
   void updateTenantAdmin_Should_UpdateTenantAndEnrichResponseWithTenantSubdomain() {
     // given
     EasyRandom random = new EasyRandom();

--- a/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/admin/service/admin/create/CreateAdminServiceTest.java
@@ -10,13 +10,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateAdminDTO;
 import de.caritas.cob.userservice.api.admin.service.consultant.validation.UserAccountInputValidator;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
@@ -117,5 +120,77 @@ class CreateAdminServiceTest {
     assertThat(exception.getCustomHttpHeaders().getFirst("X-Reason"))
         .isEqualTo(HttpStatusExceptionReason.ROLE_NOT_FOUND.name());
     verify(identityAccountRemover).rollbackUser("kc-user-id");
+  }
+
+  @Test
+  void createNewAgencyAdmin_Should_RejectForeignTenantId_WhenCallerIsTenantScoped() {
+    // given a tenant admin of tenant 9 trying to create an agency admin for tenant 7
+    ReflectionTestUtils.setField(createAdminService, "multiTenancyEnabled", true);
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+
+    CreateAdminDTO createAdminDTO = givenValidCreateAdminDTO(7);
+
+    // when, then
+    ForbiddenException exception =
+        assertThrows(
+            ForbiddenException.class,
+            () -> createAdminService.createNewAgencyAdmin(createAdminDTO));
+
+    assertThat(exception.getMessage())
+        .isEqualTo("Admin accounts can only be created for the tenant of the calling admin");
+    verifyNoInteractions(identityClient);
+    verifyNoInteractions(adminRepository);
+  }
+
+  @Test
+  void createNewAgencyAdmin_Should_KeepOwnTenantId_WhenCallerIsTenantScoped() {
+    // given
+    ReflectionTestUtils.setField(createAdminService, "multiTenancyEnabled", true);
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.getTenantId()).thenReturn(9L);
+    givenKeycloakCreatesUser();
+
+    CreateAdminDTO createAdminDTO = givenValidCreateAdminDTO(9);
+
+    // when
+    Admin admin = createAdminService.createNewAgencyAdmin(createAdminDTO);
+
+    // then
+    assertThat(admin.getTenantId()).isEqualTo(9L);
+    verify(identityAccountRemover, never()).rollbackUser(anyString());
+  }
+
+  @Test
+  void createNewAgencyAdmin_Should_AllowForeignTenantId_WhenCallerIsPlatformAdmin() {
+    // given
+    ReflectionTestUtils.setField(createAdminService, "multiTenancyEnabled", true);
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    when(authenticatedUser.isPlatformAdmin()).thenReturn(true);
+    givenKeycloakCreatesUser();
+
+    CreateAdminDTO createAdminDTO = givenValidCreateAdminDTO(7);
+
+    // when
+    Admin admin = createAdminService.createNewAgencyAdmin(createAdminDTO);
+
+    // then
+    assertThat(admin.getTenantId()).isEqualTo(7L);
+  }
+
+  private CreateAdminDTO givenValidCreateAdminDTO(Integer tenantId) {
+    CreateAdminDTO createAdminDTO = easyRandom.nextObject(CreateAdminDTO.class);
+    createAdminDTO.setUsername("valid_username");
+    createAdminDTO.setEmail("valid@email.com");
+    createAdminDTO.setTenantId(tenantId);
+    return createAdminDTO;
+  }
+
+  private void givenKeycloakCreatesUser() {
+    CreatedIdentity keycloakResponse = new CreatedIdentity();
+    keycloakResponse.setUserId("kc-user-id");
+    when(identityClient.createUser(any(), anyString(), anyString())).thenReturn(keycloakResponse);
+    when(adminRepository.save(any(Admin.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
   }
 }


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-UserService#1097

Refs OpenResilienceInitiative/ORISO-Admin#902 — frontend companion, depends on this landing.

## What was wrong

Both admin-creating endpoints took the target tenant straight out of the request body and never compared it with the tenant of the caller:

- `TenantAdminUserService.validateTenantId()` rejected only `tenantId == null` and `tenantId == 0`. Any `tenantId > 0` passed untouched and `CreateAdminService.createNewTenantAdmin` persisted it as given.
- `CreateAdminService.setTenantIdForMultiTenancy()` looked safer but was not: its guard branch triggers on `AuthenticatedUser.isTenantSuperAdmin()`, which is a pure role check with no tenant comparison. **Every** tenant admin holds `tenant-admin`, so the "coerce to the caller's own tenant" branch never ran for them.

A tenant admin of tenant 9 could therefore `POST /useradmin/tenantadmins` or `POST /useradmin/agencyadmins` with `"tenantId": 7` and get an admin account persisted into a foreign tenant.

No other layer caught it: the Hibernate `@Filter(tenantFilter)` on `Admin` is SELECT-only, `TenantHibernateInterceptor.preFlush` only backfills a **null** tenant id and never overwrites a caller-supplied one, `UserAccountInputValidator.validateUserDTO` checks email/username only, there is no `@PreAuthorize` on the controller and no DB constraint on `admin.tenant_id`.

## The fix

New `AdminTenantOwnershipValidator` (write-side counterpart of the read-side scoping in `AgencyAdminUserService.findScopedAgencyAdminsByInfix`), called from both create paths:

- `TenantAdminUserService.validateCreateAdmin` — tenant-admin creation
- `CreateAdminService.setTenantIdForMultiTenancy` — agency-admin creation

The caller's tenant comes from the authenticated principal, i.e. the Keycloak `tenantId` claim that `TenantResolverService` already derives the request context from — a tenant-scoped caller can neither omit nor influence it. A mismatch is a `ForbiddenException` (403) with a `log.warn`, mirroring `assertCallerMayAccessAgencyAdmin`.

Deliberately unchanged:

- **Platform admins** (`isPlatformAdmin()`: tenant 0 + agency-super-admin + tenant-admin) may still target any tenant, including creating `tenantId: 0` platform-admin accounts.
- The **technical/platform tenant context** (caller tenant `0`) and single-tenant deployments (no caller tenant) are not restricted — there is no tenant boundary to cross.
- The **invite-based tenant-admin onboarding** flow (`TenantAdminOnboardingService.registerTenantAdmin`) calls `CreateAdminService.createNewTenantAdmin` directly, which reaches neither call site, so unauthenticated onboarding with a reserved tenant id keeps working.
- Restricted agency admins (no `tenant-admin` role) keep the existing behaviour of having their tenant id coerced to the request context; they were already unable to cross a tenant boundary.

## Verification

**TDD, red first.** The regression tests were written and confirmed failing against the current `pre-dev` code before the fix existed. Proof at the HTTP layer (`UserAdminControllerMultiTenancyTrueE2EIT`, real Spring Security + MockMvc + DB), with only the two production call sites stashed:

```
before  createNewAgencyAdmin_Should_returnForbidden_When_tenantAdminTargetsForeignTenant  Status expected:<403> but was:<200>
before  createNewTenantAdmin_Should_returnForbidden_When_tenantAdminTargetsForeignTenant  Status expected:<403> but was:<200>
after   Tests run: 7, Failures: 0, Errors: 0
```

**Full suite green** on this branch — `./mvnw -B verify` (Java 21) → `BUILD SUCCESS`, `Tests run: 4183, Failures: 0, Errors: 0, Skipped: 0` (unit) and `Tests run: 915, Failures: 0, Errors: 0, Skipped: 15` (integration). The 15 skips are the pre-existing MariaDB/Redis-backed ITs that self-skip when those services are not provided locally; unrelated to this change.

**Proven on a locally running server**, not only in tests. Local Docker stack (`_local-stack`, fast-track profile: MariaDB + Keycloak + TenantService + this branch's UserService image), driven with **real Keycloak-issued tokens**: a `tenantadmin2` account with JWT claim `tenantId: 2` and the realm roles `tenant-admin` / `agency-admin` / `user-admin` — exactly the caller profile from the issue — plus `chucknorris` (`tenantId: 0`, platform admin).

The same script was run twice against the same stack, swapping only the UserService image — once on a build of `origin/pre-dev` (`0273cd8e`, the bug) and once on this branch:

| Request as `tenantadmin2` (JWT `tenantId: 2`) | `pre-dev` baseline | this branch |
| --- | --- | --- |
| `POST /useradmin/tenantadmins` `tenantId: 3` (foreign) | **200 OK** | **403** |
| `POST /useradmin/tenantadmins` `tenantId: 2` (own) | 200 OK | 200 OK |
| `POST /useradmin/agencyadmins` `tenantId: 3` (foreign) | **200 OK** | **403** |
| `POST /useradmin/agencyadmins` `tenantId: 2` (own) | 200 OK | 200 OK |
| as platform admin: `tenantadmins` `tenantId: 0` | 200 OK | 200 OK |
| as platform admin: `tenantadmins` `tenantId: 3` | 200 OK | 200 OK |

On the baseline the cross-tenant rows really are persisted into the foreign tenant — this is the vulnerability, reproduced:

```
admin_id                              username         type    tenant_id
70b41af9-d5f2-4844-98c5-8e3858d90145  proofXTenant...  TENANT  3     <- created by the tenant-2 admin
e4459eb2-f147-40f1-b905-c0e14d1a177d  proofXAgency...  AGENCY  3     <- created by the tenant-2 admin
17574d13-72ba-4cef-847b-349938914ce6  proofOwnTenant.. TENANT  2
```

On this branch no such row is written, and the `403`s are the new ownership check, confirmed in the service log:

```
Admin cac5797c-86a1-4d0e-8930-15662545b247 of tenant 2 attempted to create an admin account for tenant 3
```

This was **not** run against the Pre-Dev server, so nothing was swapped there and nothing needs restoring.

### Reviewer test plan

- [ ] Log into the Admin panel as a tenant admin of tenant A and create a new tenant admin for **your own** tenant → the account is created exactly as before
- [ ] As the same tenant admin, `POST /useradmin/tenantadmins` with a `tenantId` of a **different** tenant (e.g. via curl or devtools) → 403 Forbidden, no admin row and no Keycloak user is created
- [ ] Repeat both checks against `POST /useradmin/agencyadmins` → same result: own tenant succeeds, foreign tenant is rejected
- [ ] As a platform admin (tenant 0), create a platform-admin account with `tenantId: 0` → still works unchanged
- [ ] As a platform admin, create a tenant admin for some other tenant → still allowed (platform admins administer every tenant)
- [ ] Claim a tenant-admin invite link end to end (onboarding registration for a freshly reserved tenant) → still completes; the ownership check must not touch that flow
- [ ] As a restricted agency admin (Beratungsstellen-Admin, no `tenant-admin` role), create an agency admin → unchanged, the new admin lands in your own tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant ownership checks when creating administrators.
  * Tenant-scoped administrators can create admins only within their own tenant.
  * Platform administrators and eligible tenantless callers can create admins across tenants.

* **Bug Fixes**
  * Cross-tenant administrator creation attempts are now rejected with `403 Forbidden`.

* **Tests**
  * Added coverage for same-tenant, cross-tenant, platform-admin, and tenantless creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->