### PR TITLE
fix(mail-v2): address the three blocking Major findings from the #1124 review

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverPolicyCacheService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverPolicyCacheService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.tenantadminservice.generated.web.model.CaseHan
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,13 @@ public class CaseHandoverPolicyCacheService {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   public CaseHandoverPolicies getEffective(Long tenantId) {
-    return repository.findById(tenantId).map(this::deserialize).orElseGet(() -> refresh(tenantId));
+    // An unreadable snapshot is not a usable snapshot. Falling through to refresh is what the
+    // last-known-good contract promises; propagating the deserialize failure here would instead
+    // surface as "Cached Case Handover policy is invalid" and hide the real state from the caller.
+    return repository
+        .findById(tenantId)
+        .flatMap(this::deserializeQuietly)
+        .orElseGet(() -> refresh(tenantId));
   }
 
   /**
@@ -73,13 +80,51 @@ public class CaseHandoverPolicyCacheService {
           "Tenant {} Case Handover policy refresh failed; enforcing last-known-good snapshot: {}",
           tenantId,
           TenantCaseHandoverPolicyReadClient.failureSummary(exception));
-      return deserialize(cache);
+      // The snapshot itself may be unreadable. Rethrowing the ORIGINAL upstream failure keeps the
+      // real cause visible; a deserialize error raised from inside this catch block would escape
+      // refresh entirely and defeat the fallback this block exists to provide.
+      return deserializeQuietly(cache)
+          .orElseThrow(
+              () -> {
+                log.error(
+                    "Tenant {} Case Handover policy snapshot is unreadable; no enforceable policy",
+                    tenantId);
+                return exception;
+              });
     }
   }
 
   @Scheduled(fixedDelayString = "${case.handover.policy-cache-refresh-delay-ms:300000}")
   public void refreshKnownTenants() {
-    repository.findAll().forEach(cache -> refresh(cache.getTenantId()));
+    // Per-tenant isolation: one tenant's failure must not abort the sweep and leave every tenant
+    // after it silently enforcing an aging snapshot.
+    repository
+        .findAll()
+        .forEach(
+            cache -> {
+              Long tenantId = cache.getTenantId();
+              try {
+                refresh(tenantId);
+              } catch (RuntimeException exception) {
+                log.warn(
+                    "Tenant {} Case Handover policy refresh skipped in scheduled sweep: {}",
+                    tenantId,
+                    TenantCaseHandoverPolicyReadClient.failureSummary(exception));
+              }
+            });
+  }
+
+  /** Empty when the stored snapshot cannot be read back, never an exception. */
+  private Optional<CaseHandoverPolicies> deserializeQuietly(TenantCaseHandoverPolicyCache cache) {
+    try {
+      return Optional.of(deserialize(cache));
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Tenant {} cached Case Handover policy could not be read ({})",
+          cache.getTenantId(),
+          exception.getClass().getSimpleName());
+      return Optional.empty();
+    }
   }
 
   private String serialize(CaseHandoverPolicies policies) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/email/OrisoEmailDispatcher.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/email/OrisoEmailDispatcher.java
@@ -34,9 +34,39 @@ public class OrisoEmailDispatcher {
       sendOrThrow(smtp, recipient, email);
       return true;
     } catch (SmtpSendException exception) {
-      log.error("ORISO email dispatch failed", exception);
+      // Never log the exception itself. The cause chain here is the Jakarta Mail failure, and SMTP
+      // rejection replies routinely embed the recipient address ("550 5.1.1 <a@b.example> user
+      // unknown"). NotificationEmailService already refuses to retain these details for exactly
+      // that reason; logging the throwable here would put advice-seeker addresses on disk anyway.
+      // The type chain keeps auth failures, TLS failures and timeouts distinguishable.
+      log.error(
+          "ORISO email dispatch failed via SMTP host {}: {}", host(smtp), causeChain(exception));
       return false;
     }
+  }
+
+  /** Exception simple names only: no messages, no SMTP reply text, no addresses. */
+  static String causeChain(Throwable throwable) {
+    StringBuilder chain = new StringBuilder();
+    Throwable current = throwable;
+    int depth = 0;
+    while (current != null && depth < 5) {
+      if (depth > 0) {
+        chain.append(" <- ");
+      }
+      chain.append(current.getClass().getSimpleName());
+      if (current.getCause() == current) {
+        break;
+      }
+      current = current.getCause();
+      depth++;
+    }
+    return chain.toString();
+  }
+
+  /** The configured SMTP host is operator configuration, not personal data. */
+  private static String host(SupervisorAddedEmailSettings smtp) {
+    return smtp == null || smtp.getHost() == null ? "<unset>" : smtp.getHost();
   }
 
   /** Synchronous receipt boundary: returns only after SMTP accepts both MIME alternatives. */

--- a/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
@@ -9,8 +9,11 @@ import de.caritas.cob.userservice.tenantservice.generated.web.model.RestrictedTe
 import de.caritas.cob.userservice.tenantservice.generated.web.model.Theming;
 import java.net.URI;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -48,17 +51,54 @@ public class EmailBrandingResolver {
   private final String platformLogoUrl;
   private final String applicationBaseUrl;
 
+  /** Sentinel key for the platform lookup, which has no tenant id of its own. */
+  private static final Long PLATFORM_CACHE_KEY = Long.MIN_VALUE;
+
+  /** Bound on distinct keys held, so a pathological tenant id space cannot grow this unbounded. */
+  private static final int MAX_CACHE_ENTRIES = 1000;
+
+  private final long cacheTtlNanos;
+  private final Map<Long, CachedTenant> tenantCache = new ConcurrentHashMap<>();
+
+  private record CachedTenant(RestrictedTenantDTO tenant, long storedAtNanos) {}
+
+  /**
+   * @param cacheTtlSeconds collapses the per-recipient lookups of one batch into a single remote
+   *     call. Must stay short: source 2606d840 removed the 24-hour tenant cache precisely because a
+   *     logo change stayed invisible in mail until it expired. A few seconds keeps a branding save
+   *     effectively immediate while a digest run of N consultants costs one call instead of N. Set
+   *     to 0 to disable caching entirely.
+   */
+  @Autowired
   public EmailBrandingResolver(
       @NonNull TenantService tenantService,
       @NonNull TenantTemplateSupplier tenantTemplateSupplier,
       @Value("${email.branding.name:ORISO}") String platformName,
       @Value("${email.branding.logo-url:}") String platformLogoUrl,
-      @Value("${app.base.url:}") String applicationBaseUrl) {
+      @Value("${app.base.url:}") String applicationBaseUrl,
+      @Value("${email.branding.cache-ttl-seconds:10}") long cacheTtlSeconds) {
     this.tenantService = tenantService;
     this.tenantTemplateSupplier = tenantTemplateSupplier;
     this.platformName = platformName;
     this.platformLogoUrl = platformLogoUrl;
     this.applicationBaseUrl = normalizeBaseUrl(applicationBaseUrl);
+    this.cacheTtlNanos = Math.max(0L, cacheTtlSeconds) * 1_000_000_000L;
+  }
+
+  /** Caching disabled: every resolve performs its own lookup. */
+  public EmailBrandingResolver(
+      @NonNull TenantService tenantService,
+      @NonNull TenantTemplateSupplier tenantTemplateSupplier,
+      String platformName,
+      String platformLogoUrl,
+      String applicationBaseUrl) {
+    this(
+        tenantService,
+        tenantTemplateSupplier,
+        platformName,
+        platformLogoUrl,
+        applicationBaseUrl,
+        0L);
   }
 
   /**
@@ -183,6 +223,30 @@ public class EmailBrandingResolver {
   }
 
   private RestrictedTenantDTO loadTenantQuietly(Long tenantId) {
+    if (cacheTtlNanos <= 0L) {
+      return loadTenantUncached(tenantId);
+    }
+    Long key =
+        (tenantId == null || TenantContext.TECHNICAL_TENANT_ID.equals(tenantId))
+            ? PLATFORM_CACHE_KEY
+            : tenantId;
+    long now = System.nanoTime();
+    CachedTenant cached = tenantCache.get(key);
+    // Subtraction, not comparison of absolutes: nanoTime has no fixed epoch and may be negative.
+    if (cached != null && now - cached.storedAtNanos() < cacheTtlNanos) {
+      return cached.tenant();
+    }
+    RestrictedTenantDTO fresh = loadTenantUncached(tenantId);
+    if (tenantCache.size() >= MAX_CACHE_ENTRIES) {
+      tenantCache.clear();
+    }
+    // A null result is cached too: tenant-admin invites resolve to "no tenant yet", and that 404
+    // is the normal case, not an error worth repeating once per recipient.
+    tenantCache.put(key, new CachedTenant(fresh, now));
+    return fresh;
+  }
+
+  private RestrictedTenantDTO loadTenantUncached(Long tenantId) {
     if (tenantId == null || TenantContext.TECHNICAL_TENANT_ID.equals(tenantId)) {
       return loadPlatformTenantQuietly();
     }

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -477,14 +477,34 @@
       "status": "bounded"
     },
     {
+      "id": "email-branding-tenant-cache",
+      "source": "src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java",
+      "kind": "local-state",
+      "owner": "identity-profile",
+      "risk": "performance",
+      "components": [
+        "tenantCache"
+      ],
+      "decision": "Retain locally with a short TTL (email.branding.cache-ttl-seconds, default 10s). Unlike the template cache this holds mutable tenant branding, so replicas can disagree - but only inside the TTL window, and a miss re-reads through TenantService.getRestrictedTenantDataFresh, so no replica can serve branding older than the TTL. The cache exists to stop one lookup per recipient in a digest batch; source 2606d840 removed the previous 24h cache precisely because a logo change stayed invisible until it expired, and the TTL is chosen to keep that fix intact. Bounded at 1000 keys, and setting the TTL to 0 disables it entirely.",
+      "signals": [
+        "userservice.replica.local_state"
+      ],
+      "status": "bounded"
+    },
+    {
       "id": "event-notification-retention-scheduler",
       "source": "src/main/java/de/caritas/cob/userservice/api/workflow/notificationretention/scheduler/EventNotificationRetentionScheduler.java",
       "kind": "scheduler",
       "owner": "notifications",
       "risk": "duplicate-side-effect",
-      "components": ["purgeExpiredNotifications"],
+      "components": [
+        "purgeExpiredNotifications"
+      ],
       "decision": "Leases the run through ScheduledTaskClaimService; the purge itself is an idempotent bulk delete of expired rows.",
-      "signals": ["userservice.scheduler.executions", "userservice.scheduler.duration"],
+      "signals": [
+        "userservice.scheduler.executions",
+        "userservice.scheduler.duration"
+      ],
       "status": "bounded"
     },
     {

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
@@ -15,6 +15,7 @@ class ReplicaSafetyInventoryContractTest {
   private static final Set<String> REQUIRED_COMPONENTS =
       Set.of(
           "email-template-cache",
+          "email-branding-tenant-cache",
           "matrix-access-token-cache",
           "matrix-browser-login-locks",
           "matrix-sync-token-cache",

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverPolicyCacheServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverPolicyCacheServiceTest.java
@@ -186,4 +186,65 @@ class CaseHandoverPolicyCacheServiceTest {
     verify(tenantControllerApi, never()).getTenantPermissionPolicies(any());
     verify(repository, never()).save(any());
   }
+
+  @Test
+  void refresh_rethrowsTheUpstreamFailureWhenTheSnapshotItselfIsUnreadable() {
+    var cache =
+        TenantCaseHandoverPolicyCache.builder()
+            .tenantId(42L)
+            .policies("{ this is not valid json")
+            .refreshedAt(LocalDateTime.of(2026, 8, 16, 9, 0))
+            .build();
+    when(repository.findById(42L)).thenReturn(Optional.of(cache));
+    when(tenantControllerApi.getTenantPermissionPolicies(42L))
+        .thenThrow(new RestClientException("TenantService unavailable"));
+
+    // The real cause must survive. Raising "Cached Case Handover policy is invalid" from inside
+    // the fallback would hide the outage and defeat the last-known-good contract.
+    assertThatThrownBy(() -> service.refresh(42L))
+        .isInstanceOf(RestClientException.class)
+        .hasMessageContaining("unavailable");
+  }
+
+  @Test
+  void getEffective_refreshesInsteadOfFailingWhenTheStoredSnapshotIsUnreadable() {
+    var cache =
+        TenantCaseHandoverPolicyCache.builder().tenantId(42L).policies("<<corrupt>>").build();
+    var policies = new CaseHandoverPolicies().reasons(Map.of());
+    when(repository.findById(42L)).thenReturn(Optional.of(cache));
+    when(tenantControllerApi.getTenantPermissionPolicies(42L))
+        .thenReturn(
+            new TenantPermissionPolicies()
+                .tenantId(42L)
+                .policies(Map.of())
+                .caseHandoverPolicies(policies));
+
+    assertThat(service.getEffective(42L)).isSameAs(policies);
+  }
+
+  @Test
+  void refreshKnownTenants_continuesAfterATenantThatFails() {
+    var failing =
+        TenantCaseHandoverPolicyCache.builder().tenantId(41L).policies("{\"reasons\":{}}").build();
+    var healthy =
+        TenantCaseHandoverPolicyCache.builder().tenantId(42L).policies("{\"reasons\":{}}").build();
+    when(repository.findAll()).thenReturn(java.util.List.of(failing, healthy));
+    // No persisted snapshot for 41: refresh has nothing to fall back on and propagates.
+    when(repository.findById(41L)).thenReturn(Optional.empty());
+    when(tenantControllerApi.getTenantPermissionPolicies(41L))
+        .thenThrow(new RestClientException("TenantService unavailable"));
+    when(repository.findById(42L)).thenReturn(Optional.of(healthy));
+    when(tenantControllerApi.getTenantPermissionPolicies(42L))
+        .thenReturn(
+            new TenantPermissionPolicies()
+                .tenantId(42L)
+                .policies(Map.of())
+                .caseHandoverPolicies(new CaseHandoverPolicies().reasons(Map.of())));
+
+    service.refreshKnownTenants();
+
+    // The second tenant must still be refreshed; an aborted sweep would leave it silently aging.
+    verify(tenantControllerApi).getTenantPermissionPolicies(42L);
+    verify(repository).save(healthy);
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/email/OrisoEmailDispatcherTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/email/OrisoEmailDispatcherTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 
+import ch.qos.logback.classic.Level;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.service.notification.SystemNotificationEmailSettingsService.SupervisorAddedEmailSettings;
+import de.caritas.cob.userservice.testutils.LogbackCaptor;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
@@ -55,5 +57,51 @@ class OrisoEmailDispatcherTest {
           .isInstanceOf(SmtpSendException.class);
       assertThat(dispatcher.send(smtp, "recipient@example.org", email)).isFalse();
     }
+  }
+
+  @Test
+  void neverLogsTheRecipientAddressCarriedInAnSmtpRejectionReply() {
+    // A real provider reply embeds the address it rejected. Logging the throwable would put it
+    // on disk; NotificationEmailService refuses to retain these details for the same reason.
+    String reply = "550 5.1.1 <advice.seeker@example.org> user unknown";
+    try (var transport = mockStatic(Transport.class);
+        var logs = LogbackCaptor.forClass(OrisoEmailDispatcher.class)) {
+      transport
+          .when(() -> Transport.send(any(Message.class)))
+          .thenThrow(new MessagingException(reply));
+
+      assertThat(dispatcher.send(smtp, "advice.seeker@example.org", email)).isFalse();
+
+      assertThat(logs.count(Level.ERROR)).isEqualTo(1);
+      assertThat(logs.events())
+          .allSatisfy(
+              event -> {
+                assertThat(event.getFormattedMessage()).doesNotContain("advice.seeker@example.org");
+                assertThat(event.getFormattedMessage()).doesNotContain(reply);
+                assertThat(event.getThrowableProxy()).isNull();
+              });
+      // The operator still needs to tell an auth failure from a timeout.
+      assertThat(logs.messages(Level.ERROR).get(0))
+          .contains("smtp.example.org")
+          .contains("SmtpSendException")
+          .contains("MessagingException");
+    }
+  }
+
+  @Test
+  void causeChainIsBoundedSoAWrappedChainCannotFloodTheLog() {
+    Throwable deepest = new IllegalStateException("root");
+    for (int depth = 0; depth < 7; depth++) {
+      deepest = new IllegalArgumentException("wrap", deepest);
+    }
+    assertThat(OrisoEmailDispatcher.causeChain(deepest).split(" <- ")).hasSize(5);
+  }
+
+  @Test
+  void causeChainSurvivesACyclicCauseChain() {
+    var first = new IllegalStateException("first");
+    var second = new IllegalArgumentException("second", first);
+    first.initCause(second);
+    assertThat(OrisoEmailDispatcher.causeChain(first).split(" <- ")).hasSizeLessThanOrEqualTo(5);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
@@ -322,5 +324,50 @@ class EmailBrandingResolverTest {
 
     assertThat(branding.imprintUrl()).isEqualTo("https://app.oriso.org/impressum");
     assertThat(branding.privacyUrl()).isEqualTo("https://app.oriso.org/datenschutz");
+  }
+
+  @Test
+  void collapsesOneBatchOfRecipientsIntoASingleTenantLookup() {
+    givenNoTemplateAttributes();
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant("Nord", new Theming()));
+    var cached =
+        new EmailBrandingResolver(
+            tenantService, tenantTemplateSupplier, "ORISO", "", "https://app.oriso.org", 10L);
+
+    for (int recipient = 0; recipient < 25; recipient++) {
+      assertThat(cached.resolve(7L).brandName()).isEqualTo("Nord");
+    }
+
+    // A digest run of N consultants must not cost N remote calls against a shared service.
+    verify(tenantService, times(1)).getRestrictedTenantDataFresh(7L);
+  }
+
+  @Test
+  void ttlZeroKeepsEveryResolveFresh() {
+    givenNoTemplateAttributes();
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant("Nord", new Theming()));
+    var uncached =
+        new EmailBrandingResolver(
+            tenantService, tenantTemplateSupplier, "ORISO", "", "https://app.oriso.org", 0L);
+
+    uncached.resolve(7L);
+    uncached.resolve(7L);
+    uncached.resolve(7L);
+
+    verify(tenantService, times(3)).getRestrictedTenantDataFresh(7L);
+  }
+
+  @Test
+  void doesNotServeOneTenantsBrandingToAnother() {
+    givenNoTemplateAttributes();
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant("Nord", new Theming()));
+    when(tenantService.getRestrictedTenantDataFresh(8L)).thenReturn(tenant("Sued", new Theming()));
+    var cached =
+        new EmailBrandingResolver(
+            tenantService, tenantTemplateSupplier, "ORISO", "", "https://app.oriso.org", 10L);
+
+    assertThat(cached.resolve(7L).brandName()).isEqualTo("Nord");
+    assertThat(cached.resolve(8L).brandName()).isEqualTo("Sued");
+    assertThat(cached.resolve(7L).brandName()).isEqualTo("Nord");
   }
 }


### PR DESCRIPTION
Targets `emails-v2` so the fixes land inside PR #1124 rather than alongside it.

Addresses the three findings from the CodeRabbit review on #1124 that block a
`pre-dev` merge, plus the paired test finding. The other ten Majors are
deliberately untouched — see *Not in scope* below.

## What changed

**`fix(email)` — SMTP rejection replies out of the application log** *(Major, Security & Privacy)*

`OrisoEmailDispatcher.send` logged the whole `SmtpSendException`. Its cause chain
is the Jakarta Mail failure, and provider rejection replies routinely embed the
address they rejected (`550 5.1.1 <a@b.example> user unknown`), so every failed
send wrote an advice-seeker address to disk. `NotificationEmailService` already
refuses to retain these details for exactly this reason, and
`WelcomeEmailService` still routes through this call site.

Now logs the exception type chain plus the configured SMTP host — operator
configuration, not personal data — following the `getClass().getSimpleName()`
convention already used in `GlobalSmtpSettingsResolver` and
`CaseHandoverEmailNotification`. Auth failures, TLS failures and timeouts stay
distinguishable. The chain is bounded at five links and tolerates a cyclic cause.

**`perf(email)` — collapse per-recipient tenant branding lookups** *(Major, Performance & Scalability)*

Source `2606d840` switched to `getRestrictedTenantDataFresh` so a logo change
reaches mail immediately. That fixed the staleness, but `resolve()` runs once per
recipient: `NotificationEmailService.render` calls `valuesForTenant` for every
entry in a batch, so a daily digest of N consultants issues N remote calls to
TenantService, nearly all for the same tenant.

This is **not** a restoration of the 24-hour cache that was removed. It is a memo
keyed by tenant id with a 10-second default TTL, configurable via
`email.branding.cache-ttl-seconds`. A branding save is still visible in the next
mail within seconds; one batch costs one lookup. Setting the TTL to `0` disables
it, and the existing five-argument constructor delegates with `0`, so current
behaviour and test determinism are preserved. Null results are memoised too (the
tenant-admin invite resolves to "no tenant yet", and repeating that 404 once per
recipient helps nobody). The platform lookup uses its own sentinel key, so no
tenant can be served another tenant's brand.

**`fix(handover)` — isolate policy cache failures per tenant** *(Major, Stability & Availability, + the test finding)*

Two defects in the last-known-good path:

- `refreshKnownTenants` ran `refresh` inside a plain `forEach`. One tenant whose
  snapshot could not be read aborted the sweep, so every tenant after it was
  never refreshed and silently kept an aging snapshot.
- Inside `refresh`, the upstream-failure branch called `deserialize`, which
  throws `IllegalStateException` on invalid JSON — escaping the very catch block
  meant to provide the fallback, and surfacing as "Cached Case Handover policy is
  invalid" rather than the real outage. `getEffective` had the same defect on the
  read path.

Deserialisation now yields an `Optional`. `getEffective` refreshes when the
stored snapshot is unreadable; `refresh` rethrows the **original** upstream
failure so the real cause stays visible; the scheduled sweep isolates and logs
each tenant. Adds the two cases the review identified as missing.

Why this one is not cosmetic: when the policy read fails, `CaseHandoverService`
falls back to the legacy reason rows — and on Dev all five of those carry
`client_consent_required = 0`. A silently skipped refresh is a silently weakened
consent gate.

## Verification

Full unit suite on this branch, JDK 21:

```
Tests run: 4440, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Spotless passes (bound to `compile`, so a clean build proves formatting).
Testcontainers ITs were not run locally — no Docker on this machine; CI's
Docker validation job covers them.

## Reviewer test plan

- [ ] Force an SMTP rejection and confirm the log line carries the host and the
      exception type chain, and no address or reply text.
- [ ] Send a digest batch to several consultants of one tenant; confirm a single
      `getRestrictedTenantDataFresh` call rather than one per recipient.
- [ ] Save a tenant logo, then trigger a mail within ~10s and confirm the new
      logo appears — the freshness `2606d840` restored must still hold.
- [ ] Corrupt one tenant's `tenant_case_handover_policy_cache.policies` value and
      confirm the scheduled sweep still refreshes the other tenants.

## Not in scope

The remaining ten Majors are untriaged here by agreement: findings 1, 2, 5, 10,
11 and 12 are queued before a `dev` promotion; 6, 7 and 9 (unbounded queries and
in-memory pagination) are follow-up tickets.

Separately, and not changed here: `refreshKnownTenants` calls `refresh` on
`this`, so Spring's proxy is bypassed and `@Transactional` never applies on the
scheduled path. Harmless today because the repository methods carry their own
transactions, but it deserves its own ticket rather than a smuggled-in change.

Also still open and a product decision, not a code fix: `case_handover_reason_policy`
on Dev holds the five legacy codes with `client_consent_required = 0` for all of
them. Someone should confirm that is the intended product state before this
reaches an environment where handover is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
