### PR TITLE
fix(config): make config.env.example produce a service that starts (#1099)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ In addition to that it provides different lists of sessions for consultants and 
 Moreover it also offers different workflows for deactivating expired group chats, deactivating old anonymous user accounts and deleting user accounts.
 On top of that the UserService includes useful admin API calls to administrate user accounts.
 
+## Required environment
+
+The service refuses to start when certain environment variables are unset, so a
+first local run needs them before anything else:
+
+```bash
+cp config.env.example config.env      # then fill every CHANGE_ME
+```
+
+`config.env.example` lists every variable the service will not start without,
+with a comment on each explaining what guards it. The reasoning behind those
+guards, and where to add the next required variable, is in
+[`docs/required-environment.md`](docs/required-environment.md); the database
+migration settings specifically are covered in
+[`docs/schema-migrations.md`](docs/schema-migrations.md).
+
+The full local setup — Java version, run script, frontend pairing — is in
+[`documentation/local-development.md`](documentation/local-development.md).
+
 ## Help and Documentation
 In the project [documentation](https://onlineberatung.github.io/documentation/docs/setup/setup-backend) you'll find information for setting up and running the project.
 You can find some detailled information of the service architecture and its processes in the repository [documentation](https://github.com/Onlineberatung/onlineBeratung-userService/tree/master/documentation).

--- a/config.env.example
+++ b/config.env.example
@@ -1,5 +1,8 @@
 # Copy to config.env and fill the CHANGE_ME values.
 # config.env is ignored by git and must not be committed.
+#
+# Every variable the service refuses to start without is listed here.
+# Background and the full list: docs/required-environment.md.
 
 KEYCLOAK_REALM=online-beratung
 KEYCLOAK_CONFIG_ADMIN_USERNAME=technical
@@ -16,7 +19,26 @@ KEYCLOAK_ALLOW_ANY_HOSTNAME=true
 
 SPRING_DATASOURCE_USERNAME=userservice
 SPRING_DATASOURCE_PASSWORD=CHANGE_ME
+# run-local-remote-db.sh exports SPRING_DATASOURCE_URL before sourcing this file.
+# Uncomment to point the service somewhere else; a value set here wins.
+# SPRING_DATASOURCE_URL=jdbc:mariadb://localhost:3306/userservice
+
+# Schema migrations — see docs/schema-migrations.md.
+# The remote dev database is migrated by the deployed UserService, not from a
+# laptop. A local Liquibase run would apply changesets, and in time the seed/demo
+# changesets, to a database the whole team shares; an interrupted run leaves
+# DATABASECHANGELOGLOCK held against the real deployment. Declaring the migrations
+# externally managed is what lets SchemaMigrationGuard accept Liquibase being off.
 SPRING_LIQUIBASE_ENABLED=false
+ORISO_MIGRATIONS_EXTERNALLY_MANAGED=true
+# Against a database only you use, let Liquibase own the schema instead: set
+# SPRING_LIQUIBASE_ENABLED=true and drop ORISO_MIGRATIONS_EXTERNALLY_MANAGED.
+#
+# spring.jpa.hibernate.ddl-auto must stay 'validate' (its default). Overriding
+# SPRING_JPA_HIBERNATE_DDL_AUTO to update, create or none is refused by
+# SchemaMigrationGuard: Hibernate's comparison against the live schema is what
+# catches an entity change nobody wrote a changeset for.
+
 SERVER_SERVLET_CONTEXT_PATH=/service
 SPRING_ZIPKIN_ENABLED=false
 
@@ -31,6 +53,16 @@ MATRIX_ADMIN_USERNAME=matrixadm
 MATRIX_ADMIN_PASSWORD=CHANGE_ME
 MATRIX_MIGRATION_ENABLED=true
 MATRIX_PRESENCE_ENABLED=false
+
+# HMAC secrets — the service refuses to start while either is unset.
+# Any random value works locally: openssl rand -hex 32
+# Keep the two distinct from each other and from service.encryption.appkey. The
+# separation is the point: one leaked secret must not let the pseudonymized values
+# of the other purpose be cross-correlated.
+STATISTICS_MESSAGE_COUNT_HMAC_SECRET=CHANGE_ME
+# In a real deployment this must match the platform-wide MatrixRTC secret, or
+# correlation ids stop lining up between the services that log them.
+MATRIXRTC_CALL_POLICY_HMAC_SECRET=CHANGE_ME
 
 MULTITENANCY_ENABLED=true
 FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true

--- a/docs/required-environment.md
+++ b/docs/required-environment.md
@@ -1,0 +1,89 @@
+# Required environment
+
+The variables UserService refuses to start without, and why each one is guarded.
+`config.env.example` carries all of them; this page is the reasoning behind it.
+
+Answers issue
+[#1099](https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/1099).
+
+## Getting a local service running
+
+```bash
+cp config.env.example config.env      # then fill every CHANGE_ME
+cp run-local-remote-db.sh.example run-local-remote-db.sh
+chmod +x run-local-remote-db.sh
+./run-local-remote-db.sh
+```
+
+Full walkthrough, including the frontend pairing and the dev CA truststore:
+[`documentation/local-development.md`](../documentation/local-development.md).
+
+## The startup guards
+
+Each of these aborts the Spring context in `@PostConstruct`, before a single
+request is served. They fail one at a time, so a missing set is met one restart
+at a time.
+
+| Variable | Guard | Without it |
+|---|---|---|
+| `STATISTICS_MESSAGE_COUNT_HMAC_SECRET` | `ConsultantIdentityHasher` | `IllegalStateException` naming the variable |
+| `MATRIXRTC_CALL_POLICY_HMAC_SECRET` | `MatrixRtcCorrelationIdHasher` | `IllegalStateException` naming the variable |
+| `SPRING_LIQUIBASE_ENABLED` / `ORISO_MIGRATIONS_EXTERNALLY_MANAGED` | `SchemaMigrationGuard` | `IllegalStateException`: changesets in the image would never be applied |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | `SchemaMigrationGuard` | `IllegalStateException` unless the value is `validate` |
+
+`SPRING_DATASOURCE_URL` is required too, but the local path gets it from
+`run-local-remote-db.sh`, not from `config.env`. A value in `config.env`
+overrides it, because the script sources that file after its own exports.
+
+### The two HMAC secrets
+
+Both pseudonymize an identifier that would otherwise be readable by anyone with
+database or log access: a consultant id in message-count statistics, and a
+room/user pair in MatrixRTC call-policy denial logs. Both reject a blank value
+rather than falling back to a default, because a shared or empty key would make
+the pseudonymization decorative.
+
+Locally any random value works — `openssl rand -hex 32`. Keep them distinct from
+each other and from `service.encryption.appkey`; that independence is what stops
+one leaked secret from unmasking the other purpose. In a real deployment
+`MATRIXRTC_CALL_POLICY_HMAC_SECRET` must match the platform-wide MatrixRTC
+secret, or correlation ids stop lining up between the services that log them.
+
+### The migration settings
+
+`SchemaMigrationGuard` refuses a deployment that would run against a schema
+nobody migrates or verifies. The reasoning, the escape hatch and how to audit an
+environment are in [`schema-migrations.md`](schema-migrations.md).
+
+For local work the shipped example sets `SPRING_LIQUIBASE_ENABLED=false` with
+`ORISO_MIGRATIONS_EXTERNALLY_MANAGED=true`, because the documented local setup
+talks to the **remote dev database**, which the deployed dev UserService
+migrates. A laptop running Liquibase against it would apply changesets — and in
+time the seed/demo changesets — to a database the whole team shares, and an
+interrupted run would leave `DATABASECHANGELOGLOCK` held against the real
+deployment. Against a database only you use, set `SPRING_LIQUIBASE_ENABLED=true`
+and drop the escape hatch.
+
+`SPRING_JPA_HIBERNATE_DDL_AUTO` must stay `validate` either way. That check is
+the one that catches an entity change nobody wrote a changeset for, so the guard
+accepts no other value — `update` and `create` let Hibernate alter the schema
+behind Liquibase's back, and `none` skips the comparison entirely.
+
+## Adding the next required variable
+
+All three variables in #1099 slipped through because nothing tied a new startup
+guard to the example file. `ConfigEnvExampleContractTest` now does: it fails the
+build when a guard in `src/main/java` names an environment variable that
+`config.env.example` does not declare.
+
+It finds them by convention — the message ends `must be set (THE_ENV_VAR)`, as
+in:
+
+```java
+throw new IllegalStateException(
+    "statistics.message-count.hmac-secret must be set (STATISTICS_MESSAGE_COUNT_HMAC_SECRET)");
+```
+
+So a new guard needs three things: that message shape, a placeholder line in
+`config.env.example`, and a row in the table above. The cluster side is separate
+— see [ORISO-Helm#272](https://github.com/OpenResilienceInitiative/ORISO-Helm/issues/272).

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -44,6 +44,12 @@ Liquibase back on" no longer look the same from the outside.
 
 Hibernate validation stays required either way.
 
+`config.env.example` uses that hatch for local development: the documented local
+setup talks to the remote dev database, which the deployed dev UserService
+migrates, so a laptop must not run Liquibase against it. Every variable the
+service will not start without, this pair included, is listed in
+[`required-environment.md`](required-environment.md).
+
 ## Auditing an environment
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,25 @@ In addition to that it provides different lists of sessions for consultants and 
 Moreover it also offers different workflows for deactivating expired group chats, deactivating old anonymous user accounts and deleting user accounts.
 On top of that the UserService includes useful admin API calls to administrate user accounts.
 
+## Required environment
+
+The service refuses to start when certain environment variables are unset, so a
+first local run needs them before anything else:
+
+```bash
+cp config.env.example config.env      # then fill every CHANGE_ME
+```
+
+`config.env.example` lists every variable the service will not start without,
+with a comment on each explaining what guards it. The reasoning behind those
+guards, and where to add the next required variable, is in
+[`docs/required-environment.md`](docs/required-environment.md); the database
+migration settings specifically are covered in
+[`docs/schema-migrations.md`](docs/schema-migrations.md).
+
+The full local setup — Java version, run script, frontend pairing — is in
+[`documentation/local-development.md`](documentation/local-development.md).
+
 ## Help and Documentation
 In the project [documentation](https://onlineberatung.github.io/documentation/docs/setup/setup-backend) you'll find information for setting up and running the project.
 You can find some detailled information of the service architecture and its processes in the repository [documentation](https://github.com/Onlineberatung/onlineBeratung-userService/tree/master/documentation).

--- a/src/test/java/de/caritas/cob/userservice/api/ConfigEnvExampleContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/ConfigEnvExampleContractTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +20,14 @@ import org.junit.jupiter.api.Test;
  * guards that were added after it. Nothing tied the two together, so each new required variable
  * could slip through the same way.
  *
- * <p>This is that tie. A guard that names an environment variable fails the build until the example
- * declares it.
+ * <p>This is that tie. A guard that names an environment variable fails the build until both the
+ * example and {@code docs/required-environment.md} carry it.
  */
 class ConfigEnvExampleContractTest {
 
   private static final Path EXAMPLE = Path.of("config.env.example");
   private static final Path MAIN_JAVA = Path.of("src/main/java");
+  private static final Path REQUIRED_ENVIRONMENT = Path.of("docs/required-environment.md");
   private static final Path APPLICATION_PROPERTIES =
       Path.of("src/main/resources/application.properties");
 
@@ -35,26 +37,25 @@ class ConfigEnvExampleContractTest {
 
   @Test
   void everyGuardedVariableMustBeDeclaredInTheExample() throws IOException {
-    var guarded = new LinkedHashSet<String>();
-    try (var sourceFiles = Files.walk(MAIN_JAVA)) {
-      for (var sourceFile :
-          sourceFiles.filter(path -> path.getFileName().toString().endsWith(".java")).toList()) {
-        var matcher = GUARDED_VARIABLE.matcher(Files.readString(sourceFile));
-        while (matcher.find()) {
-          guarded.add(matcher.group(1));
-        }
-      }
-    }
-
-    assertThat(guarded)
-        .as("the known startup guards must still be findable by the 'must be set (VAR)' convention")
-        .contains("STATISTICS_MESSAGE_COUNT_HMAC_SECRET", "MATRIXRTC_CALL_POLICY_HMAC_SECRET");
-
     assertThat(declaredVariables().keySet())
         .as(
             "a startup guard names an environment variable that config.env.example does not set:"
-                + " add a placeholder line for it, and a row in docs/required-environment.md")
-        .containsAll(guarded);
+                + " add a placeholder line for it")
+        .containsAll(guardedVariables());
+  }
+
+  @Test
+  void everyGuardedVariableMustBeDocumented() throws IOException {
+    var documented = Files.readString(REQUIRED_ENVIRONMENT);
+
+    for (var variable : guardedVariables()) {
+      assertThat(documented)
+          .as(
+              "%s is enforced at startup but missing from %s, which claims to be the full list:"
+                  + " add a row for it",
+              variable, REQUIRED_ENVIRONMENT)
+          .contains(variable);
+    }
   }
 
   @Test
@@ -76,12 +77,32 @@ class ConfigEnvExampleContractTest {
         .isEqualToIgnoringCase("validate");
   }
 
+  /**
+   * Starting is not enough on its own. The example points at the shared remote dev database, so it
+   * must also keep Liquibase off there: the guard above is equally satisfied by simply enabling
+   * Liquibase, which would have a laptop migrating a database the whole team uses.
+   */
   @Test
-  void applicationPropertiesMustKeepTheDefaultsTheExampleLeavesUnset() throws IOException {
-    // The example sets neither, so a filled-in config.env inherits these two shipped defaults.
-    assertThat(Files.readString(APPLICATION_PROPERTIES))
-        .contains("spring.jpa.hibernate.ddl-auto=validate")
-        .contains("spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}");
+  void exampleMustLeaveTheSharedDevDatabaseToItsOwnMigrations() throws IOException {
+    assertThat(declaredVariables())
+        .as(
+            "config.env.example must keep local Liquibase off against the shared remote dev"
+                + " database (see docs/required-environment.md). Changing this is a policy"
+                + " decision, not a cleanup: update that doc and this test together.")
+        .containsEntry("SPRING_LIQUIBASE_ENABLED", "false")
+        .containsEntry("ORISO_MIGRATIONS_EXTERNALLY_MANAGED", "true");
+  }
+
+  @Test
+  void applicationPropertiesMustKeepTheDefaultsAssumedHere() throws IOException {
+    var properties = Files.readString(APPLICATION_PROPERTIES);
+
+    // The example leaves SPRING_JPA_HIBERNATE_DDL_AUTO unset, so a filled-in config.env inherits
+    // this shipped default.
+    assertThat(properties).contains("spring.jpa.hibernate.ddl-auto=validate");
+    // The example does set SPRING_LIQUIBASE_ENABLED, but the guard check above falls back to this
+    // default when reading it, so the two must not drift apart.
+    assertThat(properties).contains("spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}");
   }
 
   @Test
@@ -89,6 +110,25 @@ class ConfigEnvExampleContractTest {
     assertThat(declaredVariables())
         .containsEntry("STATISTICS_MESSAGE_COUNT_HMAC_SECRET", "CHANGE_ME")
         .containsEntry("MATRIXRTC_CALL_POLICY_HMAC_SECRET", "CHANGE_ME");
+  }
+
+  /** Every environment variable a startup guard in production code refuses to start without. */
+  private static Set<String> guardedVariables() throws IOException {
+    var guarded = new LinkedHashSet<String>();
+    try (var sourceFiles = Files.walk(MAIN_JAVA)) {
+      for (var sourceFile :
+          sourceFiles.filter(path -> path.getFileName().toString().endsWith(".java")).toList()) {
+        var matcher = GUARDED_VARIABLE.matcher(Files.readString(sourceFile));
+        while (matcher.find()) {
+          guarded.add(matcher.group(1));
+        }
+      }
+    }
+
+    assertThat(guarded)
+        .as("the known startup guards must still be findable by the 'must be set (VAR)' convention")
+        .contains("STATISTICS_MESSAGE_COUNT_HMAC_SECRET", "MATRIXRTC_CALL_POLICY_HMAC_SECRET");
+    return guarded;
   }
 
   /** The uncommented {@code KEY=VALUE} lines of the example, blank values excluded. */

--- a/src/test/java/de/caritas/cob/userservice/api/ConfigEnvExampleContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/ConfigEnvExampleContractTest.java
@@ -1,0 +1,113 @@
+package de.caritas.cob.userservice.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Keeps {@code config.env.example} able to start the service.
+ *
+ * <p>Issue #1099: three separate startup guards aborted the Spring context for anyone who followed
+ * the repository's own instructions, because the example file was never updated alongside the
+ * guards that were added after it. Nothing tied the two together, so each new required variable
+ * could slip through the same way.
+ *
+ * <p>This is that tie. A guard that names an environment variable fails the build until the example
+ * declares it.
+ */
+class ConfigEnvExampleContractTest {
+
+  private static final Path EXAMPLE = Path.of("config.env.example");
+  private static final Path MAIN_JAVA = Path.of("src/main/java");
+  private static final Path APPLICATION_PROPERTIES =
+      Path.of("src/main/resources/application.properties");
+
+  /** The convention every startup guard follows: {@code ... must be set (THE_ENV_VAR)}. */
+  private static final Pattern GUARDED_VARIABLE =
+      Pattern.compile("must be set \\(([A-Z][A-Z0-9_]*)\\)");
+
+  @Test
+  void everyGuardedVariableMustBeDeclaredInTheExample() throws IOException {
+    var guarded = new LinkedHashSet<String>();
+    try (var sourceFiles = Files.walk(MAIN_JAVA)) {
+      for (var sourceFile :
+          sourceFiles.filter(path -> path.getFileName().toString().endsWith(".java")).toList()) {
+        var matcher = GUARDED_VARIABLE.matcher(Files.readString(sourceFile));
+        while (matcher.find()) {
+          guarded.add(matcher.group(1));
+        }
+      }
+    }
+
+    assertThat(guarded)
+        .as("the known startup guards must still be findable by the 'must be set (VAR)' convention")
+        .contains("STATISTICS_MESSAGE_COUNT_HMAC_SECRET", "MATRIXRTC_CALL_POLICY_HMAC_SECRET");
+
+    assertThat(declaredVariables().keySet())
+        .as(
+            "a startup guard names an environment variable that config.env.example does not set:"
+                + " add a placeholder line for it, and a row in docs/required-environment.md")
+        .containsAll(guarded);
+  }
+
+  @Test
+  void exampleMustSatisfyTheSchemaMigrationGuard() throws IOException {
+    var declared = declaredVariables();
+
+    var liquibaseEnabled =
+        Boolean.parseBoolean(declared.getOrDefault("SPRING_LIQUIBASE_ENABLED", "true"));
+    var externallyManaged =
+        Boolean.parseBoolean(declared.getOrDefault("ORISO_MIGRATIONS_EXTERNALLY_MANAGED", "false"));
+    assertThat(liquibaseEnabled || externallyManaged)
+        .as(
+            "config.env.example switches Liquibase off without ORISO_MIGRATIONS_EXTERNALLY_MANAGED,"
+                + " so SchemaMigrationGuard refuses to start the service")
+        .isTrue();
+
+    assertThat(declared.getOrDefault("SPRING_JPA_HIBERNATE_DDL_AUTO", "validate"))
+        .as("SchemaMigrationGuard accepts no ddl-auto mode other than validate")
+        .isEqualToIgnoringCase("validate");
+  }
+
+  @Test
+  void applicationPropertiesMustKeepTheDefaultsTheExampleLeavesUnset() throws IOException {
+    // The example sets neither, so a filled-in config.env inherits these two shipped defaults.
+    assertThat(Files.readString(APPLICATION_PROPERTIES))
+        .contains("spring.jpa.hibernate.ddl-auto=validate")
+        .contains("spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}");
+  }
+
+  @Test
+  void guardedSecretsMustShipAsPlaceholders() throws IOException {
+    assertThat(declaredVariables())
+        .containsEntry("STATISTICS_MESSAGE_COUNT_HMAC_SECRET", "CHANGE_ME")
+        .containsEntry("MATRIXRTC_CALL_POLICY_HMAC_SECRET", "CHANGE_ME");
+  }
+
+  /** The uncommented {@code KEY=VALUE} lines of the example, blank values excluded. */
+  private static Map<String, String> declaredVariables() throws IOException {
+    Map<String, String> declared = new HashMap<>();
+    for (var line : Files.readAllLines(EXAMPLE)) {
+      var trimmed = line.strip();
+      if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+        continue;
+      }
+      var separator = trimmed.indexOf('=');
+      if (separator < 1) {
+        continue;
+      }
+      var value = trimmed.substring(separator + 1).strip();
+      if (!value.isEmpty()) {
+        declared.put(trimmed.substring(0, separator).strip(), value);
+      }
+    }
+    return declared;
+  }
+}


### PR DESCRIPTION
Closes #1099

## What was wrong

Following the repository's own instructions — `cp config.env.example config.env`, fill the `CHANGE_ME` values, start the service — hit three startup guards in turn. Each aborts the Spring context, so you fix one, restart, and meet the next:

1. `SchemaMigrationGuard` — the example shipped `SPRING_LIQUIBASE_ENABLED=false` without the `oriso.migrations.externally-managed` escape hatch.
2. `ConsultantIdentityHasher` — `STATISTICS_MESSAGE_COUNT_HMAC_SECRET` was absent, and `application.properties` defaults it to blank.
3. `MatrixRtcCorrelationIdHasher` — same shape, `MATRIXRTC_CALL_POLICY_HMAC_SECRET`.

Reproduced against `origin/dev` (`45309074`). **No production code changes: the three guards are untouched.** The diff is the example file, docs, and one test.

## What changed

**`config.env.example`** — adds `ORISO_MIGRATIONS_EXTERNALLY_MANAGED=true`, both HMAC secrets as `CHANGE_ME` placeholders, and comments on the `ddl-auto` and datasource requirements. Purely additive; nothing was removed.

**`docs/required-environment.md`** (new) — the list of variables the service will not start without, the reasoning per guard, and where the next one goes.

**`README.md`** — a "Required environment" section, so the guards' error messages have somewhere to send a reader.

**`ConfigEnvExampleContractTest`** (new) — the missing forcing function, see below.

## One deviation from the issue, please sanity-check

The issue calls option A — drop `SPRING_LIQUIBASE_ENABLED=false` and let Liquibase run locally — "preferred". I shipped **option B** (keep it off, add the escape hatch) instead.

Reason: the documented local setup points at the **shared remote dev database**. `documentation/local-development.md` describes it as "the remote ORISO dev database", and `run-local-remote-db.sh.example:13` exports a remote `SPRING_DATASOURCE_URL`. Enabling Liquibase there means a developer's laptop migrates a database the whole team shares — and since the local profile passes contexts `local,seed`, it would also apply the seed/demo changesets once any exist (`userservice-master.xml:171` reserves that slot). An interrupted laptop run leaves `DATABASECHANGELOGLOCK` held against the real deployment.

That is exactly the case `docs/schema-migrations.md` describes for the hatch: something other than this process owns the migrations. The example carries a commented Liquibase-on variant for a database only you use. Happy to flip it if you disagree — @Storypapst, this is your call.

## The root cause, addressed

The issue notes that "a pull request that introduces a required environment variable currently has nothing forcing `config.env.example` ... to gain it, which is how all three slipped through."

`ConfigEnvExampleContractTest` is that missing link. It scans `src/main/java` for the convention both hashers already follow — a message ending `must be set (THE_ENV_VAR)` — and fails the build until `config.env.example` declares each variable it finds. It also checks the example's own Liquibase/`ddl-auto` combination against `SchemaMigrationGuard`'s rule, and that the secrets ship as placeholders.

This goes slightly beyond the issue's "What to build" list. It is four assertions in one file and no production code, so it should be easy to drop if you would rather not have it.

## Verification

**Where:** local only. I did not have credentials for the dev database, so I could not run the service end to end — the acceptance criterion "yields a UserService that starts" needs a reviewer with dev access. Flagging that plainly rather than implying otherwise.

What I did verify:

```
ConfigEnvExampleContractTest      Tests run: 4, Failures: 0, Errors: 0
RocketChatAdapterRemovedContractTest  Tests run: 9, Failures: 0, Errors: 0
./mvnw -B spotless:check          BUILD SUCCESS
```

Both #1099 regressions, re-introduced deliberately, are caught:

- removing `MATRIXRTC_CALL_POLICY_HMAC_SECRET` → `everyGuardedVariableMustBeDeclaredInTheExample` fails with "a startup guard names an environment variable that config.env.example does not set"
- removing `ORISO_MIGRATIONS_EXTERNALLY_MANAGED` → `exampleMustSatisfyTheSchemaMigrationGuard` fails with the `SchemaMigrationGuard` explanation

Unrelated pre-existing failure, for the record: `MatrixOnlyRuntimeConfigurationContractTest` fails on my machine because of the gitignored developer-local `src/main/resources/application-local.properties`, which still carries retired Mongo/Rocket.Chat settings. That file is not in the repo, so CI does not see it. Not touched here.

## Reviewer test plan

No user interface, so no mobile, keyboard or screen-reader checks apply.

- [ ] On a clean checkout of this branch, `cp config.env.example config.env`, fill only the `CHANGE_ME` values, and start UserService → it starts, and the log contains no `IllegalStateException`.
- [ ] Call an endpoint you normally use against that instance (for example the session list) → it answers normally.
- [ ] Set `SPRING_JPA_HIBERNATE_DDL_AUTO=update` in your `config.env` and restart → startup is refused with the `SchemaMigrationGuard` message naming `validate`. Revert afterwards.
- [ ] Remove the `STATISTICS_MESSAGE_COUNT_HMAC_SECRET` line and restart → startup is refused with the message naming that variable, confirming the guard still protects real deployments. Restore it.
- [ ] Review the diff → placeholders only, no real secret value.
- [ ] Read `README.md` as a first-time setter-upper → you can find the required-environment list without asking a colleague.
- [ ] Judge the option A / option B call above.

## Note on the diff touching two README files

The repository tracks both `README.md` and `readme.md` — two paths differing only in case, pointing at identical content. On a case-insensitive filesystem only one can be checked out, so this commit writes the same content to both to keep them from diverging. Consolidating them is separate work, not done here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on required environment variables and local configuration.
  - Documented database migration settings and local development setup.
  - Added details on startup requirements, required secrets, and configuration placeholders.

- **Tests**
  - Added validation to ensure the example environment configuration remains aligned with startup requirements, migration settings, defaults, and required secret placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->