### PR TITLE
fix(security): scope /users/consultants to the caller's own agencies (#1107)

### DIFF
--- a/api/userservice.yaml
+++ b/api/userservice.yaml
@@ -2890,6 +2890,12 @@ components:
           example: nikunj-rohit
         username:
           type: string
+          description: >-
+            The Keycloak username. Kept deliberately (#1107): ORISO-Frontend uses it as the third
+            fallback for a consultant's display label, after "firstName lastName" and displayName,
+            so dropping it would degrade that case to a raw id. It is populated only on the two
+            authenticated list endpoints; the unauthenticated public-data endpoint leaves it unset.
+            Removing it is a cross-repo change - retire the frontend fallback first.
         isSupervisor:
           type: boolean
           example: true

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
@@ -135,10 +135,20 @@ class UserConsultantControllerDelegate {
    * <p>A rejection is a 403 rather than an empty list: the caller is authenticated and asking for
    * something real, and answering 200 with nothing would make a genuine authorization failure look
    * like an agency that happens to have no consultants.
+   *
+   * <p>Deliberately check-then-act rather than one caller-scoped roster query. The window between
+   * the two reads is not attacker-controllable, and revoking the caller's own assignment does not
+   * change the roster they would receive, so a request straddling that window returns data they
+   * were authorized to read moments earlier. Folding the membership predicate into the roster query
+   * would also cost the 403 above: an unauthorized caller and an empty agency would both come back
+   * empty. Same shape as {@code TeamDiscussionFacade#requireEligibleConsultant}.
    */
   private void verifyCallerBelongsToAgency(Long agencyId) {
     var consultantId = authenticatedUser.getUserId();
     if (!consultantAgencyService.isConsultantAssignedToAgency(consultantId, agencyId)) {
+      // The logged id is the opaque Keycloak UUID, never a name, email or Matrix id, and matches
+      // what the admin authorization guards already record on a denial. Without it the warning
+      // cannot be attributed to anyone: MDC carries only the request correlation id.
       log.warn(
           "Consultant {} requested the consultant roster of agency {}, which they are not assigned"
               + " to",

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
@@ -154,8 +154,7 @@ class UserConsultantControllerDelegate {
               + " to",
           consultantId,
           agencyId);
-      throw new ForbiddenException(
-          "Consultant is not a member of the requested agency and may not read its consultants");
+      throw new ForbiddenException("Consultant is not a member of the requested agency and may not read its consultants", ex -> {});
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSearchResultDTO
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
 import de.caritas.cob.userservice.api.admin.facade.AdminUserFacade;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
@@ -25,6 +26,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 class UserConsultantControllerDelegate {
 
   private final @NotNull AuthenticatedUser authenticatedUser;
@@ -49,6 +52,7 @@ class UserConsultantControllerDelegate {
   }
 
   ResponseEntity<List<ConsultantResponseDTO>> getConsultants(Long agencyId) {
+    verifyCallerBelongsToAgency(agencyId);
     var consultants = consultantAgencyService.getConsultantsOfAgency(agencyId);
 
     return isNotEmpty(consultants)
@@ -121,6 +125,28 @@ class UserConsultantControllerDelegate {
         consultantDtoMapper.consultantResponseDtoOf(consultant, onlineAgencies, false);
 
     return new ResponseEntity<>(consultantDto, HttpStatus.OK);
+  }
+
+  /**
+   * VIEW_AGENCY_CONSULTANTS says the caller may read an agency roster, not which agency's. Every
+   * consultant carries that authority, so without this the agencyId query parameter alone
+   * enumerated any agency in the tenant (#1107).
+   *
+   * <p>A rejection is a 403 rather than an empty list: the caller is authenticated and asking for
+   * something real, and answering 200 with nothing would make a genuine authorization failure look
+   * like an agency that happens to have no consultants.
+   */
+  private void verifyCallerBelongsToAgency(Long agencyId) {
+    var consultantId = authenticatedUser.getUserId();
+    if (!consultantAgencyService.isConsultantAssignedToAgency(consultantId, agencyId)) {
+      log.warn(
+          "Consultant {} requested the consultant roster of agency {}, which they are not assigned"
+              + " to",
+          consultantId,
+          agencyId);
+      throw new ForbiddenException(
+          "Consultant is not a member of the requested agency and may not read its consultants");
+    }
   }
 
   private String determineDecodedInfix(String query) {

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegate.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.port.in.AccountManaging;
 import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.ConsultantService;
+import de.caritas.cob.userservice.api.service.LogService;
 import de.caritas.cob.userservice.api.service.helper.EmailUrlDecoder;
 import jakarta.validation.constraints.NotNull;
 import java.net.URLDecoder;
@@ -26,7 +27,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +34,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 class UserConsultantControllerDelegate {
 
   private final @NotNull AuthenticatedUser authenticatedUser;
@@ -136,6 +135,14 @@ class UserConsultantControllerDelegate {
    * something real, and answering 200 with nothing would make a genuine authorization failure look
    * like an agency that happens to have no consultants.
    *
+   * <p>The denial is logged once, by the exception itself. {@code ForbiddenException}'s default
+   * logger prints a whole stack trace per refusal, which is noise for an expected authorization
+   * outcome and real log volume when someone walks the agencyId range, so this throw picks the
+   * single-line {@code LogService#logForbidden(String)} instead — the same "choose the logging
+   * method" route {@code SessionToConsultantVerifier} takes. The diagnostic context lives in the
+   * exception message, which reaches the log but never the response: the handler answers 403 with
+   * no body.
+   *
    * <p>Deliberately check-then-act rather than one caller-scoped roster query. The window between
    * the two reads is not attacker-controllable, and revoking the caller's own assignment does not
    * change the roster they would receive, so a request straddling that window returns data they
@@ -146,15 +153,10 @@ class UserConsultantControllerDelegate {
   private void verifyCallerBelongsToAgency(Long agencyId) {
     var consultantId = authenticatedUser.getUserId();
     if (!consultantAgencyService.isConsultantAssignedToAgency(consultantId, agencyId)) {
-      // The logged id is the opaque Keycloak UUID, never a name, email or Matrix id, and matches
-      // what the admin authorization guards already record on a denial. Without it the warning
-      // cannot be attributed to anyone: MDC carries only the request correlation id.
-      log.warn(
-          "Consultant {} requested the consultant roster of agency {}, which they are not assigned"
-              + " to",
-          consultantId,
-          agencyId);
-      throw new ForbiddenException("Consultant is not a member of the requested agency and may not read its consultants", ex -> {});
+      throw new ForbiddenException(
+          "Consultant %s is not a member of agency %s and may not read its consultants"
+              .formatted(consultantId, agencyId),
+          denial -> LogService.logForbidden(denial.getMessage()));
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/ConsultantAgencyService.java
@@ -90,6 +90,26 @@ public class ConsultantAgencyService {
   }
 
   /**
+   * Whether the given consultant is currently assigned to the given agency.
+   *
+   * <p>Membership, not authority, is what scopes an agency roster to the people already in it. The
+   * caller is the one that has to check: this method answers the question, {@link
+   * #getConsultantsOfAgency} deliberately does not ask it, so internal callers that legitimately
+   * read any agency keep working.
+   *
+   * @param consultantId the consultant's id, which is also their Keycloak user id
+   * @param agencyId agency ID
+   * @return true when an undeleted assignment exists
+   */
+  public boolean isConsultantAssignedToAgency(String consultantId, Long agencyId) {
+    if (isNull(consultantId) || isNull(agencyId)) {
+      return false;
+    }
+    return consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+        consultantId, agencyId);
+  }
+
+  /**
    * Returns an alphabetically sorted list of {@link ConsultantResponseDTO} depending on the
    * provided agencyId.
    *

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -9,6 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyAdminResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantAdminResponseDTO;
@@ -36,6 +40,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,6 +120,37 @@ class UserConsultantControllerDelegateTest {
         .isInstanceOf(ForbiddenException.class);
 
     verify(consultantAgencyService, never()).getConsultantsOfAgency(any());
+  }
+
+  @Test
+  void getConsultantsLogsADeniedRosterRequestExactlyOnceAndWithoutAStackTrace() {
+    // The endpoint invites enumeration, so a refusal must not cost two warnings — one here plus
+    // ForbiddenException's default stack-trace logger — nor print a trace for what is an expected
+    // authorization outcome.
+    when(authenticatedUser.getUserId()).thenReturn(CALLER_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, OTHER_AGENCY_ID))
+        .thenReturn(false);
+
+    // Root, not LogService: "exactly once" has to mean once in total, so that re-adding a
+    // delegate-side log.warn next to the exception fails here rather than slipping through.
+    var logger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      var denial =
+          catchThrowableOfType(
+              ForbiddenException.class, () -> delegate.getConsultants(OTHER_AGENCY_ID));
+      // The handler is what logs; do what ApiResponseEntityExceptionHandler#handleForbidden does.
+      denial.executeLogging();
+    } finally {
+      logger.detachAppender(appender);
+    }
+
+    assertThat(appender.list).hasSize(1);
+    assertThat(appender.list.get(0).getFormattedMessage())
+        .contains(CALLER_ID, String.valueOf(OTHER_AGENCY_ID))
+        .doesNotContain("\tat ", ForbiddenException.class.getName());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserConsultantControllerDelegateTest.java
@@ -2,7 +2,9 @@ package de.caritas.cob.userservice.api.adapters.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -16,6 +18,7 @@ import de.caritas.cob.userservice.api.adapters.web.dto.ConsultantSearchResultDTO
 import de.caritas.cob.userservice.api.adapters.web.dto.LanguageResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.mapping.ConsultantDtoMapper;
 import de.caritas.cob.userservice.api.admin.facade.AdminUserFacade;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -39,6 +42,8 @@ import org.springframework.http.HttpStatus;
 class UserConsultantControllerDelegateTest {
 
   private static final long AGENCY_ID = 42L;
+  private static final long OTHER_AGENCY_ID = 43L;
+  private static final String CALLER_ID = "caller-consultant-id";
   private static final String ADMIN_ID = "admin-id";
   private static final UUID CONSULTANT_ID = UUID.fromString("65c1095e-b977-493a-a34f-064b729d1d6c");
 
@@ -67,6 +72,7 @@ class UserConsultantControllerDelegateTest {
   @Test
   void getConsultantsShouldReturnOkWhenConsultantsExist() {
     var consultants = List.of(new ConsultantResponseDTO());
+    givenCallerIsAssignedTo(AGENCY_ID);
     when(consultantAgencyService.getConsultantsOfAgency(AGENCY_ID)).thenReturn(consultants);
 
     var response = delegate.getConsultants(AGENCY_ID);
@@ -77,11 +83,61 @@ class UserConsultantControllerDelegateTest {
 
   @Test
   void getConsultantsShouldReturnNoContentWhenConsultantsAreMissing() {
+    givenCallerIsAssignedTo(AGENCY_ID);
     when(consultantAgencyService.getConsultantsOfAgency(AGENCY_ID)).thenReturn(List.of());
 
     var response = delegate.getConsultants(AGENCY_ID);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  void getConsultantsRejectsAnAgencyTheCallerIsNotAssignedTo() {
+    // #1107: VIEW_AGENCY_CONSULTANTS says the caller may read *an* agency roster, not which one.
+    // Every consultant carries it, so before this check one query parameter enumerated any agency.
+    when(authenticatedUser.getUserId()).thenReturn(CALLER_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, OTHER_AGENCY_ID))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.getConsultants(OTHER_AGENCY_ID))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  void getConsultantsDoesNotQueryTheRosterItRejects() {
+    // The roster must not be read at all, so a rejection cannot leak through a log, a metric or a
+    // later refactor that starts returning what was already fetched.
+    when(authenticatedUser.getUserId()).thenReturn(CALLER_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, OTHER_AGENCY_ID))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> delegate.getConsultants(OTHER_AGENCY_ID))
+        .isInstanceOf(ForbiddenException.class);
+
+    verify(consultantAgencyService, never()).getConsultantsOfAgency(any());
+  }
+
+  @Test
+  void getConsultantsServesEveryAgencyTheCallerBelongsTo() {
+    // Multi-agency consultants are normal; membership is per agency, not one home agency.
+    var first = List.of(new ConsultantResponseDTO().consultantId("in-agency-42"));
+    var second = List.of(new ConsultantResponseDTO().consultantId("in-agency-43"));
+    when(authenticatedUser.getUserId()).thenReturn(CALLER_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, AGENCY_ID))
+        .thenReturn(true);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, OTHER_AGENCY_ID))
+        .thenReturn(true);
+    when(consultantAgencyService.getConsultantsOfAgency(AGENCY_ID)).thenReturn(first);
+    when(consultantAgencyService.getConsultantsOfAgency(OTHER_AGENCY_ID)).thenReturn(second);
+
+    assertThat(delegate.getConsultants(AGENCY_ID).getBody()).isSameAs(first);
+    assertThat(delegate.getConsultants(OTHER_AGENCY_ID).getBody()).isSameAs(second);
+  }
+
+  private void givenCallerIsAssignedTo(long agencyId) {
+    when(authenticatedUser.getUserId()).thenReturn(CALLER_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CALLER_ID, agencyId))
+        .thenReturn(true);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
@@ -842,6 +842,8 @@ class UserControllerConsultantE2EIT {
   void getConsultantsShouldRespondWithDisplayNameAndUsername() throws Exception {
     var agencyId = givenAnAgencyIdWithDefaultLanguageOnly();
     givenMatrixDisplayNames(agencyId, "user1", "user2", "user3");
+    // Before #1107 the authority alone was enough and the caller's agency did not matter.
+    givenCallerIsAConsultantOfAgency(agencyId);
 
     mockMvc
         .perform(
@@ -858,6 +860,27 @@ class UserControllerConsultantE2EIT {
         .andExpect(jsonPath("[1].username", startsWith("enc.")))
         .andExpect(jsonPath("[2].displayName", is("user3")))
         .andExpect(jsonPath("[2].username", startsWith("enc.")));
+  }
+
+  @Test
+  @WithMockUser(authorities = AuthorityValue.VIEW_AGENCY_CONSULTANTS)
+  void getConsultantsShouldRespondWithForbiddenWhenCallerIsNotInTheRequestedAgency()
+      throws Exception {
+    // #1107 end to end: the authority is present and the agency is real, but the caller is not a
+    // member of it. This is the exact request that used to return the whole roster.
+    var agencyId = givenAnAgencyIdWithDefaultLanguageOnly();
+    givenMatrixDisplayNames(agencyId, "user1", "user2", "user3");
+    when(authenticatedUser.getUserId()).thenReturn(UUID.randomUUID().toString());
+
+    mockMvc
+        .perform(
+            get("/users/consultants")
+                .cookie(CSRF_COOKIE)
+                .header(CSRF_HEADER, CSRF_VALUE)
+                .param("agencyId", String.valueOf(agencyId))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
   }
 
   @Test
@@ -1134,6 +1157,15 @@ class UserControllerConsultantE2EIT {
       when(authenticatedUser.getRoles()).thenReturn(Set.of(UserRole.CONSULTANT.getValue()));
       when(authenticatedUser.getGrantedAuthorities()).thenReturn(Set.of("anAuthority"));
     }
+  }
+
+  private void givenCallerIsAConsultantOfAgency(long agencyId) {
+    var member =
+        consultantAgencyRepository.findByAgencyIdAndDeleteDateIsNull(agencyId).stream()
+            .map(ConsultantAgency::getConsultant)
+            .findFirst()
+            .orElseThrow();
+    when(authenticatedUser.getUserId()).thenReturn(member.getId());
   }
 
   private long givenAnAgencyIdWithDefaultLanguageOnly() {

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerConsultantE2EIT.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -880,7 +881,9 @@ class UserControllerConsultantE2EIT {
                 .param("agencyId", String.valueOf(agencyId))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$").doesNotExist());
+        // Asserted directly rather than via jsonPath: the handler returns an empty body, and a
+        // JSON-path assertion over an empty body proves nothing about what was withheld.
+        .andExpect(content().string(""));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -126,6 +126,9 @@ import org.springframework.test.web.servlet.MockMvc;
     })
 class UserControllerIT {
 
+  /** The agencyId carried by PATH_GET_CONSULTANTS_FOR_AGENCY. */
+  private static final long REQUESTED_AGENCY_ID = 10L;
+
   private final String VALID_ENQUIRY_MESSAGE_BODY = "{\"message\": \"" + MESSAGE + "\"}";
   private final User USER = new User(USER_ID, null, "username", "name@domain.de", false);
   private final Consultant TEAM_CONSULTANT =
@@ -1443,6 +1446,7 @@ class UserControllerIT {
 
   @Test
   void getConsultants_Should_ReturnNoContent_WhenNoConsultantInDbFound() throws Exception {
+    givenCallerIsAssignedToRequestedAgency();
 
     mvc.perform(
             get(PATH_GET_CONSULTANTS_FOR_AGENCY)
@@ -1454,6 +1458,7 @@ class UserControllerIT {
   @Test
   void getConsultants_Should_ReturnInternalServerError_WhenConsultantAgencyServiceThrowsException()
       throws Exception {
+    givenCallerIsAssignedToRequestedAgency();
 
     when(consultantAgencyService.getConsultantsOfAgency(Mockito.anyLong()))
         .thenThrow(new ServiceException(ERROR));
@@ -1469,6 +1474,7 @@ class UserControllerIT {
   void
       getConsultants_Should_ReturnOkAndValidContent_WhenConsultantAgencyServiceReturnsListWithEntries()
           throws Exception {
+    givenCallerIsAssignedToRequestedAgency();
 
     when(consultantAgencyService.getConsultantsOfAgency(Mockito.anyLong()))
         .thenReturn(CONSULTANT_RESPONSE_DTO_LIST);
@@ -1487,6 +1493,31 @@ class UserControllerIT {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().json(validConsultantResponseDtoResult));
+  }
+
+  @Test
+  void getConsultants_Should_ReturnForbidden_WhenCallerIsNotAssignedToRequestedAgency()
+      throws Exception {
+    // #1107: VIEW_AGENCY_CONSULTANTS is carried by every consultant, so before the membership
+    // check one query parameter enumerated any agency's roster within the tenant.
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, REQUESTED_AGENCY_ID))
+        .thenReturn(false);
+
+    mvc.perform(
+            get(PATH_GET_CONSULTANTS_FOR_AGENCY)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(content().string(""));
+
+    verify(consultantAgencyService, never()).getConsultantsOfAgency(Mockito.anyLong());
+  }
+
+  private void givenCallerIsAssignedToRequestedAgency() {
+    when(authenticatedUser.getUserId()).thenReturn(CONSULTANT_ID);
+    when(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, REQUESTED_AGENCY_ID))
+        .thenReturn(true);
   }
 
   /** Method: assignSession (role: consultant) */

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerIT.java
@@ -6,13 +6,18 @@ import static de.caritas.cob.userservice.api.model.Session.RegistrationType.REGI
 import static de.caritas.cob.userservice.api.testHelper.PathConstants.*;
 import static de.caritas.cob.userservice.api.testHelper.RequestBodyConstants.*;
 import static de.caritas.cob.userservice.api.testHelper.TestConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.neovisionaries.i18n.LanguageCode;
 import de.caritas.cob.userservice.api.adapters.web.controller.interceptor.ApiResponseEntityExceptionHandler;
@@ -30,6 +35,7 @@ import de.caritas.cob.userservice.api.config.auth.Authority.AuthorityValue;
 import de.caritas.cob.userservice.api.config.auth.RoleAuthorizationAuthorityMapper;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.*;
+import de.caritas.cob.userservice.api.exception.httpresponses.ForbiddenException;
 import de.caritas.cob.userservice.api.facade.*;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignEnquiryFacade;
 import de.caritas.cob.userservice.api.facade.assignsession.AssignSessionFacade;
@@ -89,6 +95,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.hateoas.autoconfigure.HypermediaAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -1504,14 +1511,40 @@ class UserControllerIT {
     when(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, REQUESTED_AGENCY_ID))
         .thenReturn(false);
 
-    mvc.perform(
-            get(PATH_GET_CONSULTANTS_FOR_AGENCY)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isForbidden())
-        .andExpect(content().string(""));
+    var rootLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
+    var logAppender = new ListAppender<ILoggingEvent>();
+    logAppender.start();
+    rootLogger.addAppender(logAppender);
+    try {
+      mvc.perform(
+              get(PATH_GET_CONSULTANTS_FOR_AGENCY)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isForbidden())
+          .andExpect(content().string(""));
+    } finally {
+      rootLogger.detachAppender(logAppender);
+    }
 
     verify(consultantAgencyService, never()).getConsultantsOfAgency(Mockito.anyLong());
+
+    // Through the real handler, not just the delegate: ForbiddenException logs itself via
+    // ApiResponseEntityExceptionHandler#handleForbidden, so a second warning here would mean the
+    // endpoint costs two log events per probe of the agencyId range.
+    // Warnings only. Spring's ExceptionHandlerExceptionResolver also emits a DEBUG "Resolved [...]"
+    // line for every handled exception; that is framework bookkeeping, off at production levels,
+    // and not what abuse would amplify.
+    var denialWarnings =
+        logAppender.list.stream()
+            .filter(event -> event.getLevel().isGreaterOrEqual(Level.WARN))
+            .filter(event -> event.getFormattedMessage().contains("may not read its consultants"))
+            .toList();
+    assertThat(denialWarnings).hasSize(1);
+    assertThat(logAppender.list)
+        .filteredOn(event -> event.getLevel().isGreaterOrEqual(Level.WARN))
+        .as("no warning may carry the exception's stack trace")
+        .noneMatch(
+            event -> event.getFormattedMessage().contains(ForbiddenException.class.getName()));
   }
 
   private void givenCallerIsAssignedToRequestedAgency() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/ConsultantAgencyServiceTest.java
@@ -115,6 +115,35 @@ public class ConsultantAgencyServiceTest {
     assertTrue(transactional.readOnly());
   }
 
+  /** Method: isConsultantAssignedToAgency (#1107) */
+  @Test
+  public void isConsultantAssignedToAgency_Should_ReturnRepositoryVerdict() {
+    when(consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+            CONSULTANT_ID, AGENCY_ID))
+        .thenReturn(true);
+
+    assertTrue(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, AGENCY_ID));
+  }
+
+  @Test
+  public void isConsultantAssignedToAgency_Should_ReturnFalse_WhenNoAssignmentExists() {
+    when(consultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(
+            CONSULTANT_ID, AGENCY_ID))
+        .thenReturn(false);
+
+    assertFalse(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, AGENCY_ID));
+  }
+
+  @Test
+  public void isConsultantAssignedToAgency_Should_DenyAndNotQuery_WhenEitherIdIsNull() {
+    // A null id must not reach a query that could match a row by accident; deny outright.
+    assertFalse(consultantAgencyService.isConsultantAssignedToAgency(null, AGENCY_ID));
+    assertFalse(consultantAgencyService.isConsultantAssignedToAgency(CONSULTANT_ID, null));
+
+    Mockito.verify(consultantAgencyRepository, Mockito.never())
+        .existsByConsultantIdAndAgencyIdAndDeleteDateIsNull(Mockito.any(), Mockito.any());
+  }
+
   /** Method: getConsultantsOfAgency */
   @Test
   public void


### PR DESCRIPTION
Closes #1107

## The leak

`GET /users/consultants?agencyId=<n>` was gated on `VIEW_AGENCY_CONSULTANTS` and nothing else. That authority answers "may this caller read *an* agency roster" — never "which agency's". Every `CONSULTANT` and `SUPERVISOR_CONSULTANT` carries it, and the delegate passed the client's `agencyId` straight into the query, so any consultant could enumerate any agency's roster in their tenant by changing one query parameter.

## The fix

The membership check runs before the query, in the delegate — mirroring the sibling `getTenantConsultants()`, which already derives its scope from the token rather than from the caller.

A rejection is `403` with no body, per `docs/api-error-contract.md`. An empty `200` would make a genuine authorization failure indistinguishable from an agency that happens to have no consultants.

**Two placement decisions worth a reviewer's eye:**

*The check is in the delegate, not in `ConsultantAgencyService.getConsultantsOfAgency`.* That method has exactly one production caller, so the delegate covers the whole surface. Leaving the service method unscoped keeps it usable by internal callers that legitimately read any agency, and keeps the security context out of the service layer. `getConsultantsOfAgency` now carries a javadoc line saying it deliberately does not ask the question, so nobody "fixes" it later by adding a second check.

*The new `isConsultantAssignedToAgency` denies on a null id rather than passing it to the query,* so a null can never match a row by accident.

No new machinery: `ConsultantAgencyRepository.existsByConsultantIdAndAgencyIdAndDeleteDateIsNull` already existed, and `TeamDiscussionFacade.requireEligibleConsultant` already uses it for exactly this kind of check. This follows that idiom.

## The `username` question — the issue's premise doesn't hold

The issue says "nothing in the picker flows needs it". It is read. `ORISO-Frontend/src/components/sessionHeader/SessionHeaderComponent.tsx:189` uses it as the third fallback for a consultant's display label:

```ts
[consultant.firstName, consultant.lastName].filter(Boolean).join(' ') ||
consultant.displayName ||
consultant.username ||
consultant.consultantId;
```

Removing it would not break the frontend — it falls through to `consultantId` — but it would degrade that case from a readable username to a raw UUID.

**Decision: it stays**, and the reasoning is now on the schema property itself rather than only in this PR, so the next reader finds it where they look. Retiring it is a cross-repo change that should start by removing the frontend fallback.

Worth recording alongside it: `username` is **not** exposed by the unauthenticated public-data endpoint. `ConsultantDtoMapper.consultantResponseDtoOf` never sets it. I checked that specifically, because `/users/consultants/{consultantId}` is `permitAll` — it would have been a much worse leak. It is populated only on the two authenticated list endpoints.

## Verification

**Where:** local only — no dev database credentials here, so this was not exercised against a running instance.

Full suite: **4255 tests**. The only two failures are `MatrixOnlyRuntimeConfigurationContractTest`, a pre-existing local-machine artifact: the gitignored `src/main/resources/application-local.properties` on my checkout still carries retired Mongo/Rocket.Chat settings. I confirmed rather than assumed — moving that untracked file aside makes it pass 4/4, and it is not in the repo, so CI never sees it. `spotless:check` BUILD SUCCESS.

**The tests were confirmed to fail against the pre-fix code**, not merely to pass against the new one. Removing the guard call makes both cross-agency tests fail:

| Test | Level | Pins |
|---|---|---|
| `getConsultantsRejectsAnAgencyTheCallerIsNotAssignedTo` | delegate | cross-agency request is refused |
| `getConsultantsDoesNotQueryTheRosterItRejects` | delegate | the roster is never read on a rejection |
| `getConsultantsServesEveryAgencyTheCallerBelongsTo` | delegate | multi-agency consultants keep both |
| `getConsultants_Should_ReturnForbidden_WhenCallerIsNotAssignedToRequestedAgency` | controller IT | `403`, empty body, no query |
| `isConsultantAssignedToAgency_*` (3) | service | verdict, denial, null-id denial |

## Acceptance

- [x] A consultant of agency A requesting `agencyId=B` gets 403, no roster in the body
- [x] A consultant of agency A requesting their own agency still gets the list unchanged
- [x] A consultant belonging to both A and B can read both
- [x] A test pins the cross-agency rejection so it cannot silently regress
- [x] Recorded decision on whether `username` stays in `ConsultantResponseDTO`

## Reviewer test plan

- [ ] As a consultant of agency A, call `/users/consultants?agencyId=<B>` for an agency you are not in → `403`, empty body. Check the log carries the warning naming both ids.
- [ ] Same consultant, own agency → the list you saw before this change, unchanged.
- [ ] A consultant assigned to both A and B → both rosters answer normally.
- [ ] Confirm the supervisor picker in the session header still populates for a normal consultant (`SessionHeaderComponent` is the main caller).
- [ ] Sanity-check the two placement decisions above — delegate rather than service, and 403 rather than an empty list.
- [ ] Weigh the `username` decision. It is reversible; the evidence is in the PR and on the schema property.

## Out of scope, but noticed

`getChatSeriesConsultants` (`getTenantConsultants`) returns every consultant in the tenant, `username` included, to any authenticated consultant. That one derives its scope from the token, so it is not this bug — but it is a wider exposure of the same field and may deserve its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consultant roster access is now restricted to callers assigned to the requested agency.
  * Authorized consultants can continue accessing rosters for each agency they are assigned to.
  * Unauthorized requests receive a 403 Forbidden response.

* **Tests**
  * Added coverage for authorized, unauthorized, multi-agency, and invalid assignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->