### PR TITLE
fix(session): team-agency sessions keep AGENCY_COUNSELLING; supervision marker in the consultant session list

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2197,6 +2197,15 @@ components:
             Internal display names of the active supervisors, same order as
             supervisorConsultantIds (internal display name, else public display name, else
             username). Never a real name.
+        counsellorDisplayName:
+          type: string
+          example: "Counsellor Chris"
+          description: >-
+            Internal display name of the session's assigned (responsible) consultant, resolved by
+            the same #996 rule as supervisorDisplayNames (internal display name, else public display
+            name, else username). Never a real name. Absent when the session has no consultant yet
+            (enquiry not taken). Lets a supervisor's panel title the case by its counsellor without
+            a second lookup.
 
     SessionConsentDTO:
       type: object

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2204,6 +2204,7 @@ components:
             username). Never a real name.
         counsellorDisplayName:
           type: string
+          nullable: true
           example: "Counsellor Chris"
           description: >-
             Internal display name of the session's assigned (responsible) consultant, resolved by

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2163,6 +2163,40 @@ components:
             true when Gate 2 applies to this session and no consent pointer is recorded, i.e. the
             client must show the consent gate instead of the composer. Internal rooms (no
             help-seeker) always report false. Additive - older clients can ignore it.
+        supervision:
+          $ref: '#/components/schemas/SessionSupervisionDTO'
+
+    SessionSupervisionDTO:
+      type: object
+      description: >-
+        ADR-008 supervision marker for consultant-facing session lists. Filled for the requesting
+        consultant only; absent on advice-seeker responses. Additive - older clients can ignore it.
+      required:
+        - supervisedByMe
+        - supervisorConsultantIds
+        - supervisorDisplayNames
+      properties:
+        supervisedByMe:
+          type: boolean
+          example: true
+          description: >-
+            true when the requesting consultant is an active SessionSupervisor of this session,
+            i.e. the entry is in their list because they supervise it, not because they counsel it.
+        supervisorConsultantIds:
+          type: array
+          items:
+            type: string
+          example: ["926b9777-4eef-443d-925a-4aa534797bd7"]
+          description: Keycloak ids of all active supervisors of this session (empty when none).
+        supervisorDisplayNames:
+          type: array
+          items:
+            type: string
+          example: ["Supervisor Sam"]
+          description: >-
+            Internal display names of the active supervisors, same order as
+            supervisorConsultantIds (internal display name, else public display name, else
+            username). Never a real name.
 
     SessionConsentDTO:
       type: object
@@ -2333,6 +2367,8 @@ components:
           pattern: "^[a-zA-Z0-9]{1,8}$"
           maxLength: 8
           example: '12345678'
+        supervision:
+          $ref: '#/components/schemas/SessionSupervisionDTO'
 
     UserChatDTO:
       type: object

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2120,6 +2120,10 @@ components:
           type: string
           example: "@asker:matrix.example"
           description: Matrix user ID of the asker
+        consultantMatrixUserId:
+          type: string
+          example: "@consultant:matrix.example"
+          description: Matrix user id of the assigned consultant (null when no consultant is assigned)
         e2eLastMessage:
           $ref: '#/components/schemas/LastMessageDTO'
         lastMessage:

--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2122,6 +2122,7 @@ components:
           description: Matrix user ID of the asker
         consultantMatrixUserId:
           type: string
+          nullable: true
           example: "@consultant:matrix.example"
           description: Matrix user id of the assigned consultant (null when no consultant is assigned)
         e2eLastMessage:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -242,6 +242,7 @@ public class SessionSupervisorController {
     dto.setSessionId(supervisor.getSession().getId());
     dto.setSupervisorConsultantId(supervisor.getSupervisorConsultant().getId());
     dto.setSupervisorUsername(supervisor.getSupervisorConsultant().getUsername());
+    dto.setSupervisorMatrixUserId(supervisor.getSupervisorConsultant().getMatrixUserId());
     dto.setAddedByConsultantId(supervisor.getAddedByConsultant().getId());
     dto.setAddedDate(supervisor.getAddedDate());
     dto.setMatrixRoomId(supervisor.getMatrixRoomId());
@@ -358,6 +359,7 @@ public class SessionSupervisorController {
     private Long sessionId;
     private String supervisorConsultantId;
     private String supervisorUsername;
+    private String supervisorMatrixUserId;
     private String addedByConsultantId;
     private java.time.LocalDateTime addedDate;
     private String matrixRoomId;
@@ -397,6 +399,14 @@ public class SessionSupervisorController {
 
     public void setSupervisorUsername(String supervisorUsername) {
       this.supervisorUsername = supervisorUsername;
+    }
+
+    public String getSupervisorMatrixUserId() {
+      return supervisorMatrixUserId;
+    }
+
+    public void setSupervisorMatrixUserId(String supervisorMatrixUserId) {
+      this.supervisorMatrixUserId = supervisorMatrixUserId;
     }
 
     public String getAddedByConsultantId() {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorController.java
@@ -242,7 +242,11 @@ public class SessionSupervisorController {
     dto.setSessionId(supervisor.getSession().getId());
     dto.setSupervisorConsultantId(supervisor.getSupervisorConsultant().getId());
     dto.setSupervisorUsername(supervisor.getSupervisorConsultant().getUsername());
-    dto.setSupervisorMatrixUserId(supervisor.getSupervisorConsultant().getMatrixUserId());
+    String supervisorMatrixUserId = supervisor.getSupervisorConsultant().getMatrixUserId();
+    dto.setSupervisorMatrixUserId(
+        supervisorMatrixUserId == null || supervisorMatrixUserId.isBlank()
+            ? null
+            : supervisorMatrixUserId);
     dto.setAddedByConsultantId(supervisor.getAddedByConsultant().getId());
     dto.setAddedDate(supervisor.getAddedDate());
     dto.setMatrixRoomId(supervisor.getMatrixRoomId());

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProvider.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -38,6 +39,7 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
   private final @NonNull SessionRepository sessionRepository;
   private final @NonNull ConsultantSessionEnricher consultantSessionEnricher;
   private final @NonNull ConsultantTopicRepository consultantTopicRepository;
+  private final @NonNull SessionSupervisionMarkerService supervisionMarkerService;
 
   @Value("${user.anonymous.deactivateworkflow.periodMinutes}")
   private long liveChatQueueActivePeriodMinutes;
@@ -68,6 +70,16 @@ public class AnonymousEnquiryConversationListProvider implements ConversationLis
     } catch (Exception e) {
       log.error(
           "Anonymous enquiry enrichment failed for consultant {} — returning {} un-enriched queue entries",
+          consultant.getId(),
+          sessions.size(),
+          e);
+    }
+
+    try {
+      supervisionMarkerService.enrich(sessions, consultant);
+    } catch (Exception e) {
+      log.error(
+          "Anonymous enquiry supervision enrichment failed for consultant {} — returning {} queue entries without supervision markers",
           consultant.getId(),
           sessions.size(),
           e);

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/ArchivedSessionConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/ArchivedSessionConversationListProvider.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResp
 import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import lombok.NonNull;
@@ -21,8 +22,9 @@ public class ArchivedSessionConversationListProvider extends DefaultConversation
   public ArchivedSessionConversationListProvider(
       @NonNull UserAccountService userAccountProvider,
       @NonNull ConsultantSessionEnricher consultantSessionEnricher,
+      @NonNull SessionSupervisionMarkerService supervisionMarkerService,
       @NonNull SessionService sessionService) {
-    super(consultantSessionEnricher);
+    super(consultantSessionEnricher, supervisionMarkerService);
     this.sessionService = sessionService;
     this.userAccountProvider = userAccountProvider;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/ArchivedTeamSessionConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/ArchivedTeamSessionConversationListProvider.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResp
 import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import lombok.NonNull;
@@ -21,8 +22,9 @@ public class ArchivedTeamSessionConversationListProvider extends DefaultConversa
   public ArchivedTeamSessionConversationListProvider(
       @NonNull UserAccountService userAccountProvider,
       @NonNull ConsultantSessionEnricher consultantSessionEnricher,
+      @NonNull SessionSupervisionMarkerService supervisionMarkerService,
       @NonNull SessionService sessionService) {
-    super(consultantSessionEnricher);
+    super(consultantSessionEnricher, supervisionMarkerService);
     this.sessionService = sessionService;
     this.userAccountProvider = userAccountProvider;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProvider.java
@@ -4,6 +4,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResp
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import java.util.List;
 import lombok.NonNull;
@@ -15,6 +16,7 @@ import org.springframework.beans.support.PagedListHolder;
 public abstract class DefaultConversationListProvider implements ConversationListProvider {
 
   private final @NonNull ConsultantSessionEnricher consultantSessionEnricher;
+  private final @NonNull SessionSupervisionMarkerService supervisionMarkerService;
 
   /** {@inheritDoc} */
   protected ConsultantSessionListResponseDTO buildConversations(
@@ -30,6 +32,8 @@ public abstract class DefaultConversationListProvider implements ConversationLis
 
     List<ConsultantSessionResponseDTO> pageList = enquiriesForConsultant.getPageList();
     consultantSessionEnricher.updateRequiredConsultantSessionValues(pageList);
+    // ADR-008 marker for the requester, resolved for the page only (one batched query).
+    supervisionMarkerService.enrich(pageList, consultant);
 
     return new ConsultantSessionListResponseDTO()
         .sessions(pageList)

--- a/src/main/java/de/caritas/cob/userservice/api/conversation/provider/RegisteredEnquiryConversationListProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/conversation/provider/RegisteredEnquiryConversationListProvider.java
@@ -6,6 +6,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionListResp
 import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import lombok.NonNull;
@@ -21,8 +22,9 @@ public class RegisteredEnquiryConversationListProvider extends DefaultConversati
   public RegisteredEnquiryConversationListProvider(
       @NonNull UserAccountService userAccountProvider,
       @NonNull ConsultantSessionEnricher consultantSessionEnricher,
+      @NonNull SessionSupervisionMarkerService supervisionMarkerService,
       @NonNull SessionService sessionService) {
-    super(consultantSessionEnricher);
+    super(consultantSessionEnricher, supervisionMarkerService);
     this.sessionService = sessionService;
     this.userAccountProvider = userAccountProvider;
   }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -103,8 +103,14 @@ public class CreateChatFacade {
     session.setAgencyId(agencyId);
     session.setStatus(SessionStatus.IN_PROGRESS);
     session.setRegistrationType(RegistrationType.REGISTERED);
-    session.setTeamSession(true); // Mark as group chat
-    session.setConversationType(chat.getConversationType());
+    // teamSession keeps the group visible through the team-session queries. It is NOT the
+    // modality (ADR-006 addendum 2026-09-04): the modality is stamped explicitly here, because
+    // this facade is the only producer of INTERNAL_GROUP / SELF_HELP sessions.
+    session.setTeamSession(true);
+    session.setConversationType(
+        chat.getConversationType() == null
+            ? ConversationType.INTERNAL_GROUP
+            : chat.getConversationType());
     session.setLanguageCode(LanguageCode.de); // Default language
     session.setIsConsultantDirectlySet(false); // Not directly assigned
 

--- a/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacade.java
@@ -267,6 +267,7 @@ public class SessionListFacade {
       consultantSessionsSublist =
           retrieveConsultantSessionsSublist(sessionListQueryParameter, consultantSessions);
     }
+    consultantSessionListService.enrichWithSupervision(consultantSessionsSublist, consultant);
 
     return new ConsultantSessionListResponseDTO()
         .sessions(consultantSessionsSublist)
@@ -335,6 +336,7 @@ public class SessionListFacade {
     if (topicsFeatureEnabled) {
       enrichWithTopicData(teamSessionsSublist);
     }
+    consultantSessionListService.enrichWithSupervision(teamSessionsSublist, consultant);
 
     return new ConsultantSessionListResponseDTO()
         .sessions(teamSessionsSublist)

--- a/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolver.java
@@ -40,6 +40,42 @@ public class ConsultantDisplayNameResolver {
   }
 
   /**
+   * The name a <em>colleague</em> sees on internal surfaces (team lists, the ADR-008 supervision
+   * marker, internal group chats): the #996 rule {@code internalDisplayName ?? displayName}, with
+   * the same usability check as {@link #resolveMatrixDisplayName(Consultant)} and the same username
+   * fallback. Never the real name. Advice-seeker surfaces must not call this.
+   *
+   * @param internalDisplayName the internal display name (nullable)
+   * @param publicDisplayName the public display name (nullable)
+   * @param username the (encoded) username, the last resort
+   * @return the display name for internal surfaces
+   */
+  public String resolveInternalDisplayName(
+      String internalDisplayName, String publicDisplayName, String username) {
+    if (isUsable(internalDisplayName)) {
+      return internalDisplayName;
+    }
+    if (isUsable(publicDisplayName)) {
+      return publicDisplayName;
+    }
+    return usernameTranscoder.decodeUsername(username);
+  }
+
+  /**
+   * Entity overload of {@link #resolveInternalDisplayName(String, String, String)}.
+   *
+   * @param consultant the colleague (nullable)
+   * @return the display name for internal surfaces, or null when the consultant is null
+   */
+  public String resolveInternalDisplayName(Consultant consultant) {
+    if (consultant == null) {
+      return null;
+    }
+    return resolveInternalDisplayName(
+        consultant.getInternalDisplayName(), consultant.getDisplayName(), consultant.getUsername());
+  }
+
+  /**
    * An encoded value would render as noise rather than as a pseudonym, so it is treated as absent
    * and the username is used instead. Mirrors the check the notification service applies before
    * putting a counsellor's name in front of a client.

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorMarkerRow.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorMarkerRow.java
@@ -1,0 +1,19 @@
+package de.caritas.cob.userservice.api.port.out;
+
+/**
+ * One active supervisor of one session, projected to exactly the columns the ADR-008 list marker
+ * needs. A scalar projection on purpose: resolving the marker for a whole session list must stay a
+ * single query and must not pull the {@code Session} or {@code Consultant} entity graphs.
+ *
+ * @param sessionId the supervised session
+ * @param consultantId keycloak id of the supervising consultant
+ * @param username the supervisor's (encoded) username — last-resort display name
+ * @param displayName the supervisor's public display name (nullable)
+ * @param internalDisplayName the supervisor's internal display name, #996 (nullable)
+ */
+public record SessionSupervisorMarkerRow(
+    Long sessionId,
+    String consultantId,
+    String username,
+    String displayName,
+    String internalDisplayName) {}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionSupervisorRepository.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.SessionSupervisor;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -43,6 +44,22 @@ public interface SessionSupervisorRepository extends JpaRepository<SessionSuperv
           + "AND ss.isActive = true")
   List<SessionSupervisor> findActiveSupervisionsByConsultantId(
       @Param("consultantId") String consultantId);
+
+  /**
+   * ADR-008 list marker: every active supervisor of every given session in ONE query, projected to
+   * the columns the marker needs. Callers group the rows by {@link
+   * SessionSupervisorMarkerRow#sessionId()}; sessions without supervisors simply yield no row.
+   *
+   * @param sessionIds the sessions of one list page (or a singleton for a single read)
+   * @return the marker rows, unordered
+   */
+  @Query(
+      "SELECT new de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow("
+          + "ss.session.id, c.id, c.username, c.displayName, c.internalDisplayName) "
+          + "FROM SessionSupervisor ss JOIN ss.supervisorConsultant c "
+          + "WHERE ss.session.id IN :sessionIds AND ss.isActive = true")
+  List<SessionSupervisorMarkerRow> findActiveMarkerRowsBySessionIdIn(
+      @Param("sessionIds") Collection<Long> sessionIds);
 
   /**
    * Find active supervisor relationship for a session and consultant.

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
@@ -106,6 +106,26 @@ public class SessionMapper {
       List<SessionSupervisorMarkerRow> activeSupervisors,
       String requestingConsultantId,
       Function<SessionSupervisorMarkerRow, String> displayName) {
+    return toSupervisionDTO(activeSupervisors, requestingConsultantId, displayName, null);
+  }
+
+  /**
+   * {@link #toSupervisionDTO(List, String, Function)} plus the counsellor's internal display name,
+   * so a supervisor's panel can title the case by its responsible consultant without a second
+   * lookup (the public consultant endpoint hides the name of a non-public consultant).
+   *
+   * @param activeSupervisors the active supervisor rows of this session (nullable = none)
+   * @param requestingConsultantId the requester's keycloak id (nullable = nobody)
+   * @param displayName resolves the display name shown to colleagues for one row
+   * @param counsellorDisplayName the assigned consultant's internal display name (#996 rule),
+   *     nullable when the session has no consultant
+   * @return the marker, never null
+   */
+  public SessionSupervisionDTO toSupervisionDTO(
+      List<SessionSupervisorMarkerRow> activeSupervisors,
+      String requestingConsultantId,
+      Function<SessionSupervisorMarkerRow, String> displayName,
+      String counsellorDisplayName) {
     List<String> ids = new ArrayList<>();
     List<String> names = new ArrayList<>();
     boolean supervisedByMe = false;
@@ -120,7 +140,8 @@ public class SessionMapper {
     return new SessionSupervisionDTO()
         .supervisedByMe(supervisedByMe)
         .supervisorConsultantIds(ids)
-        .supervisorDisplayNames(names);
+        .supervisorDisplayNames(names)
+        .counsellorDisplayName(counsellorDisplayName);
   }
 
   private SessionUserDTO convertToSessionUserDTO(Session session) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.GroupSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionSupervisionDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionTopicDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionUserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
@@ -18,10 +19,14 @@ import de.caritas.cob.userservice.api.helper.SessionDataKeyRegistration;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
 import java.sql.Date;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
 /** Mapper class to map a {@link Session} to possible dto objects. */
@@ -82,6 +87,40 @@ public class SessionMapper {
         .consentRequired(
             session.isConsentGateApplicable() && isNull(session.getConsentedLegalVersionId()))
         .topic(new SessionTopicDTO().id(session.getMainTopicId()));
+  }
+
+  /**
+   * Builds the ADR-008 supervision marker of one session as seen by the requesting consultant.
+   *
+   * <p>{@code supervisedByMe} is true exactly when the requester is one of the active supervisors —
+   * the reason a supervised case shows up in their list at all. Ids and display names are parallel
+   * lists in row order. Always returns an object (empty marker when nothing is supervised), so the
+   * frontend needs no null check on consultant-facing lists.
+   *
+   * @param activeSupervisors the active supervisor rows of this session (nullable = none)
+   * @param requestingConsultantId the requester's keycloak id (nullable = nobody)
+   * @param displayName resolves the display name shown to colleagues for one row
+   * @return the marker, never null
+   */
+  public SessionSupervisionDTO toSupervisionDTO(
+      List<SessionSupervisorMarkerRow> activeSupervisors,
+      String requestingConsultantId,
+      Function<SessionSupervisorMarkerRow, String> displayName) {
+    List<String> ids = new ArrayList<>();
+    List<String> names = new ArrayList<>();
+    boolean supervisedByMe = false;
+    if (nonNull(activeSupervisors)) {
+      for (var row : activeSupervisors) {
+        ids.add(row.consultantId());
+        names.add(displayName.apply(row));
+        supervisedByMe |=
+            nonNull(requestingConsultantId) && requestingConsultantId.equals(row.consultantId());
+      }
+    }
+    return new SessionSupervisionDTO()
+        .supervisedByMe(supervisedByMe)
+        .supervisorConsultantIds(ids)
+        .supervisorDisplayNames(names);
   }
 
   private SessionUserDTO convertToSessionUserDTO(Session session) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionMapper.java
@@ -74,6 +74,11 @@ public class SessionMapper {
             nonNull(session.getUser()) && nonNull(session.getUser().getMatrixUserId())
                 ? session.getUser().getMatrixUserId()
                 : null)
+        /* ADR-002 silent membership: the room header shows only asker, assigned counsellor and
+        active supervisors, so the list/room DTO names the counsellor's Matrix id itself — never
+        the username. */
+        .consultantMatrixUserId(
+            nonNull(session.getConsultant()) ? session.getConsultant().getMatrixUserId() : null)
         .messageDate(toUnixTime(session.getEnquiryMessageDate()))
         .isTeamSession(session.isTeamSession())
         .language(LanguageCode.fromValue(session.getLanguageCode().name()))

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -906,7 +906,7 @@ public class SessionService {
     var consultantSessionDTO =
         new ConsultantSessionDTO()
             .isTeamSession(session.isTeamSession())
-            .supervision(supervisionMarkerService.buildFor(session.getId(), requester))
+            .supervision(supervisionMarkerService.buildFor(session, requester))
             .agencyId(session.getAgencyId())
             .consultingType(session.getConsultingTypeId())
             .id(session.getId())

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionService.java
@@ -80,6 +80,7 @@ public class SessionService {
   private final @NonNull ConsultingTypeManager consultingTypeManager;
   private final @Nullable ConsultantSessionTopicEnrichmentService sessionTopicEnrichmentService;
   private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  private final @NonNull SessionSupervisionMarkerService supervisionMarkerService;
 
   @Value("${feature.topics.enabled}")
   private boolean topicsFeatureEnabled;
@@ -288,12 +289,15 @@ public class SessionService {
    */
   public Session saveSession(Session session) {
     if (session.getConversationType() == null) {
+      /* ADR-006 addendum 2026-09-04: `teamSession` is NOT a modality. It also marks a
+       * "Team-Beratungsstelle" 1:1 case (every counsellor of the agency may see it), so deriving
+       * INTERNAL_GROUP from it labelled ordinary counselling as an internal group chat. The only
+       * producer of INTERNAL_GROUP/SELF_HELP sessions is CreateChatFacade, which stamps the
+       * modality explicitly before saving; everything that reaches this default is a 1:1 case. */
       session.setConversationType(
-          session.isTeamSession()
-              ? ConversationType.INTERNAL_GROUP
-              : session.getRegistrationType() == Session.RegistrationType.ANONYMOUS
-                  ? ConversationType.LIVE_CHAT
-                  : ConversationType.AGENCY_COUNSELLING);
+          session.getRegistrationType() == Session.RegistrationType.ANONYMOUS
+              ? ConversationType.LIVE_CHAT
+              : ConversationType.AGENCY_COUNSELLING);
     }
     return sessionRepository.save(session);
   }
@@ -881,7 +885,7 @@ public class SessionService {
             .orElseThrow(() -> new NotFoundException("Session with id %s not found.", sessionId));
 
     checkPermissionForConsultantSession(session, consultant);
-    return toConsultantSessionDTO(session);
+    return toConsultantSessionDTO(session, consultant);
   }
 
   private boolean isTeamSessionOrNew(Session session) {
@@ -897,11 +901,12 @@ public class SessionService {
         new BadRequestException(String.format("Consultant with id %s does not exist", userId));
   }
 
-  private ConsultantSessionDTO toConsultantSessionDTO(Session session) {
+  private ConsultantSessionDTO toConsultantSessionDTO(Session session, Consultant requester) {
 
     var consultantSessionDTO =
         new ConsultantSessionDTO()
             .isTeamSession(session.isTeamSession())
+            .supervision(supervisionMarkerService.buildFor(session.getId(), requester))
             .agencyId(session.getAgencyId())
             .consultingType(session.getConsultingTypeId())
             .id(session.getId())

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerService.java
@@ -1,0 +1,103 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionSupervisionDTO;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Fills {@code SessionDTO.supervision} — the explicit ADR-008 supervisor marker — for the
+ * consultant who asked for the list (ADR-008 addendum 2026-09-04, presentation).
+ *
+ * <p>Before this marker the frontend had to guess "am I the supervisor here?" from {@code
+ * consultant.id !== me}, which is also true for team-agency cases and for handed-over cases. The
+ * marker states it: {@code supervisedByMe} is true exactly when the requester is an active {@code
+ * SessionSupervisor} of the session.
+ *
+ * <p>One batched query per list page, never one per session.
+ */
+@Service
+@RequiredArgsConstructor
+public class SessionSupervisionMarkerService {
+
+  private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
+  private final @NonNull ConsultantDisplayNameResolver consultantDisplayNameResolver;
+
+  /**
+   * Sets the supervision marker on every entry that carries a session id, as seen by the requester.
+   * Entries without a session (pure chat rows) are left untouched.
+   *
+   * @param entries the list page (returned as-is, mutated in place)
+   * @param requester the consultant reading the list
+   * @return the same list
+   */
+  public List<ConsultantSessionResponseDTO> enrich(
+      List<ConsultantSessionResponseDTO> entries, Consultant requester) {
+    if (isNull(entries) || entries.isEmpty() || isNull(requester)) {
+      return entries;
+    }
+    Set<Long> sessionIds = new LinkedHashSet<>();
+    for (var entry : entries) {
+      if (nonNull(entry.getSession()) && nonNull(entry.getSession().getId())) {
+        sessionIds.add(entry.getSession().getId());
+      }
+    }
+    if (sessionIds.isEmpty()) {
+      return entries;
+    }
+
+    var rowsBySession = loadRowsBySession(sessionIds);
+    var mapper = new SessionMapper();
+    for (var entry : entries) {
+      var session = entry.getSession();
+      if (nonNull(session) && nonNull(session.getId())) {
+        session.setSupervision(
+            mapper.toSupervisionDTO(
+                rowsBySession.getOrDefault(session.getId(), List.of()),
+                requester.getId(),
+                this::displayNameOf));
+      }
+    }
+    return entries;
+  }
+
+  /**
+   * The marker of a single session (single-session read), same query and same rule as the list.
+   *
+   * @param sessionId the session
+   * @param requester the consultant reading it
+   * @return the marker, or null when either argument is missing
+   */
+  public SessionSupervisionDTO buildFor(Long sessionId, Consultant requester) {
+    if (isNull(sessionId) || isNull(requester)) {
+      return null;
+    }
+    var rows = loadRowsBySession(Set.of(sessionId)).getOrDefault(sessionId, List.of());
+    return new SessionMapper().toSupervisionDTO(rows, requester.getId(), this::displayNameOf);
+  }
+
+  private Map<Long, List<SessionSupervisorMarkerRow>> loadRowsBySession(
+      Collection<Long> sessionIds) {
+    return sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(sessionIds).stream()
+        .collect(Collectors.groupingBy(SessionSupervisorMarkerRow::sessionId));
+  }
+
+  private String displayNameOf(SessionSupervisorMarkerRow row) {
+    return consultantDisplayNameResolver.resolveInternalDisplayName(
+        row.internalDisplayName(), row.displayName(), row.username());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerService.java
@@ -7,9 +7,13 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponse
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionSupervisionDTO;
 import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +32,12 @@ import org.springframework.stereotype.Service;
  * marker states it: {@code supervisedByMe} is true exactly when the requester is an active {@code
  * SessionSupervisor} of the session.
  *
- * <p>One batched query per list page, never one per session.
+ * <p>The marker also carries {@code counsellorDisplayName} — the assigned consultant's internal
+ * display name (#996 rule, never a real name) — because the consultant-facing list DTO exposes only
+ * id/firstName/lastName and the public consultant endpoint hides the display name of a non-public
+ * consultant; without it a supervisor's panel cannot title the case by its counsellor.
+ *
+ * <p>Two batched queries per list page (supervisor rows, counsellor names), never one per session.
  */
 @Service
 @RequiredArgsConstructor
@@ -36,6 +45,7 @@ public class SessionSupervisionMarkerService {
 
   private final @NonNull SessionSupervisorRepository sessionSupervisorRepository;
   private final @NonNull ConsultantDisplayNameResolver consultantDisplayNameResolver;
+  private final @NonNull ConsultantRepository consultantRepository;
 
   /**
    * Sets the supervision marker on every entry that carries a session id, as seen by the requester.
@@ -51,9 +61,13 @@ public class SessionSupervisionMarkerService {
       return entries;
     }
     Set<Long> sessionIds = new LinkedHashSet<>();
+    Set<String> counsellorIds = new LinkedHashSet<>();
     for (var entry : entries) {
       if (nonNull(entry.getSession()) && nonNull(entry.getSession().getId())) {
         sessionIds.add(entry.getSession().getId());
+        if (nonNull(entry.getConsultant()) && nonNull(entry.getConsultant().getId())) {
+          counsellorIds.add(entry.getConsultant().getId());
+        }
       }
     }
     if (sessionIds.isEmpty()) {
@@ -61,33 +75,56 @@ public class SessionSupervisionMarkerService {
     }
 
     var rowsBySession = loadRowsBySession(sessionIds);
+    var counsellorNames = loadCounsellorDisplayNames(counsellorIds);
     var mapper = new SessionMapper();
     for (var entry : entries) {
       var session = entry.getSession();
       if (nonNull(session) && nonNull(session.getId())) {
+        var counsellorId = nonNull(entry.getConsultant()) ? entry.getConsultant().getId() : null;
         session.setSupervision(
             mapper.toSupervisionDTO(
                 rowsBySession.getOrDefault(session.getId(), List.of()),
                 requester.getId(),
-                this::displayNameOf));
+                this::displayNameOf,
+                nonNull(counsellorId) ? counsellorNames.get(counsellorId) : null));
       }
     }
     return entries;
   }
 
   /**
-   * The marker of a single session (single-session read), same query and same rule as the list.
+   * The marker of a single session (single-session read), same query and same rule as the list. The
+   * counsellor name comes straight from {@code session.getConsultant()} — no extra query.
    *
-   * @param sessionId the session
+   * @param session the loaded session
    * @param requester the consultant reading it
-   * @return the marker, or null when either argument is missing
+   * @return the marker, or null when the session, its id or the requester is missing
    */
-  public SessionSupervisionDTO buildFor(Long sessionId, Consultant requester) {
-    if (isNull(sessionId) || isNull(requester)) {
+  public SessionSupervisionDTO buildFor(Session session, Consultant requester) {
+    if (isNull(session) || isNull(session.getId()) || isNull(requester)) {
       return null;
     }
+    var sessionId = session.getId();
     var rows = loadRowsBySession(Set.of(sessionId)).getOrDefault(sessionId, List.of());
-    return new SessionMapper().toSupervisionDTO(rows, requester.getId(), this::displayNameOf);
+    return new SessionMapper()
+        .toSupervisionDTO(
+            rows,
+            requester.getId(),
+            this::displayNameOf,
+            consultantDisplayNameResolver.resolveInternalDisplayName(session.getConsultant()));
+  }
+
+  /** One query for all counsellors of the page; id → internal display name (#996 rule). */
+  private Map<String, String> loadCounsellorDisplayNames(Collection<String> consultantIds) {
+    Map<String, String> names = new HashMap<>();
+    if (consultantIds.isEmpty()) {
+      return names;
+    }
+    for (var consultant : consultantRepository.findAllByIdIn(new ArrayList<>(consultantIds))) {
+      names.put(
+          consultant.getId(), consultantDisplayNameResolver.resolveInternalDisplayName(consultant));
+    }
+    return names;
   }
 
   private Map<Long, List<SessionSupervisorMarkerRow>> loadRowsBySession(

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
@@ -11,6 +11,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ public class ConsultantSessionListService {
   private final @NonNull ChatService chatService;
   private final @NonNull ConsultantSessionEnricher consultantSessionEnricher;
   private final @NonNull ConsultantChatEnricher consultantChatEnricher;
+  private final @NonNull SessionSupervisionMarkerService supervisionMarkerService;
 
   /**
    * @param consultant {@link Consultant}
@@ -194,6 +196,8 @@ public class ConsultantSessionListService {
 
     if (isNotEmpty(sessions)) {
       enrichedSessions = updateConsultantSessionValues(sessions);
+      // ADR-008 marker for the requester — one batched query, see SessionSupervisionMarkerService.
+      supervisionMarkerService.enrich(enrichedSessions, consultant);
     }
 
     if (isNotEmpty(chats)) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListService.java
@@ -47,7 +47,9 @@ public class ConsultantSessionListService {
         sessionService.getAllowedSessionsByConsultantAndRoomIds(consultant, matrixRoomIds, roles);
     var chats = chatService.getChatSessionsForConsultantByRoomIds(matrixRoomIds);
 
-    return mergeConsultantSessionsAndChats(consultant, sessions, chats);
+    var result = mergeConsultantSessionsAndChats(consultant, sessions, chats);
+    enrichWithSupervision(result, consultant);
+    return result;
   }
 
   /**
@@ -66,7 +68,9 @@ public class ConsultantSessionListService {
             .collect(Collectors.toSet());
     var chats = chatService.getChatSessionsForConsultantByRoomIds(matrixRoomIds);
 
-    return mergeConsultantSessionsAndChats(consultant, sessions, chats);
+    var result = mergeConsultantSessionsAndChats(consultant, sessions, chats);
+    enrichWithSupervision(result, consultant);
+    return result;
   }
 
   /**
@@ -196,8 +200,6 @@ public class ConsultantSessionListService {
 
     if (isNotEmpty(sessions)) {
       enrichedSessions = updateConsultantSessionValues(sessions);
-      // ADR-008 marker for the requester — one batched query, see SessionSupervisionMarkerService.
-      supervisionMarkerService.enrich(enrichedSessions, consultant);
     }
 
     if (isNotEmpty(chats)) {
@@ -226,6 +228,14 @@ public class ConsultantSessionListService {
     allSessions.addAll(chatsByMatrixRoomId.values());
 
     return allSessions;
+  }
+
+  /** Adds ADR-008 requester markers to the final response slice with one batched query. */
+  public void enrichWithSupervision(
+      List<ConsultantSessionResponseDTO> sessions, Consultant consultant) {
+    if (isNotEmpty(sessions)) {
+      supervisionMarkerService.enrich(sessions, consultant);
+    }
   }
 
   private void sortSessionsByLastMessageDateDesc(List<ConsultantSessionResponseDTO> sessions) {

--- a/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+  <!-- ADR-006 addendum 2026-09-04: team-agency 1:1 cases were persisted as INTERNAL_GROUP because
+       saveSession derived the modality from is_team_session. Re-stamps those rows by registration
+       type; real group chats (group_chat_participant row / shared chat room / system user) are left
+       alone. Data-only, no schema change. See migrate.sql.
+
+       Guarded twice: the SQL's WHERE clause excludes already-corrected rows, and runOnChange lets a
+       later edit of migrate.sql re-apply without a new id. -->
+  <changeSet id="0091-team-agency-session-modality" author="frank" runOnChange="true">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="session"/>
+      <tableExists tableName="group_chat_participant"/>
+      <tableExists tableName="chat"/>
+      <columnExists tableName="session" columnName="conversation_type"/>
+    </preConditions>
+    <sqlFile
+      path="db/changelog/changeset/0091_team_agency_session_modality/migrate.sql"
+      relativeToChangelogFile="false" splitStatements="true" stripComments="true" endDelimiter=";"
+      encoding="UTF-8"/>
+    <rollback>
+      <comment>The previous INTERNAL_GROUP label was the defect; there is nothing correct to
+        restore. Rolling back is a no-op.</comment>
+      <sql>SELECT 1;</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
@@ -16,6 +16,7 @@
       <tableExists tableName="group_chat_participant"/>
       <tableExists tableName="chat"/>
       <columnExists tableName="session" columnName="conversation_type"/>
+      <columnExists tableName="group_chat_participant" columnName="chat_id"/>
     </preConditions>
     <sqlFile
       path="db/changelog/changeset/0091_team_agency_session_modality/migrate.sql"

--- a/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml
@@ -8,9 +8,9 @@
        type; real group chats (group_chat_participant row / shared chat room / system user) are left
        alone. Data-only, no schema change. See migrate.sql.
 
-       Guarded twice: the SQL's WHERE clause excludes already-corrected rows, and runOnChange lets a
-       later edit of migrate.sql re-apply without a new id. -->
-  <changeSet id="0091-team-agency-session-modality" author="frank" runOnChange="true">
+       The SQL's WHERE clause excludes already-corrected rows. Future corrections must use a new
+       append-only changeset rather than editing and rerunning this one. -->
+  <changeSet id="0091-team-agency-session-modality" author="frank">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="session"/>
       <tableExists tableName="group_chat_participant"/>

--- a/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/migrate.sql
@@ -1,0 +1,25 @@
+-- ADR-006 addendum 2026-09-04: `is_team_session` has two meanings — an internal group chat
+-- (created by CreateChatFacade) and a "Team-Beratungsstelle" 1:1 case (every counsellor of the
+-- agency may see it). SessionService.saveSession used to derive INTERNAL_GROUP from the flag, so
+-- every 1:1 case of a team agency was persisted as an internal group chat.
+--
+-- Group chats are recognised by what only the group-chat path produces (any one is enough):
+--   * a group_chat_participant row whose chat_id is the session id (the creator is always added),
+--   * a chat row sharing the session's Matrix room id (both rows carry the same room),
+--   * the tenant system user "group-chat-system[-<tenant>]" as the session's user.
+-- Everything else with is_team_session = 1 is a 1:1 case and gets its modality by registration
+-- type, exactly as saveSession now defaults it. SELF_HELP rows are never touched.
+--
+-- Idempotent: the WHERE clause excludes every row a previous run has already corrected.
+UPDATE session
+SET conversation_type = CASE
+                          WHEN registration_type = 'ANONYMOUS' THEN 'LIVE_CHAT'
+                          ELSE 'AGENCY_COUNSELLING'
+                        END
+WHERE is_team_session = 1
+  AND (conversation_type = 'INTERNAL_GROUP' OR conversation_type IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM group_chat_participant gcp WHERE gcp.chat_id = session.id)
+  AND NOT EXISTS (SELECT 1 FROM chat c
+                  WHERE c.matrix_room_id IS NOT NULL
+                    AND c.matrix_room_id = session.matrix_room_id)
+  AND session.user_id NOT LIKE 'group-chat-system%';

--- a/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0091_team_agency_session_modality/migrate.sql
@@ -18,7 +18,8 @@ SET conversation_type = CASE
                         END
 WHERE is_team_session = 1
   AND (conversation_type = 'INTERNAL_GROUP' OR conversation_type IS NULL)
-  AND NOT EXISTS (SELECT 1 FROM group_chat_participant gcp WHERE gcp.chat_id = session.id)
+  AND NOT EXISTS (SELECT 1 FROM group_chat_participant gcp
+                  WHERE gcp.chat_id = session.id)
   AND NOT EXISTS (SELECT 1 FROM chat c
                   WHERE c.matrix_room_id IS NOT NULL
                     AND c.matrix_room_id = session.matrix_room_id)

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -171,6 +171,8 @@
     file="db/changelog/changeset/0091_account_invite_active_recipient/0091_changeSet.xml" />
   <include
     file="db/changelog/changeset/0092_id_reservation_release_task/0092_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0091_team_agency_session_modality/0091_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorControllerTest.java
@@ -204,6 +204,17 @@ class SessionSupervisorControllerTest {
   }
 
   @Test
+  void getSupervisors_blankMatrixAccount_leavesMatrixUserIdNull() {
+    var first = supervisor(32L, "sup-5", "added-by-5", "Display Five", "Full Five", user("u-5"));
+    first.getSupervisorConsultant().setMatrixUserId("  ");
+    when(sessionSupervisorFacade.getSupervisors(80L)).thenReturn(List.of(first));
+
+    var response = controller.getSupervisors(80L);
+
+    assertNull(response.getBody().get(0).getSupervisorMatrixUserId());
+  }
+
+  @Test
   void getSupervisors_emptyList_returnsEmptyArrayNotNull() {
     // Business reason: frontend expects stable empty arrays instead of null for list endpoints.
     when(sessionSupervisorFacade.getSupervisors(78L)).thenReturn(List.of());

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/SessionSupervisorControllerTest.java
@@ -186,9 +186,21 @@ class SessionSupervisorControllerTest {
     assertEquals(77L, dto.getSessionId());
     assertEquals("sup-3", dto.getSupervisorConsultantId());
     assertEquals("Display Three", dto.getSupervisorUsername());
+    assertEquals("rc-sup-3", dto.getSupervisorMatrixUserId());
     assertEquals("added-by-3", dto.getAddedByConsultantId());
     assertEquals("room-77", dto.getMatrixRoomId());
     assertEquals("note-30", dto.getNotes());
+  }
+
+  @Test
+  void getSupervisors_supervisorWithoutMatrixAccount_leavesMatrixUserIdNull() {
+    var first = supervisor(31L, "sup-4", "added-by-4", "Display Four", "Full Four", user("u-4"));
+    first.getSupervisorConsultant().setMatrixUserId(null);
+    when(sessionSupervisorFacade.getSupervisors(79L)).thenReturn(List.of(first));
+
+    var response = controller.getSupervisors(79L);
+
+    assertNull(response.getBody().get(0).getSupervisorMatrixUserId());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/AnonymousEnquiryConversationListProviderCrossTenantTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.port.out.ConsultantTopicRepository;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
@@ -44,6 +46,7 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
   @Mock private SessionRepository sessionRepository;
   @Mock private ConsultantSessionEnricher consultantSessionEnricher;
   @Mock private ConsultantTopicRepository consultantTopicRepository;
+  @Mock private SessionSupervisionMarkerService supervisionMarkerService;
 
   @AfterEach
   void clearTenant() {
@@ -56,7 +59,8 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
             userAccountProvider,
             sessionRepository,
             consultantSessionEnricher,
-            consultantTopicRepository);
+            consultantTopicRepository,
+            supervisionMarkerService);
     ReflectionTestUtils.setField(provider, "liveChatQueueActivePeriodMinutes", 60L);
     return provider;
   }
@@ -88,6 +92,31 @@ class AnonymousEnquiryConversationListProviderCrossTenantTest {
 
     assertThat(tenantDuringQuery.get()).isEqualTo(TenantContext.TECHNICAL_TENANT_ID);
     assertThat(TenantContext.getCurrentTenant()).isEqualTo(CONSULTANT_TENANT);
+  }
+
+  @Test
+  void buildConversations_Should_addSupervisionMarkersToTheReturnedPage() {
+    var consultant = consultant();
+    var session =
+        Session.builder()
+            .id(91L)
+            .registrationType(Session.RegistrationType.ANONYMOUS)
+            .postcode("12345")
+            .languageCode(LanguageCode.de)
+            .status(Session.SessionStatus.NEW)
+            .teamSession(false)
+            .build();
+    when(userAccountProvider.retrieveValidatedConsultant()).thenReturn(consultant);
+    when(consultantTopicRepository.findTopicIdsByConsultantId("consultant-83"))
+        .thenReturn(List.of(11L));
+    when(sessionRepository.findAnonymousEnquiriesVisibleForConsultantsByTopicsOnly(
+            anySet(), any(), any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(session)));
+
+    var response =
+        newProvider().buildConversations(PageableListRequest.builder().count(5).offset(0).build());
+
+    verify(supervisionMarkerService).enrich(response.getSessions(), consultant);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/conversation/provider/DefaultConversationListProviderTest.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.conversation.model.ConversationListType;
 import de.caritas.cob.userservice.api.conversation.model.PageableListRequest;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import de.caritas.cob.userservice.api.service.sessionlist.ConsultantSessionEnricher;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import org.mockito.quality.Strictness;
 class DefaultConversationListProviderTest {
 
   @Mock private ConsultantSessionEnricher consultantSessionEnricher;
+  @Mock private SessionSupervisionMarkerService supervisionMarkerService;
 
   private DefaultConversationListProvider provider;
 
@@ -37,7 +39,7 @@ class DefaultConversationListProviderTest {
         .thenAnswer(inv -> inv.getArgument(0));
 
     provider =
-        new DefaultConversationListProvider(consultantSessionEnricher) {
+        new DefaultConversationListProvider(consultantSessionEnricher, supervisionMarkerService) {
           @Override
           public ConsultantSessionListResponseDTO buildConversations(
               PageableListRequest pageableListRequest) {
@@ -129,6 +131,22 @@ class DefaultConversationListProviderTest {
     provider.buildConversations(request, consultant, sessions);
 
     verify(consultantSessionEnricher).updateRequiredConsultantSessionValues(sessions);
+  }
+
+  @Test
+  void buildConversations_Should_AddSupervisionMarker_ForTheRequestingConsultant_OnThePageOnly() {
+    List<ConsultantSessionResponseDTO> sessions = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      sessions.add(new ConsultantSessionResponseDTO());
+    }
+    PageableListRequest request = PageableListRequest.builder().offset(0).count(2).build();
+    Consultant consultant = new Consultant();
+
+    ConsultantSessionListResponseDTO result =
+        provider.buildConversations(request, consultant, sessions);
+
+    verify(supervisionMarkerService).enrich(result.getSessions(), consultant);
+    assertThat(result.getSessions()).hasSize(2);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -224,6 +224,27 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
+  void createSimplifiedGroupChatShouldStampTheSessionAsInternalGroupExplicitly() throws Exception {
+    // ADR-006 addendum 2026-09-04: the group-chat path is the ONLY producer of INTERNAL_GROUP
+    // sessions and stamps the modality itself. SessionService.saveSession no longer derives it
+    // from teamSession, because teamSession also means "Team-Beratungsstelle" 1:1 case.
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    // No series fields at all (the mock would answer 0 for repeatCount) -> internal team chat.
+    when(chatDto.getRepeatCount()).thenReturn((Integer) null);
+    when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
+        .thenReturn(matrixRoomResponse("!room:matrix.org"));
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
+
+    createChatFacade.createChatV2(chatDto, consultant);
+
+    ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+    verify(sessionService, times(2)).saveSession(sessionCaptor.capture());
+    Session created = sessionCaptor.getAllValues().get(0);
+    assertThat(created.getConversationType()).isEqualTo(ConversationType.INTERNAL_GROUP);
+    assertThat(created.isTeamSession()).isTrue();
+  }
+
+  @Test
   void createSimplifiedGroupChatShouldStampBothRowsAsSelfHelpForOneOccurrenceSeries()
       throws Exception {
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));

--- a/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/sessionlist/SessionListFacadeTest.java
@@ -246,6 +246,8 @@ public class SessionListFacadeTest {
             CONSULTANT, sessionListQueryParameter);
 
     assertEquals(COUNT_1, result.getSessions().size());
+    Mockito.verify(consultantSessionListService)
+        .enrichWithSupervision(result.getSessions(), CONSULTANT);
   }
 
   @Test
@@ -384,6 +386,8 @@ public class SessionListFacadeTest {
             CONSULTANT, sessionListQueryParameter);
 
     assertEquals(COUNT_1, result.getSessions().size());
+    Mockito.verify(consultantSessionListService)
+        .enrichWithSupervision(result.getSessions(), CONSULTANT);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
@@ -63,4 +63,41 @@ class ConsultantDisplayNameResolverTest {
   void resolveMatrixDisplayName_Should_ReturnNull_When_ConsultantIsNull() {
     assertThat(resolver.resolveMatrixDisplayName(null)).isNull();
   }
+
+  // ---------------------------------------------------------------------------
+  // resolveInternalDisplayName — internal surfaces (team lists, supervision marker, #996)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("internal surfaces prefer the internal display name")
+  void resolveInternalDisplayName_Should_PreferTheInternalDisplayName() {
+    assertThat(resolver.resolveInternalDisplayName("Team Angela", "Frau A.", "beraterin1"))
+        .isEqualTo("Team Angela");
+  }
+
+  @Test
+  @DisplayName("falls back to the public display name, then to the decoded username")
+  void resolveInternalDisplayName_Should_FallBackToPublicNameThenUsername() {
+    assertThat(resolver.resolveInternalDisplayName(" ", "Frau A.", "beraterin1"))
+        .isEqualTo("Frau A.");
+    assertThat(resolver.resolveInternalDisplayName(null, null, "beraterin1"))
+        .isEqualTo("beraterin1");
+  }
+
+  @Test
+  @DisplayName("an encoded internal name is treated as absent")
+  void resolveInternalDisplayName_Should_IgnoreAnEncodedInternalName() {
+    assertThat(resolver.resolveInternalDisplayName("enc.QW5nZWxh", null, "beraterin1"))
+        .isEqualTo("beraterin1");
+  }
+
+  @Test
+  @DisplayName("the entity overload applies the same rule")
+  void resolveInternalDisplayName_Should_AcceptTheConsultantEntity() {
+    var consultant = consultantWith("beraterin1", "Frau A.");
+    consultant.setInternalDisplayName("Team Angela");
+
+    assertThat(resolver.resolveInternalDisplayName(consultant)).isEqualTo("Team Angela");
+    assertThat(resolver.resolveInternalDisplayName((Consultant) null)).isNull();
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/helper/ConsultantDisplayNameResolverTest.java
@@ -87,6 +87,8 @@ class ConsultantDisplayNameResolverTest {
   @Test
   @DisplayName("an encoded internal name is treated as absent")
   void resolveInternalDisplayName_Should_IgnoreAnEncodedInternalName() {
+    assertThat(resolver.resolveInternalDisplayName("enc.QW5nZWxh", "Frau A.", "beraterin1"))
+        .isEqualTo("Frau A.");
     assertThat(resolver.resolveInternalDisplayName("enc.QW5nZWxh", null, "beraterin1"))
         .isEqualTo("beraterin1");
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
@@ -4,6 +4,8 @@ import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.toIsoTim
 import static de.caritas.cob.userservice.api.model.Session.RegistrationType.ANONYMOUS;
 import static de.caritas.cob.userservice.api.model.Session.RegistrationType.REGISTERED;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -21,7 +23,9 @@ import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.SessionData;
 import de.caritas.cob.userservice.api.model.User;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
 
@@ -315,5 +319,50 @@ class SessionMapperTest {
     assertEquals("Alice", response.getConsultant().getFirstName());
     assertEquals("Smith", response.getConsultant().getLastName());
     assertEquals("Alice S.", response.getConsultant().getDisplayName());
+  }
+
+  // ---------------------------------------------------------------------------
+  // toSupervisionDTO — ADR-008 supervisor marker for consultant session lists
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void toSupervisionDTOShouldMarkRequesterAsSupervisorAndListAllActiveSupervisors() {
+    var rows =
+        List.of(
+            new SessionSupervisorMarkerRow(1L, "sup-1", "u1", "Public One", "Internal One"),
+            new SessionSupervisorMarkerRow(1L, "sup-2", "u2", null, null));
+
+    var dto = new SessionMapper().toSupervisionDTO(rows, "sup-2", row -> row.consultantId() + "!");
+
+    assertThat(dto.getSupervisedByMe(), is(true));
+    assertThat(dto.getSupervisorConsultantIds(), contains("sup-1", "sup-2"));
+    assertThat(dto.getSupervisorDisplayNames(), contains("sup-1!", "sup-2!"));
+  }
+
+  @Test
+  void toSupervisionDTOShouldNotMarkRequesterWhoIsNotAmongTheSupervisors() {
+    var rows = List.of(new SessionSupervisorMarkerRow(1L, "sup-1", "u1", "Public One", null));
+
+    var dto = new SessionMapper().toSupervisionDTO(rows, "owner", row -> row.consultantId());
+
+    assertThat(dto.getSupervisedByMe(), is(false));
+    assertThat(dto.getSupervisorConsultantIds(), contains("sup-1"));
+  }
+
+  @Test
+  void toSupervisionDTOShouldReportEmptyMarkerWhenNothingIsSupervised() {
+    var dto = new SessionMapper().toSupervisionDTO(List.of(), "me", row -> row.consultantId());
+
+    assertThat(dto.getSupervisedByMe(), is(false));
+    assertThat(dto.getSupervisorConsultantIds(), is(empty()));
+    assertThat(dto.getSupervisorDisplayNames(), is(empty()));
+  }
+
+  @Test
+  void toSupervisionDTOShouldTreatNullRowsAndNullRequesterAsNothingSupervised() {
+    var dto = new SessionMapper().toSupervisionDTO(null, null, row -> row.consultantId());
+
+    assertThat(dto.getSupervisedByMe(), is(false));
+    assertThat(dto.getSupervisorConsultantIds(), is(empty()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
@@ -364,5 +364,28 @@ class SessionMapperTest {
 
     assertThat(dto.getSupervisedByMe(), is(false));
     assertThat(dto.getSupervisorConsultantIds(), is(empty()));
+    assertThat(dto.getCounsellorDisplayName(), is(nullValue()));
+  }
+
+  @Test
+  void toSupervisionDTOShouldCarryTheCounsellorDisplayNameNextToTheSupervisors() {
+    var rows = List.of(new SessionSupervisorMarkerRow(1L, "sup-1", "u1", "Public One", null));
+
+    var dto =
+        new SessionMapper()
+            .toSupervisionDTO(rows, "sup-1", row -> row.consultantId(), "Anna (int)");
+
+    assertThat(dto.getSupervisedByMe(), is(true));
+    assertThat(dto.getSupervisorConsultantIds(), contains("sup-1"));
+    assertThat(dto.getCounsellorDisplayName(), is("Anna (int)"));
+  }
+
+  @Test
+  void toSupervisionDTOShouldLeaveTheCounsellorDisplayNameNullWhenNoneIsGiven() {
+    var dto =
+        new SessionMapper().toSupervisionDTO(List.of(), "me", row -> row.consultantId(), null);
+
+    assertThat(dto.getSupervisedByMe(), is(false));
+    assertThat(dto.getCounsellorDisplayName(), is(nullValue()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
@@ -193,7 +193,7 @@ class SessionMapperTest {
 
     SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
 
-    assertEquals("@counsellor:matrix.example", sessionDTO.getConsultantMatrixUserId());
+    assertEquals("@counsellor:matrix.example", sessionDTO.getConsultantMatrixUserId().orElse(null));
   }
 
   @Test
@@ -204,7 +204,7 @@ class SessionMapperTest {
 
     SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
 
-    assertNull(sessionDTO.getConsultantMatrixUserId());
+    assertNull(sessionDTO.getConsultantMatrixUserId().orElse(null));
   }
 
   @Test
@@ -392,7 +392,7 @@ class SessionMapperTest {
 
     assertThat(dto.getSupervisedByMe(), is(false));
     assertThat(dto.getSupervisorConsultantIds(), is(empty()));
-    assertThat(dto.getCounsellorDisplayName(), is(nullValue()));
+    assertThat(dto.getCounsellorDisplayName().orElse(null), is(nullValue()));
   }
 
   @Test
@@ -405,7 +405,7 @@ class SessionMapperTest {
 
     assertThat(dto.getSupervisedByMe(), is(true));
     assertThat(dto.getSupervisorConsultantIds(), contains("sup-1"));
-    assertThat(dto.getCounsellorDisplayName(), is("Anna (int)"));
+    assertThat(dto.getCounsellorDisplayName().orElse(null), is("Anna (int)"));
   }
 
   @Test
@@ -414,6 +414,6 @@ class SessionMapperTest {
         new SessionMapper().toSupervisionDTO(List.of(), "me", row -> row.consultantId(), null);
 
     assertThat(dto.getSupervisedByMe(), is(false));
-    assertThat(dto.getCounsellorDisplayName(), is(nullValue()));
+    assertThat(dto.getCounsellorDisplayName().orElse(null), is(nullValue()));
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionMapperTest.java
@@ -19,6 +19,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForUserD
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
 import de.caritas.cob.userservice.api.config.AppConfig;
+import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.SessionData;
@@ -177,6 +178,33 @@ class SessionMapperTest {
     SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
 
     assertNull(sessionDTO.getAskerMatrixUserId());
+  }
+
+  @Test
+  void convertToSessionDTO_Should_carryTheAssignedConsultantsMatrixUserId() {
+    // ADR-002 silent membership: the room header shows only asker, assigned counsellor and
+    // active supervisors, so the list/room DTO has to name the counsellor's Matrix id itself.
+    Session session = new EasyRandom().nextObject(Session.class);
+    session.setRegistrationType(REGISTERED);
+    Consultant consultant = new Consultant();
+    consultant.setMatrixUserId("@counsellor:matrix.example");
+    consultant.setUsername("must-not-leak");
+    session.setConsultant(consultant);
+
+    SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
+
+    assertEquals("@counsellor:matrix.example", sessionDTO.getConsultantMatrixUserId());
+  }
+
+  @Test
+  void convertToSessionDTO_Should_leaveConsultantMatrixUserIdNull_When_noConsultantIsAssigned() {
+    Session session = new EasyRandom().nextObject(Session.class);
+    session.setRegistrationType(REGISTERED);
+    session.setConsultant(null);
+
+    SessionDTO sessionDTO = new SessionMapper().convertToSessionDTO(session);
+
+    assertNull(sessionDTO.getConsultantMatrixUserId());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceAccessTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceAccessTest.java
@@ -47,6 +47,7 @@ class SessionServiceAccessTest {
   @Mock private ConsultingTypeManager consultingTypeManager;
   @Mock private ConsultantSessionTopicEnrichmentService sessionTopicEnrichmentService;
   @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+  @Mock private SessionSupervisionMarkerService supervisionMarkerService;
 
   private SessionService sessionService;
 
@@ -62,7 +63,8 @@ class SessionServiceAccessTest {
             userService,
             consultingTypeManager,
             sessionTopicEnrichmentService,
-            sessionSupervisorRepository);
+            sessionSupervisorRepository,
+            supervisionMarkerService);
 
     lenient()
         .when(

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -51,6 +51,7 @@ import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionSupervisionDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.UserSessionResponseDTO;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
@@ -62,6 +63,7 @@ import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManag
 import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
+import de.caritas.cob.userservice.api.model.ConversationType;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
 import de.caritas.cob.userservice.api.model.Session;
 import de.caritas.cob.userservice.api.model.Session.SessionStatus;
@@ -196,6 +198,7 @@ class SessionServiceTest {
   @Mock private ConsultantTopicRepository consultantTopicRepository;
   @Mock private GroupChatParticipantRepository groupChatParticipantRepository;
   @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+  @Mock private SessionSupervisionMarkerService supervisionMarkerService;
   @Mock private AgencyService agencyService;
   @Mock private ConsultantService consultantService;
   @Mock private ConsultingTypeManager consultingTypeManager;
@@ -605,6 +608,80 @@ class SessionServiceTest {
         sessionDTO.getId() != null
             && sessionDTO.getFirstName() != null
             && sessionDTO.getLastName() != null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // saveSession — ADR-006 modality default (teamSession != INTERNAL_GROUP)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void saveSession_Should_DefaultTeamAgencySessionToAgencyCounselling_NotInternalGroup() {
+    // A "Team-Beratungsstelle" 1:1 case: teamSession=true means every counsellor of the agency
+    // may see it. It is NOT an internal group chat — those stamp their type explicitly.
+    Session session = easyRandom.nextObject(Session.class);
+    session.setTeamSession(true);
+    session.setRegistrationType(REGISTERED);
+    session.setConversationType(null);
+    when(sessionRepository.save(session)).thenReturn(session);
+
+    sessionService.saveSession(session);
+
+    assertEquals(ConversationType.AGENCY_COUNSELLING, session.getConversationType());
+  }
+
+  @Test
+  void saveSession_Should_DefaultAnonymousTeamAgencySessionToLiveChat() {
+    Session session = easyRandom.nextObject(Session.class);
+    session.setTeamSession(true);
+    session.setRegistrationType(ANONYMOUS);
+    session.setConversationType(null);
+    when(sessionRepository.save(session)).thenReturn(session);
+
+    sessionService.saveSession(session);
+
+    assertEquals(ConversationType.LIVE_CHAT, session.getConversationType());
+  }
+
+  @Test
+  void saveSession_Should_KeepAnExplicitConversationType() {
+    Session session = easyRandom.nextObject(Session.class);
+    session.setTeamSession(true);
+    session.setRegistrationType(REGISTERED);
+    session.setConversationType(ConversationType.INTERNAL_GROUP);
+    when(sessionRepository.save(session)).thenReturn(session);
+
+    sessionService.saveSession(session);
+
+    assertEquals(ConversationType.INTERNAL_GROUP, session.getConversationType());
+  }
+
+  @Test
+  void saveSession_Should_DefaultRegisteredSingleSessionToAgencyCounselling() {
+    Session session = easyRandom.nextObject(Session.class);
+    session.setTeamSession(false);
+    session.setRegistrationType(REGISTERED);
+    session.setConversationType(null);
+    when(sessionRepository.save(session)).thenReturn(session);
+
+    sessionService.saveSession(session);
+
+    assertEquals(ConversationType.AGENCY_COUNSELLING, session.getConversationType());
+  }
+
+  @Test
+  void fetchSessionForConsultant_Should_CarryTheSupervisionMarkerForTheRequester() {
+    Session session = easyRandom.nextObject(Session.class);
+    session.setConsultant(CONSULTANT_WITH_AGENCY);
+    session.setUser(USER_WITH_MATRIX_ID);
+    when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
+    var marker = new SessionSupervisionDTO().supervisedByMe(true);
+    when(supervisionMarkerService.buildFor(session.getId(), CONSULTANT_WITH_AGENCY))
+        .thenReturn(marker);
+
+    ConsultantSessionDTO result =
+        sessionService.fetchSessionForConsultant(session.getId(), CONSULTANT_WITH_AGENCY);
+
+    assertEquals(marker, result.getSupervision());
   }
 
   @Test
@@ -1433,23 +1510,6 @@ class SessionServiceTest {
 
     assertThat(session.getConversationType())
         .isEqualTo(de.caritas.cob.userservice.api.model.ConversationType.LIVE_CHAT);
-  }
-
-  @Test
-  void saveSessionShouldDefaultTeamSessionsToInternalGroupBeforeRegistrationType() {
-    var session =
-        Session.builder()
-            .registrationType(ANONYMOUS)
-            .postcode("00000")
-            .status(SessionStatus.NEW)
-            .teamSession(true)
-            .build();
-    when(sessionRepository.save(session)).thenReturn(session);
-
-    sessionService.saveSession(session);
-
-    assertThat(session.getConversationType())
-        .isEqualTo(de.caritas.cob.userservice.api.model.ConversationType.INTERNAL_GROUP);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionServiceTest.java
@@ -675,8 +675,7 @@ class SessionServiceTest {
     session.setUser(USER_WITH_MATRIX_ID);
     when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
     var marker = new SessionSupervisionDTO().supervisedByMe(true);
-    when(supervisionMarkerService.buildFor(session.getId(), CONSULTANT_WITH_AGENCY))
-        .thenReturn(marker);
+    when(supervisionMarkerService.buildFor(session, CONSULTANT_WITH_AGENCY)).thenReturn(marker);
 
     ConsultantSessionDTO result =
         sessionService.fetchSessionForConsultant(session.getId(), CONSULTANT_WITH_AGENCY);

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
@@ -1,0 +1,144 @@
+package de.caritas.cob.userservice.api.service.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
+import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * ADR-008 supervisor marker: the requesting consultant learns whether a list entry is theirs
+ * because they supervise it, and who supervises it — resolved with ONE batched query per list.
+ */
+@ExtendWith(MockitoExtension.class)
+class SessionSupervisionMarkerServiceTest {
+
+  @InjectMocks private SessionSupervisionMarkerService service;
+  @Mock private SessionSupervisorRepository sessionSupervisorRepository;
+  @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
+
+  private static Consultant consultant(String id) {
+    var consultant = new Consultant();
+    consultant.setId(id);
+    return consultant;
+  }
+
+  private static ConsultantSessionResponseDTO entry(Long sessionId) {
+    return new ConsultantSessionResponseDTO().session(new SessionDTO().id(sessionId));
+  }
+
+  @Test
+  void enrich_Should_MarkSupervisedEntries_With_OneBatchedQuery() {
+    var mine = entry(1L);
+    var theirs = entry(2L);
+    var unsupervised = entry(3L);
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(anyCollection()))
+        .thenReturn(
+            List.of(
+                new SessionSupervisorMarkerRow(1L, "me", "me-user", null, null),
+                new SessionSupervisorMarkerRow(1L, "colleague", "c-user", "Colleague", null),
+                new SessionSupervisorMarkerRow(2L, "colleague", "c-user", "Colleague", null)));
+    when(consultantDisplayNameResolver.resolveInternalDisplayName(any(), any(), any()))
+        .thenAnswer(inv -> "name-of-" + inv.getArgument(2));
+
+    var result =
+        service.enrich(new ArrayList<>(List.of(mine, theirs, unsupervised)), consultant("me"));
+
+    assertThat(result).containsExactly(mine, theirs, unsupervised);
+    ArgumentCaptor<Collection<Long>> ids = ArgumentCaptor.forClass(Collection.class);
+    verify(sessionSupervisorRepository, times(1)).findActiveMarkerRowsBySessionIdIn(ids.capture());
+    assertThat(ids.getValue()).containsExactlyInAnyOrder(1L, 2L, 3L);
+
+    var mineMarker = mine.getSession().getSupervision();
+    assertThat(mineMarker.getSupervisedByMe()).isTrue();
+    assertThat(mineMarker.getSupervisorConsultantIds()).containsExactly("me", "colleague");
+    assertThat(mineMarker.getSupervisorDisplayNames())
+        .containsExactly("name-of-me-user", "name-of-c-user");
+
+    var theirsMarker = theirs.getSession().getSupervision();
+    assertThat(theirsMarker.getSupervisedByMe()).isFalse();
+    assertThat(theirsMarker.getSupervisorConsultantIds()).containsExactly("colleague");
+
+    var noneMarker = unsupervised.getSession().getSupervision();
+    assertThat(noneMarker.getSupervisedByMe()).isFalse();
+    assertThat(noneMarker.getSupervisorConsultantIds()).isEmpty();
+    assertThat(noneMarker.getSupervisorDisplayNames()).isEmpty();
+  }
+
+  @Test
+  void enrich_Should_ResolveDisplayNames_Through_TheInternalNameRule() {
+    var entry = entry(7L);
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(anyCollection()))
+        .thenReturn(
+            List.of(new SessionSupervisorMarkerRow(7L, "sup", "enc.abc", "Public", "Internal")));
+    when(consultantDisplayNameResolver.resolveInternalDisplayName("Internal", "Public", "enc.abc"))
+        .thenReturn("Internal");
+
+    service.enrich(List.of(entry), consultant("me"));
+
+    assertThat(entry.getSession().getSupervision().getSupervisorDisplayNames())
+        .containsExactly("Internal");
+  }
+
+  @Test
+  void enrich_Should_NotQuery_When_ListIsEmptyOrRequesterMissing() {
+    assertThat(service.enrich(List.of(), consultant("me"))).isEmpty();
+    var entries = List.of(entry(1L));
+    assertThat(service.enrich(entries, null)).isSameAs(entries);
+    assertThat(service.enrich(null, consultant("me"))).isNull();
+
+    verify(sessionSupervisorRepository, never()).findActiveMarkerRowsBySessionIdIn(any());
+    assertThat(entries.get(0).getSession().getSupervision()).isNull();
+  }
+
+  @Test
+  void enrich_Should_SkipEntriesWithoutSession_And_NotQueryWhenNoIds() {
+    var chatOnly = new ConsultantSessionResponseDTO();
+    var noId = new ConsultantSessionResponseDTO().session(new SessionDTO());
+
+    service.enrich(List.of(chatOnly, noId), consultant("me"));
+
+    verify(sessionSupervisorRepository, never()).findActiveMarkerRowsBySessionIdIn(any());
+    assertThat(noId.getSession().getSupervision()).isNull();
+  }
+
+  @Test
+  void buildFor_Should_ResolveASingleSession_With_TheSameQuery() {
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(Set.of(5L)))
+        .thenReturn(List.of(new SessionSupervisorMarkerRow(5L, "me", "me-user", null, null)));
+    when(consultantDisplayNameResolver.resolveInternalDisplayName(any(), any(), any()))
+        .thenReturn("Me");
+
+    var marker = service.buildFor(5L, consultant("me"));
+
+    assertThat(marker.getSupervisedByMe()).isTrue();
+    assertThat(marker.getSupervisorConsultantIds()).containsExactly("me");
+    assertThat(marker.getSupervisorDisplayNames()).containsExactly("Me");
+  }
+
+  @Test
+  void buildFor_Should_ReturnNull_When_SessionIdOrRequesterMissing() {
+    assertThat(service.buildFor(null, consultant("me"))).isNull();
+    assertThat(service.buildFor(5L, null)).isNull();
+    verify(sessionSupervisorRepository, never()).findActiveMarkerRowsBySessionIdIn(any());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
@@ -3,15 +3,19 @@ package de.caritas.cob.userservice.api.service.session;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSessionResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.SessionConsultantForConsultantDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.SessionDTO;
 import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
 import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorMarkerRow;
 import de.caritas.cob.userservice.api.port.out.SessionSupervisorRepository;
 import java.util.ArrayList;
@@ -35,6 +39,7 @@ class SessionSupervisionMarkerServiceTest {
   @InjectMocks private SessionSupervisionMarkerService service;
   @Mock private SessionSupervisorRepository sessionSupervisorRepository;
   @Mock private ConsultantDisplayNameResolver consultantDisplayNameResolver;
+  @Mock private ConsultantRepository consultantRepository;
 
   private static Consultant consultant(String id) {
     var consultant = new Consultant();
@@ -44,6 +49,17 @@ class SessionSupervisionMarkerServiceTest {
 
   private static ConsultantSessionResponseDTO entry(Long sessionId) {
     return new ConsultantSessionResponseDTO().session(new SessionDTO().id(sessionId));
+  }
+
+  private static ConsultantSessionResponseDTO entry(Long sessionId, String counsellorId) {
+    return entry(sessionId).consultant(new SessionConsultantForConsultantDTO().id(counsellorId));
+  }
+
+  private static Session session(Long id, Consultant counsellor) {
+    var session = new Session();
+    session.setId(id);
+    session.setConsultant(counsellor);
+    return session;
   }
 
   @Test
@@ -100,6 +116,47 @@ class SessionSupervisionMarkerServiceTest {
   }
 
   @Test
+  void enrich_Should_CarryTheCounsellorDisplayName_With_OneBatchedQuery() {
+    var ownedByAnna = entry(1L, "anna");
+    var alsoAnna = entry(2L, "anna");
+    var ownedByBob = entry(3L, "bob");
+    var unassigned = entry(4L);
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(anyCollection()))
+        .thenReturn(List.of());
+    var anna = consultant("anna");
+    var bob = consultant("bob");
+    when(consultantRepository.findAllByIdIn(anyList())).thenReturn(List.of(anna, bob));
+    when(consultantDisplayNameResolver.resolveInternalDisplayName(anna)).thenReturn("Anna (int)");
+    when(consultantDisplayNameResolver.resolveInternalDisplayName(bob)).thenReturn("Bob (int)");
+
+    service.enrich(List.of(ownedByAnna, alsoAnna, ownedByBob, unassigned), consultant("me"));
+
+    ArgumentCaptor<List<String>> ids = ArgumentCaptor.forClass(List.class);
+    verify(consultantRepository, times(1)).findAllByIdIn(ids.capture());
+    assertThat(ids.getValue()).containsExactlyInAnyOrder("anna", "bob");
+    assertThat(ownedByAnna.getSession().getSupervision().getCounsellorDisplayName())
+        .isEqualTo("Anna (int)");
+    assertThat(alsoAnna.getSession().getSupervision().getCounsellorDisplayName())
+        .isEqualTo("Anna (int)");
+    assertThat(ownedByBob.getSession().getSupervision().getCounsellorDisplayName())
+        .isEqualTo("Bob (int)");
+    assertThat(unassigned.getSession().getSupervision()).isNotNull();
+    assertThat(unassigned.getSession().getSupervision().getCounsellorDisplayName()).isNull();
+  }
+
+  @Test
+  void enrich_Should_NotLoadCounsellors_When_NoEntryHasOne() {
+    var entry = entry(1L);
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(anyCollection()))
+        .thenReturn(List.of());
+
+    service.enrich(List.of(entry), consultant("me"));
+
+    verify(consultantRepository, never()).findAllByIdIn(any());
+    assertThat(entry.getSession().getSupervision().getCounsellorDisplayName()).isNull();
+  }
+
+  @Test
   void enrich_Should_NotQuery_When_ListIsEmptyOrRequesterMissing() {
     assertThat(service.enrich(List.of(), consultant("me"))).isEmpty();
     var entries = List.of(entry(1L));
@@ -127,18 +184,36 @@ class SessionSupervisionMarkerServiceTest {
         .thenReturn(List.of(new SessionSupervisorMarkerRow(5L, "me", "me-user", null, null)));
     when(consultantDisplayNameResolver.resolveInternalDisplayName(any(), any(), any()))
         .thenReturn("Me");
+    var anna = consultant("anna");
+    when(consultantDisplayNameResolver.resolveInternalDisplayName(anna)).thenReturn("Anna (int)");
 
-    var marker = service.buildFor(5L, consultant("me"));
+    var marker = service.buildFor(session(5L, anna), consultant("me"));
 
     assertThat(marker.getSupervisedByMe()).isTrue();
     assertThat(marker.getSupervisorConsultantIds()).containsExactly("me");
     assertThat(marker.getSupervisorDisplayNames()).containsExactly("Me");
+    assertThat(marker.getCounsellorDisplayName()).isEqualTo("Anna (int)");
+    verify(consultantRepository, never()).findAllByIdIn(any());
   }
 
   @Test
-  void buildFor_Should_ReturnNull_When_SessionIdOrRequesterMissing() {
+  void buildFor_Should_LeaveCounsellorNameNull_When_SessionHasNoConsultant() {
+    when(sessionSupervisorRepository.findActiveMarkerRowsBySessionIdIn(Set.of(6L)))
+        .thenReturn(List.of());
+    when(consultantDisplayNameResolver.resolveInternalDisplayName((Consultant) null))
+        .thenReturn(null);
+
+    var marker = service.buildFor(session(6L, null), consultant("me"));
+
+    assertThat(marker.getSupervisedByMe()).isFalse();
+    assertThat(marker.getCounsellorDisplayName()).isNull();
+  }
+
+  @Test
+  void buildFor_Should_ReturnNull_When_SessionOrIdOrRequesterMissing() {
     assertThat(service.buildFor(null, consultant("me"))).isNull();
-    assertThat(service.buildFor(5L, null)).isNull();
+    assertThat(service.buildFor(session(null, null), consultant("me"))).isNull();
+    assertThat(service.buildFor(session(5L, null), null)).isNull();
     verify(sessionSupervisorRepository, never()).findActiveMarkerRowsBySessionIdIn(any());
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/session/SessionSupervisionMarkerServiceTest.java
@@ -134,14 +134,15 @@ class SessionSupervisionMarkerServiceTest {
     ArgumentCaptor<List<String>> ids = ArgumentCaptor.forClass(List.class);
     verify(consultantRepository, times(1)).findAllByIdIn(ids.capture());
     assertThat(ids.getValue()).containsExactlyInAnyOrder("anna", "bob");
-    assertThat(ownedByAnna.getSession().getSupervision().getCounsellorDisplayName())
+    assertThat(ownedByAnna.getSession().getSupervision().getCounsellorDisplayName().orElse(null))
         .isEqualTo("Anna (int)");
-    assertThat(alsoAnna.getSession().getSupervision().getCounsellorDisplayName())
+    assertThat(alsoAnna.getSession().getSupervision().getCounsellorDisplayName().orElse(null))
         .isEqualTo("Anna (int)");
-    assertThat(ownedByBob.getSession().getSupervision().getCounsellorDisplayName())
+    assertThat(ownedByBob.getSession().getSupervision().getCounsellorDisplayName().orElse(null))
         .isEqualTo("Bob (int)");
     assertThat(unassigned.getSession().getSupervision()).isNotNull();
-    assertThat(unassigned.getSession().getSupervision().getCounsellorDisplayName()).isNull();
+    assertThat(unassigned.getSession().getSupervision().getCounsellorDisplayName().orElse(null))
+        .isNull();
   }
 
   @Test
@@ -153,7 +154,8 @@ class SessionSupervisionMarkerServiceTest {
     service.enrich(List.of(entry), consultant("me"));
 
     verify(consultantRepository, never()).findAllByIdIn(any());
-    assertThat(entry.getSession().getSupervision().getCounsellorDisplayName()).isNull();
+    assertThat(entry.getSession().getSupervision().getCounsellorDisplayName().orElse(null))
+        .isNull();
   }
 
   @Test
@@ -192,7 +194,7 @@ class SessionSupervisionMarkerServiceTest {
     assertThat(marker.getSupervisedByMe()).isTrue();
     assertThat(marker.getSupervisorConsultantIds()).containsExactly("me");
     assertThat(marker.getSupervisorDisplayNames()).containsExactly("Me");
-    assertThat(marker.getCounsellorDisplayName()).isEqualTo("Anna (int)");
+    assertThat(marker.getCounsellorDisplayName().orElse(null)).isEqualTo("Anna (int)");
     verify(consultantRepository, never()).findAllByIdIn(any());
   }
 
@@ -206,7 +208,7 @@ class SessionSupervisionMarkerServiceTest {
     var marker = service.buildFor(session(6L, null), consultant("me"));
 
     assertThat(marker.getSupervisedByMe()).isFalse();
-    assertThat(marker.getCounsellorDisplayName()).isNull();
+    assertThat(marker.getCounsellorDisplayName().orElse(null)).isNull();
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListServiceTest.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.container.SessionListQueryParameter;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.session.SessionFilter;
 import de.caritas.cob.userservice.api.service.session.SessionService;
+import de.caritas.cob.userservice.api.service.session.SessionSupervisionMarkerService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,7 @@ class ConsultantSessionListServiceTest {
   @Mock private ChatService chatService;
   @Mock private ConsultantSessionEnricher consultantSessionEnricher;
   @Mock private ConsultantChatEnricher consultantChatEnricher;
+  @Mock private SessionSupervisionMarkerService supervisionMarkerService;
 
   @Test
   void
@@ -59,6 +61,20 @@ class ConsultantSessionListServiceTest {
       assertNotNull(consultantSessionResponseDTO.getSession());
     }
     verify(chatService, never()).getChatsForConsultant(CONSULTANT);
+  }
+
+  @Test
+  void retrieveSessionsForAuthenticatedConsultant_Should_AddTheSupervisionMarkerForTheRequester() {
+    when(sessionService.getRegisteredEnquiriesForConsultant(Mockito.any()))
+        .thenReturn(CONSULTANT_SESSION_RESPONSE_DTO_LIST);
+    when(this.consultantSessionEnricher.updateRequiredConsultantSessionValues(
+            eq(CONSULTANT_SESSION_RESPONSE_DTO_LIST)))
+        .thenReturn(CONSULTANT_SESSION_RESPONSE_DTO_LIST);
+
+    consultantSessionListService.retrieveSessionsForAuthenticatedConsultant(
+        CONSULTANT, createStandardSessionListQueryParameterObject(SESSION_STATUS_NEW));
+
+    verify(supervisionMarkerService).enrich(CONSULTANT_SESSION_RESPONSE_DTO_LIST, CONSULTANT);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/sessionlist/ConsultantSessionListServiceTest.java
@@ -64,7 +64,7 @@ class ConsultantSessionListServiceTest {
   }
 
   @Test
-  void retrieveSessionsForAuthenticatedConsultant_Should_AddTheSupervisionMarkerForTheRequester() {
+  void retrieveSessionsForAuthenticatedConsultant_Should_DeferSupervisionUntilAfterPagination() {
     when(sessionService.getRegisteredEnquiriesForConsultant(Mockito.any()))
         .thenReturn(CONSULTANT_SESSION_RESPONSE_DTO_LIST);
     when(this.consultantSessionEnricher.updateRequiredConsultantSessionValues(
@@ -74,7 +74,8 @@ class ConsultantSessionListServiceTest {
     consultantSessionListService.retrieveSessionsForAuthenticatedConsultant(
         CONSULTANT, createStandardSessionListQueryParameterObject(SESSION_STATUS_NEW));
 
-    verify(supervisionMarkerService).enrich(CONSULTANT_SESSION_RESPONSE_DTO_LIST, CONSULTANT);
+    verify(supervisionMarkerService, never())
+        .enrich(CONSULTANT_SESSION_RESPONSE_DTO_LIST, CONSULTANT);
   }
 
   @Test


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-UserService#1111
Refs OpenResilienceInitiative/ORISO-Frontend#1299
Refs OpenResilienceInitiative/ORISO-Frontend#1303

## Team-agency sessions keep AGENCY_COUNSELLING; supervision marker and Matrix ids in the session DTOs

### What this changes (plain language)

A counsellor's normal 1:1 case in a **team** advice center was stored as an internal group chat, so the app showed "Interna" and raw first-response JSON, and the assigned supervisor landed in the case-handover UI instead of supervision. This PR fixes the stored modality, corrects existing rows, adds a supervision marker to the session list, and — new in this revision — tells the frontend **who** the assigned counsellor and the supervisors are in Matrix terms, so the room header can show exactly the advice seeker, the counsellor and the active supervisors (ADR-002 silent membership) without exposing usernames. The ADR-008 supervision mechanics themselves (read-only client room + separate side room, standing supervisor auto-attach) were already correct and are untouched.

### What changed

- `SessionService.saveSession` no longer derives `INTERNAL_GROUP` from `teamSession`; `CreateChatFacade` stamps it explicitly for real group chats (ADR-006 gap: "teamSession has two meanings").
- Liquibase `0091_team_agency_session_modality` re-stamps existing team-agency 1:1 rows to `AGENCY_COUNSELLING`.
- `SessionDTO.supervision { supervisedByMe, supervisorConsultantIds, supervisorDisplayNames, counsellorDisplayName }` via `SessionSupervisionMarkerService` (one batched query per list page), exposed in `api/userservice.yaml`; wired into all conversation list providers.
- **`SessionDTO.consultantMatrixUserId`** (null when no counsellor is assigned; `api/userservice.yaml` next to `askerMatrixUserId`) and **`SessionSupervisorResponseDTO.supervisorMatrixUserId`** (null when the account has no Matrix user). Usernames are deliberately not added.
- `ConsultantDisplayNameResolver` for the internal display name (refs ORISO-Frontend#1076 wording).
- ADR-006 and ADR-008 addenda in `0 - Docs`.
- Tests: `SessionMapperTest` (30) and `SessionSupervisorControllerTest` (11) green on JDK 21, incl. the null cases; `DatabaseChangelogDriftIT` green against MariaDB.

### Not in this PR

- `supervision.message.new` event, side-room unread count, "Supervision:" preview prefix (`SessionDTO.supervision.sideRoomId`).
- The supervisors endpoint is still a hand-written DTO outside `userservice.yaml` (pre-existing).
- ORISO-Frontend#1271 (supervisor picker empty in admin) is a different surface and not touched.

### Verification

- pre-dev (predev.oriso.org), image `oriso-userservice:supervision-wpa-995e06d5` together with `oriso-frontend:supervision-wpb-4286059c` (the frontend image includes the two review-r9 fixes from ORISO-Frontend#1303: composer re-measure after the pane opens, `b2326516`, and the side-room system notice on an empty room, `4286059c`, which previously sent every session with a freshly assigned standing supervisor to the error page); tenant 1, advice center "Supervision Team-Beratungsstelle", Mona Simpson and Stampy Elephant (counsellors), Bettina Berg (standing supervisor), sessions 73 (team) and 74.
- Before (image `2.0.3`): the supervisor's list showed the eye icon and "Zugriff anfragen" on her supervised cases, and the team case was labelled "Interna" with the first response as raw JSON. After: `supervisedByMe: true`, `counsellorDisplayName` and the Matrix ids arrive in the list, the team case is `AGENCY_COUNSELLING` and shows a "Mail" chip. Screenshots are attached through the evidence gateway on the frontend PR (ORISO-Frontend#1303), which is where the result is visible.

### Related

- Frontend PRs: `fix/supervision-list-marker` (ORISO-Frontend#1300, list) and `feat/supervision-parallel-panel` (ORISO-Frontend#1303, pane) — both consume `session.supervision`.

### Reviewer test plan

- [ ] As Bettina, `GET /users/sessions/consultants` → sessions 73 and 74 carry `supervision.supervisedByMe: true`, `counsellorDisplayName` "Stampy Elephant" / "Mona Simpson", and `consultantMatrixUserId` = the counsellor's `@…:` id.
- [ ] As Mona, `GET /users/sessions/{74}/supervisors` → the row carries `supervisorMatrixUserId` for Bettina and **no** field beyond the documented ones; session 74 carries `supervisedByMe: false` and `supervisorDisplayNames: ["Bettina Berg"]`.
- [ ] A session without an assigned counsellor (fresh enquiry) → `consultantMatrixUserId` is `null`, no 500.
- [ ] Session 73 (team advice center) → `conversationType` is not `INTERNAL_GROUP`; the app shows a "Mail" chip instead of "Interna".
- [ ] Create a new group chat as a consultant → it is still listed as an internal group chat.
- [ ] Register a new test client with the team advice center and accept as Stampy → the new session is `AGENCY_COUNSELLING` from the start.
- [ ] Open a session whose supervision side room has no messages yet (e.g. a freshly assigned standing supervisor) as consultant and as supervisor: the panel shows exactly one system notice, no error page.
- [ ] Run the two test classes and `DatabaseChangelogDriftIT` locally on JDK 21 → green; attach the output to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session lists and individual sessions now display supervision markers, including supervisor details, requester status, and counsellor names.
  - Supervisor responses include the supervisor’s Matrix user ID when available.
  - Consultant display names use the most appropriate available name.

- **Improvements**
  - Conversation types are assigned more accurately for registered, anonymous, team, and group-chat sessions.
  - Existing team-session data is updated to the appropriate agency counselling or live chat modality.

- **Tests**
  - Added coverage for supervision markers, modalities, display names, and Matrix IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->