### PR TITLE
fix(security): pin Tomcat 11.0.25 to clear three CRITICAL CVEs on dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
 		<!-- Spring Boot 4.0.7 still manages HttpCore 5.3.6; 5.4.3 fixes
 		     CVE-2026-54399 and is compatible with the managed HttpClient 5.5.2. -->
 		<httpcore5.version>5.4.3</httpcore5.version>
+		<!-- Spring Boot 4.0.7 manages Tomcat 11.0.22; 4.0.8 and 4.1.1 still
+		     manage 11.0.24. The image CVE gate fails on three CRITICAL findings
+		     that are only fixed in 11.0.25: CVE-2026-65182 (security-constraint
+		     bypass), CVE-2026-65905 (DIGEST authenticator replay), CVE-2026-68525
+		     (FORM authentication bypass). A Boot upgrade does not remove the need
+		     for this override. Drop it once the Boot BOM manages >= 11.0.25. -->
+		<tomcat.version>11.0.25</tomcat.version>
 		<!-- Spring Boot 4.0.7 under-pins the RabbitMQ Java client at 5.27.1 (via
 		     spring-boot-starter-amqp -> spring-rabbit 4.0.4). 5.33.1 is the lowest
 		     version that clears all three HIGH findings of the image CVE gate:

--- a/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/DependencySecurityContractTest.java
@@ -14,4 +14,10 @@ class DependencySecurityContractTest {
     assertThat(Files.readString(Path.of("pom.xml")))
         .contains("<httpcore5.version>5.4.3</httpcore5.version>");
   }
+
+  @Test
+  void tomcatMustStayOnTheFixedEmbeddedRelease() throws IOException {
+    assertThat(Files.readString(Path.of("pom.xml")))
+        .contains("<tomcat.version>11.0.25</tomcat.version>");
+  }
 }


### PR DESCRIPTION
## What

Pins `tomcat.version` to `11.0.25`, cherry-picked from #1104 (merged to `pre-dev` on 2026-09-03, never promoted to `dev`).

## Why

The `dev` build [run 33961981529](https://github.com/OpenResilienceInitiative/ORISO-UserService/actions/runs/33961981529/job/101295950546) fails the **Reject fixable high or critical image vulnerabilities** step with 3 CRITICAL findings, all in `org.apache.tomcat.embed:tomcat-embed-core` 11.0.22 (the version Spring Boot 4.0.7's BOM manages):

| CVE | Title |
| --- | --- |
| CVE-2026-65182 | Security constraint bypass due to improper access control |
| CVE-2026-65905 | Authentication bypass via limited replay attack in DIGEST authenticator |
| CVE-2026-68525 | Unauthorized resource access via FORM authentication bypass |

All three are first fixed in 11.0.25. Boot 4.0.8 and 4.1.1 still manage 11.0.24, so a Boot upgrade does not remove the need for this override.

## Verification

- `mvn dependency:tree` resolves `tomcat-embed-core`, `tomcat-embed-websocket` and `tomcat-embed-el` to 11.0.25.
- `DependencySecurityContractTest` passes (2/2), including the new `tomcatMustStayOnTheFixedEmbeddedRelease` guard that fails the build if the pin is dropped before the Boot BOM catches up.

## Follow-up (not in this PR)

`dev` runs the CVE gate *after* `Publish UserService Docker image`, so the vulnerable image was pushed to GHCR before being rejected. #1045 reorders the scan ahead of the publish, but it is one of 5 commits sitting on `pre-dev` that have not been promoted to `dev`. Worth a separate `pre-dev` → `dev` sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
