### PR TITLE
fix(security): pin Tomcat 11.0.25 to clear three CRITICAL CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
 		<!-- Spring Boot 4.0.7 still manages HttpCore 5.3.6; 5.4.3 fixes
 		     CVE-2026-54399 and is compatible with the managed HttpClient 5.5.2. -->
 		<httpcore5.version>5.4.3</httpcore5.version>
+		<!-- Spring Boot 4.0.7 manages Tomcat 11.0.22; 4.0.8 and 4.1.1 still
+		     manage 11.0.24. The image CVE gate fails on three CRITICAL findings
+		     that are only fixed in 11.0.25: CVE-2026-65182 (security-constraint
+		     bypass), CVE-2026-65905 (DIGEST authenticator replay), CVE-2026-68525
+		     (FORM authentication bypass). A Boot upgrade does not remove the need
+		     for this override. Drop it once the Boot BOM manages >= 11.0.25. -->
+		<tomcat.version>11.0.25</tomcat.version>
 		<!-- Spring Boot 4.0.7 under-pins the RabbitMQ Java client at 5.27.1 (via
 		     spring-boot-starter-amqp -> spring-rabbit 4.0.4). 5.33.1 is the lowest
 		     version that clears all three HIGH findings of the image CVE gate:

--- a/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
@@ -14,4 +14,10 @@ class DependencySecurityContractTest {
     assertThat(Files.readString(Path.of("pom.xml")))
         .contains("<httpcore5.version>5.4.3</httpcore5.version>");
   }
+
+  @Test
+  void tomcatMustStayOnTheFixedEmbeddedRelease() throws IOException {
+    assertThat(Files.readString(Path.of("pom.xml")))
+        .contains("<tomcat.version>11.0.25</tomcat.version>");
+  }
 }


### PR DESCRIPTION
## Summary
- The [pre-dev Build and Publish run](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/33731698171/job/100576522647) failed at **Reject fixable high or critical image vulnerabilities** with 3 CRITICAL findings in `tomcat-embed-core` 11.0.22:
  - CVE-2026-65182 (security-constraint bypass)
  - CVE-2026-65905 (DIGEST authenticator replay)
  - CVE-2026-68525 (FORM authentication bypass)
- Override Spring Boot's `tomcat.version` to **11.0.25**, the lowest release that clears all three. Boot 4.0.8 and 4.1.1 still manage 11.0.24, so a Boot upgrade does not fix this.
- Add a source contract so the override cannot disappear silently.

## Test plan
- [ ] `./mvnw -q help:evaluate -Dexpression=tomcat.version -DforceStdout` prints `11.0.25`
- [ ] `./mvnw -DskipTests -DskipITs dependency:tree -Dincludes=org.apache.tomcat.embed` shows `tomcat-embed-core/websocket/el` 11.0.25
- [ ] `./mvnw -DskipITs -Dtest=DependencySecurityContractTest test` is green
- [ ] After merge, the pre-dev **test, build and publish image** job passes the Trivy gate


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Updated the embedded Tomcat version to 11.0.25 to address three critical security vulnerabilities and help images pass security checks.

* **Tests**
  * Added a safeguard test to ensure the fixed Tomcat version remains pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->