### PR TITLE
chore(cursor): target agent PRs at origin/dev

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,79 @@
+# Cursor agent README (this repo)
+
+How to run tickets in Cursor. Superpowers is **optional**: use it when installed; otherwise use the skills under `.cursor/skills/`. PRs target **`dev`**. Never commit on `dev`.
+
+## Commands (slash / attach)
+
+In Cursor chat you can type `/` and pick a skill, or `@` a file/folder.
+
+| You type or attach | When |
+| --- | --- |
+| Paste a GitHub issue URL | Start from a real ticket |
+| `/goal-loop` | Iterate until acceptance criteria pass |
+| `/using-superpowers` | Prefer Superpowers method (only if the plugin is installed) |
+| `@AGENTS.md` | Force the agent to use this repo’s test commands |
+| `@.cursor/README.md` | Re-read these prompts |
+
+Branch: `cursor/<issue-number>/<short-slug>` from `origin/dev`. Link the issue in the PR (`Refs #<n>` or `Closes #<n>`).
+
+## Always name the issue
+
+Start every prompt with the issue URL or `OpenResilienceInitiative/<this-repo>#<n>`. One parent issue per effort. If the change spans repos, still use that issue as the anchor and comment each PR on it.
+
+## Demo — small feature or bug (one repo)
+
+```text
+Issue: https://github.com/OpenResilienceInitiative/<this-repo>/issues/<n>
+
+Small change. Branch from origin/dev. Do not commit on dev.
+
+Problem: <one sentence what is wrong today>
+Expected: <one sentence what the user should see>
+Out of scope: <anything we are not doing>
+
+Use Superpowers if installed; otherwise problem-intake → failing test → fix → verify.
+Run the repo checks from AGENTS.md. Open a PR against dev. Then update the GitHub issue
+with proof (commands + screenshot or log snippet + PR link).
+```
+
+## Demo — large feature (plan first, then implement)
+
+```text
+Issue: https://github.com/OpenResilienceInitiative/<this-repo>/issues/<n>
+
+Large feature. Do not skip planning.
+
+1. Summarize the issue: current vs expected user-visible behavior, acceptance criteria.
+2. If anything is unclear about users, data, permissions, or APIs, ask before coding.
+3. If Superpowers is installed: brainstorming then writing-plans. If not: spike-doc then
+   task-implementation-doc under docs/agent-tasks/YYYY-MM-DD_short-name/.
+4. Implement with TDD (RED → GREEN → REFACTOR). One behavior at a time.
+5. Verify with AGENTS.md commands. PR against origin/dev. Do not merge.
+6. Update the GitHub issue with the proof template below and attach screenshots.
+```
+
+## After the feature — update the issue (required)
+
+Post a comment on the **parent GitHub issue** (not only in Slack/chat). Attach screenshots or log files in that comment. Include actual commands, not “tests passed”.
+
+```markdown
+### Status
+Done for this repo / blocked / in review — PR: <url>
+
+### What changed
+<2–4 bullets, user language>
+
+### User-visible behavior
+Before: …
+After: …
+
+### Proof
+- Command: `<exact command>` → pass (counts or one-line result)
+- Screenshot / recording: <attached>
+- PR: <url> (base `dev`)
+
+### Risks / follow-up
+<none, or what is still open>
+```
+
+Also comment the PR link on the issue when you open the PR (`Frontend part: <url>`).

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -48,7 +48,7 @@ Large feature. Do not skip planning.
 3. If Superpowers is installed: brainstorming then writing-plans. If not: spike-doc then
    task-implementation-doc under docs/agent-tasks/YYYY-MM-DD_short-name/.
 4. Implement with TDD (RED → GREEN → REFACTOR). One behavior at a time.
-5. Verify with AGENTS.md commands. PR against origin/dev. Do not merge.
+5. Verify with AGENTS.md commands. PR against `dev`. Do not merge.
 6. Update the GitHub issue with the proof template below and attach screenshots.
 ```
 

--- a/.cursor/agents/codebase-explorer.md
+++ b/.cursor/agents/codebase-explorer.md
@@ -1,0 +1,15 @@
+---
+name: codebase-explorer
+description: Use for broad codebase exploration - finding where behavior lives, mapping call sites, or surveying patterns across many files. Keeps noisy search output out of the main context.
+model: inherit
+readonly: true
+---
+
+You explore this ORISO repository and return compact, high-signal answers.
+
+When invoked:
+
+1. Start from `.understand-anything/` when present, then targeted search.
+2. Answer the specific question asked; do not survey the whole repo.
+3. Return only relevant file paths with one-line notes.
+4. Never return long file dumps.

--- a/.cursor/agents/planner.md
+++ b/.cursor/agents/planner.md
@@ -1,0 +1,19 @@
+---
+name: planner
+description: Use proactively for complex features, unclear requirements, architecture work, or multi-file changes. Produces spike and implementation plan documents before coding. Never writes code.
+model: inherit
+readonly: true
+---
+
+You produce implementation plans, not code changes, for this ORISO Java service.
+
+When invoked:
+
+1. Read the problem brief (`00-problem-brief.md` in the task folder) and the existing implementation. Skim `.understand-anything/ARCHITECTURE.md` before raw files.
+2. Identify affected modules, existing patterns to reuse, risks, dependencies, and unknowns.
+3. Produce content for `01-spike.md` and `02-implementation-plan.md` (subtask table with per-subtask verify commands).
+4. Every subtask must be small enough for one focused loop iteration and have a concrete verification command (`./mvnw -B test` scoped when possible).
+5. If requirements are incomplete, list only the smallest set of blocking questions.
+6. Respect ORISO invariants: branch from `dev`, reuse existing controllers/DTOs/OpenAPI, do not invent APIs.
+
+Keep output concise, actionable, and file-oriented. No narrative essays.

--- a/.cursor/agents/security-auditor.md
+++ b/.cursor/agents/security-auditor.md
@@ -5,11 +5,13 @@ model: inherit
 readonly: true
 ---
 
-You audit only the touched scope of the current change. Ignore unrelated files.
+# Security auditor
+
+You audit only the touched scope of the current change. Ignore unrelated files. Do not edit files or run state-changing commands.
 
 When invoked:
 
 1. Identify changed trust boundaries from the diff.
 2. Review validation, authorization, secrets, injection, and data exposure.
 3. Classify findings by severity and prefer the least disruptive safe fix.
-4. Record `05-security-review.md` in the task folder when this subagent ran.
+4. Return the full `05-security-review.md` body to the parent. The parent workflow must persist that file in the task folder.

--- a/.cursor/agents/security-auditor.md
+++ b/.cursor/agents/security-auditor.md
@@ -1,0 +1,15 @@
+---
+name: security-auditor
+description: Use proactively when changes touch auth, permissions, secrets, input handling, network requests, file uploads, or storage of sensitive data. Audits only the touched scope.
+model: inherit
+readonly: true
+---
+
+You audit only the touched scope of the current change. Ignore unrelated files.
+
+When invoked:
+
+1. Identify changed trust boundaries from the diff.
+2. Review validation, authorization, secrets, injection, and data exposure.
+3. Classify findings by severity and prefer the least disruptive safe fix.
+4. Record `05-security-review.md` in the task folder when this subagent ran.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -5,11 +5,13 @@ model: inherit
 readonly: true
 ---
 
+# Verifier
+
 You are the independent verifier for this ORISO Java service. You did not write this code; judge it on evidence.
 
 When invoked:
 
-1. Read `02-implementation-plan.md` and `00-problem-brief.md`.
-2. Diff the changed files against the plan; flag scope creep.
-3. Run `./mvnw -B test` for touched modules, then package if the plan requires it.
+1. Read `00-problem-brief.md`. Read `02-implementation-plan.md` only when it exists (trivial tasks have no plan).
+2. If the plan exists, diff the changed files against it and flag scope creep. Otherwise use the brief and the diff.
+3. Do not run Maven yourself (`readonly` blocks `target/` writes). The parent workflow must run `./mvnw -B test` and, for PR-bound work, `./mvnw -B package -DskipTests`, then pass that output here. Do not mark PR-ready without that evidence.
 4. Report verified/unverified work, risks, and PR-ready vs blockers.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,0 +1,15 @@
+---
+name: verifier
+description: Use proactively after implementation for independent validation - checks changed files against the plan, runs targeted tests, and judges whether the task is PR-ready.
+model: inherit
+readonly: true
+---
+
+You are the independent verifier for this ORISO Java service. You did not write this code; judge it on evidence.
+
+When invoked:
+
+1. Read `02-implementation-plan.md` and `00-problem-brief.md`.
+2. Diff the changed files against the plan; flag scope creep.
+3. Run `./mvnw -B test` for touched modules, then package if the plan requires it.
+4. Report verified/unverified work, risks, and PR-ready vs blockers.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,19 @@
+{
+	"version": 1,
+	"hooks": {
+		"beforeShellExecution": [
+			{
+				"command": "bash .cursor/hooks/guard-destructive.sh",
+				"timeout": 10,
+				"failClosed": true
+			}
+		],
+		"beforeReadFile": [
+			{
+				"command": "bash .cursor/hooks/guard-secrets-read.sh",
+				"timeout": 10,
+				"failClosed": true
+			}
+		]
+	}
+}

--- a/.cursor/hooks/guard-destructive.sh
+++ b/.cursor/hooks/guard-destructive.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# beforeShellExecution: ask on narrowly matched destructive commands.
+# stdin: hook JSON; stdout: permission JSON. Requires jq.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Safety hook requires jq","agent_message":"Install jq; destructive-command guard could not parse input."}'
+  exit 0
+fi
+
+input="$(cat || true)"
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Malformed hook input","agent_message":"beforeShellExecution input was not valid JSON."}'
+  exit 0
+fi
+
+command="$(printf '%s' "$input" | jq -r '.command // empty')"
+if [[ -z "$command" ]]; then
+  printf '%s\n' '{"permission":"allow"}'
+  exit 0
+fi
+
+patterns=(
+  'rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)'
+  'git[[:space:]]+push[[:space:]].*(--force([^-]|$)|[[:space:]]-f([[:space:]]|$))'
+  'git[[:space:]]+reset[[:space:]].*--hard'
+  'git[[:space:]]+clean[[:space:]].*-[a-zA-Z]*f'
+  'git[[:space:]]+branch[[:space:]].*-D[[:space:]]'
+  'DROP[[:space:]]+(TABLE|DATABASE|SCHEMA)'
+  'drop[[:space:]]+(table|database|schema)'
+  'terraform[[:space:]]+destroy'
+  'kubectl[[:space:]]+delete'
+  'docker[[:space:]]+(system|volume)[[:space:]]+prune'
+  'chmod[[:space:]]+-R[[:space:]]+777'
+  'mkfs\.'
+  '>([[:space:]]*)/dev/(sd|disk|nvme)'
+)
+
+for p in "${patterns[@]}"; do
+  if [[ "$command" =~ $p ]]; then
+    jq -n --arg cmd "$command" '{
+      permission: "ask",
+      user_message: ("Potentially destructive command flagged by safety hook — review before running:\n" + $cmd),
+      agent_message: "A safety hook flagged this command as potentially destructive. It requires explicit user approval. Do not bypass by rephrasing."
+    }'
+    exit 0
+  fi
+done
+
+printf '%s\n' '{"permission":"allow"}'
+exit 0

--- a/.cursor/hooks/guard-secrets-read.sh
+++ b/.cursor/hooks/guard-secrets-read.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# beforeReadFile: deny known secret / private-key paths.
+# stdin: hook JSON; stdout: { permission: allow|deny, ... }. Requires jq.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Secret-path guard requires jq"}'
+  exit 0
+fi
+
+input="$(cat || true)"
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf '%s\n' '{"permission":"deny","user_message":"Malformed beforeReadFile input"}'
+  exit 0
+fi
+
+file_path="$(printf '%s' "$input" | jq -r '.file_path // empty')"
+if [[ -z "$file_path" ]]; then
+  printf '%s\n' '{"permission":"allow"}'
+  exit 0
+fi
+
+base="$(basename "$file_path")"
+lower="$(printf '%s' "$file_path" | tr '[:upper:]' '[:lower:]')"
+
+is_example=0
+if [[ "$base" == *.example || "$base" == *.sample || "$base" == *.template || "$base" == *.example.* ]]; then
+  is_example=1
+fi
+
+deny=0
+
+if [[ "$is_example" -eq 0 ]]; then
+  if [[ "$base" == ".env" || "$base" == .env.* || "$base" == *.secrets.env || "$base" == "config.env" ]]; then
+    deny=1
+  fi
+fi
+
+if [[ "$base" == *.pem || "$base" == *.key || "$base" == "id_rsa" || "$base" == "id_ed25519" ]]; then
+  deny=1
+fi
+
+if [[ "$base" == realm.json.backup* || "$lower" == *"/backup/"*realm* ]]; then
+  deny=1
+fi
+
+if [[ "$deny" -eq 1 ]]; then
+  jq -n --arg p "$file_path" '{
+    permission: "deny",
+    user_message: ("Blocked read of sensitive path: " + $p),
+    agent_message: "Do not read secret or private-key files. Use *.example templates or ask the user to provide redacted values."
+  }'
+  exit 0
+fi
+
+printf '%s\n' '{"permission":"allow"}'
+exit 0

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,13 @@
+---
+description: Branch discipline and safe git operations for ORISO feature work
+alwaysApply: true
+---
+
+# Git Workflow
+
+- Inspect `git status` before starting implementation.
+- Never implement directly on `dev`. Branch from `dev` first: `cursor/<ticket-or-feature>/<short-slug>`.
+- If the working tree is dirty with unrelated changes, ask before any fetch/rebase/reset/checkout that could touch them.
+- Commit only when the user asks. Keep the diff coherent — no drive-by edits to unrelated files.
+- Compare PRs against `origin/dev`.
+- Never force-push, hard-reset, or rewrite pushed history without an explicit user request.

--- a/.cursor/rules/orchestrator-core.mdc
+++ b/.cursor/rules/orchestrator-core.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 Before coding, classify the task:
 
 - **Trivial** (one file, no new behavior, no UI/security impact): just do it, no docs required.
-- **Non-trivial** (anything else): Superpowers is required (see `superpowers-workflow.mdc`). If the plugin is missing, stop and ask for `/add-plugin superpowers`. Then follow the goal-loop trail — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only).
+- **Non-trivial** (anything else): follow the goal-loop trail — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. If Superpowers is installed, use it as well (see `superpowers-workflow.mdc`); if it is not, continue with these repo skills. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only). Demo prompts and issue-update steps: `.cursor/README.md`.
 
 When the user says "loop" or asks to iterate until done, use the `goal-loop` skill.
 

--- a/.cursor/rules/orchestrator-core.mdc
+++ b/.cursor/rules/orchestrator-core.mdc
@@ -1,0 +1,41 @@
+---
+description: Task orchestration - triage, documentation trail, loop discipline, and approval gates
+alwaysApply: true
+---
+
+# Orchestrator Core
+
+## Triage first
+
+Before coding, classify the task:
+
+- **Trivial** (one file, no new behavior, no UI/security impact): just do it, no docs required.
+- **Non-trivial** (anything else): follow the goal-loop workflow — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only).
+
+When the user says "loop" or asks to iterate until done, use the `goal-loop` skill.
+
+## Context discipline
+
+- Prefer file references over copying content into docs or chat.
+- Delegate broad codebase searches to the `codebase-explorer` subagent or Explore; keep raw results out of the main context.
+- Summarize long logs and long source documents; never paste them.
+- Keep every orchestrator doc concise and implementation-oriented.
+
+## Delegation
+
+- `planner` subagent: spikes and implementation plans for complex/ambiguous work.
+- `verifier` subagent: independent post-implementation validation.
+- `security-auditor` subagent: touched-scope security review when auth, input handling, storage, network, or privacy boundaries change.
+- Browser: UI verification for frontend changes.
+
+## Approval gates — always stop and ask before
+
+- using credentials or tokens
+- configuring external services
+- destructive commands (reset, force push, rm of tracked files)
+- opening, updating, or merging a PR
+- installing marketplace skills or third-party tools
+
+## Learnings
+
+After a task that involved a wrong assumption, a repeated failure, or a correction from the user, append one short entry to `.learnings/LEARNINGS.md` (or `.learnings/ERRORS.md` for bugs in our process). One concept per entry. Promote a lesson to AGENTS.md only if it applies to most future tasks.

--- a/.cursor/rules/orchestrator-core.mdc
+++ b/.cursor/rules/orchestrator-core.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 Before coding, classify the task:
 
 - **Trivial** (one file, no new behavior, no UI/security impact): just do it, no docs required.
-- **Non-trivial** (anything else): follow the goal-loop workflow — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only).
+- **Non-trivial** (anything else): Superpowers is required (see `superpowers-workflow.mdc`). If the plugin is missing, stop and ask for `/add-plugin superpowers`. Then follow the goal-loop trail — `problem-intake` → `spike-doc` → `task-implementation-doc` → iterate think/implement/verify → `regression-check` → `pr-prep`. Artifacts go in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only).
 
 When the user says "loop" or asks to iterate until done, use the `goal-loop` skill.
 

--- a/.cursor/rules/security-review.mdc
+++ b/.cursor/rules/security-review.mdc
@@ -9,4 +9,4 @@ alwaysApply: false
 - Trigger a security pass (via the `security-auditor` subagent) when a change touches: authentication or authorization, user input handling, secrets or tokens, network requests to new endpoints, file uploads, localStorage/sessionStorage of sensitive data, or Matrix/chat/draft privacy boundaries.
 - ORISO-specific invariant: plaintext message previews and draft contents must never move into server-visible state.
 - Classify findings by severity (critical/high/medium/low) and prefer the least disruptive safe fix.
-- Record the outcome in the task folder as `05-security-review.md`, even if the result is "no findings".
+- The `security-auditor` subagent is readonly: it returns the `05-security-review.md` body. The parent workflow must persist that file in the task folder, even if the result is "no findings".

--- a/.cursor/rules/security-review.mdc
+++ b/.cursor/rules/security-review.mdc
@@ -1,0 +1,12 @@
+---
+description: Scope-limited security review policy for changes touching auth, input handling, storage, network, uploads, or Matrix/chat privacy boundaries
+alwaysApply: false
+---
+
+# Security Review
+
+- Review only the touched scope; do not audit unrelated files.
+- Trigger a security pass (via the `security-auditor` subagent) when a change touches: authentication or authorization, user input handling, secrets or tokens, network requests to new endpoints, file uploads, localStorage/sessionStorage of sensitive data, or Matrix/chat/draft privacy boundaries.
+- ORISO-specific invariant: plaintext message previews and draft contents must never move into server-visible state.
+- Classify findings by severity (critical/high/medium/low) and prefer the least disruptive safe fix.
+- Record the outcome in the task folder as `05-security-review.md`, even if the result is "no findings".

--- a/.cursor/rules/superpowers-workflow.mdc
+++ b/.cursor/rules/superpowers-workflow.mdc
@@ -1,0 +1,25 @@
+---
+description: Superpowers is required for tickets, bugs, PR review, and ticket updates
+alwaysApply: true
+---
+
+# Superpowers workflow
+
+Required for ticket implementation, bug fixes, PR review, and ticket updates.
+
+**Install (other developers):** in Cursor run `/add-plugin superpowers`, or Settings → Plugins → Superpowers → Install, then reload. This repo cannot install the plugin for you.
+
+If any of these skills are missing, STOP. Tell the human to install Superpowers. Do not pretend a missing skill exists: `brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `receiving-code-review`, `verification-before-completion`, `finishing-a-development-branch`.
+
+Use this order (do not skip TDD or verification):
+
+1. `brainstorming` — expected behavior; get approval before coding
+2. `writing-plans` — small steps, each with a test cycle
+3. `systematic-debugging` — bugs and unexpected failures only; root cause first
+4. `test-driven-development` — RED → GREEN → REFACTOR
+5. `requesting-code-review` — independent review of the artifact
+6. `receiving-code-review` — evaluate feedback; do not rubber-stamp
+7. `verification-before-completion` — fresh command evidence before “done”
+8. `finishing-a-development-branch` — PR options; never merge unless the human names that PR
+
+ORISO overlays (win on conflict): branch from `origin/dev`; compare PRs to `origin/dev`; use `AGENTS.md` test commands; `problem-intake` / `goal-loop` / `pr-prep` still write the task folder. Never copy Superpowers plugin files into git.

--- a/.cursor/rules/superpowers-workflow.mdc
+++ b/.cursor/rules/superpowers-workflow.mdc
@@ -1,17 +1,15 @@
 ---
-description: Superpowers is required for tickets, bugs, PR review, and ticket updates
+description: Prefer Superpowers when installed; continue with ORISO skills if not
 alwaysApply: true
 ---
 
 # Superpowers workflow
 
-Required for ticket implementation, bug fixes, PR review, and ticket updates.
+**Not mandatory.** If Superpowers is installed, use it — it is the better method for tickets, bugs, PR review, and issue updates. If it is missing, **keep going** with this repo’s `problem-intake` / `goal-loop` / `pr-prep` skills. Do not block the human or fake missing plugin skills.
 
-**Install (other developers):** in Cursor run `/add-plugin superpowers`, or Settings → Plugins → Superpowers → Install, then reload. This repo cannot install the plugin for you.
+**Optional install:** `/add-plugin superpowers`, or Settings → Plugins → Superpowers → Install, then reload.
 
-If any of these skills are missing, STOP. Tell the human to install Superpowers. Do not pretend a missing skill exists: `brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `receiving-code-review`, `verification-before-completion`, `finishing-a-development-branch`.
-
-Use this order (do not skip TDD or verification):
+When Superpowers **is** available, prefer this order:
 
 1. `brainstorming` — expected behavior; get approval before coding
 2. `writing-plans` — small steps, each with a test cycle
@@ -22,4 +20,4 @@ Use this order (do not skip TDD or verification):
 7. `verification-before-completion` — fresh command evidence before “done”
 8. `finishing-a-development-branch` — PR options; never merge unless the human names that PR
 
-ORISO overlays (win on conflict): branch from `origin/dev`; compare PRs to `origin/dev`; use `AGENTS.md` test commands; `problem-intake` / `goal-loop` / `pr-prep` still write the task folder. Never copy Superpowers plugin files into git.
+ORISO overlays (always): branch from `origin/dev`; PRs target `dev`; use `AGENTS.md` test commands. After the PR, update the GitHub issue with proof (see `.cursor/README.md`). Never copy Superpowers plugin files into git.

--- a/.cursor/skills/goal-loop/SKILL.md
+++ b/.cursor/skills/goal-loop/SKILL.md
@@ -10,7 +10,7 @@ Run the whole loop in one turn. Do not stop between iterations to ask "shall I c
 ## Setup (once, before iteration 1)
 
 1. Normalize the goal with the `problem-intake` skill → `00-problem-brief.md`. The acceptance criteria in that brief are the loop's exit test. If the goal is one sentence, write criteria yourself from context; ask the user only for genuinely blocking unknowns.
-2. If non-trivial (more than one file, new behavior, UI, security, or unclear requirements): run the `planner` subagent → `01-spike.md` and `02-implementation-plan.md` (see `spike-doc` and `task-implementation-doc` skills).
+2. If non-trivial (more than one file, new behavior, UI, security, or unclear requirements): run the `planner` subagent (readonly). The parent workflow must write the returned `01-spike.md` and `02-implementation-plan.md` into the task folder before verification.
 3. Git: check `git status`; confirm with user if the tree is dirty. Branch from `dev` as `cursor/<ticket-or-feature>/<short-slug>`. Never implement on `dev`.
 4. Create `03-progress-log.md` with the iteration table (template below).
 
@@ -30,9 +30,8 @@ Repeat THINK → IMPLEMENT → VERIFY → DECIDE.
 
 **VERIFY**
 
-- Narrowest check first: the specific vitest file(s) for touched code, then `npm run lint:scripts` / `npm run lint:style` on style changes, `npm run build` only when imports/config/types changed broadly.
-- For UI changes, use Browser verification and save screenshots to the task folder.
-- Never paste long logs into the conversation; summarize failures in the progress log.
+- Run the current plan subtask’s `Verify with` command first. Default in this repo: `./mvnw -B test`.
+- Never paste long logs into the conversation; summarize failures in the progress log. Redact secrets, tokens, credentials, PII, and raw payloads before writing `03-progress-log.md`.
 
 **DECIDE**
 
@@ -57,9 +56,9 @@ One short block per iteration in `03-progress-log.md`:
 ## Finish
 
 1. Run the `regression-check` skill on touched areas → `04-test-evidence.md`.
-2. If auth, input handling, storage, network, or privacy boundaries were touched: run the `security-auditor` subagent → `05-security-review.md`.
+2. If auth, input handling, storage, network, or privacy boundaries were touched: run the `security-auditor` subagent (readonly). The parent must persist the returned text as `05-security-review.md`.
 3. Run the `pr-prep` skill → `06-pr-summary.md`.
-4. Record any reusable lesson in `.learnings/LEARNINGS.md` (one concept per entry, keep short).
+4. Record any reusable lesson in `.learnings/LEARNINGS.md` (one concept per entry, keep short). Redact secrets, tokens, credentials, PII, and raw payloads.
 5. STOP for user confirmation before opening or updating a PR.
 
 ## Artifacts

--- a/.cursor/skills/goal-loop/SKILL.md
+++ b/.cursor/skills/goal-loop/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: goal-loop
+description: Autonomous convergence loop that takes a goal from problem statement to verified, PR-ready code. Iterates think, implement, verify, diagnose until acceptance criteria pass or a blocker needs the user. Use when the user says "loop", "goal-loop", "run the loop", "keep going until it works", or gives a task and asks the agent to iterate until done.
+---
+
+# Goal Loop
+
+Run the whole loop in one turn. Do not stop between iterations to ask "shall I continue?" — only stop at the exit conditions below.
+
+## Setup (once, before iteration 1)
+
+1. Normalize the goal with the `problem-intake` skill → `00-problem-brief.md`. The acceptance criteria in that brief are the loop's exit test. If the goal is one sentence, write criteria yourself from context; ask the user only for genuinely blocking unknowns.
+2. If non-trivial (more than one file, new behavior, UI, security, or unclear requirements): run the `planner` subagent → `01-spike.md` and `02-implementation-plan.md` (see `spike-doc` and `task-implementation-doc` skills).
+3. Git: check `git status`; confirm with user if the tree is dirty. Branch from `dev` as `cursor/<ticket-or-feature>/<short-slug>`. Never implement on `dev`.
+4. Create `03-progress-log.md` with the iteration table (template below).
+
+## Iteration protocol
+
+Repeat THINK → IMPLEMENT → VERIFY → DECIDE.
+
+**THINK**
+
+- Iteration 1: pick the first unchecked criterion or subtask from the plan.
+- Iteration >1: read the failure output from the last VERIFY. Diagnose the root cause before touching code — state the hypothesis in one line in the progress log. If the same failure has appeared twice, the hypothesis must be different from the last one; re-read the surrounding code instead of re-trying the same fix.
+
+**IMPLEMENT**
+
+- Smallest coherent change that addresses the current criterion or failure. Touch only files the task requires.
+- Prefer red-green: write/adjust the failing test first when adding behavior (per AGENTS.md).
+
+**VERIFY**
+
+- Narrowest check first: the specific vitest file(s) for touched code, then `npm run lint:scripts` / `npm run lint:style` on style changes, `npm run build` only when imports/config/types changed broadly.
+- For UI changes, use Browser verification and save screenshots to the task folder.
+- Never paste long logs into the conversation; summarize failures in the progress log.
+
+**DECIDE**
+
+- All acceptance criteria met and checks green → exit loop, go to Finish.
+- Failures remain → append one progress-log entry and return to THINK.
+- Same failure 3 consecutive iterations, or 10 iterations total → STOP and report the blocker with your best diagnosis. Do not thrash.
+- Need credentials, destructive commands, external service setup → STOP and ask.
+
+## Progress log entry format
+
+One short block per iteration in `03-progress-log.md`:
+
+```markdown
+### Iteration N — <status: pass|fail|blocked>
+
+- Target: <criterion or failing check>
+- Hypothesis: <one line, iterations >1 only>
+- Change: <files touched, one line>
+- Verify: <command run → result summary>
+```
+
+## Finish
+
+1. Run the `regression-check` skill on touched areas → `04-test-evidence.md`.
+2. If auth, input handling, storage, network, or privacy boundaries were touched: run the `security-auditor` subagent → `05-security-review.md`.
+3. Run the `pr-prep` skill → `06-pr-summary.md`.
+4. Record any reusable lesson in `.learnings/LEARNINGS.md` (one concept per entry, keep short).
+5. STOP for user confirmation before opening or updating a PR.
+
+## Artifacts
+
+All docs live in `docs/agent-tasks/YYYY-MM-DD_short-feature-name/` (legacy `docs/cursor-orchestrator/` is historical only). Reference file paths; do not copy large file contents into docs.

--- a/.cursor/skills/pr-prep/SKILL.md
+++ b/.cursor/skills/pr-prep/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: pr-prep
+description: Package a finished task into a PR-ready summary with test evidence, screenshots, and risk notes. Use after regression-check passes, or when the user asks to prepare or open a PR.
+---
+
+# PR Prep
+
+Create `06-pr-summary.md` in the current task folder, then STOP for user confirmation before opening or updating any PR.
+
+Contents:
+
+- **Summary**: what changed and why, 2–4 sentences
+- **Files changed**: from `git diff --stat origin/dev...HEAD`
+- **Test evidence**: link to `04-test-evidence.md`, plus the headline results inline
+- **Screenshots**: embed if UI changed
+- **Risks / follow-ups**: anything reviewers should watch, deferred work
+- **Security**: link `05-security-review.md` if one was produced
+
+PR conventions for this repo:
+
+- Base branch is `dev`; compare against `origin/dev`.
+- Branch name: `cursor/<ticket-or-feature>/<short-slug>`.
+- Only commit when the user asks; never push or open the PR without explicit confirmation.

--- a/.cursor/skills/pr-prep/SKILL.md
+++ b/.cursor/skills/pr-prep/SKILL.md
@@ -10,7 +10,7 @@ Create `06-pr-summary.md` in the current task folder, then STOP for user confirm
 Contents:
 
 - **Summary**: what changed and why, 2–4 sentences
-- **Files changed**: from `git diff --stat origin/dev...HEAD`
+- **Files changed**: working tree vs `origin/dev` (`git diff --stat origin/dev` plus `git status --short` for staged and untracked paths)
 - **Test evidence**: link to `04-test-evidence.md`, plus the headline results inline
 - **Screenshots**: embed if UI changed
 - **Risks / follow-ups**: anything reviewers should watch, deferred work

--- a/.cursor/skills/problem-intake/SKILL.md
+++ b/.cursor/skills/problem-intake/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: problem-intake
+description: Normalize problem statements from tickets, GitHub issues, raw docs, chat text, or MCP sources into a minimal implementation brief with acceptance criteria. Use at the start of any task, or when the user pastes a ticket, requirement doc, or bug report.
+---
+
+# Problem Intake
+
+Create `docs/agent-tasks/YYYY-MM-DD_short-feature-name/00-problem-brief.md`.
+
+Include only:
+
+- **Source**: links or "chat" — never copy long source text, summarize it
+- **Problem**: the exact reported problem, 1–3 sentences
+- **Goal**: business outcome in one line
+- **Acceptance criteria**: checkbox list; each must be verifiable by a test, lint, build, or observable UI behavior — these are the goal-loop exit test
+- **Constraints / non-goals**
+- **Affected area**: modules or paths, best guess is fine
+- **Open questions**: only questions that block implementation
+
+Rules:
+
+- Keep the whole brief under ~300 words.
+- If requirements are sufficient, do not ask redundant questions; proceed.
+- If a question is genuinely blocking, ask it before planning, not mid-loop.
+- Everything else (findings, options, risks) belongs in `01-spike.md`, not here.

--- a/.cursor/skills/problem-intake/SKILL.md
+++ b/.cursor/skills/problem-intake/SKILL.md
@@ -22,4 +22,4 @@ Rules:
 - Keep the whole brief under ~300 words.
 - If requirements are sufficient, do not ask redundant questions; proceed.
 - If a question is genuinely blocking, ask it before planning, not mid-loop.
-- Everything else (findings, options, risks) belongs in `01-spike.md`, not here.
+- Findings, options, and risks go in `01-spike.md` when a spike is created; otherwise a short section in `00-problem-brief.md`.

--- a/.cursor/skills/regression-check/SKILL.md
+++ b/.cursor/skills/regression-check/SKILL.md
@@ -9,11 +9,9 @@ Run after the loop exits green, before PR prep. Record results in `04-test-evide
 
 Order (stop escalating when confidence is sufficient):
 
-1. Targeted vitest files for every touched module: `npx vitest run <files>`
-2. `npm run lint:scripts` and, if styles changed, `npm run lint:style`
-3. `npm run test:unit` if changes span multiple modules
-4. `npm run build` if imports, types, or config changed
-5. UI changes: Browser check of the affected screens; save screenshots into the task folder; verify keyboard/focus behavior per AGENTS.md
+1. `./mvnw -B test` for touched modules
+2. `./mvnw -B package -DskipTests` for PR-bound work
+3. Spotless/checkstyle only when this repo’s `pom.xml` defines them and you touched Java sources
 
 Evidence format in `04-test-evidence.md` — one line per check:
 

--- a/.cursor/skills/regression-check/SKILL.md
+++ b/.cursor/skills/regression-check/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: regression-check
+description: Final verification pass over touched code after the goal-loop converges. Runs targeted then broader checks and records evidence. Use before PR prep, or when the user asks "did this break anything".
+---
+
+# Regression Check
+
+Run after the loop exits green, before PR prep. Record results in `04-test-evidence.md`.
+
+Order (stop escalating when confidence is sufficient):
+
+1. Targeted vitest files for every touched module: `npx vitest run <files>`
+2. `npm run lint:scripts` and, if styles changed, `npm run lint:style`
+3. `npm run test:unit` if changes span multiple modules
+4. `npm run build` if imports, types, or config changed
+5. UI changes: Browser check of the affected screens; save screenshots into the task folder; verify keyboard/focus behavior per AGENTS.md
+
+Evidence format in `04-test-evidence.md` — one line per check:
+
+```markdown
+- `<command>` → pass|fail (<counts or short failure summary>)
+```
+
+If a check fails on something unrelated to this change, say so precisely and note the pre-existing failure; do not silently skip it.

--- a/.cursor/skills/spike-doc/SKILL.md
+++ b/.cursor/skills/spike-doc/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: spike-doc
+description: Analyze existing implementation and produce a concise spike document before coding a non-trivial change. Use after problem intake when the task touches multiple files, new behavior, architecture, or unclear code paths.
+---
+
+# Spike Document
+
+Create `01-spike.md` in the current task folder under `docs/agent-tasks/`.
+
+Before writing, analyze the existing implementation:
+
+- Use the `codebase-explorer` subagent (or Explore) for broad searches; keep raw search results out of the main context.
+- Skim `.understand-anything/ARCHITECTURE.md` and `graphify-out/GRAPH_REPORT.md` for structure before reading raw files.
+- Reuse existing patterns, hooks, tokens, and mixins before inventing new abstractions.
+
+Structure (keep each section short, file-oriented, no narrative essays):
+
+- **Current behavior**: how it works today, with file paths and line references
+- **Root cause / gap**: for bugs, the diagnosed cause; for features, what's missing
+- **Approach**: the chosen approach and one line on why over the obvious alternative
+- **Files likely to change**: bullet list of paths with one-line intent each
+- **Risks and edge cases**
+- **Test strategy**: which existing tests cover this area, what new tests are needed

--- a/.cursor/skills/task-implementation-doc/SKILL.md
+++ b/.cursor/skills/task-implementation-doc/SKILL.md
@@ -12,9 +12,9 @@ Structure:
 - **Objective**: one line
 - **Impacted files**: paths only
 - **Subtasks**: table with columns `#`, `Subtask`, `Files`, `Verify with`, `Status`
-    - Each subtask must be small enough for one loop iteration and have a concrete verify command (e.g. `npx vitest run src/foo.test.ts`)
+    - Each subtask must be small enough for one loop iteration and have a concrete verify command using this repo’s toolchain (`./mvnw -B test`, scoped when possible)
     - Status values: `todo`, `doing`, `done`, `blocked`
-- **Verification checklist**: which of `npm run test:unit`, `lint:scripts`, `lint:style`, `build`, Browser check apply to this task
+- **Verification checklist**: `./mvnw -B test` when Java, tests, or config change; `./mvnw -B package -DskipTests` for PR-bound work
 - **Risks**
 
 Update the Status column as the loop progresses — this file is the loop's source of truth for what's next.

--- a/.cursor/skills/task-implementation-doc/SKILL.md
+++ b/.cursor/skills/task-implementation-doc/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: task-implementation-doc
+description: Create a compact implementation plan with subtasks, status, and verification checklist that drives the goal-loop iterations. Use after the spike is done and before implementation starts.
+---
+
+# Task Implementation Document
+
+Create `02-implementation-plan.md` in the current task folder.
+
+Structure:
+
+- **Objective**: one line
+- **Impacted files**: paths only
+- **Subtasks**: table with columns `#`, `Subtask`, `Files`, `Verify with`, `Status`
+    - Each subtask must be small enough for one loop iteration and have a concrete verify command (e.g. `npx vitest run src/foo.test.ts`)
+    - Status values: `todo`, `doing`, `done`, `blocked`
+- **Verification checklist**: which of `npm run test:unit`, `lint:scripts`, `lint:style`, `build`, Browser check apply to this task
+- **Risks**
+
+Update the Status column as the loop progresses — this file is the loop's source of truth for what's next.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ CI (GitHub Actions): `./mvnw -B test` then `./mvnw -B package -DskipTests` on Ja
 
 ## Context
 
-- Integration branch: `pre-dev` when used for ORISO feature work.
+- Integration branch: `dev` when used for ORISO feature work.
 - Skim `.understand-anything/` before non-trivial changes; verify graph freshness.
 - Do not invent DTOs/OpenAPI — read existing controllers and generated clients.
 - Controller/facade/saga changes follow `docs/api-error-contract.md` — never
@@ -47,7 +47,7 @@ delivery rules"). Summary:
   requested reviewers is not open for review.
 - **"Pre-Dev is free" means the server, not the branch.** Deploying images,
   mutating config or data and running E2E on the Pre-Dev server needs no
-  approval; the `pre-dev` *branch* is review-gated like any shared branch.
+  approval; the `dev` *branch* is review-gated like any shared branch.
 - **Restore what you borrowed.** Record image reference *and* `imagePullPolicy`
   before swapping anything on Pre-Dev, put both back before reporting done, and
   say so in the report.

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialStatisticsControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/TutorialStatisticsControllerE2EIT.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.TutorialProgress;
 import de.caritas.cob.userservice.api.port.out.TutorialProgressRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import java.time.LocalDateTime;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -42,6 +43,7 @@ class TutorialStatisticsControllerE2EIT {
 
   @BeforeEach
   void seedProgressAcrossTenants() {
+    TenantContext.clear();
     tutorialProgressRepository.deleteAll();
     save("user-a", "frontend", "consultant-walkthrough", 1, "completed", 2L);
     save("user-b", "frontend", "consultant-walkthrough", 1, "completed", 2L);
@@ -52,6 +54,7 @@ class TutorialStatisticsControllerE2EIT {
   @AfterEach
   void cleanUp() {
     tutorialProgressRepository.deleteAll();
+    TenantContext.clear();
   }
 
   private void save(
@@ -100,6 +103,7 @@ class TutorialStatisticsControllerE2EIT {
 
   @Test
   void tutorialStatistics_tenantAdminSeesOnlyOwnTenantWithCorrectCounts() throws Exception {
+    TenantContext.setCurrentTenant(2L);
     when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
     when(authenticatedUser.getTenantId()).thenReturn(2L);
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
@@ -50,6 +50,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.UserAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.testConfig.TestAgencyControllerApi;
 import de.caritas.cob.userservice.topicservice.generated.web.TopicControllerApi;
 import jakarta.servlet.http.Cookie;
@@ -149,6 +150,7 @@ class UserControllerConsultantE2EIT {
 
   @BeforeEach
   void setUp() {
+    TenantContext.clear();
     when(agencyServiceApiControllerFactory.createControllerApi())
         .thenReturn(
             new TestAgencyControllerApi(
@@ -159,6 +161,7 @@ class UserControllerConsultantE2EIT {
 
   @AfterEach
   void reset() {
+    TenantContext.clear();
     if (nonNull(user)) {
       user.setDeleteDate(null);
       userRepository.save(user);


### PR DESCRIPTION
### Summary
Add a repo Cursor harness and point AGENTS.md at `dev` so agents no longer branch from `pre-dev`.

### Ticket
Chore (no product ticket). Counterpart PRs in Frontend, Admin, and the other services.

### User-visible behavior
None. Agent/docs only.

### Implementation
New `.cursor` rules, skills, agents, and safety hooks. AGENTS.md integration branch is `dev`.

### Test evidence
Docs-only. No Java/Helm behavior change.

### Manual verification
Not applicable.

### Risks
None for runtime. Agents will open PRs against `dev` after merge.

### Screenshots
None.

### Reviewer notes
Please confirm PRs should land on `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guided workflows for problem intake, technical investigation, implementation planning, implementation, verification, regression checks, security review, and pull request preparation.
  - Added specialized read-only assistants for codebase exploration, planning, security auditing, and independent verification.
  - Added an autonomous development loop to coordinate implementation and validation steps.
  - Added repository guidance for branch usage, contribution workflows, and issue/PR updates.

- **Documentation**
  - Updated integration guidance to use the `dev` branch and clarified related review requirements.

- **Tests**
  - Improved end-to-end test isolation by explicitly managing tenant context between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->