### PR TITLE
Fix live chat session data lazy loading

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -657,6 +657,7 @@ public class SessionService {
    * fallback the open path uses so a visible request can always be opened; it never widens access
    * to registered sessions.
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getVisibleAnonymousLiveChatEnquiriesByIds(
       Consultant consultant, Set<Long> sessionIds) {
     if (!isNotEmpty(sessionIds)) {
@@ -690,6 +691,7 @@ public class SessionService {
    * never widens access by agency or topic, and it does not change the session's tenant ownership
    * (the asker keeps seeing their own chat).
    */
+  @Transactional(readOnly = true)
   public List<ConsultantSessionResponseDTO> getDirectlyAssignedSessionsByIdsCrossTenant(
       Consultant consultant, Set<Long> sessionIds) {
     if (!isNotEmpty(sessionIds)) {

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -76,6 +76,7 @@ import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.user.UserService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.testHelper.TestConstants;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -93,6 +94,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
@@ -1216,6 +1218,19 @@ class SessionServiceTest {
   }
 
   @Test
+  void getVisibleAnonymousLiveChatEnquiriesByIds_Should_RunReadOnlyTransactional()
+      throws Exception {
+    Method method =
+        SessionService.class.getMethod(
+            "getVisibleAnonymousLiveChatEnquiriesByIds", Consultant.class, Set.class);
+
+    Transactional transactional = method.getAnnotation(Transactional.class);
+
+    assertNotNull(transactional);
+    assertTrue(transactional.readOnly());
+  }
+
+  @Test
   void
       getDirectlyAssignedSessionsByIdsCrossTenant_Should_ReturnSession_When_ConsultantIsAssignedAdvisor() {
     Consultant consultant = mock(Consultant.class);
@@ -1229,6 +1244,19 @@ class SessionServiceTest {
         sessionService.getDirectlyAssignedSessionsByIdsCrossTenant(consultant, Set.of(103510L));
 
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void getDirectlyAssignedSessionsByIdsCrossTenant_Should_RunReadOnlyTransactional()
+      throws Exception {
+    Method method =
+        SessionService.class.getMethod(
+            "getDirectlyAssignedSessionsByIdsCrossTenant", Consultant.class, Set.class);
+
+    Transactional transactional = method.getAnnotation(Transactional.class);
+
+    assertNotNull(transactional);
+    assertTrue(transactional.readOnly());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add read-only transactions around cross-tenant live-chat session open fallbacks so DTO mapping can read lazy sessionData safely.
- Add regression coverage that keeps both fallback methods transaction-scoped.

## Context
Dev logs showed LazyInitializationException while opening anonymous LIVE_CHAT sessions through UserSessionControllerDelegate -> SessionService.getVisibleAnonymousLiveChatEnquiriesByIds -> SessionMapper.buildSessionDataMapFromSession. The same vulnerable code path exists on pre-dev even though pre-dev data does not currently trigger it.

## Test
- ./mvnw -Dtest=SessionServiceTest test