### PR TITLE
fix(consultant): exclude soft-deleted agencies from consultant profiles (#1125)

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/Consultant.java
@@ -37,7 +37,7 @@ import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.ParamDef;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.AnalyzerDef;
 import org.hibernate.search.annotations.Field;
@@ -211,7 +211,7 @@ public class Consultant implements TenantAware, NotificationsAware {
 
   @OneToMany(mappedBy = "consultant")
   @IndexedEmbedded
-  @Where(clause = "delete_date IS NULL")
+  @SQLRestriction("delete_date IS NULL")
   private Set<ConsultantAgency> consultantAgencies;
 
   @OneToMany(mappedBy = "consultant")

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryIT.java
@@ -109,6 +109,36 @@ class ConsultantRepositoryIT {
   }
 
   @Test
+  void findByAgencyIdShouldExcludeConsultantsWhoseAgencyRelationIsSoftDeleted() {
+    var consultantId = originalConsultant.getId();
+    saveConsultantAgency(originalConsultant, 900003L);
+    saveConsultantAgency(originalConsultant, 900004L);
+    var removed =
+        originalConsultant.getConsultantAgencies().stream()
+            .filter(relation -> relation.getAgencyId().equals(900004L))
+            .findFirst()
+            .orElseThrow();
+    removed.setDeleteDate(LocalDateTime.now());
+    consultantAgencyRepository.save(removed);
+    entityManager.flush();
+    entityManager.clear();
+
+    var stillAssigned = underTest.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(900003L);
+    assertTrue(stillAssigned.stream().anyMatch(found -> found.getId().equals(consultantId)));
+
+    var removedAssignment = underTest.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(900004L);
+    assertFalse(removedAssignment.stream().anyMatch(found -> found.getId().equals(consultantId)));
+
+    var byRemovedAgencyOnly =
+        underTest.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(List.of(900004L));
+    assertFalse(byRemovedAgencyOnly.stream().anyMatch(found -> found.getId().equals(consultantId)));
+
+    var byBothAgencies =
+        underTest.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull(List.of(900003L, 900004L));
+    assertTrue(byBothAgencies.stream().anyMatch(found -> found.getId().equals(consultantId)));
+  }
+
+  @Test
   void deleteShouldDeleteConsultantAndAppointment() {
     givenACreatedConsultantWithAnAppointment();
 

--- a/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/port/out/ConsultantRepositoryIT.java
@@ -14,6 +14,7 @@ import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.ConsultantAgency;
 import de.caritas.cob.userservice.api.model.ConsultantStatus;
 import de.caritas.cob.userservice.api.model.Language;
+import jakarta.persistence.EntityManager;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDateTime;
@@ -54,6 +55,8 @@ class ConsultantRepositoryIT {
 
   @Autowired private ConsultantRepository underTest;
 
+  @Autowired private EntityManager entityManager;
+
   @Autowired private ConsultantAgencyRepository consultantAgencyRepository;
 
   @Autowired private AppointmentRepository appointmentRepository;
@@ -73,6 +76,36 @@ class ConsultantRepositoryIT {
     matchingIds = new ArrayList<>();
     nonMatchingIds.forEach(id -> underTest.deleteById(id));
     nonMatchingIds = new ArrayList<>();
+  }
+
+  @Test
+  void loginProfileShouldExcludeSoftDeletedAgencyRelationsWithoutDeletingHistory() {
+    var consultantId = originalConsultant.getId();
+    var expectedIds =
+        originalConsultant.getConsultantAgencies().stream()
+            .map(ConsultantAgency::getAgencyId)
+            .collect(Collectors.toCollection(HashSet::new));
+    saveConsultantAgency(originalConsultant, 900001L);
+    saveConsultantAgency(originalConsultant, 900002L);
+    var removed =
+        originalConsultant.getConsultantAgencies().stream()
+            .filter(relation -> relation.getAgencyId().equals(900002L))
+            .findFirst()
+            .orElseThrow();
+    removed.setDeleteDate(LocalDateTime.now());
+    consultantAgencyRepository.save(removed);
+    entityManager.flush();
+    var removedId = removed.getId();
+    entityManager.clear();
+
+    var reloaded = underTest.findByIdAndDeleteDateIsNull(consultantId).orElseThrow();
+    expectedIds.add(900001L);
+    assertEquals(
+        expectedIds,
+        reloaded.getConsultantAgencies().stream()
+            .map(ConsultantAgency::getAgencyId)
+            .collect(Collectors.toSet()));
+    assertNotNull(consultantAgencyRepository.findById(removedId).orElseThrow().getDeleteDate());
   }
 
   @Test


### PR DESCRIPTION
## The bug (#1125)

When an agency is removed from a consultant, the removal is a **soft delete**: the `consultant_agency` row is kept and its `delete_date` is set, so the assignment history stays auditable. The consultant's profile is supposed to hide those rows.

It did not. After an agency was removed, it **still appeared in the consultant's agency list** on profile reload — so a consultant looked like they were still assigned to an agency they had been taken off.

## Cause — one annotation

`Consultant.consultantAgencies` was annotated with the Hibernate 5 annotation:

```java
@Where(clause = "delete_date IS NULL")
```

`org.hibernate.annotations.Where` **does not exist in Hibernate ORM 7.2.19**, the version this project actually runs on (via Spring Boot 4.0.7). It is still on the *compile* classpath only because `hibernate-search-orm:5.11.12.Final` transitively pulls in `hibernate-core:5.4.33.Final`.

So the annotation compiled fine, but the running ORM never looked at it — **the restriction was silently a no-op**. No compiler warning, no runtime error, just an unfiltered collection.

The fix replaces it with the supported Hibernate 7 equivalent:

```java
@SQLRestriction("delete_date IS NULL")
```

Soft-deleted rows are still retained in the database; they are only excluded from the mapped collection. `@Where` was deprecated in Hibernate 6.3 in favour of `@SQLRestriction` and removed in Hibernate 7 — verified that `SQLRestriction.class` is present and `Where.class` is absent in `hibernate-core-7.2.19.Final.jar`.

This was the **last remaining** `org.hibernate.annotations.Where` in `src/main` — `grep -rn "org.hibernate.annotations.Where\|@Where(" src/main/` now returns nothing.

## Why this is split out of #1124

The fix was written on `emails-v2` (commit `c053740f`) and is currently carried by draft PR #1124, which is an **8,183-line email rework**. This is a Medium data-correctness bug that should not wait on a large draft to be finished and reviewed. This PR is the two-line production change plus its regression tests, cherry-picked onto `dev`. #1124 is untouched and can drop or keep the commit when it rebases.

## Blast radius — this is NOT limited to the profile collection

An earlier revision of this description said the behaviour change is "limited to the `Consultant.consultantAgencies` collection". **That was wrong, and it understated the change.** Correction:

`@SQLRestriction` is applied by Hibernate wherever the mapped collection is used — including the **join that Spring Data generates for derived queries that navigate the collection path**. Two such queries exist:

- `ConsultantRepository.findByConsultantAgenciesAgencyIdAndDeleteDateIsNull` (`port/out/ConsultantRepository.java:38`)
- `ConsultantRepository.findByConsultantAgenciesAgencyIdInAndDeleteDateIsNull` (`port/out/ConsultantRepository.java:36`)

Note the `DeleteDateIsNull` in those names refers to the **Consultant**, not to the `consultant_agency` row. Before this PR nothing filtered the relation row; now the restriction lands in the `ON` clause of the generated join. Emitted SQL, captured from the new IT:

```sql
... from consultant c1_0
     left join consultant_agency ca1_0
            on c1_0.consultant_id = ca1_0.consultant_id
           and (ca1_0.delete_date IS NULL)
   where ca1_0.agency_id = ? and c1_0.delete_date is null
```

Both queries therefore now **exclude consultants whose relation to that agency was soft-deleted**. Behaviour changes for these callers:

| Caller | Where | Effect |
| --- | --- | --- |
| `ConsultantService.findConsultantsByAgencyIds` | `service/ConsultantService.java:131,135` | agency-scoped consultant lookups no longer return ex-members |
| `ConsultantService.findConsultantsByAgencyId` | `service/ConsultantService.java:144,145` | same, single-agency variant |
| `AgencySilentMembershipService.joinAgencyConsultants` | `service/session/AgencySilentMembershipService.java:59,65` | Matrix room fan-out: removed counsellors are no longer silently joined to new rooms |
| `UnauthorizedMembersProvider` | `facade/assignsession/UnauthorizedMembersProvider.java:78,80` | the "authorized members" allow-list shrinks, so removed counsellors are now **removed from the room** on reassignment |
| `ChatService.getChatModerators` | `service/ChatService.java:130,141` | group-chat moderator list no longer includes removed counsellors |
| `ConsultantAgencyAdminService.removeConsultantsFromTeamSessionsByAgencyId` | `admin/service/agency/ConsultantAgencyAdminService.java:188,196-197` | the team-consultant flag is now cleared for consultants whose only remaining relations are soft-deleted |

All six are **directionally correct** — every one of them is asking "who currently belongs to this agency?", and the honest answer excludes soft-deleted relations. But the change is real, it is visible to users, and it is broader than a profile page. Worth flagging on the last row: `ConsultantAgencyAdminService` deliberately uses the repository query rather than `consultant.getConsultantAgencies()` (see its comment at `:209-213`, because `open-in-view` is disabled) — so it *only* gets the corrected behaviour through this PR.

## Release note / behaviour change

Written for a colleague who does not read code. Two effects are visible **the moment this deploys** — both are the intended semantics, but both will read as an incident if they are not announced first.

**(a) Removing a counsellor from an agency now takes effect immediately and completely.**

Until now, a counsellor who was removed from an agency kept seeing that agency's work. From this deploy on, the removal is real: they immediately lose that agency's

- team sessions (`service/session/SessionService.java:313-317`)
- registered enquiries (`service/session/SessionService.java:383-388`)
- archived team sessions (`service/session/SessionService.java:983-990`)
- group chats (`service/ChatService.java:74`)

This includes **a team session they were actively working on but do not own**. Such a session does not disappear from the system — it stays visible to its owner and to everyone still in the agency — but it disappears from the removed counsellor's list without warning. If someone is removed from an agency mid-conversation, their in-flight work needs a hand-over.

**(b) Assigning or re-assigning a session to such a counsellor now returns 403.**

Session (re)assignment checks whether the target counsellor belongs to the session's agency, and whether they cover its consulting type (`facade/assignsession/SessionToConsultantConditionProvider.java:76-84` and `:107-118`, enforced by `SessionToConsultantVerifier.java:86-110` and `:112-125`). Both checks read the same collection. A counsellor whose relation to the agency is soft-deleted now fails them, and the API answers **HTTP 403 Forbidden** where it previously succeeded — **unless** the session's main topic is one the counsellor owns, which is an explicit escape hatch in the same check (`SessionToConsultantVerifier.java:93` → `isConsultantAssignedToSessionTopic`).

Assigning sessions is a **daily admin workflow**. It will start throwing 403 for exactly those counsellors who were previously removed from the agency and were, until now, still assignable by accident. Again: correct, but it needs to be said out loud before the deploy, not diagnosed afterwards.

## Cleared risks — please do not re-litigate these

Each of these was checked; none of them is a blocker.

- **No consultant disappears from a profile or listing.** The restriction lands in the `ON` clause of a `LEFT JOIN`, not in the `WHERE` (emitted SQL quoted above). A consultant with *only* soft-deleted agency relations still loads; their agency collection is simply empty.
- **The deletion workflow still hard-deletes soft-deleted rows.** `workflow/delete/action/consultant/DeleteDatabaseConsultantAgencyAction.java:34-37` uses `consultantAgencyRepository.findByConsultantId(...)`, which has **no** `deleteDate` predicate (`ConsultantAgencyRepository.java:27`), so GDPR deletion still removes the history rows. No orphans.
- **Admin listing / search / update were already correct.** `admin/service/consultant/querybuilder/ConsultantFilterSpecification.java` already filtered the consultant at `:21` and already added `isNull(agencyJoin.get("deleteDate"))` on the agency join at `:37-41`. Unchanged by this PR.
- **Statistics get *more* consistent, not less.** `port/out/AdminStatisticsRepository.java:106-115` is native SQL that already said `ca.delete_date IS NULL` (line 113). The ORM path now agrees with it instead of contradicting it.
- **Hibernate Search index divergence is a dead path.** `ConsultantFilterQueryBuilder` has no callers anywhere in `src/main` or `src/test`; `ConsultantReindexer` carries no stereotype annotation and is never registered as a bean, so its `afterPropertiesSet()` never runs; and the index backend is `local-heap` (`src/main/resources/hibernate.properties:1`), i.e. per-instance and rebuilt on restart. Nothing durable can drift.
- **The rest of the suite is unaffected.** The full integration-test suite is 102 IT classes / **932 tests** on this branch, identical to `dev` apart from the two tests added here. The only local red is 3 failures + 19 errors, **all** in `UserControllerE2EIT` and **all** rooted in `org.springframework.data.redis.RedisConnectionFailureException: Unable to connect to Redis` — no local Redis, because Docker is not running on the dev machine. Unrelated to this change; CI covers it.

## Verification

Run locally against `dev` in a clean worktree, JDK 21. Both regression tests were confirmed **red first**.

**Red — test 1, the mapped collection.** With only the test applied and `Consultant.java` still on the `dev` version:

```
ConsultantRepositoryIT.loginProfileShouldExcludeSoftDeletedAgencyRelationsWithoutDeletingHistory
  expected: <[1, 1731, 900001]> but was: <[1, 1731, 900001, 900002]>
Tests run: 23, Failures: 1
```

Agency `900002` is the soft-deleted one, and it was still there.

**Red — test 2, the derived queries.** Same procedure (`git checkout origin/dev -- src/main/java/.../model/Consultant.java`, restoring `@Where`):

```
ConsultantRepositoryIT.findByAgencyIdShouldExcludeConsultantsWhoseAgencyRelationIsSoftDeleted:130
  expected: <false> but was: <true>
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

Line 130 is the assertion that `findByConsultantAgenciesAgencyIdAndDeleteDateIsNull(900004L)` must **not** return the consultant whose relation to agency `900004` is soft-deleted. On `dev` it did.

**Green after the change:**

| What was run | Result |
| --- | --- |
| `mvn integration-test -Dtest=ConsultantRepositoryIT#findByAgencyIdShouldExcludeConsultantsWhoseAgencyRelationIsSoftDeleted` | 1 test, 0 failures |
| `mvn integration-test -Dtest=ConsultantRepositoryIT` | **24 tests, 0 failures, 0 errors** |
| `mvn integration-test` on the 4 consultant repository ITs | **27 tests, 0 failures, 0 errors** |
| `mvn test` (full unit suite) | **4295 tests, 0 failures, 0 errors** |
| `mvn integration-test` (full IT suite, 102 classes) | 932 tests; the only red is 22 `UserControllerE2EIT` cases failing on `RedisConnectionFailureException` — no local Redis, environmental |
| `mvn spotless:apply` / spotless check at compile | clean |

The ITs run against the in-memory H2 database used by the `testing` profile, so they need no Docker and run in CI as-is.

## Deploy impact

No schema change, no migration, no config change, no API contract change — but see **Blast radius** and **Release note** above: this is not a silent fix. Announce it.

## Before merging

Please size the blast radius on **Dev** before approving, and paste the results into a comment:

```sql
-- 1. How many soft-deleted agency relations exist at all?
SELECT COUNT(*) FROM consultant_agency WHERE delete_date IS NOT NULL;

-- 2. How many consultants go from "has agencies" to "has none"?
SELECT COUNT(DISTINCT consultant_id) FROM consultant_agency ca
 WHERE delete_date IS NOT NULL
   AND NOT EXISTS (SELECT 1 FROM consultant_agency x
                    WHERE x.consultant_id = ca.consultant_id AND x.delete_date IS NULL);
```

- [ ] Query 1 result pasted: `______`
- [ ] Query 2 result pasted: `______`

**Query 2 is the one that matters.** It counts the consultants who currently appear to have agencies and will have none after this deploys — the population that hits both effects in the release note (loses their session/enquiry/chat lists, and becomes un-assignable with a 403). If that number is 0 on Dev, the change is invisible there and the release note is precautionary. If it is not 0, those accounts should be looked at by hand before this goes to Prod.

## Reviewer test plan

- [ ] Open a consultant who is assigned to at least two agencies and note the agency list on their profile.
- [ ] Remove one of those agencies from the consultant (admin agency assignment).
- [ ] Reload the consultant's profile — the removed agency should **no longer** be listed.
- [ ] The remaining agency (or agencies) should still be listed, unchanged.
- [ ] Confirm the consultant can still be found by a search filtered on an agency they are *still* assigned to.
- [ ] Confirm the consultant is **not** returned by a search filtered on the agency they were just removed from.
- [ ] Try to assign a session of the *removed* agency to that consultant — expect **403** (this is the new behaviour from the release note, not a bug).
- [ ] Confirm a consultant still in the agency can still be assigned that session.
- [ ] Optional, DB: confirm the removed `consultant_agency` row still exists with a non-null `delete_date` — history must be retained, not deleted.

Refs #1125. Split out of #1124.
