### PR TITLE
fix(absence): let the public consultant endpoint carry the out-of-office message

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2901,7 +2901,7 @@ components:
         absenceMessage:
           type: string
           example: I am absent until...
-          description: The out-of-office message; only present when absent is true, otherwise omitted
+          description: The out-of-office message; carries a value only while absent is true, otherwise null
         agencies:
           type: array
           items:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2900,8 +2900,9 @@ components:
           description: Flag that indicates if the consultant is currently absent
         absenceMessage:
           type: string
+          nullable: true
           example: I am absent until...
-          description: The out-of-office message the consultant published for their absence
+          description: The out-of-office message; only returned when absent is true, otherwise null/omitted
         agencies:
           type: array
           items:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2900,6 +2900,7 @@ components:
           description: Flag that indicates if the consultant is currently absent
         absenceMessage:
           type: string
+          nullable: true
           example: I am absent until...
           description: The out-of-office message; carries a value only while absent is true, otherwise null
         agencies:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2900,9 +2900,8 @@ components:
           description: Flag that indicates if the consultant is currently absent
         absenceMessage:
           type: string
-          nullable: true
           example: I am absent until...
-          description: The out-of-office message; only returned when absent is true, otherwise null/omitted
+          description: The out-of-office message; only present when absent is true, otherwise omitted
         agencies:
           type: array
           items:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2894,6 +2894,14 @@ components:
           type: boolean
           example: true
           description: Flag that indicates if the consultant can be added as a supervisor
+        absent:
+          type: boolean
+          example: true
+          description: Flag that indicates if the consultant is currently absent
+        absenceMessage:
+          type: string
+          example: I am absent until...
+          description: The out-of-office message the consultant published for their absence
         agencies:
           type: array
           items:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
@@ -43,6 +43,7 @@ public class TenantContextCleanupFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
+    TenantContext.clear();
     try {
       filterChain.doFilter(request, response);
     } finally {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
@@ -1,0 +1,52 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Removes the tenant ThreadLocal once a request is finished, whatever established it.
+ *
+ * <p>{@link TenantContext} lives on a pooled thread, so a tenant left behind by one request
+ * silently scopes whichever request picks that thread up next. Two paths used to leave one:
+ *
+ * <ul>
+ *   <li>{@code HttpTenantFilter} cleared after the chain rather than in a {@code finally}, so a
+ *       request that threw kept its tenant;
+ *   <li>whitelisted paths skip that filter altogether, yet their handlers do establish a context —
+ *       {@code CreateUserFacade#initializeTenantContextForRegistration} does exactly that for
+ *       {@code /users/askers/new}, and nothing removed it afterwards.
+ * </ul>
+ *
+ * <p>Cleaning up here rather than inside the handler is deliberate. The context has to survive the
+ * whole request: {@code UserRegistrationControllerDelegate#registerUser} calls {@code
+ * markAsDirectConsultant} after the facade returns, and with multitenancy on, a tenant-filtered
+ * query under a cleared context matches nothing instead of failing — the session would not be found
+ * and registration with a preselected counsellor would answer 500.
+ *
+ * <p>Deliberately unconditional, unlike {@code HttpTenantFilter}, which only exists when {@code
+ * multitenancy.enabled}. The ThreadLocal can be set on any profile, so it must be cleaned on any
+ * profile too.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TenantContextCleanupFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      TenantContext.clear();
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilter.java
@@ -20,9 +20,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * <ul>
  *   <li>{@code HttpTenantFilter} cleared after the chain rather than in a {@code finally}, so a
  *       request that threw kept its tenant;
- *   <li>whitelisted paths skip that filter altogether, yet their handlers do establish a context —
- *       {@code CreateUserFacade#initializeTenantContextForRegistration} does exactly that for
- *       {@code /users/askers/new}, and nothing removed it afterwards.
+ *   <li>on a whitelisted path that filter still runs but skips tenant resolution, so it neither
+ *       sets nor clears anything, while the handler behind it does establish a context — {@code
+ *       CreateUserFacade#initializeTenantContextForRegistration} does exactly that for {@code
+ *       /users/askers/new}, and nothing removed it afterwards.
  * </ul>
  *
  * <p>Cleaning up here rather than inside the handler is deliberate. The context has to survive the

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
@@ -69,7 +69,9 @@ public class ConsultantDtoMapper implements DtoMapperUtils {
             .consultantId(consultant.getId())
             .publicSlug(consultant.getPublicSlug())
             .agencies(agencyDtoList)
-            .isSupervisor(consultant.isSupervisor());
+            .isSupervisor(consultant.isSupervisor())
+            .absent(consultant.isAbsent())
+            .absenceMessage(consultant.isAbsent() ? consultant.getAbsenceMessage() : null);
 
     if (mapNames) {
       consultantResponseDto.firstName(consultant.getFirstName()).lastName(consultant.getLastName());

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapper.java
@@ -70,8 +70,14 @@ public class ConsultantDtoMapper implements DtoMapperUtils {
             .publicSlug(consultant.getPublicSlug())
             .agencies(agencyDtoList)
             .isSupervisor(consultant.isSupervisor())
-            .absent(consultant.isAbsent())
-            .absenceMessage(consultant.isAbsent() ? consultant.getAbsenceMessage() : null);
+            .absent(consultant.isAbsent());
+
+    // Only published while the counsellor is actually away: this endpoint is
+    // unauthenticated, so a stale message from someone who has already returned
+    // must not be left readable there.
+    if (consultant.isAbsent()) {
+      consultantResponseDto.absenceMessage(consultant.getAbsenceMessage());
+    }
 
     if (mapNames) {
       consultantResponseDto.firstName(consultant.getFirstName()).lastName(consultant.getLastName());

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/interceptor/TenantContextCleanupFilterTest.java
@@ -1,0 +1,77 @@
+package de.caritas.cob.userservice.api.adapters.web.controller.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import jakarta.servlet.FilterChain;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * The filter is the only thing standing between a tenant set during one request and the next
+ * request that happens to get the same pooled thread, so each guarantee is pinned here rather than
+ * left to the integration suite, where it only shows up as an ordering-dependent failure somewhere
+ * else entirely.
+ */
+class TenantContextCleanupFilterTest {
+
+  private final TenantContextCleanupFilter filter = new TenantContextCleanupFilter();
+  private final MockHttpServletRequest request = new MockHttpServletRequest();
+  private final MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void doFilterInternal_Should_ClearTenantContext_When_TheHandlerEstablishedOne() throws Exception {
+    FilterChain chain = (req, res) -> TenantContext.setCurrentTenant(42L);
+
+    filter.doFilterInternal(request, response, chain);
+
+    assertThat(TenantContext.getCurrentTenant()).isNull();
+  }
+
+  @Test
+  void doFilterInternal_Should_ClearTenantContext_When_TheChainThrows() {
+    FilterChain chain =
+        (req, res) -> {
+          TenantContext.setCurrentTenant(42L);
+          throw new IllegalStateException("handler blew up");
+        };
+
+    // The clear has to sit in a finally: a request that fails must not hand its tenant on.
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, chain))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(TenantContext.getCurrentTenant()).isNull();
+  }
+
+  @Test
+  void doFilterInternal_Should_NotLeakAPreviousTenant_Into_TheHandler() throws Exception {
+    TenantContext.setCurrentTenant(99L);
+    var seenByHandler = new AtomicReference<Long>(-1L);
+    FilterChain chain = (req, res) -> seenByHandler.set(TenantContext.getCurrentTenant());
+
+    filter.doFilterInternal(request, response, chain);
+
+    assertThat(seenByHandler.get()).isNull();
+    assertThat(TenantContext.getCurrentTenant()).isNull();
+  }
+
+  @Test
+  void doFilterInternal_Should_AlwaysInvokeTheChain() throws Exception {
+    var invoked = new AtomicBoolean(false);
+    FilterChain chain = (req, res) -> invoked.set(true);
+
+    filter.doFilterInternal(request, response, chain);
+
+    assertThat(invoked).isTrue();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -9,6 +9,8 @@ import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.HalLink.MethodEnum;
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.UpdateConsultantDTO;
+import de.caritas.cob.userservice.api.config.ConsultantActivityInterceptor;
+import de.caritas.cob.userservice.api.config.CustomWebMvcConfigurer;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.port.in.IdentityManaging;
@@ -25,11 +27,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.JsonNode;
 
 @ExtendWith(MockitoExtension.class)
 class ConsultantDtoMapperTest {
@@ -37,6 +42,8 @@ class ConsultantDtoMapperTest {
   @Mock private IdentityManaging identityManager;
   @Mock private ConsultantTopicRepository consultantTopicRepository;
   @Mock private TopicService topicService;
+
+  @Mock private ObjectProvider<ConsultantActivityInterceptor> objectProvider;
 
   @BeforeEach
   void setupRequestContext() {
@@ -344,10 +351,10 @@ class ConsultantDtoMapperTest {
 
     var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
 
-    var mapper = JsonMapper.builder().build();
-    var tree = mapper.readTree(mapper.writeValueAsString(result));
-    assertThat(tree.path("absent").asBoolean()).isTrue();
-    assertThat(tree.path("absenceMessage").asText()).isEqualTo("I am out of office");
+    var json = serialize(result);
+    assertThat(json.path("absent").asBoolean()).isTrue();
+    assertThat(json.path("absenceMessage").asString()).isEqualTo("I am out of office");
+  }
 
   @Test
   void consultantResponseDtoOf_Should_NotExposeAbsenceMessage_When_ConsultantIsNotAbsent() {
@@ -366,11 +373,27 @@ class ConsultantDtoMapperTest {
 
     var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
 
-    assertThat(serialize(result)).contains("\"absent\":false").doesNotContain("I am out of office");
+    // isNull() rather than "the old text is gone": this fails both if the
+    // message were swapped for another counsellor's and if the property
+    // vanished from the payload altogether.
+    var json = serialize(result);
+    assertThat(json.path("absent").asBoolean()).isFalse();
+    assertThat(json.path("absenceMessage").isNull()).isTrue();
   }
 
-  private String serialize(Object dto) {
-    return JsonMapper.builder().build().writeValueAsString(dto);
+  /**
+   * Serialises through the very converter the app answers HTTP with, rather than a bare mapper.
+   * {@link CustomWebMvcConfigurer} registers a JsonNullable serialiser on it, so a mapper built
+   * here by hand would render an optional property differently from the response the browser
+   * receives — exactly the mismatch this assertion exists to catch.
+   */
+  private JsonNode serialize(Object dto) {
+    List<HttpMessageConverter<?>> converters =
+        new ArrayList<>(List.of(new JacksonJsonHttpMessageConverter()));
+    new CustomWebMvcConfigurer(objectProvider).extendMessageConverters(converters);
+    var mapper = ((JacksonJsonHttpMessageConverter) converters.get(0)).getMapper();
+
+    return mapper.readTree(mapper.writeValueAsString(dto));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -327,6 +327,48 @@ class ConsultantDtoMapperTest {
   }
 
   @Test
+  void consultantResponseDtoOf_Should_MapAbsence_When_ConsultantIsAbsent() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .matrixUserId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .absent(true)
+            .absenceMessage("I am out of office")
+            .build();
+
+    var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
+
+    assertThat(result.getAbsent()).isTrue();
+    assertThat(result.getAbsenceMessage()).isEqualTo("I am out of office");
+  }
+
+  @Test
+  void consultantResponseDtoOf_Should_NotExposeAbsenceMessage_When_ConsultantIsNotAbsent() {
+    ConsultantDtoMapper consultantDtoMapper = givenAMapper();
+    Consultant consultant =
+        Consultant.builder()
+            .id("consultantId")
+            .matrixUserId("rcId")
+            .username("username")
+            .firstName("Firstname")
+            .lastName("Lastname")
+            .email("mail@example.com")
+            .absent(false)
+            .absenceMessage("I am out of office")
+            .build();
+
+    var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
+
+    assertThat(result.getAbsent()).isFalse();
+    assertThat(result.getAbsenceMessage()).isNull();
+  }
+
+  @Test
   void consultantLinkOf_Should_BuildGetLink_When_MethodIsDefault() {
     ConsultantDtoMapper consultantDtoMapper = givenAMapper();
 

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -29,6 +29,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class ConsultantDtoMapperTest {
@@ -343,8 +344,12 @@ class ConsultantDtoMapperTest {
 
     var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
 
-    assertThat(result.getAbsent()).isTrue();
-    assertThat(result.getAbsenceMessage()).isEqualTo("I am out of office");
+    // Asserted on the wire format, not on the accessor: the generated DTO's
+    // optional-string representation is not stable across environments, while
+    // the JSON the browser reads is exactly the contract that matters here.
+    assertThat(serialize(result))
+        .contains("\"absent\":true")
+        .contains("\"absenceMessage\":\"I am out of office\"");
   }
 
   @Test
@@ -364,8 +369,11 @@ class ConsultantDtoMapperTest {
 
     var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
 
-    assertThat(result.getAbsent()).isFalse();
-    assertThat(result.getAbsenceMessage()).isNull();
+    assertThat(serialize(result)).contains("\"absent\":false").doesNotContain("I am out of office");
+  }
+
+  private String serialize(Object dto) {
+    return JsonMapper.builder().build().writeValueAsString(dto);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConsultantDtoMapperTest.java
@@ -344,13 +344,10 @@ class ConsultantDtoMapperTest {
 
     var result = consultantDtoMapper.consultantResponseDtoOf(consultant, List.of(), false);
 
-    // Asserted on the wire format, not on the accessor: the generated DTO's
-    // optional-string representation is not stable across environments, while
-    // the JSON the browser reads is exactly the contract that matters here.
-    assertThat(serialize(result))
-        .contains("\"absent\":true")
-        .contains("\"absenceMessage\":\"I am out of office\"");
-  }
+    var mapper = JsonMapper.builder().build();
+    var tree = mapper.readTree(mapper.writeValueAsString(result));
+    assertThat(tree.path("absent").asBoolean()).isTrue();
+    assertThat(tree.path("absenceMessage").asText()).isEqualTo("I am out of office");
 
   @Test
   void consultantResponseDtoOf_Should_NotExposeAbsenceMessage_When_ConsultantIsNotAbsent() {


### PR DESCRIPTION
> **This PR now carries two unrelated fixes.** It began as the out-of-office fix below; the tenant-context leak was added at the author's request to unblock `required integration tests`, which was failing on every branch. The two are in separate commits and can be reviewed independently.

## What

`GET /users/consultants/{consultantId}` (unauthenticated) and its public-slug twin never returned the counsellor's absence state. `ConsultantResponseDTO` had no `absent`/`absenceMessage` properties at all, and `ConsultantDtoMapper.consultantResponseDtoOf` never set them.

The frontend has rendered an absence notice from exactly those two fields for a while — `PreselectedConsultant.tsx:30` and `preselectionDrawer.tsx:29` both branch on `consultant?.absent` and print `consultant.absenceMessage`. It typechecks because `ConsultantDataInterface` inherits both as optional from `UserDataInterface`, so `absent` was silently `undefined` forever and the branch never taken.

Net effect: an advice seeker following a counsellor's link was never told the counsellor was away, no matter what that counsellor had saved under "Meine Abwesenheit".

## Changes

- `api/userservice.yaml` — add `absent` and `absenceMessage` to `ConsultantResponseDTO`.
- `ConsultantDtoMapper.consultantResponseDtoOf` — populate both. `absenceMessage` is returned **only while `absent` is true**: this endpoint is unauthenticated, and a stale message from a counsellor who has already returned has no business being publicly readable.
- Two tests in `ConsultantDtoMapperTest` covering the absent and not-absent cases.

No frontend change is needed — the UI is already there and reads `absent` / `absenceMessage`.

## Testing

`ConsultantDtoMapperTest` — 24/24 pass.

## Scope note

This does **not** touch the in-chat composer banner, the other surface where absence is shown. I checked that path and could not fault it on `dev`:

- `SessionMapper.toGroupSessionResponse` maps absence into the room-session response on `dev`.
- Serializing the compiled `GroupSessionConsultantDTO` / `SessionConsultantForUserDTO` from `target/UserService.jar` with the bundled Jackson 3.1.4 yields `{"absenceMessage":"...","displayName":"...","absent":true}`.
- The deployed dev bundle reads `ASKER_DEFAULT && consultant?.absent` and renders `consultant.absent.message` + `absenceMessage`, matching source.

If a blank composer is still seen in a *running* chat, that needs a live capture of `/service/users/sessions/room` for the affected asker — it is not reproducible from the code.

## Follow-up (not in this PR)

`api/userservice.yaml` documents the same flag as `isAbsent` on `SessionConsultantForUserDTO` and `GroupSessionConsultantDTO`, but the server sends `absent` (Lombok `isAbsent()` + Jackson bean naming). `ORISO-Frontend/src/generated/userservice.d.ts` is therefore wrong for that field; runtime code is unaffected only because it reads the hand-written `SessionConsultantInterface`.

Refs OpenResilienceInitiative/ORISO-Frontend#1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consultant responses now indicate whether a consultant is currently absent.
  * Absence messages are included only when the consultant is absent.

* **Bug Fixes**
  * Availability information is represented consistently in consultant responses.
  * Request-specific tenant information is cleared after each request, preventing it from affecting subsequent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

# Second fix: registration leaks its tenant onto the thread

Unrelated to the absence work, added here to unblock CI.

## The bug

`/users/askers/new` is whitelisted in `HttpTenantFilter`, so a registration is never wrapped by the filter that tears the tenant context down. `CreateUserFacade.createUserAccountWithInitializedConsultingType` calls `initializeTenantContextForRegistration`, which sets `TenantContext` from the agency and never clears it. `TenantContext` is a ThreadLocal on a pooled thread, so the tenant outlives the request and scopes whatever lands on that thread next.

**This is a production bug, not only a test-ordering one.** In a real container those threads are shared across users, so a registration can leave a tenant id that silently scopes an unrelated later request — cross-tenant scoping on a multi-tenant platform.

## Why CI looked flaky

`UserControllerE2EIT` registers seven times and leaks a tenant. Whether anything breaks depends purely on run order:

| | `UserControllerE2EIT` | failing classes | Result |
|---|---|---|---|
| Linux (CI) | 70 | 71, 73 | fails — leak lands first |
| macOS (local) | 46 | 31 | passes — leak lands after |

Downstream, `AccountManager.resolveEffectiveTenantId` falls back to the ThreadLocal and `ConsultantRepository.findAllByInfix` filters on `(?2 IS NULL OR ?2 = 0 OR c.tenantId = ?2)`, so a leaked id matches nothing and the search returns `total: 0`.

Instrumenting a replay of CI's order caught it directly: `effectiveTenantId=1326634973105178603` — the EasyRandom value from the mocked agency, still on the thread.

## Changes

`9bd6b32` adds `TenantContextCleanupFilter`: an unconditional `OncePerRequestFilter` at highest precedence that clears the ThreadLocal in a `finally`.

Cleaning up at the request boundary rather than inside the handler is the load-bearing part. An earlier attempt cleared inside `CreateUserFacade` and **broke registration**: `UserRegistrationControllerDelegate#registerUser` calls `markAsDirectConsultant` after the facade returns, and with multitenancy on a tenant-filtered query under a cleared context matches nothing rather than failing — measured at 100 rows under the technical context versus 0 under a cleared one — so the session would not be found and a registration with a preselected counsellor would answer 500. No suite caught that: the `testing` profile disables multitenancy, so `TenantAspect` is never registered. That approach was dropped.

The filter is unconditional on purpose, unlike `HttpTenantFilter` which only exists when `multitenancy.enabled`. The ThreadLocal can be set on any profile, so it has to be cleaned on any profile.

## Verification

Replaying CI's class order locally reproduces all 6 `searchConsultants` failures plus `TutorialStatisticsControllerE2EIT` before the fix, and none after. Full integration suite **908/908**. Unit suite 4243/4245 — the 2 failures are `MatrixOnlyRuntimeConfigurationContractTest` asserting on a gitignored `application-local.properties` that exists only on my machine and never reaches CI.
