### PR TITLE
feat(retention): purge team discussions 90 days after archiving (#1116)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -733,18 +733,44 @@ public class MatrixSynapseService implements MatrixUserClient {
     }
   }
 
+  /** Outcome of a Synapse room purge, distinguishing "already gone" from a genuine failure. */
+  public enum RoomPurgeOutcome {
+    /** Synapse accepted the purge. */
+    PURGED,
+    /** Synapse does not know the room id any more, so there is nothing left to purge. */
+    ALREADY_GONE,
+    /** The purge did not happen and the room may still exist. */
+    FAILED
+  }
+
   /**
    * Purges a Matrix room and its message history via the Synapse admin API.
+   *
+   * <p>A room Synapse no longer knows counts as a failure here, which is what the account and chat
+   * deletion workflows expect. Callers that must not orphan a still-existing room but may forget a
+   * vanished one use {@link #purgeRoomOrConfirmGone(String)} instead.
    *
    * @param matrixRoomId the Matrix room ID
    * @return true if successful, false otherwise
    */
   public boolean purgeRoom(String matrixRoomId) {
+    return purgeRoomOrConfirmGone(matrixRoomId) == RoomPurgeOutcome.PURGED;
+  }
+
+  /**
+   * Purges a Matrix room and reports whether the room is gone afterwards, either because Synapse
+   * purged it now or because it did not exist any more (#1116, #1118).
+   *
+   * @param matrixRoomId the Matrix room ID
+   * @return {@link RoomPurgeOutcome#ALREADY_GONE} on a 404 from Synapse, {@link
+   *     RoomPurgeOutcome#FAILED} on any other problem
+   */
+  public RoomPurgeOutcome purgeRoomOrConfirmGone(String matrixRoomId) {
     try {
       String adminToken = getAdminToken();
       if (adminToken == null) {
         log.warn("Could not get admin token for Matrix room purge");
-        return false;
+        return RoomPurgeOutcome.FAILED;
       }
 
       var url =
@@ -764,12 +790,20 @@ public class MatrixSynapseService implements MatrixUserClient {
           restTemplate.exchange(
               url, org.springframework.http.HttpMethod.DELETE, request, String.class);
 
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        log.warn(
+            "Failed to purge Matrix room {}: status {}", matrixRoomId, response.getStatusCode());
+        return RoomPurgeOutcome.FAILED;
+      }
       log.info("Successfully purged Matrix room: {}", matrixRoomId);
-      return response.getStatusCode().is2xxSuccessful();
+      return RoomPurgeOutcome.PURGED;
 
+    } catch (HttpClientErrorException.NotFound ex) {
+      log.info("Matrix room {} no longer exists, nothing to purge", matrixRoomId);
+      return RoomPurgeOutcome.ALREADY_GONE;
     } catch (Exception ex) {
       log.warn("Failed to purge Matrix room {}: {}", matrixRoomId, ex.getMessage());
-      return false;
+      return RoomPurgeOutcome.FAILED;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseService.java
@@ -762,8 +762,9 @@ public class MatrixSynapseService implements MatrixUserClient {
    * purged it now or because it did not exist any more (#1116, #1118).
    *
    * @param matrixRoomId the Matrix room ID
-   * @return {@link RoomPurgeOutcome#ALREADY_GONE} on a 404 from Synapse, {@link
-   *     RoomPurgeOutcome#FAILED} on any other problem
+   * @return {@link RoomPurgeOutcome#PURGED} when Synapse accepted the purge, {@link
+   *     RoomPurgeOutcome#ALREADY_GONE} on a 404 from Synapse, {@link RoomPurgeOutcome#FAILED} on
+   *     any other problem
    */
   public RoomPurgeOutcome purgeRoomOrConfirmGone(String matrixRoomId) {
     try {

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionParticipantRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionParticipantRepository.java
@@ -3,6 +3,9 @@ package de.caritas.cob.userservice.api.port.out;
 import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamDiscussionParticipantRepository
     extends JpaRepository<TeamDiscussionParticipant, Long> {
@@ -10,4 +13,14 @@ public interface TeamDiscussionParticipantRepository
   List<TeamDiscussionParticipant> findByTeamDiscussionId(Long teamDiscussionId);
 
   boolean existsByTeamDiscussionIdAndConsultantId(Long teamDiscussionId, String consultantId);
+
+  /**
+   * Removes every participant record of one discussion (#1116). The table has no foreign key to
+   * {@code team_discussion}, so a purge has to delete the participants explicitly.
+   *
+   * @return the number of rows removed
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("delete from TeamDiscussionParticipant p where p.teamDiscussionId = :teamDiscussionId")
+  int deleteByTeamDiscussionId(@Param("teamDiscussionId") Long teamDiscussionId);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
@@ -20,12 +20,4 @@ public interface TeamDiscussionRepository extends JpaRepository<TeamDiscussion, 
    */
   List<TeamDiscussion> findByStatusAndArchiveDateBefore(
       TeamDiscussion.Status status, LocalDateTime cutoff);
-
-  /**
-   * Discussions in the given status created strictly before the cutoff (#1116). With {@link
-   * TeamDiscussion.Status#OPEN} this finds discussions that were never archived, so an abandoned
-   * discussion is measured from its creation date under the same period as an archived one.
-   */
-  List<TeamDiscussion> findByStatusAndCreateDateBefore(
-      TeamDiscussion.Status status, LocalDateTime cutoff);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/TeamDiscussionRepository.java
@@ -1,6 +1,8 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +11,21 @@ public interface TeamDiscussionRepository extends JpaRepository<TeamDiscussion, 
   Optional<TeamDiscussion> findBySessionId(Long sessionId);
 
   Optional<TeamDiscussion> findByMatrixRoomId(String matrixRoomId);
+
+  /**
+   * Archived discussions whose archive date lies strictly before the cutoff (#1116).
+   *
+   * <p>Pass {@link TeamDiscussion.Status#ARCHIVED}; the status is a parameter only because JPQL
+   * enum literals of a nested enum are brittle across Hibernate versions.
+   */
+  List<TeamDiscussion> findByStatusAndArchiveDateBefore(
+      TeamDiscussion.Status status, LocalDateTime cutoff);
+
+  /**
+   * Discussions in the given status created strictly before the cutoff (#1116). With {@link
+   * TeamDiscussion.Status#OPEN} this finds discussions that were never archived, so an abandoned
+   * discussion is measured from its creation date under the same period as an archived one.
+   */
+  List<TeamDiscussion> findByStatusAndCreateDateBefore(
+      TeamDiscussion.Status status, LocalDateTime cutoff);
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
@@ -1,0 +1,44 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.scheduler;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service.TeamDiscussionRetentionService;
+import java.time.Duration;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduler for the team discussion archive purge (KDG epic #1010, #1116).
+ *
+ * <p>Every replica runs the same cron; the claim makes sure exactly one of them purges. The
+ * technical tenant context lifts the Hibernate tenant filter so a single run covers all tenants.
+ */
+@Component
+@RequiredArgsConstructor
+public class TeamDiscussionRetentionScheduler {
+
+  static final String TASK_NAME = "team-discussion-archive-retention";
+
+  private final @NonNull TeamDiscussionRetentionService teamDiscussionRetentionService;
+  private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull ScheduledTaskClaimService taskClaimService;
+
+  @Value("${team-discussion.archive.retention.claim.duration:PT12H}")
+  private Duration claimDuration;
+
+  /** Entry method to purge discussions that have outlived their retention period. */
+  @Scheduled(cron = "${team-discussion.archive.retention.cron:0 45 3 * * ?}")
+  public void purgeExpiredDiscussions() {
+    if (!teamDiscussionRetentionService.isEnabled()) {
+      return;
+    }
+    if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+      return;
+    }
+    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+    teamDiscussionRetentionService.purgeExpiredDiscussions();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.scheduler;
 
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
 import de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service.TeamDiscussionRetentionService;
@@ -38,7 +39,12 @@ public class TeamDiscussionRetentionScheduler {
     if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
       return;
     }
-    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
-    teamDiscussionRetentionService.purgeExpiredDiscussions();
+    try {
+      tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+      teamDiscussionRetentionService.purgeExpiredDiscussions();
+    } finally {
+      // Scheduler threads are pooled; never leave the technical context behind for the next task.
+      TenantContext.clear();
+    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java
@@ -33,17 +33,17 @@ public class TeamDiscussionRetentionScheduler {
   /** Entry method to purge discussions that have outlived their retention period. */
   @Scheduled(cron = "${team-discussion.archive.retention.cron:0 45 3 * * ?}")
   public void purgeExpiredDiscussions() {
-    if (!teamDiscussionRetentionService.isEnabled()) {
-      return;
-    }
-    if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
-      return;
-    }
     try {
+      if (!teamDiscussionRetentionService.isEnabled()) {
+        return;
+      }
+      if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+        return;
+      }
       tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
       teamDiscussionRetentionService.purgeExpiredDiscussions();
     } finally {
-      // Scheduler threads are pooled; never leave the technical context behind for the next task.
+      // Scheduler threads are pooled; never leave any tenant context behind for the next task.
       TenantContext.clear();
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriter.java
@@ -1,0 +1,30 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service;
+
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Removes one team discussion and its participant records in a single transaction (#1116).
+ *
+ * <p>Kept apart from {@link TeamDiscussionRetentionService} so the database delete runs in its own
+ * transaction after the Matrix purge has succeeded, never around the remote call. The participant
+ * table carries no foreign key to {@code team_discussion}, so both deletes are explicit.
+ */
+@Component
+@RequiredArgsConstructor
+public class TeamDiscussionPurgeWriter {
+
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull TeamDiscussionParticipantRepository participantRepository;
+
+  @Transactional
+  public void deleteDiscussionAndParticipants(TeamDiscussion discussion) {
+    participantRepository.deleteByTeamDiscussionId(discussion.getId());
+    teamDiscussionRepository.deleteById(discussion.getId());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriter.java
@@ -6,14 +6,18 @@ import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Removes one team discussion and its participant records in a single transaction (#1116).
  *
  * <p>Kept apart from {@link TeamDiscussionRetentionService} so the database delete runs in its own
- * transaction after the Matrix purge has succeeded, never around the remote call. The participant
- * table carries no foreign key to {@code team_discussion}, so both deletes are explicit.
+ * transaction after the Matrix purge has succeeded, never around the remote call. {@code
+ * REQUIRES_NEW} enforces that regardless of the caller, as {@code ScheduledTaskClaimWriter} does: a
+ * transactional caller must not be able to stretch this delete around the Synapse call or roll it
+ * back after the room is already gone. The participant table carries no foreign key to {@code
+ * team_discussion}, so both deletes are explicit.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,7 +26,7 @@ public class TeamDiscussionPurgeWriter {
   private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
   private final @NonNull TeamDiscussionParticipantRepository participantRepository;
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void deleteDiscussionAndParticipants(TeamDiscussion discussion) {
     participantRepository.deleteByTeamDiscussionId(discussion.getId());
     teamDiscussionRepository.deleteById(discussion.getId());

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
@@ -1,0 +1,142 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService.RoomPurgeOutcome;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Purges team discussions that have outlived their retention period (KDG epic #1010, #1116).
+ *
+ * <p>Archiving a discussion (ADR-016 hard close) only flips a status and makes the Matrix room
+ * read-only; nothing was ever deleted, and the room kept everything the team wrote about the advice
+ * seeker in plain text. ADR-016 §3 assumed an archive auto-deletion that never existed; this job is
+ * the replacement decided in the addendum of 2026-09-05.
+ *
+ * <p>The period starts at {@code archive_date}. A discussion that was never archived and is still
+ * {@code OPEN} is measured from {@code create_date} under the same period, so an abandoned
+ * discussion cannot outlive an archived one. Cutoffs use the same local clock that stamps those
+ * columns in {@code TeamDiscussionFacade}.
+ *
+ * <p>The Matrix room is purged before the row goes. A failed purge keeps the row, so the pointer to
+ * a room that may still exist is never lost and the next run retries; a room Synapse no longer
+ * knows counts as already purged and does not block the row deletion.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamDiscussionRetentionService {
+
+  private final @NonNull TeamDiscussionRepository teamDiscussionRepository;
+  private final @NonNull TeamDiscussionPurgeWriter purgeWriter;
+  private final @NonNull MatrixSynapseService matrixSynapseService;
+
+  @Value("${team-discussion.archive.retention.days:90}")
+  private int retentionDays;
+
+  /** Whether the job is switched on. A period of zero or less disables it entirely. */
+  public boolean isEnabled() {
+    return retentionDays > 0;
+  }
+
+  /**
+   * Purges every discussion past its retention period and writes one summary line per run.
+   *
+   * <p>Not transactional on purpose: each discussion is removed in its own transaction by {@link
+   * TeamDiscussionPurgeWriter} once its room is gone, so one failure neither rolls back the others
+   * nor holds a transaction open across the Synapse call.
+   */
+  public void purgeExpiredDiscussions() {
+    if (!isEnabled()) {
+      return;
+    }
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+
+    List<TeamDiscussion> expired = new ArrayList<>();
+    expired.addAll(
+        teamDiscussionRepository.findByStatusAndArchiveDateBefore(
+            TeamDiscussion.Status.ARCHIVED, cutoff));
+    expired.addAll(
+        teamDiscussionRepository.findByStatusAndCreateDateBefore(
+            TeamDiscussion.Status.OPEN, cutoff));
+
+    Map<String, int[]> countsByTenant = new TreeMap<>();
+    int purged = 0;
+    int failures = 0;
+    for (TeamDiscussion discussion : expired) {
+      int[] counts = countsByTenant.computeIfAbsent(tenantKey(discussion), key -> new int[2]);
+      if (purge(discussion)) {
+        purged++;
+        counts[0]++;
+      } else {
+        failures++;
+        counts[1]++;
+      }
+    }
+
+    log.info(
+        "Team discussion retention run: retentionDays={}, cutoff={}, tenants={}, purged={},"
+            + " purgeFailures={}",
+        retentionDays,
+        cutoff,
+        summarise(countsByTenant),
+        purged,
+        failures);
+  }
+
+  private boolean purge(TeamDiscussion discussion) {
+    RoomPurgeOutcome outcome =
+        matrixSynapseService.purgeRoomOrConfirmGone(discussion.getMatrixRoomId());
+    if (outcome == RoomPurgeOutcome.FAILED) {
+      log.warn(
+          "Team discussion {} (room {}, tenant {}) kept: Matrix purge failed, will retry next run",
+          discussion.getId(),
+          discussion.getMatrixRoomId(),
+          discussion.getTenantId());
+      return false;
+    }
+    try {
+      purgeWriter.deleteDiscussionAndParticipants(discussion);
+      return true;
+    } catch (RuntimeException ex) {
+      log.error(
+          "Team discussion {} (room {}, tenant {}) row could not be deleted after the room purge: {}",
+          discussion.getId(),
+          discussion.getMatrixRoomId(),
+          discussion.getTenantId(),
+          ex.getMessage());
+      return false;
+    }
+  }
+
+  private static String tenantKey(TeamDiscussion discussion) {
+    return discussion.getTenantId() == null ? "none" : String.valueOf(discussion.getTenantId());
+  }
+
+  private static String summarise(Map<String, int[]> countsByTenant) {
+    if (countsByTenant.isEmpty()) {
+      return "{}";
+    }
+    StringBuilder out = new StringBuilder("{");
+    countsByTenant.forEach(
+        (tenant, counts) ->
+            out.append(tenant)
+                .append(": purged=")
+                .append(counts[0])
+                .append(" failed=")
+                .append(counts[1])
+                .append(", "));
+    out.setLength(out.length() - 2);
+    return out.append("}").toString();
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
@@ -5,7 +5,6 @@ import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService.RoomP
 import de.caritas.cob.userservice.api.model.TeamDiscussion;
 import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -23,10 +22,12 @@ import org.springframework.stereotype.Service;
  * seeker in plain text. ADR-016 §3 assumed an archive auto-deletion that never existed; this job is
  * the replacement decided in the addendum of 2026-09-05.
  *
- * <p>The period starts at {@code archive_date}. A discussion that was never archived and is still
- * {@code OPEN} is measured from {@code create_date} under the same period, so an abandoned
- * discussion cannot outlive an archived one. Cutoffs use the same local clock that stamps those
- * columns in {@code TeamDiscussionFacade}.
+ * <p>The period starts at {@code archive_date} and only {@code ARCHIVED} discussions are eligible.
+ * An {@code OPEN} discussion is deliberately left alone: the entity carries no activity signal, so
+ * "open" means "not archived", not "abandoned", and purging it by creation date would delete a room
+ * still in use. A discussion whose session is deleted is purged by the deletion workflow instead
+ * (#1118). The cutoff uses the same local clock that stamps {@code archive_date} in {@code
+ * TeamDiscussionFacade}.
  *
  * <p>The Matrix room is purged before the row goes. A failed purge keeps the row, so the pointer to
  * a room that may still exist is never lost and the next run retries; a room Synapse no longer
@@ -62,13 +63,9 @@ public class TeamDiscussionRetentionService {
     }
     LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
 
-    List<TeamDiscussion> expired = new ArrayList<>();
-    expired.addAll(
+    List<TeamDiscussion> expired =
         teamDiscussionRepository.findByStatusAndArchiveDateBefore(
-            TeamDiscussion.Status.ARCHIVED, cutoff));
-    expired.addAll(
-        teamDiscussionRepository.findByStatusAndCreateDateBefore(
-            TeamDiscussion.Status.OPEN, cutoff));
+            TeamDiscussion.Status.ARCHIVED, cutoff);
 
     Map<String, int[]> countsByTenant = new TreeMap<>();
     int purged = 0;

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionService.java
@@ -99,9 +99,8 @@ public class TeamDiscussionRetentionService {
         matrixSynapseService.purgeRoomOrConfirmGone(discussion.getMatrixRoomId());
     if (outcome == RoomPurgeOutcome.FAILED) {
       log.warn(
-          "Team discussion {} (room {}, tenant {}) kept: Matrix purge failed, will retry next run",
+          "Team discussion {} (tenant {}) kept: Matrix purge failed, will retry next run",
           discussion.getId(),
-          discussion.getMatrixRoomId(),
           discussion.getTenantId());
       return false;
     }
@@ -110,11 +109,10 @@ public class TeamDiscussionRetentionService {
       return true;
     } catch (RuntimeException ex) {
       log.error(
-          "Team discussion {} (room {}, tenant {}) row could not be deleted after the room purge: {}",
+          "Team discussion {} (tenant {}) row could not be deleted after the room purge",
           discussion.getId(),
-          discussion.getMatrixRoomId(),
           discussion.getTenantId(),
-          ex.getMessage());
+          ex);
       return false;
     }
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -386,3 +386,11 @@ privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}
 
 # US#473 Team-Besprechung (ADR-016). Deploy-level gate; tenant-level flag is a follow-up.
 team-discussion.enabled=true
+# Team discussion archive purge (KDG epic #1010, #1116; ADR-016 addendum of 2026-09-05). Archiving
+# only made the room read-only and nothing was ever deleted. After the period the Matrix room, the
+# team_discussion row and its participant records are removed. Measured from archive_date; a
+# discussion still OPEN is measured from create_date under the same period. A value of 0 or less
+# switches the job off. 90 days is the DPIA figure, pending the data protection officer's sign-off.
+team-discussion.archive.retention.days=${TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS:90}
+team-discussion.archive.retention.cron=0 45 3 * * ?
+team-discussion.archive.retention.claim.duration=PT12H

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -388,9 +388,10 @@ privacy.ipMode=${PRIVACY_IP_MODE:STANDARD}
 team-discussion.enabled=true
 # Team discussion archive purge (KDG epic #1010, #1116; ADR-016 addendum of 2026-09-05). Archiving
 # only made the room read-only and nothing was ever deleted. After the period the Matrix room, the
-# team_discussion row and its participant records are removed. Measured from archive_date; a
-# discussion still OPEN is measured from create_date under the same period. A value of 0 or less
-# switches the job off. 90 days is the DPIA figure, pending the data protection officer's sign-off.
+# team_discussion row and its participant records are removed. Measured from archive_date; only
+# ARCHIVED discussions are eligible (an OPEN one has no activity signal and may still be in use; a
+# deleted session purges its discussion via #1118). A value of 0 or less switches the job off.
+# 90 days is the DPIA figure, pending the data protection officer's sign-off.
 team-discussion.archive.retention.days=${TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS:90}
 team-discussion.archive.retention.cron=0 45 3 * * ?
 team-discussion.archive.retention.claim.duration=PT12H

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -486,6 +486,17 @@
       "decision": "Leases the run through ScheduledTaskClaimService; the purge itself is an idempotent bulk delete of expired rows.",
       "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
       "status": "bounded"
+    },
+    {
+      "id": "team-discussion-retention-scheduler",
+      "source": "src/main/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionScheduler.java",
+      "kind": "scheduler",
+      "owner": "team-discussion",
+      "risk": "duplicate-side-effect",
+      "components": ["purgeExpiredDiscussions"],
+      "decision": "Leases the run through ScheduledTaskClaimService. Each expired discussion is purged from Synapse before its row and participants are deleted in one transaction, so a second replica or a retried run finds either the whole discussion or nothing; a room Synapse no longer knows is treated as already purged.",
+      "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
+      "status": "bounded"
     }
   ]
 }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSynapseServiceTest.java
@@ -246,6 +246,44 @@ class MatrixSynapseServiceTest {
     assertThat(matrixSynapseService().purgeRoom(MATRIX_ROOM_ID)).isFalse();
   }
 
+  /** #1116: a room Synapse no longer knows must be distinguishable from a failed purge. */
+  @Test
+  void purgeRoomOrConfirmGoneShouldReportAlreadyGoneWhenSynapseReturnsNotFound() {
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            eq(
+                URI.create(
+                    "https://matrix.example.com/_synapse/admin/v2/rooms/%21room%3Amatrix.example.com")),
+            eq(HttpMethod.DELETE),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenThrow(
+            HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null));
+
+    assertThat(matrixSynapseService().purgeRoomOrConfirmGone(MATRIX_ROOM_ID))
+        .isEqualTo(MatrixSynapseService.RoomPurgeOutcome.ALREADY_GONE);
+    assertThat(matrixSynapseService().purgeRoom(MATRIX_ROOM_ID))
+        .as(
+            "the boolean form keeps treating a missing room as a failure for the deletion workflows")
+        .isFalse();
+  }
+
+  @Test
+  void purgeRoomOrConfirmGoneShouldReportFailedWhenSynapseReturnsServiceUnavailable() {
+    stubAdminLogin();
+    when(restTemplate.exchange(
+            eq(
+                URI.create(
+                    "https://matrix.example.com/_synapse/admin/v2/rooms/%21room%3Amatrix.example.com")),
+            eq(HttpMethod.DELETE),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenThrow(new HttpServerErrorException(HttpStatus.SERVICE_UNAVAILABLE));
+
+    assertThat(matrixSynapseService().purgeRoomOrConfirmGone(MATRIX_ROOM_ID))
+        .isEqualTo(MatrixSynapseService.RoomPurgeOutcome.FAILED);
+  }
+
   private void stubAdminLogin() {
     matrixConfig.setAdminUsername("admin");
     matrixConfig.setAdminPassword("admin-password");

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
@@ -44,7 +44,8 @@ class ReplicaSafetyInventoryContractTest {
           "registered-only-deletion-scheduler",
           "handshake-expiry-scheduler",
           "support-room-expiry-scheduler",
-          "event-notification-retention-scheduler");
+          "event-notification-retention-scheduler",
+          "team-discussion-retention-scheduler");
 
   @Test
   void shouldInventoryEveryKnownReplicaLocalComponentWithAnActionableSignal() throws Exception {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
@@ -78,6 +78,19 @@ class TeamDiscussionRetentionSchedulerTest {
     verifyNoMoreInteractions(retentionService);
   }
 
+  /** Even an early return must not leave a context on the pooled thread. */
+  @Test
+  void purgeExpiredDiscussions_clearsTheTenantContext_When_theClaimIsLost() {
+    when(taskClaimService.tryClaim(
+            TeamDiscussionRetentionScheduler.TASK_NAME, Duration.ofHours(12)))
+        .thenReturn(false);
+    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+
+    underTest.purgeExpiredDiscussions();
+
+    org.assertj.core.api.Assertions.assertThat(TenantContext.contextIsSet()).isFalse();
+  }
+
   /** A disabled job must not even take the claim, so nothing is logged or leased for nothing. */
   @Test
   void purgeExpiredDiscussions_doesNotClaim_When_theJobIsDisabled() {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.scheduler;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service.TeamDiscussionRetentionService;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TeamDiscussionRetentionSchedulerTest {
+
+  @InjectMocks private TeamDiscussionRetentionScheduler underTest;
+
+  @Mock private TeamDiscussionRetentionService retentionService;
+  @Mock private TenantContextProvider tenantContextProvider;
+  @Mock private ScheduledTaskClaimService taskClaimService;
+
+  @BeforeEach
+  void setUp() {
+    setField(underTest, "claimDuration", Duration.ofHours(12));
+    when(retentionService.isEnabled()).thenReturn(true);
+  }
+
+  @Test
+  void purgeExpiredDiscussions_purgesUnderTheTechnicalTenantContext() {
+    when(taskClaimService.tryClaim("team-discussion-archive-retention", Duration.ofHours(12)))
+        .thenReturn(true);
+
+    underTest.purgeExpiredDiscussions();
+
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(retentionService).purgeExpiredDiscussions();
+  }
+
+  /** Every replica runs the same cron, so exactly one of them may do the deleting. */
+  @Test
+  void purgeExpiredDiscussions_skipsAllDownstreamCalls_When_claimIsLost() {
+    when(taskClaimService.tryClaim("team-discussion-archive-retention", Duration.ofHours(12)))
+        .thenReturn(false);
+
+    underTest.purgeExpiredDiscussions();
+
+    verifyNoInteractions(tenantContextProvider);
+    verify(retentionService).isEnabled();
+    verifyNoMoreInteractions(retentionService);
+  }
+
+  /** A disabled job must not even take the claim, so nothing is logged or leased for nothing. */
+  @Test
+  void purgeExpiredDiscussions_doesNotClaim_When_theJobIsDisabled() {
+    when(retentionService.isEnabled()).thenReturn(false);
+
+    underTest.purgeExpiredDiscussions();
+
+    verifyNoInteractions(taskClaimService, tenantContextProvider);
+    verify(retentionService).isEnabled();
+    verifyNoMoreInteractions(retentionService);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/scheduler/TeamDiscussionRetentionSchedulerTest.java
@@ -1,11 +1,13 @@
 package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.scheduler;
 
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
 import de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service.TeamDiscussionRetentionService;
@@ -34,19 +36,39 @@ class TeamDiscussionRetentionSchedulerTest {
 
   @Test
   void purgeExpiredDiscussions_purgesUnderTheTechnicalTenantContext() {
-    when(taskClaimService.tryClaim("team-discussion-archive-retention", Duration.ofHours(12)))
+    when(taskClaimService.tryClaim(
+            TeamDiscussionRetentionScheduler.TASK_NAME, Duration.ofHours(12)))
         .thenReturn(true);
 
     underTest.purgeExpiredDiscussions();
 
-    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
-    verify(retentionService).purgeExpiredDiscussions();
+    var inOrder = inOrder(tenantContextProvider, retentionService);
+    inOrder.verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    inOrder.verify(retentionService).purgeExpiredDiscussions();
+  }
+
+  /** The technical context must not leak into the next task on the pooled scheduler thread. */
+  @Test
+  void purgeExpiredDiscussions_clearsTheTenantContextAfterwards_evenWhenThePurgeThrows() {
+    when(taskClaimService.tryClaim(
+            TeamDiscussionRetentionScheduler.TASK_NAME, Duration.ofHours(12)))
+        .thenReturn(true);
+    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+    org.mockito.Mockito.doThrow(new IllegalStateException("boom"))
+        .when(retentionService)
+        .purgeExpiredDiscussions();
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(underTest::purgeExpiredDiscussions)
+        .isInstanceOf(IllegalStateException.class);
+
+    org.assertj.core.api.Assertions.assertThat(TenantContext.contextIsSet()).isFalse();
   }
 
   /** Every replica runs the same cron, so exactly one of them may do the deleting. */
   @Test
   void purgeExpiredDiscussions_skipsAllDownstreamCalls_When_claimIsLost() {
-    when(taskClaimService.tryClaim("team-discussion-archive-retention", Duration.ofHours(12)))
+    when(taskClaimService.tryClaim(
+            TeamDiscussionRetentionScheduler.TASK_NAME, Duration.ofHours(12)))
         .thenReturn(false);
 
     underTest.purgeExpiredDiscussions();

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
@@ -1,0 +1,123 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Executes the retention queries and the purge delete against the H2 testing schema (#1116).
+ *
+ * <p>The selection predicate decides which team rooms are wiped, and the participant table has no
+ * foreign key to lean on, so only a real execution proves the right rows go and nothing is left
+ * behind.
+ */
+@DataJpaTest
+@Import(TeamDiscussionPurgeWriter.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class TeamDiscussionPurgeWriterIT {
+
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 9, 6, 12, 0);
+  private static final LocalDateTime CUTOFF = NOW.minusDays(90);
+
+  @Autowired private TeamDiscussionRepository discussions;
+  @Autowired private TeamDiscussionParticipantRepository participants;
+  @Autowired private TeamDiscussionPurgeWriter underTest;
+
+  @Test
+  void findByStatusAndArchiveDateBefore_selectsOnlyArchivedDiscussionsPastTheCutoff() {
+    TeamDiscussion stale = archived(1L, NOW.minusDays(200), NOW.minusDays(120));
+    archived(2L, NOW.minusDays(200), NOW.minusDays(10));
+    open(3L, NOW.minusDays(200));
+
+    var expired =
+        discussions.findByStatusAndArchiveDateBefore(TeamDiscussion.Status.ARCHIVED, CUTOFF);
+
+    assertThat(expired).extracting(TeamDiscussion::getId).containsExactly(stale.getId());
+  }
+
+  /** An abandoned discussion is measured from creation, under the same period. */
+  @Test
+  void findByStatusAndCreateDateBefore_selectsOnlyOpenDiscussionsCreatedPastTheCutoff() {
+    TeamDiscussion abandoned = open(1L, NOW.minusDays(120));
+    open(2L, NOW.minusDays(10));
+    archived(3L, NOW.minusDays(200), NOW.minusDays(10));
+
+    var expired = discussions.findByStatusAndCreateDateBefore(TeamDiscussion.Status.OPEN, CUTOFF);
+
+    assertThat(expired).extracting(TeamDiscussion::getId).containsExactly(abandoned.getId());
+  }
+
+  /** Strictly before: a row exactly on the cutoff is still inside its retention period. */
+  @Test
+  void cutoffsAreExclusive() {
+    archived(1L, NOW.minusDays(200), CUTOFF);
+    open(2L, CUTOFF);
+
+    assertThat(discussions.findByStatusAndArchiveDateBefore(TeamDiscussion.Status.ARCHIVED, CUTOFF))
+        .isEmpty();
+    assertThat(discussions.findByStatusAndCreateDateBefore(TeamDiscussion.Status.OPEN, CUTOFF))
+        .isEmpty();
+  }
+
+  @Test
+  void deleteDiscussionAndParticipants_removesTheRowAndAllItsParticipants_andNothingElse() {
+    TeamDiscussion doomed = archived(1L, NOW.minusDays(200), NOW.minusDays(120));
+    TeamDiscussion kept = archived(2L, NOW.minusDays(200), NOW.minusDays(10));
+    participant(doomed, "consultant-a");
+    participant(doomed, "consultant-b");
+    participant(kept, "consultant-a");
+
+    underTest.deleteDiscussionAndParticipants(doomed);
+
+    assertThat(discussions.findAll())
+        .extracting(TeamDiscussion::getId)
+        .containsExactly(kept.getId());
+    assertThat(participants.findAll())
+        .extracting(TeamDiscussionParticipant::getTeamDiscussionId)
+        .containsExactly(kept.getId());
+  }
+
+  private TeamDiscussion archived(long sessionId, LocalDateTime created, LocalDateTime archived) {
+    return discussions.save(
+        TeamDiscussion.builder()
+            .sessionId(sessionId)
+            .matrixRoomId("!room-" + sessionId + ":matrix.example.com")
+            .status(TeamDiscussion.Status.ARCHIVED)
+            .createDate(created)
+            .archiveDate(archived)
+            .tenantId(1L)
+            .build());
+  }
+
+  private TeamDiscussion open(long sessionId, LocalDateTime created) {
+    return discussions.save(
+        TeamDiscussion.builder()
+            .sessionId(sessionId)
+            .matrixRoomId("!room-" + sessionId + ":matrix.example.com")
+            .status(TeamDiscussion.Status.OPEN)
+            .createDate(created)
+            .tenantId(1L)
+            .build());
+  }
+
+  private void participant(TeamDiscussion discussion, String consultantId) {
+    participants.save(
+        TeamDiscussionParticipant.builder()
+            .teamDiscussionId(discussion.getId())
+            .consultantId(consultantId)
+            .joinDate(NOW.minusDays(150))
+            .build());
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
@@ -1,6 +1,9 @@
 package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 
 import de.caritas.cob.userservice.api.model.TeamDiscussion;
 import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
@@ -13,7 +16,11 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Executes the retention queries and the purge delete against the H2 testing schema (#1116).
@@ -31,7 +38,7 @@ class TeamDiscussionPurgeWriterIT {
   private static final LocalDateTime NOW = LocalDateTime.of(2026, 9, 6, 12, 0);
   private static final LocalDateTime CUTOFF = NOW.minusDays(90);
 
-  @Autowired private TeamDiscussionRepository discussions;
+  @MockitoSpyBean private TeamDiscussionRepository discussions;
   @Autowired private TeamDiscussionParticipantRepository participants;
   @Autowired private TeamDiscussionPurgeWriter underTest;
 
@@ -87,6 +94,29 @@ class TeamDiscussionPurgeWriterIT {
     assertThat(participants.findAll())
         .extracting(TeamDiscussionParticipant::getTeamDiscussionId)
         .containsExactly(kept.getId());
+  }
+
+  /**
+   * The participant delete and the row delete are one unit: if the row cannot go, the participants
+   * must come back too, or the next run finds a discussion without its participant records.
+   */
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  void deleteDiscussionAndParticipants_rollsBackTheParticipantDelete_When_theRowDeleteFails() {
+    TeamDiscussion doomed = archived(1L, NOW.minusDays(200), NOW.minusDays(120));
+    participant(doomed, "consultant-a");
+    doThrow(new DataIntegrityViolationException("simulated")).when(discussions).deleteById(any());
+    try {
+      assertThatThrownBy(() -> underTest.deleteDiscussionAndParticipants(doomed))
+          .isInstanceOf(DataIntegrityViolationException.class);
+
+      assertThat(discussions.findById(doomed.getId())).isPresent();
+      assertThat(participants.findByTeamDiscussionId(doomed.getId())).hasSize(1);
+    } finally {
+      // No test transaction to roll back here, so clean up by hand.
+      participants.deleteAll();
+      discussions.deleteAll();
+    }
   }
 
   private TeamDiscussion archived(long sessionId, LocalDateTime created, LocalDateTime archived) {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
@@ -77,27 +77,21 @@ class TeamDiscussionPurgeWriterIT {
     assertThat(expired).extracting(TeamDiscussion::getId).containsExactly(stale.getId());
   }
 
-  /** An abandoned discussion is measured from creation, under the same period. */
+  /** OPEN means "not archived", not "abandoned": an open discussion is never selected. */
   @Test
-  void findByStatusAndCreateDateBefore_selectsOnlyOpenDiscussionsCreatedPastTheCutoff() {
-    TeamDiscussion abandoned = open(1L, NOW.minusDays(120));
-    open(2L, NOW.minusDays(10));
-    archived(3L, NOW.minusDays(200), NOW.minusDays(10));
+  void findByStatusAndArchiveDateBefore_neverSelectsAnOpenDiscussion_howeverOld() {
+    open(1L, NOW.minusDays(3650));
 
-    var expired = discussions.findByStatusAndCreateDateBefore(TeamDiscussion.Status.OPEN, CUTOFF);
-
-    assertThat(expired).extracting(TeamDiscussion::getId).containsExactly(abandoned.getId());
+    assertThat(discussions.findByStatusAndArchiveDateBefore(TeamDiscussion.Status.ARCHIVED, CUTOFF))
+        .isEmpty();
   }
 
   /** Strictly before: a row exactly on the cutoff is still inside its retention period. */
   @Test
-  void cutoffsAreExclusive() {
+  void cutoffIsExclusive() {
     archived(1L, NOW.minusDays(200), CUTOFF);
-    open(2L, CUTOFF);
 
     assertThat(discussions.findByStatusAndArchiveDateBefore(TeamDiscussion.Status.ARCHIVED, CUTOFF))
-        .isEmpty();
-    assertThat(discussions.findByStatusAndCreateDateBefore(TeamDiscussion.Status.OPEN, CUTOFF))
         .isEmpty();
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionPurgeWriterIT.java
@@ -10,6 +10,7 @@ import de.caritas.cob.userservice.api.model.TeamDiscussionParticipant;
 import de.caritas.cob.userservice.api.port.out.TeamDiscussionParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -33,6 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(TeamDiscussionPurgeWriter.class)
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+// The writer opens a REQUIRES_NEW transaction, which cannot see rows an uncommitted test
+// transaction inserted. Run without a test transaction and clean up by hand instead.
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 class TeamDiscussionPurgeWriterIT {
 
   private static final LocalDateTime NOW = LocalDateTime.of(2026, 9, 6, 12, 0);
@@ -41,6 +45,25 @@ class TeamDiscussionPurgeWriterIT {
   @MockitoSpyBean private TeamDiscussionRepository discussions;
   @Autowired private TeamDiscussionParticipantRepository participants;
   @Autowired private TeamDiscussionPurgeWriter underTest;
+
+  @AfterEach
+  void cleanUp() {
+    participants.deleteAll();
+    discussions.deleteAll();
+  }
+
+  /** The guarantee in the class Javadoc is only real if the propagation enforces it. */
+  @Test
+  void deleteDiscussionAndParticipants_runsInItsOwnTransaction_regardlessOfTheCaller()
+      throws NoSuchMethodException {
+    var transactional =
+        TeamDiscussionPurgeWriter.class
+            .getMethod("deleteDiscussionAndParticipants", TeamDiscussion.class)
+            .getAnnotation(Transactional.class);
+
+    assertThat(transactional).isNotNull();
+    assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+  }
 
   @Test
   void findByStatusAndArchiveDateBefore_selectsOnlyArchivedDiscussionsPastTheCutoff() {
@@ -101,22 +124,16 @@ class TeamDiscussionPurgeWriterIT {
    * must come back too, or the next run finds a discussion without its participant records.
    */
   @Test
-  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   void deleteDiscussionAndParticipants_rollsBackTheParticipantDelete_When_theRowDeleteFails() {
     TeamDiscussion doomed = archived(1L, NOW.minusDays(200), NOW.minusDays(120));
     participant(doomed, "consultant-a");
     doThrow(new DataIntegrityViolationException("simulated")).when(discussions).deleteById(any());
-    try {
-      assertThatThrownBy(() -> underTest.deleteDiscussionAndParticipants(doomed))
-          .isInstanceOf(DataIntegrityViolationException.class);
 
-      assertThat(discussions.findById(doomed.getId())).isPresent();
-      assertThat(participants.findByTeamDiscussionId(doomed.getId())).hasSize(1);
-    } finally {
-      // No test transaction to roll back here, so clean up by hand.
-      participants.deleteAll();
-      discussions.deleteAll();
-    }
+    assertThatThrownBy(() -> underTest.deleteDiscussionAndParticipants(doomed))
+        .isInstanceOf(DataIntegrityViolationException.class);
+
+    assertThat(discussions.findById(doomed.getId())).isPresent();
+    assertThat(participants.findByTeamDiscussionId(doomed.getId())).hasSize(1);
   }
 
   private TeamDiscussion archived(long sessionId, LocalDateTime created, LocalDateTime archived) {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -41,22 +42,18 @@ class TeamDiscussionRetentionServiceTest {
   }
 
   @Test
-  void purge_selectsArchivedByArchiveDateAndOpenByCreateDate_underTheSameCutoff() {
+  void purge_selectsOnlyArchivedDiscussions_byArchiveDate() {
     LocalDateTime before = LocalDateTime.now();
 
     underTest.purgeExpiredDiscussions();
     LocalDateTime after = LocalDateTime.now();
 
-    ArgumentCaptor<LocalDateTime> archivedCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
-    ArgumentCaptor<LocalDateTime> openCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> cutoff = ArgumentCaptor.forClass(LocalDateTime.class);
     verify(teamDiscussionRepository)
-        .findByStatusAndArchiveDateBefore(
-            eq(TeamDiscussion.Status.ARCHIVED), archivedCutoff.capture());
-    verify(teamDiscussionRepository)
-        .findByStatusAndCreateDateBefore(eq(TeamDiscussion.Status.OPEN), openCutoff.capture());
+        .findByStatusAndArchiveDateBefore(eq(TeamDiscussion.Status.ARCHIVED), cutoff.capture());
+    verifyNoMoreInteractions(teamDiscussionRepository);
 
-    assertThat(archivedCutoff.getValue()).isBetween(before.minusDays(90), after.minusDays(90));
-    assertThat(openCutoff.getValue()).isEqualTo(archivedCutoff.getValue());
+    assertThat(cutoff.getValue()).isBetween(before.minusDays(90), after.minusDays(90));
   }
 
   @Test
@@ -89,7 +86,7 @@ class TeamDiscussionRetentionServiceTest {
   @Test
   void purge_deletesTheRow_When_theRoomNoLongerExists() {
     TeamDiscussion discussion = discussion(7L);
-    when(teamDiscussionRepository.findByStatusAndCreateDateBefore(any(), any()))
+    when(teamDiscussionRepository.findByStatusAndArchiveDateBefore(any(), any()))
         .thenReturn(List.of(discussion));
     when(matrixSynapseService.purgeRoomOrConfirmGone(ROOM))
         .thenReturn(RoomPurgeOutcome.ALREADY_GONE);

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/teamdiscussionretention/service/TeamDiscussionRetentionServiceTest.java
@@ -1,0 +1,150 @@
+package de.caritas.cob.userservice.api.workflow.teamdiscussionretention.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService.RoomPurgeOutcome;
+import de.caritas.cob.userservice.api.model.TeamDiscussion;
+import de.caritas.cob.userservice.api.port.out.TeamDiscussionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class TeamDiscussionRetentionServiceTest {
+
+  private static final String ROOM = "!discussion:matrix.example.com";
+
+  @InjectMocks private TeamDiscussionRetentionService underTest;
+
+  @Mock private TeamDiscussionRepository teamDiscussionRepository;
+  @Mock private TeamDiscussionPurgeWriter purgeWriter;
+  @Mock private MatrixSynapseService matrixSynapseService;
+
+  @BeforeEach
+  void setUp() {
+    setField(underTest, "retentionDays", 90);
+  }
+
+  @Test
+  void purge_selectsArchivedByArchiveDateAndOpenByCreateDate_underTheSameCutoff() {
+    LocalDateTime before = LocalDateTime.now();
+
+    underTest.purgeExpiredDiscussions();
+    LocalDateTime after = LocalDateTime.now();
+
+    ArgumentCaptor<LocalDateTime> archivedCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    ArgumentCaptor<LocalDateTime> openCutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(teamDiscussionRepository)
+        .findByStatusAndArchiveDateBefore(
+            eq(TeamDiscussion.Status.ARCHIVED), archivedCutoff.capture());
+    verify(teamDiscussionRepository)
+        .findByStatusAndCreateDateBefore(eq(TeamDiscussion.Status.OPEN), openCutoff.capture());
+
+    assertThat(archivedCutoff.getValue()).isBetween(before.minusDays(90), after.minusDays(90));
+    assertThat(openCutoff.getValue()).isEqualTo(archivedCutoff.getValue());
+  }
+
+  @Test
+  void purge_purgesTheRoomBeforeDeletingTheRow() {
+    TeamDiscussion discussion = discussion(7L);
+    when(teamDiscussionRepository.findByStatusAndArchiveDateBefore(any(), any()))
+        .thenReturn(List.of(discussion));
+    when(matrixSynapseService.purgeRoomOrConfirmGone(ROOM)).thenReturn(RoomPurgeOutcome.PURGED);
+
+    underTest.purgeExpiredDiscussions();
+
+    var inOrder = org.mockito.Mockito.inOrder(matrixSynapseService, purgeWriter);
+    inOrder.verify(matrixSynapseService).purgeRoomOrConfirmGone(ROOM);
+    inOrder.verify(purgeWriter).deleteDiscussionAndParticipants(discussion);
+  }
+
+  /** Never lose the pointer to a room that may still exist: keep the row and retry next run. */
+  @Test
+  void purge_keepsTheRow_When_theSynapsePurgeFails() {
+    TeamDiscussion discussion = discussion(7L);
+    when(teamDiscussionRepository.findByStatusAndArchiveDateBefore(any(), any()))
+        .thenReturn(List.of(discussion));
+    when(matrixSynapseService.purgeRoomOrConfirmGone(ROOM)).thenReturn(RoomPurgeOutcome.FAILED);
+
+    underTest.purgeExpiredDiscussions();
+
+    verifyNoInteractions(purgeWriter);
+  }
+
+  @Test
+  void purge_deletesTheRow_When_theRoomNoLongerExists() {
+    TeamDiscussion discussion = discussion(7L);
+    when(teamDiscussionRepository.findByStatusAndCreateDateBefore(any(), any()))
+        .thenReturn(List.of(discussion));
+    when(matrixSynapseService.purgeRoomOrConfirmGone(ROOM))
+        .thenReturn(RoomPurgeOutcome.ALREADY_GONE);
+
+    underTest.purgeExpiredDiscussions();
+
+    verify(purgeWriter).deleteDiscussionAndParticipants(discussion);
+  }
+
+  /** One failing discussion must not stop the run for the others. */
+  @Test
+  void purge_continuesWithTheNextDiscussion_When_oneRowDeleteFails() {
+    TeamDiscussion first = discussion(1L);
+    TeamDiscussion second = discussion(2L);
+    when(teamDiscussionRepository.findByStatusAndArchiveDateBefore(any(), any()))
+        .thenReturn(List.of(first, second));
+    when(matrixSynapseService.purgeRoomOrConfirmGone(ROOM)).thenReturn(RoomPurgeOutcome.PURGED);
+    org.mockito.Mockito.doThrow(new DataIntegrityViolationException("boom"))
+        .when(purgeWriter)
+        .deleteDiscussionAndParticipants(first);
+
+    underTest.purgeExpiredDiscussions();
+
+    verify(purgeWriter).deleteDiscussionAndParticipants(second);
+  }
+
+  @Test
+  void purge_doesNothing_When_thePeriodIsZero() {
+    setField(underTest, "retentionDays", 0);
+
+    assertThat(underTest.isEnabled()).isFalse();
+    underTest.purgeExpiredDiscussions();
+
+    verifyNoInteractions(teamDiscussionRepository, matrixSynapseService, purgeWriter);
+  }
+
+  @Test
+  void purge_doesNothing_When_thePeriodIsNegative() {
+    setField(underTest, "retentionDays", -5);
+
+    underTest.purgeExpiredDiscussions();
+
+    verifyNoInteractions(teamDiscussionRepository, matrixSynapseService, purgeWriter);
+    verify(matrixSynapseService, never()).purgeRoomOrConfirmGone(any());
+  }
+
+  private static TeamDiscussion discussion(Long id) {
+    return TeamDiscussion.builder()
+        .id(id)
+        .sessionId(id * 100)
+        .matrixRoomId(ROOM)
+        .status(TeamDiscussion.Status.ARCHIVED)
+        .createDate(LocalDateTime.now().minusDays(200))
+        .archiveDate(LocalDateTime.now().minusDays(120))
+        .tenantId(1L)
+        .build();
+  }
+}


### PR DESCRIPTION
Closes #1116.

## Why

Archiving a Team-Besprechung only flipped a status and made the Matrix room read-only. Nothing was ever deleted: the repository had no delete operation and the room kept the team's notes about the advice seeker in plain text indefinitely. ADR-016 §3 assumed an archive auto-deletion that never existed (corrected by the ADR addendum PR in ORISO-Docs).

## What

- `TeamDiscussionRetentionService`: selects `ARCHIVED` discussions by `archive_date`. **`OPEN` discussions are not purged** (decision recorded on #1116 after review: the entity has no activity signal, so "open" is not "abandoned"; a deleted session purges its discussion via #1118 instead). Purges the Synapse room **first**, then deletes the row and its participants in one transaction (`TeamDiscussionPurgeWriter`). A failed purge keeps the row for the next run; a room Synapse no longer knows (404) counts as already purged. One summary log line per run (cutoff, per-tenant purged/failed counts).
- `TeamDiscussionRetentionScheduler`: follows `EventNotificationRetentionScheduler` — nightly `0 45 3 * * ?` (offset from the other retention jobs), leased through `ScheduledTaskClaimService` under claim key `team-discussion-archive-retention`, technical tenant context so one run covers all tenants. Registered in `replica-safety-components.json`.
- `MatrixSynapseService.purgeRoomOrConfirmGone` returns `PURGED` / `ALREADY_GONE` / `FAILED`. The boolean `purgeRoom` delegates to it and keeps its contract, so the deletion workflows are unchanged. #1118 can reuse the new outcome.
- Config: `team-discussion.archive.retention.days=${TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS:90}`, `.cron`, `.claim.duration`. A value of `0` or less switches the job off (it does not even take the claim).

Note: the ticket says "tenant iteration via TenantContextProvider"; the existing retention pattern does not iterate but sets the technical context for one bulk pass. This PR follows the existing pattern and groups the summary counts by tenant.

## Companion PRs

- ORISO-Helm: wires `TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS` in configmap + deployment.
- ORISO-Docs: ADR-016 addendum correcting §3 and recording the 90-day period for the DPIA.

## Verified

Locally (H2 testing profile, Java 21):
- New: `TeamDiscussionRetentionServiceTest` (7), `TeamDiscussionRetentionSchedulerTest` (3), `TeamDiscussionPurgeWriterIT` (4, real queries + delete on H2), two 404/503 cases in `MatrixSynapseServiceTest`.
- Related: `ReplicaSafetyInventoryContractTest`, `ConfigEnvExampleContractTest`, `UserServiceApplicationTest`, `UserServiceApplicationIT` (context boots with the new scheduler), `DeleteChatActionTest`, `MatrixChatShutdownServiceTest`, `TeamDiscussionFacadeTest`, `ScheduledTaskClaimServiceTest`. All green.

Not yet verified on Pre-Dev against a real Synapse.

## Reviewer test plan

1. On Pre-Dev set `TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS=1` and create a team discussion, archive it (accept the enquiry), and backdate `archive_date` by two days.
2. Trigger the cron (or wait for 03:45). Expect: room gone in Synapse admin, `team_discussion` and `team_discussion_participant` rows gone, one `Team discussion retention run:` log line.
3. Repeat with an `OPEN` discussion whose `create_date` is backdated far beyond the period: it must **not** be purged.
4. Stop Synapse (or block the admin API) and run again with an expired discussion: row stays, log line shows `purgeFailures=1`.
5. Set `TEAM_DISCUSSION_ARCHIVE_RETENTION_DAYS=0`: no claim row, no log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of team discussions after a configurable retention period (default: 90 days).
  * Archived discussions are evaluated by archive date; open discussions are never purged (corrected after review).
  * Associated discussion rooms and participant records are removed together after successful cleanup.
  * Cleanup runs on a scheduled basis and can be disabled through configuration.
* **Bug Fixes**
  * Rooms that have already been removed are now handled as successfully cleaned up.
  * Failed cleanup operations remain available for retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

