### PR TITLE
fix(mail-v2): close the remaining CodeRabbit findings on #1124

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
@@ -61,11 +61,20 @@ public interface CaseHandoverRequestRepository extends JpaRepository<CaseHandove
           + " where request.status = :status"
           + " and request.accessType = :accessType"
           + " and request.expiresAt <= :expiresAt"
-          + " order by request.expiresAt asc")
+          // Keyset cursor on (expiresAt, id). Page-zero paging cannot work here: a row whose
+          // Matrix removal fails stays GRANTED, so it comes back at the head of the next page and
+          // starves every later expired grant. The cursor steps past it instead, and the next
+          // scheduled run retries it from the start.
+          + " and (:afterExpiresAt is null"
+          + "   or request.expiresAt > :afterExpiresAt"
+          + "   or (request.expiresAt = :afterExpiresAt and request.id > :afterId))"
+          + " order by request.expiresAt asc, request.id asc")
   List<CaseHandoverRequest> findExpiredCoAccessBatch(
       @Param("status") CaseHandoverRequest.Status status,
       @Param("accessType") CaseHandoverRequest.AccessType accessType,
       @Param("expiresAt") LocalDateTime expiresAt,
+      @Param("afterExpiresAt") LocalDateTime afterExpiresAt,
+      @Param("afterId") Long afterId,
       Pageable pageable);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/CaseHandoverRequestRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -49,11 +50,27 @@ public interface CaseHandoverRequestRepository extends JpaRepository<CaseHandove
 
   List<CaseHandoverRequest> findByPreviousConsultantId(String previousConsultantId);
 
+  /**
+   * Bounded sweep input, oldest window first. Deliberately unlocked and deliberately paged: the
+   * sweep reconciles Matrix between reading a row and writing its outcome, so a lock taken here
+   * would be held across external round trips for the whole backlog. The row lock is taken instead
+   * by {@link #findByIdForUpdate(Long)} in the short write transaction that follows.
+   */
+  @Query(
+      "select request from CaseHandoverRequest request"
+          + " where request.status = :status"
+          + " and request.accessType = :accessType"
+          + " and request.expiresAt <= :expiresAt"
+          + " order by request.expiresAt asc")
+  List<CaseHandoverRequest> findExpiredCoAccessBatch(
+      @Param("status") CaseHandoverRequest.Status status,
+      @Param("accessType") CaseHandoverRequest.AccessType accessType,
+      @Param("expiresAt") LocalDateTime expiresAt,
+      Pageable pageable);
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  List<CaseHandoverRequest> findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-      CaseHandoverRequest.Status status,
-      CaseHandoverRequest.AccessType accessType,
-      LocalDateTime expiresAt);
+  @Query("select request from CaseHandoverRequest request where request.id = :id")
+  Optional<CaseHandoverRequest> findByIdForUpdate(@Param("id") Long id);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   List<CaseHandoverRequest> findBySessionIdAndStatusAndAccessType(

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/OffsetPageable.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/OffsetPageable.java
@@ -1,0 +1,77 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * A {@link Pageable} whose offset is a row offset, not a page index.
+ *
+ * <p>{@code PageRequest} pages in units of the page size, so it can only express offsets that are
+ * multiples of it. The candidate-search API takes {@code offset} and {@code count} independently
+ * and permits any non-negative offset, so paging it through {@code PageRequest} would silently move
+ * the window. Spring Data JPA reads {@link #getOffset()} and {@link #getPageSize()} straight into
+ * {@code setFirstResult}/{@code setMaxResults}, so this carries the caller's offset exactly.
+ */
+public final class OffsetPageable implements Pageable {
+
+  private final long offset;
+  private final int size;
+  private final Sort sort;
+
+  public OffsetPageable(long offset, int size) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset must not be negative");
+    }
+    if (size < 1) {
+      throw new IllegalArgumentException("size must be at least 1");
+    }
+    this.offset = offset;
+    this.size = size;
+    this.sort = Sort.unsorted();
+  }
+
+  @Override
+  public int getPageNumber() {
+    return (int) (offset / size);
+  }
+
+  @Override
+  public int getPageSize() {
+    return size;
+  }
+
+  @Override
+  public long getOffset() {
+    return offset;
+  }
+
+  @Override
+  public Sort getSort() {
+    return sort;
+  }
+
+  @Override
+  public Pageable next() {
+    return new OffsetPageable(offset + size, size);
+  }
+
+  @Override
+  public Pageable previousOrFirst() {
+    return hasPrevious() ? new OffsetPageable(offset - size, size) : first();
+  }
+
+  @Override
+  public Pageable first() {
+    return new OffsetPageable(0, size);
+  }
+
+  @Override
+  public Pageable withPage(int pageNumber) {
+    return new OffsetPageable((long) pageNumber * size, size);
+  }
+
+  @Override
+  public boolean hasPrevious() {
+    return offset >= size;
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -111,6 +111,50 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
       List<Long> agencyIds, Consultant consultant, List<SessionStatus> statuses);
 
   /**
+   * Bounded, newest-first window of candidate ids, narrowed in the database.
+   *
+   * <p>The topic predicate here is a <b>performance</b> narrowing, not the authority on scope.
+   * {@code CaseHandoverService.isInRequesterDepartment} still decides what the requester may see,
+   * and keeps doing so in Java where it stays unit-testable. That ordering is deliberate: a mistake
+   * in this JPQL can only return too many rows, which the Java predicate then drops — it cannot
+   * widen access. Least-privilege must not depend on a query string no unit test can execute.
+   *
+   * <p>{@code allTopics} carries the "topics feature is off, so a department is just the agency"
+   * case. {@code topicIds} must stay non-empty even then, because an empty IN list is not portable.
+   *
+   * <p>Ids rather than entities, so the fetch below can join {@code sessionTopics} without
+   * Hibernate paginating a fetch join in memory.
+   */
+  @Query(
+      "select distinct session.id from Session session"
+          + " left join session.sessionTopics sessionTopic"
+          + " where session.agencyId in :agencyIds"
+          + " and session.consultant <> :requester"
+          + " and session.status in :statuses"
+          + " and (:allTopics = true"
+          + "   or session.mainTopicId in :topicIds"
+          + "   or sessionTopic.topicId in :topicIds)"
+          + " order by session.updateDate desc")
+  List<Long> findCaseHandoverCandidateIds(
+      @Param("agencyIds") List<Long> agencyIds,
+      @Param("requester") Consultant requester,
+      @Param("statuses") List<SessionStatus> statuses,
+      @Param("allTopics") boolean allTopics,
+      @Param("topicIds") Set<Long> topicIds,
+      Pageable pageable);
+
+  /**
+   * Loads the windowed candidates with their topics in one query. Without the fetch join the
+   * department predicate reads the LAZY {@code sessionTopics} collection once per candidate.
+   */
+  @Query(
+      "select distinct session from Session session"
+          + " left join fetch session.sessionTopics"
+          + " where session.id in :ids"
+          + " order by session.updateDate desc")
+  List<Session> findCaseHandoverCandidatesWithTopics(@Param("ids") List<Long> ids);
+
+  /**
    * Find team {@link Session} list by agency ids and status where consultant is not the given
    * consultant ordered by creation date descending.
    *

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/SessionRepository.java
@@ -123,19 +123,31 @@ public interface SessionRepository extends CrudRepository<Session, Long> {
    * case. {@code topicIds} must stay non-empty even then, because an empty IN list is not portable.
    *
    * <p>Ids rather than entities, so the fetch below can join {@code sessionTopics} without
-   * Hibernate paginating a fetch join in memory.
+   * Hibernate paginating a fetch join in memory. A {@link Page} rather than a list, because a
+   * browse without a search term needs a real total: capping it would make the endpoint report a
+   * truncated count and return empty pages past the cap while candidates still exist.
    */
   @Query(
-      "select distinct session.id from Session session"
-          + " left join session.sessionTopics sessionTopic"
-          + " where session.agencyId in :agencyIds"
-          + " and session.consultant <> :requester"
-          + " and session.status in :statuses"
-          + " and (:allTopics = true"
-          + "   or session.mainTopicId in :topicIds"
-          + "   or sessionTopic.topicId in :topicIds)"
-          + " order by session.updateDate desc")
-  List<Long> findCaseHandoverCandidateIds(
+      value =
+          "select distinct session.id from Session session"
+              + " left join session.sessionTopics sessionTopic"
+              + " where session.agencyId in :agencyIds"
+              + " and session.consultant <> :requester"
+              + " and session.status in :statuses"
+              + " and (:allTopics = true"
+              + "   or session.mainTopicId in :topicIds"
+              + "   or sessionTopic.topicId in :topicIds)"
+              + " order by session.updateDate desc",
+      countQuery =
+          "select count(distinct session.id) from Session session"
+              + " left join session.sessionTopics sessionTopic"
+              + " where session.agencyId in :agencyIds"
+              + " and session.consultant <> :requester"
+              + " and session.status in :statuses"
+              + " and (:allTopics = true"
+              + "   or session.mainTopicId in :topicIds"
+              + "   or sessionTopic.topicId in :topicIds)")
+  Page<Long> findCaseHandoverCandidateIds(
       @Param("agencyIds") List<Long> agencyIds,
       @Param("requester") Consultant requester,
       @Param("statuses") List<SessionStatus> statuses,

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverCoAccessExpiryStore.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverCoAccessExpiryStore.java
@@ -41,6 +41,7 @@ public class CaseHandoverCoAccessExpiryStore {
    */
   public record ExpiringCoAccess(
       Long requestId,
+      LocalDateTime expiresAt,
       Long sessionId,
       String matrixRoomId,
       String requesterConsultantId,
@@ -49,12 +50,25 @@ public class CaseHandoverCoAccessExpiryStore {
       String ownerMatrixUserId,
       String previousConsultantMatrixUserId) {}
 
-  /** A bounded, oldest-first page of grants whose window has closed. */
+  /**
+   * A bounded, oldest-first page of grants whose window has closed, strictly after the given
+   * cursor.
+   *
+   * <p>The cursor is what keeps a failing row from starving the sweep: an unconfirmed Matrix
+   * removal leaves the row GRANTED, so page-zero paging would hand it back forever and never reach
+   * the grants behind it. Pass {@code null}/{@code null} to start.
+   */
   @Transactional(readOnly = true)
-  public List<ExpiringCoAccess> findExpiredBatch(LocalDateTime now, int limit) {
+  public List<ExpiringCoAccess> findExpiredBatch(
+      LocalDateTime now, LocalDateTime afterExpiresAt, Long afterId, int limit) {
     return caseHandoverRequestRepository
         .findExpiredCoAccessBatch(
-            Status.GRANTED, AccessType.CO_ACCESS, now, PageRequest.of(0, Math.max(1, limit)))
+            Status.GRANTED,
+            AccessType.CO_ACCESS,
+            now,
+            afterExpiresAt,
+            afterId,
+            PageRequest.of(0, Math.max(1, limit)))
         .stream()
         .map(CaseHandoverCoAccessExpiryStore::toExpiring)
         .toList();
@@ -91,6 +105,7 @@ public class CaseHandoverCoAccessExpiryStore {
     Consultant previous = request.getPreviousConsultant();
     return new ExpiringCoAccess(
         request.getId(),
+        request.getExpiresAt(),
         session == null ? null : session.getId(),
         session == null ? null : session.getMatrixRoomId(),
         requester == null ? null : requester.getId(),

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverCoAccessExpiryStore.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverCoAccessExpiryStore.java
@@ -1,0 +1,102 @@
+package de.caritas.cob.userservice.api.service;
+
+import de.caritas.cob.userservice.api.model.CaseHandoverRequest;
+import de.caritas.cob.userservice.api.model.CaseHandoverRequest.AccessType;
+import de.caritas.cob.userservice.api.model.CaseHandoverRequest.Status;
+import de.caritas.cob.userservice.api.model.Consultant;
+import de.caritas.cob.userservice.api.model.Session;
+import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Transaction boundaries for the co-access expiry sweep.
+ *
+ * <p>This exists so the sweep can talk to Matrix <em>outside</em> a database transaction. The sweep
+ * previously ran as one {@code @Transactional} method over an unbounded result set, performing
+ * {@code getRoomMembers}, {@code loginAsUserAccessToken} and {@code removeUserFromRoom} per row: a
+ * slow or hanging Synapse held a pooled connection and the row locks for the whole backlog.
+ *
+ * <p>Splitting it into a separate bean rather than adding methods to {@link CaseHandoverService} is
+ * deliberate — a self-invocation would bypass the Spring proxy and silently run with no transaction
+ * at all, which is the same trap in a different shape.
+ */
+@Service
+@RequiredArgsConstructor
+public class CaseHandoverCoAccessExpiryStore {
+
+  private final @NonNull CaseHandoverRequestRepository caseHandoverRequestRepository;
+
+  /**
+   * Everything the Matrix reconciliation needs, as plain values.
+   *
+   * <p>Values, not entities: the reconciliation runs after this transaction has closed, and reading
+   * an association off a detached entity is the kind of failure that passes every mock-based test
+   * and then throws in production.
+   */
+  public record ExpiringCoAccess(
+      Long requestId,
+      Long sessionId,
+      String matrixRoomId,
+      String requesterConsultantId,
+      String requesterMatrixUserId,
+      String ownerConsultantId,
+      String ownerMatrixUserId,
+      String previousConsultantMatrixUserId) {}
+
+  /** A bounded, oldest-first page of grants whose window has closed. */
+  @Transactional(readOnly = true)
+  public List<ExpiringCoAccess> findExpiredBatch(LocalDateTime now, int limit) {
+    return caseHandoverRequestRepository
+        .findExpiredCoAccessBatch(
+            Status.GRANTED, AccessType.CO_ACCESS, now, PageRequest.of(0, Math.max(1, limit)))
+        .stream()
+        .map(CaseHandoverCoAccessExpiryStore::toExpiring)
+        .toList();
+  }
+
+  /**
+   * Persists one expiry in its own short transaction, under a row lock taken here and released at
+   * commit — never held across a Matrix call.
+   *
+   * @return whether this call is the one that expired the row
+   */
+  @Transactional
+  public boolean markExpired(Long requestId, LocalDateTime now, String auditOutcome) {
+    return caseHandoverRequestRepository
+        .findByIdForUpdate(requestId)
+        // Re-checked under the lock: the grant may have been resolved between the batch read and
+        // the Matrix round trip, and a second EXPIRED write would overwrite that outcome.
+        .filter(request -> request.getStatus() == Status.GRANTED)
+        .map(
+            request -> {
+              request.setStatus(Status.EXPIRED);
+              request.setAuditOutcome(auditOutcome);
+              request.setResolvedAt(now);
+              caseHandoverRequestRepository.save(request);
+              return true;
+            })
+        .orElse(false);
+  }
+
+  private static ExpiringCoAccess toExpiring(CaseHandoverRequest request) {
+    Session session = request.getSession();
+    Consultant requester = request.getRequesterConsultant();
+    Consultant owner = session == null ? null : session.getConsultant();
+    Consultant previous = request.getPreviousConsultant();
+    return new ExpiringCoAccess(
+        request.getId(),
+        session == null ? null : session.getId(),
+        session == null ? null : session.getMatrixRoomId(),
+        requester == null ? null : requester.getId(),
+        requester == null ? null : requester.getMatrixUserId(),
+        owner == null ? null : owner.getId(),
+        owner == null ? null : owner.getMatrixUserId(),
+        previous == null ? null : previous.getMatrixUserId());
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -29,6 +29,7 @@ import de.caritas.cob.userservice.api.port.out.CaseHandoverReasonPolicyRepositor
 import de.caritas.cob.userservice.api.port.out.CaseHandoverRequestRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantAgencyRepository;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
+import de.caritas.cob.userservice.api.port.out.OffsetPageable;
 import de.caritas.cob.userservice.api.port.out.SessionRepository;
 import de.caritas.cob.userservice.api.service.matrix.MatrixSessionSystemMessageService;
 import de.caritas.cob.userservice.api.service.notification.CaseHandoverEmailNotification;
@@ -64,7 +65,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -455,6 +456,9 @@ public class CaseHandoverService {
    * what the requester may see: it is the least-privilege boundary (#202), it is unit-tested, and
    * leaving it in place means a mistake in the query can only over-fetch, never over-share.
    *
+   * <p>A blank query pages in the database with a real count. Only the free-text path uses a scan
+   * window, and it says so when the window fills.
+   *
    * <p>The free-text filter cannot move into SQL at all. It matches on decoded usernames and on the
    * internal display name with fallback (#996) — values that do not exist in the columns the
    * database would have to search, because usernames are stored encoded. Moving it there means
@@ -487,20 +491,49 @@ public class CaseHandoverService {
             ? List.of(SessionStatus.IN_ARCHIVE)
             : List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE);
 
+    // Browsing without a search term is ordinary pagination and must not be capped: capping it
+    // reports a truncated total and returns empty pages past the cap while candidates still exist.
+    // Only the free-text path needs a scan window, because its filter cannot run in SQL.
+    if (normalizeSearchText(query).isBlank()) {
+      Page<Long> idPage =
+          sessionRepository.findCaseHandoverCandidateIds(
+              agencyIds,
+              requester,
+              statuses,
+              allTopics,
+              topicIds,
+              new OffsetPageable(safeOffset, safeCount));
+      List<ConsultantSessionResponseDTO> page =
+          sessionRepository.findCaseHandoverCandidatesWithTopics(idPage.getContent()).stream()
+              .filter(session -> isInRequesterDepartment(session, requester))
+              .map(this::toCandidateDto)
+              .collect(Collectors.toList());
+      return new ConsultantSessionListResponseDTO()
+          .sessions(page)
+          .offset(safeOffset)
+          .count(page.size())
+          // The count query counts what the SQL scope selects. The Java predicate re-checks the
+          // same scope rather than narrowing it further, so the two agree; if it ever drops a row,
+          // the page is short rather than the total being wrong.
+          .total((int) idPage.getTotalElements());
+    }
+
     int scanLimit = Math.max(1, candidateSearchScanLimit);
-    List<Long> windowIds =
+    Page<Long> window =
         sessionRepository.findCaseHandoverCandidateIds(
-            agencyIds, requester, statuses, allTopics, topicIds, PageRequest.of(0, scanLimit));
+            agencyIds, requester, statuses, allTopics, topicIds, new OffsetPageable(0, scanLimit));
+    List<Long> windowIds = window.getContent();
     if (windowIds.isEmpty()) {
       return emptyCandidateResponse(safeOffset);
     }
-    if (windowIds.size() == scanLimit) {
+    if (window.getTotalElements() > windowIds.size()) {
       log.warn(
-          "Case Handover candidate search for consultant {} filled its {}-row scan window; older"
-              + " candidates were not searched. Narrow the query or raise"
+          "Case Handover candidate search for consultant {} matched {} sessions in scope but only"
+              + " the newest {} were searched. Narrow the query or raise"
               + " case.handover.candidate-search-scan-limit",
           requester.getId(),
-          scanLimit);
+          window.getTotalElements(),
+          windowIds.size());
     }
     List<Session> candidates = sessionRepository.findCaseHandoverCandidatesWithTopics(windowIds);
 
@@ -1631,7 +1664,10 @@ public class CaseHandoverService {
   @Scheduled(
       fixedDelayString = "${case.handover.co-access-sweep-delay-ms:60000}",
       initialDelayString = "${case.handover.co-access-sweep-initial-delay-ms:60000}")
-  @Transactional
+  // Deliberately NOT @Transactional. The store methods use default REQUIRED propagation, so a
+  // transaction opened here would be the one they join - and the connection and row locks would
+  // stay held across every Matrix call, which is the whole thing expireCoAccess was restructured
+  // to avoid. The lease claim keeps its own transaction (ScheduledTaskClaimWriter is REQUIRES_NEW).
   public void expireCoAccessSchedule() {
     if (!scheduledTaskClaimService.tryClaim(CO_ACCESS_EXPIRY_TASK, coAccessClaimDuration)) {
       return;
@@ -1660,23 +1696,18 @@ public class CaseHandoverService {
    */
   public int expireCoAccess() {
     LocalDateTime now = LocalDateTime.now(clock);
-    Set<Long> attempted = new HashSet<>();
+    int batchSize = Math.max(1, coAccessSweepBatchSize);
     int revoked = 0;
+    LocalDateTime cursorExpiresAt = null;
+    Long cursorId = null;
 
     for (int batchNumber = 0; batchNumber < Math.max(1, coAccessSweepMaxBatches); batchNumber++) {
       List<CaseHandoverCoAccessExpiryStore.ExpiringCoAccess> batch =
-          coAccessExpiryStore.findExpiredBatch(now, coAccessSweepBatchSize);
+          coAccessExpiryStore.findExpiredBatch(now, cursorExpiresAt, cursorId, batchSize);
       if (batch.isEmpty()) {
         break;
       }
-      // A row whose Matrix removal could not be confirmed stays GRANTED and therefore comes back in
-      // the next page. Without this the sweep would re-read the same rows until the batch cap.
-      List<CaseHandoverCoAccessExpiryStore.ExpiringCoAccess> fresh =
-          batch.stream().filter(item -> attempted.add(item.requestId())).toList();
-      if (fresh.isEmpty()) {
-        break;
-      }
-      for (var expiring : fresh) {
+      for (var expiring : batch) {
         if (!removeCoAccessRequesterFromMatrixRoom(expiring)) {
           log.warn(
               "Could not remove Case Handover requester for request {}; retrying on the next expiry sweep",
@@ -1687,7 +1718,14 @@ public class CaseHandoverService {
           revoked++;
         }
       }
-      if (batch.size() < Math.max(1, coAccessSweepBatchSize)) {
+      // Advance past everything read, succeeded or not. A row whose Matrix removal could not be
+      // confirmed stays GRANTED; stepping over it here is what stops it re-appearing at the head of
+      // the next page and starving the expired grants behind it. It is retried from the start on
+      // the next scheduled run.
+      var last = batch.get(batch.size() - 1);
+      cursorExpiresAt = last.expiresAt();
+      cursorId = last.requestId();
+      if (batch.size() < batchSize) {
         break;
       }
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/CaseHandoverService.java
@@ -36,6 +36,7 @@ import de.caritas.cob.userservice.api.service.notification.EventNotificationServ
 import de.caritas.cob.userservice.api.service.session.SessionMapper;
 import de.caritas.cob.userservice.api.service.user.UserAccountService;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.tenant.TenantData;
 import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
 import java.time.Clock;
@@ -63,6 +64,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -272,10 +274,31 @@ public class CaseHandoverService {
   private final @NonNull MatrixSynapseService matrixSynapseService;
   private final @NonNull MatrixSessionSystemMessageService matrixSessionSystemMessageService;
   private final @NonNull ScheduledTaskClaimService scheduledTaskClaimService;
+  private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull CaseHandoverCoAccessExpiryStore coAccessExpiryStore;
   private final @NonNull Clock clock;
 
   @Value("${case.handover.co-access-claim-duration:PT2M}")
   private Duration coAccessClaimDuration = Duration.ofMinutes(2);
+
+  /**
+   * Rows reconciled per sweep transaction. Small on purpose: each row costs Matrix round trips, and
+   * the point of the batch is that no lock and no connection is held across them.
+   */
+  @Value("${case.handover.co-access-sweep-batch-size:50}")
+  private int coAccessSweepBatchSize = 50;
+
+  /** Hard stop for one sweep, so a large backlog cannot monopolise the scheduler thread. */
+  @Value("${case.handover.co-access-sweep-max-batches:20}")
+  private int coAccessSweepMaxBatches = 20;
+
+  /**
+   * Newest-first window scanned when a free-text candidate query is present. The text match cannot
+   * run in SQL (see {@link #searchCandidates}), so this is the bound that replaces the unbounded
+   * read it used to do.
+   */
+  @Value("${case.handover.candidate-search-scan-limit:2000}")
+  private int candidateSearchScanLimit = 2000;
 
   private final @NonNull ConsultantRepository consultantRepository;
 
@@ -420,6 +443,24 @@ public class CaseHandoverService {
   }
 
   @Transactional(readOnly = true)
+  /**
+   * Department-scoped candidate search.
+   *
+   * <p>Two things changed here, and the order matters. The agency/topic narrowing now also runs in
+   * the database and the window is bounded, so this no longer reads every selected-status session
+   * across the requester's agencies; and the candidates are loaded with their topics in one query,
+   * so the department predicate no longer triggers a lazy read per candidate.
+   *
+   * <p>{@link #isInRequesterDepartment} deliberately stays. It, not the JPQL, is the authority on
+   * what the requester may see: it is the least-privilege boundary (#202), it is unit-tested, and
+   * leaving it in place means a mistake in the query can only over-fetch, never over-share.
+   *
+   * <p>The free-text filter cannot move into SQL at all. It matches on decoded usernames and on the
+   * internal display name with fallback (#996) — values that do not exist in the columns the
+   * database would have to search, because usernames are stored encoded. Moving it there means
+   * changing how usernames are stored, which is a different change than this one. The scan window
+   * is what bounds it instead, and a truncated window is reported rather than silently trimmed.
+   */
   public ConsultantSessionListResponseDTO searchCandidates(
       String query, int offset, int count, boolean archived) {
     Consultant requester = retrieveCurrentConsultant();
@@ -431,13 +472,37 @@ public class CaseHandoverService {
       return emptyCandidateResponse(safeOffset);
     }
 
+    Set<Long> requesterTopicIds = consultantTopicIds(requester);
+    if (topicsEnabled && requesterTopicIds.isEmpty()) {
+      // Topics on, none assigned: the requester has no department, and falling back to the whole
+      // agency would be wider than least-privilege (#202).
+      return emptyCandidateResponse(safeOffset);
+    }
+    boolean allTopics = !topicsEnabled;
+    // An empty IN list is not portable, and the predicate is short-circuited by allTopics anyway.
+    Set<Long> topicIds = requesterTopicIds.isEmpty() ? Set.of(-1L) : requesterTopicIds;
+
     List<SessionStatus> statuses =
         archived
             ? List.of(SessionStatus.IN_ARCHIVE)
             : List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE);
-    List<Session> candidates =
-        sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            agencyIds, requester, statuses);
+
+    int scanLimit = Math.max(1, candidateSearchScanLimit);
+    List<Long> windowIds =
+        sessionRepository.findCaseHandoverCandidateIds(
+            agencyIds, requester, statuses, allTopics, topicIds, PageRequest.of(0, scanLimit));
+    if (windowIds.isEmpty()) {
+      return emptyCandidateResponse(safeOffset);
+    }
+    if (windowIds.size() == scanLimit) {
+      log.warn(
+          "Case Handover candidate search for consultant {} filled its {}-row scan window; older"
+              + " candidates were not searched. Narrow the query or raise"
+              + " case.handover.candidate-search-scan-limit",
+          requester.getId(),
+          scanLimit);
+    }
+    List<Session> candidates = sessionRepository.findCaseHandoverCandidatesWithTopics(windowIds);
 
     List<Session> matchingCandidates =
         candidates.stream()
@@ -655,7 +720,15 @@ public class CaseHandoverService {
   public CaseHandoverOffer createOffer(
       Long sessionId, String targetConsultantId, String reasonCode, String explanation) {
     Consultant owner = retrieveCurrentConsultant();
-    Session session = getSession(sessionId);
+    // Locked for the life of this transaction: the "one open offer per case" rule below is a
+    // read-then-write, and two concurrent offers on the same case would otherwise both pass it and
+    // land two colleagues an offer for the same case. There is no unique index to lean on - an
+    // "open PUSH offer" is a status predicate, not a column value - so the session row is the
+    // serialization point, and it scopes contention to the one case being offered.
+    Session session =
+        sessionRepository
+            .findByIdForUpdate(sessionId)
+            .orElseThrow(() -> new NotFoundException("Session not found"));
     verifyIsActiveOwner(session, owner);
 
     Consultant target = findColleague(targetConsultantId);
@@ -1563,7 +1636,10 @@ public class CaseHandoverService {
     if (!scheduledTaskClaimService.tryClaim(CO_ACCESS_EXPIRY_TASK, coAccessClaimDuration)) {
       return;
     }
-    TenantContext.setCurrentTenant(TenantContext.TECHNICAL_TENANT_ID);
+    // Same entry point as CaseHandoverOfferExpiryScheduler. Setting the technical tenant
+    // unconditionally gave a single-tenant deployment a tenant context it never has elsewhere;
+    // the provider is a no-op when multitenancy.enabled is false.
+    tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
     try {
       expireCoAccess();
     } finally {
@@ -1571,29 +1647,51 @@ public class CaseHandoverService {
     }
   }
 
-  /** Exact persisted expiry sweep; API reads also close the curtain at {@code expiresAt}. */
-  @Transactional
+  /**
+   * Exact persisted expiry sweep; API reads also close the curtain at {@code expiresAt}.
+   *
+   * <p>Deliberately NOT {@code @Transactional}. Each row needs Matrix round trips ({@code
+   * getRoomMembers}, an operator login, {@code removeUserFromRoom}) before its audit state may
+   * change, and holding a database transaction across those meant one hanging Synapse pinned a
+   * pooled connection and the row locks for the entire backlog. The work is now: read a bounded
+   * batch in a short transaction, reconcile Matrix with no transaction open, then persist each
+   * outcome in its own short locked transaction. The ordering guarantee is unchanged - confirmed
+   * removal still precedes EXPIRED.
+   */
   public int expireCoAccess() {
     LocalDateTime now = LocalDateTime.now(clock);
-    List<CaseHandoverRequest> expired =
-        caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            Status.GRANTED, AccessType.CO_ACCESS, now);
-    List<CaseHandoverRequest> revoked = new ArrayList<>();
-    expired.forEach(
-        request -> {
-          if (!removeCoAccessRequesterFromMatrixRoom(request)) {
-            log.warn(
-                "Could not remove Case Handover requester for request {}; retrying on the next expiry sweep",
-                request.getId());
-            return;
-          }
-          request.setStatus(Status.EXPIRED);
-          request.setAuditOutcome(OUTCOME_ACCESS_EXPIRED);
-          request.setResolvedAt(now);
-          revoked.add(request);
-        });
-    caseHandoverRequestRepository.saveAll(revoked);
-    return revoked.size();
+    Set<Long> attempted = new HashSet<>();
+    int revoked = 0;
+
+    for (int batchNumber = 0; batchNumber < Math.max(1, coAccessSweepMaxBatches); batchNumber++) {
+      List<CaseHandoverCoAccessExpiryStore.ExpiringCoAccess> batch =
+          coAccessExpiryStore.findExpiredBatch(now, coAccessSweepBatchSize);
+      if (batch.isEmpty()) {
+        break;
+      }
+      // A row whose Matrix removal could not be confirmed stays GRANTED and therefore comes back in
+      // the next page. Without this the sweep would re-read the same rows until the batch cap.
+      List<CaseHandoverCoAccessExpiryStore.ExpiringCoAccess> fresh =
+          batch.stream().filter(item -> attempted.add(item.requestId())).toList();
+      if (fresh.isEmpty()) {
+        break;
+      }
+      for (var expiring : fresh) {
+        if (!removeCoAccessRequesterFromMatrixRoom(expiring)) {
+          log.warn(
+              "Could not remove Case Handover requester for request {}; retrying on the next expiry sweep",
+              expiring.requestId());
+          continue;
+        }
+        if (coAccessExpiryStore.markExpired(expiring.requestId(), now, OUTCOME_ACCESS_EXPIRED)) {
+          revoked++;
+        }
+      }
+      if (batch.size() < Math.max(1, coAccessSweepBatchSize)) {
+        break;
+      }
+    }
+    return revoked;
   }
 
   private CaseHandoverStatus denyRequest(
@@ -1661,7 +1759,7 @@ public class CaseHandoverService {
   private void notifyGranted(CaseHandoverRequest request) {
     Session session = request.getSession();
     Consultant requester = request.getRequesterConsultant();
-    if (effectiveAccessType(request) == AccessType.TAKEOVER) {
+    if (effectiveAccessType(request) == AccessType.TAKEOVER && hasMailTenant(session, "granted")) {
       caseHandoverEmailNotification.ownershipGranted(
           request.getId(),
           session.getMatrixRoomId(),
@@ -1672,19 +1770,28 @@ public class CaseHandoverService {
     String requesterName = resolveConsultantName(requester);
     ClientHandoverCopy clientCopy = resolveClientHandoverCopy(session);
     boolean coAccess = effectiveAccessType(request) == AccessType.CO_ACCESS;
+    // A tenant that configures its own co-access wording must actually get it. The template is
+    // loaded into the reason and stored by toPolicy, and resolveClientNotificationDescription
+    // exists to prefer it - but this branch read the built-in defaults directly, so the configured
+    // copy was resolved and then discarded. Fall back to the built-in default when the tenant has
+    // none, or when the reason code has no default template at all (legacy codes).
+    String tenantDescription =
+        coAccess ? resolveClientNotificationDescription(request, requesterName) : null;
     String clientDescription =
-        coAccess
-            ? DEFAULT_CLIENT_NOTIFICATION_TEMPLATES
-                .get(ADVICE_NEEDED)
-                .getOrDefault(
-                    resolveSessionLanguage(session),
-                    DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get(ADVICE_NEEDED).get("de"))
-                .replace("{{newAdvisor}}", requesterName)
-                .replace(
-                    "{{duration}}",
-                    formatDuration(
-                        request.getMaxAccessDurationMinutes(), resolveSessionLanguage(session)))
-            : renderClientCopy(clientCopy.grantedDescription(), requesterName);
+        tenantDescription != null
+            ? tenantDescription
+            : coAccess
+                ? DEFAULT_CLIENT_NOTIFICATION_TEMPLATES
+                    .get(ADVICE_NEEDED)
+                    .getOrDefault(
+                        resolveSessionLanguage(session),
+                        DEFAULT_CLIENT_NOTIFICATION_TEMPLATES.get(ADVICE_NEEDED).get("de"))
+                    .replace("{{newAdvisor}}", requesterName)
+                    .replace(
+                        "{{duration}}",
+                        formatDuration(
+                            request.getMaxAccessDurationMinutes(), resolveSessionLanguage(session)))
+                : renderClientCopy(clientCopy.grantedDescription(), requesterName);
     postGrantedChatSystemMessage(session, requesterName, clientDescription);
     // #1010 task 1a: the explanation is counsellor-written free text that can reference case
     // content. It is no longer copied into the notification, which kept it in plaintext for good;
@@ -1835,36 +1942,36 @@ public class CaseHandoverService {
     return " годин";
   }
 
-  private boolean removeCoAccessRequesterFromMatrixRoom(CaseHandoverRequest request) {
+  /**
+   * Runs with no transaction open, so it takes plain values rather than an entity - see {@link
+   * CaseHandoverCoAccessExpiryStore.ExpiringCoAccess}.
+   */
+  private boolean removeCoAccessRequesterFromMatrixRoom(
+      CaseHandoverCoAccessExpiryStore.ExpiringCoAccess expiring) {
     try {
-      Session accessSession = request.getSession();
-      Consultant requester = request.getRequesterConsultant();
-      if (accessSession == null || isBlank(accessSession.getMatrixRoomId())) {
-        return true;
-      }
-      if (requester == null || isBlank(requester.getMatrixUserId())) {
+      if (isBlank(expiring.matrixRoomId()) || isBlank(expiring.requesterMatrixUserId())) {
         return true;
       }
       // The old temporary grant can expire after this advisor acquired independent ownership.
       // Expire its audit row, but retain the membership required by the current owner role.
-      if (isActiveOwner(accessSession, requester)) {
+      if (expiring.ownerConsultantId() != null
+          && expiring.ownerConsultantId().equals(expiring.requesterConsultantId())) {
         return true;
       }
-      String roomId = accessSession.getMatrixRoomId();
-      String requesterId = requester.getMatrixUserId();
+      String roomId = expiring.matrixRoomId();
+      String requesterId = expiring.requesterMatrixUserId();
       var membersBefore = matrixSynapseService.getRoomMembers(roomId);
       if (membersBefore.isPresent() && !membersBefore.get().contains(requesterId)) {
         return true;
       }
-      Consultant operator =
-          request.getPreviousConsultant() != null
-              ? request.getPreviousConsultant()
-              : accessSession.getConsultant();
-      if (operator == null || isBlank(operator.getMatrixUserId())) {
+      String operatorMatrixUserId =
+          expiring.previousConsultantMatrixUserId() != null
+              ? expiring.previousConsultantMatrixUserId()
+              : expiring.ownerMatrixUserId();
+      if (isBlank(operatorMatrixUserId)) {
         return false;
       }
-      String operatorToken =
-          matrixSynapseService.loginAsUserAccessToken(operator.getMatrixUserId());
+      String operatorToken = matrixSynapseService.loginAsUserAccessToken(operatorMatrixUserId);
       if (isBlank(operatorToken)) {
         return false;
       }
@@ -1878,7 +1985,7 @@ public class CaseHandoverService {
     } catch (RuntimeException exception) {
       log.warn(
           "Could not reconcile Matrix access for Case Handover request {}",
-          request.getId(),
+          expiring.requestId(),
           exception);
       return false;
     }
@@ -1889,6 +1996,24 @@ public class CaseHandoverService {
       return "de";
     }
     return session.getLanguageCode().name().toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * {@code Session.tenantId} is nullable, and a single-tenant deployment leaves it unset.
+   * CaseHandoverEmailNotification requires a tenant id for its committed snapshot, so passing null
+   * threw from inside the transactional grant - after the Matrix join, where rollback can no longer
+   * make the handover succeed. A handover must not fail because it could not address an e-mail; the
+   * mail is skipped and recorded instead.
+   */
+  private boolean hasMailTenant(Session session, String outcome) {
+    if (session != null && session.getTenantId() != null) {
+      return true;
+    }
+    log.warn(
+        "Case Handover {} mail skipped for session {}: the session has no tenant id",
+        outcome,
+        session == null ? null : session.getId());
+    return false;
   }
 
   private TenantData mailTenant(Session session) {
@@ -1902,7 +2027,7 @@ public class CaseHandoverService {
 
   private void notifyPendingConsent(CaseHandoverRequest request) {
     Session session = request.getSession();
-    if (effectiveAccessType(request) == AccessType.TAKEOVER) {
+    if (effectiveAccessType(request) == AccessType.TAKEOVER && hasMailTenant(session, "consent")) {
       caseHandoverEmailNotification.takeoverConsentRequested(
           request.getId(), session.getMatrixRoomId(), mailTenant(session));
     }

--- a/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolver.java
@@ -57,6 +57,15 @@ public class EmailBrandingResolver {
   /** Bound on distinct keys held, so a pathological tenant id space cannot grow this unbounded. */
   private static final int MAX_CACHE_ENTRIES = 1000;
 
+  /**
+   * The supported maximum for {@code email.branding.cache-ttl-seconds}. This is the configuration
+   * contract, not an arithmetic guard: the cache exists to collapse one batch, and source 2606d840
+   * removed the previous 24-hour cache because a logo change stayed invisible until it expired.
+   * Anything beyond a few minutes walks back that fix, so a larger configured value is clamped and
+   * reported rather than honoured. It also keeps the nanosecond conversion far below overflow.
+   */
+  private static final long MAX_CACHE_TTL_SECONDS = 300L;
+
   private final long cacheTtlNanos;
   private final Map<Long, CachedTenant> tenantCache = new ConcurrentHashMap<>();
 
@@ -67,7 +76,10 @@ public class EmailBrandingResolver {
    *     call. Must stay short: source 2606d840 removed the 24-hour tenant cache precisely because a
    *     logo change stayed invisible in mail until it expired. A few seconds keeps a branding save
    *     effectively immediate while a digest run of N consultants costs one call instead of N. Set
-   *     to 0 to disable caching entirely.
+   *     to 0 to disable caching entirely. Values above {@link #MAX_CACHE_TTL_SECONDS} are clamped
+   *     to it, so a mis-typed TTL (milliseconds pasted into a seconds field, say) can neither
+   *     overflow the nanosecond conversion into a negative value - which silently disabled the
+   *     cache - nor pin stale branding for hours.
    */
   @Autowired
   public EmailBrandingResolver(
@@ -82,7 +94,20 @@ public class EmailBrandingResolver {
     this.platformName = platformName;
     this.platformLogoUrl = platformLogoUrl;
     this.applicationBaseUrl = normalizeBaseUrl(applicationBaseUrl);
-    this.cacheTtlNanos = Math.max(0L, cacheTtlSeconds) * 1_000_000_000L;
+    this.cacheTtlNanos = boundedTtlSeconds(cacheTtlSeconds) * 1_000_000_000L;
+  }
+
+  /** Clamp before scaling, so the conversion below can never overflow into a negative TTL. */
+  private static long boundedTtlSeconds(long configuredSeconds) {
+    if (configuredSeconds > MAX_CACHE_TTL_SECONDS) {
+      log.warn(
+          "email.branding.cache-ttl-seconds={} exceeds the supported maximum of {}s and was clamped."
+              + " A longer branding cache delays tenant logo and colour changes in outgoing mail.",
+          configuredSeconds,
+          MAX_CACHE_TTL_SECONDS);
+      return MAX_CACHE_TTL_SECONDS;
+    }
+    return Math.max(0L, configuredSeconds);
   }
 
   /** Caching disabled: every resolve performs its own lookup. */

--- a/src/main/java/de/caritas/cob/userservice/api/service/notification/TenantSystemEmailDeliveryClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/notification/TenantSystemEmailDeliveryClient.java
@@ -7,13 +7,16 @@ import de.caritas.cob.userservice.api.service.email.OrisoEmailRenderer;
 import de.caritas.cob.userservice.api.service.httpheader.SecurityHeaderSupplier;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class TenantSystemEmailDeliveryClient {
   public enum Purpose {
@@ -57,7 +60,15 @@ public class TenantSystemEmailDeliveryClient {
         throw new IllegalStateException("Unexpected delivery status");
       return true;
     } catch (RuntimeException exception) {
-      // No cause: downstream bodies/SMTP replies must never enter async logs.
+      // The sanitized exception stays cause-free: downstream bodies and SMTP replies must never
+      // enter async logs. But discarding the cause entirely made a TenantService outage, an expired
+      // technical user and a serialization bug indistinguishable in production. Record the shape of
+      // the failure - type and HTTP status, never a response body - before throwing.
+      log.error(
+          "Tenant system email delivery to tenant {} for {} failed: {}",
+          tenantId,
+          purpose,
+          failureSummary(exception));
       throw new IllegalStateException("Tenant system email delivery unconfirmed");
     } finally {
       if (login != null && login.refreshToken() != null && !login.refreshToken().isBlank()) {
@@ -68,6 +79,14 @@ public class TenantSystemEmailDeliveryClient {
         }
       }
     }
+  }
+
+  /** Type and status only. A downstream body may quote the recipient address. */
+  static String failureSummary(RuntimeException exception) {
+    return exception.getClass().getSimpleName()
+        + (exception instanceof RestClientResponseException response
+            ? " HTTP " + response.getStatusCode().value()
+            : "");
   }
 
   record Delivery(

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -532,7 +532,7 @@
       "components": [
         "expireCoAccessSchedule"
       ],
-      "decision": "Claims a durable global two-minute lease before reading expired grants; expiry rows are pessimistically locked and confirmed Matrix removal precedes expired audit state. Finite lease expiry can permit overlap if work outlives its lease; external Matrix effects are not transactionally atomic, so this does not lift the replica ceiling.",
+      "decision": "Claims a durable global two-minute lease, then sweeps in bounded batches (case.handover.co-access-sweep-batch-size, capped by case.handover.co-access-sweep-max-batches). Matrix reconciliation runs with NO database transaction open; each outcome is persisted in its own short transaction under a row lock taken at write time, re-checking the grant is still GRANTED. Confirmed Matrix removal still precedes expired audit state. Finite lease expiry can permit overlap if work outlives its lease; external Matrix effects are not transactionally atomic, so this does not lift the replica ceiling.",
       "signals": [
         "userservice.scheduler.executions",
         "userservice.scheduler.duration"

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverOfferServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverOfferServiceTest.java
@@ -65,6 +65,10 @@ class CaseHandoverOfferServiceTest {
 
   @InjectMocks private CaseHandoverService caseHandoverService;
 
+  @Mock private CaseHandoverCoAccessExpiryStore coAccessExpiryStore;
+
+  @Mock private de.caritas.cob.userservice.api.tenant.TenantContextProvider tenantContextProvider;
+
   @Mock private CaseHandoverRequestRepository caseHandoverRequestRepository;
   @Mock private CaseHandoverReasonPolicyRepository caseHandoverReasonPolicyRepository;
   @Mock private SessionRepository sessionRepository;
@@ -119,6 +123,8 @@ class CaseHandoverOfferServiceTest {
 
     when(userAccountService.retrieveValidatedConsultant()).thenReturn(owner);
     when(sessionRepository.findById(123L)).thenReturn(Optional.of(session));
+    // createOffer locks the session row: the "one open offer per case" rule is a read-then-write.
+    when(sessionRepository.findByIdForUpdate(123L)).thenReturn(Optional.of(session));
     when(consultantRepository.findByIdAndDeleteDateIsNull("00000000-0000-0000-0000-000000000002"))
         .thenReturn(Optional.of(colleague));
     when(consultantRepository.findByIdAndDeleteDateIsNull("stranger"))

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -6,12 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,6 +95,9 @@ class CaseHandoverServiceTest {
   @Mock private MatrixSessionSystemMessageService matrixSessionSystemMessageService;
   @Mock private SessionSupervisorFacade sessionSupervisorFacade;
   @Mock private ScheduledTaskClaimService scheduledTaskClaimService;
+  @Mock private CaseHandoverCoAccessExpiryStore coAccessExpiryStore;
+
+  @Mock private de.caritas.cob.userservice.api.tenant.TenantContextProvider tenantContextProvider;
   @Spy private Clock clock = Clock.fixed(Instant.parse("2026-08-16T10:00:00Z"), ZoneOffset.UTC);
 
   private Consultant requester;
@@ -747,6 +753,21 @@ class CaseHandoverServiceTest {
     assertFalse(status.isCanViewContent());
   }
 
+  /** The sweep now reconciles Matrix on plain values and asks the store to persist the outcome. */
+  private CaseHandoverCoAccessExpiryStore.ExpiringCoAccess expiring(CaseHandoverRequest request) {
+    return new CaseHandoverCoAccessExpiryStore.ExpiringCoAccess(
+        request.getId(),
+        session.getId(),
+        session.getMatrixRoomId(),
+        requester.getId(),
+        requester.getMatrixUserId(),
+        session.getConsultant() == null ? null : session.getConsultant().getId(),
+        session.getConsultant() == null ? null : session.getConsultant().getMatrixUserId(),
+        previous.getMatrixUserId());
+  }
+
+  private static final LocalDateTime SWEEP_NOW = LocalDateTime.of(2026, 8, 16, 10, 0);
+
   @Test
   void expireCoAccess_persistsAuditStateUsingInjectedClock() {
     CaseHandoverRequest request = grantedAdviceRequest();
@@ -760,19 +781,17 @@ class CaseHandoverServiceTest {
     when(matrixSynapseService.removeUserFromRoom(
             "!room:matrix", "@requester:matrix", "previous-token"))
         .thenReturn(true);
-    when(caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            CaseHandoverRequest.Status.GRANTED,
-            CaseHandoverRequest.AccessType.CO_ACCESS,
-            LocalDateTime.of(2026, 8, 16, 10, 0)))
-        .thenReturn(List.of(request));
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+        .thenReturn(List.of(expiring(request)))
+        .thenReturn(List.of());
+    when(coAccessExpiryStore.markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED"))
+        .thenReturn(true);
 
     assertEquals(1, caseHandoverService.expireCoAccess());
 
-    assertEquals(CaseHandoverRequest.Status.EXPIRED, request.getStatus());
-    assertEquals("ACCESS_EXPIRED", request.getAuditOutcome());
     verify(matrixSynapseService)
         .removeUserFromRoom("!room:matrix", "@requester:matrix", "previous-token");
-    verify(caseHandoverRequestRepository).saveAll(List.of(request));
+    verify(coAccessExpiryStore).markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED");
   }
 
   @Test
@@ -782,26 +801,17 @@ class CaseHandoverServiceTest {
     requester.setMatrixUserId("@requester:matrix");
     previous.setMatrixUserId("@previous:matrix");
     session.setConsultant(requester);
-    when(matrixSynapseService.getRoomMembers("!room:matrix"))
-        .thenReturn(Optional.of(List.of("@requester:matrix")));
-    when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
-        .thenReturn("previous-token");
-    when(matrixSynapseService.removeUserFromRoom(
-            "!room:matrix", "@requester:matrix", "previous-token"))
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+        .thenReturn(List.of(expiring(request)))
+        .thenReturn(List.of());
+    when(coAccessExpiryStore.markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED"))
         .thenReturn(true);
-    when(caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            CaseHandoverRequest.Status.GRANTED,
-            CaseHandoverRequest.AccessType.CO_ACCESS,
-            LocalDateTime.of(2026, 8, 16, 10, 0)))
-        .thenReturn(List.of(request));
 
     assertEquals(1, caseHandoverService.expireCoAccess());
 
-    assertEquals(CaseHandoverRequest.Status.EXPIRED, request.getStatus());
-    assertEquals("ACCESS_EXPIRED", request.getAuditOutcome());
     assertEquals(requester, session.getConsultant());
     verify(matrixSynapseService, never()).removeUserFromRoom(anyString(), anyString(), anyString());
-    verify(caseHandoverRequestRepository).saveAll(List.of(request));
+    verify(coAccessExpiryStore).markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED");
   }
 
   @Test
@@ -814,16 +824,12 @@ class CaseHandoverServiceTest {
         .thenReturn(Optional.of(List.of("@requester:matrix")));
     when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
         .thenReturn("previous-token");
-    when(caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            CaseHandoverRequest.Status.GRANTED,
-            CaseHandoverRequest.AccessType.CO_ACCESS,
-            LocalDateTime.of(2026, 8, 16, 10, 0)))
-        .thenReturn(List.of(request));
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+        .thenReturn(List.of(expiring(request)));
 
     assertEquals(0, caseHandoverService.expireCoAccess());
 
-    assertEquals(CaseHandoverRequest.Status.GRANTED, request.getStatus());
-    verify(caseHandoverRequestRepository).saveAll(List.of());
+    verify(coAccessExpiryStore, never()).markExpired(any(), any(), anyString());
   }
 
   @Test
@@ -834,16 +840,30 @@ class CaseHandoverServiceTest {
     requester.setMatrixUserId("@requester:matrix");
     when(matrixSynapseService.getRoomMembers("!room:matrix"))
         .thenThrow(new IllegalStateException("Matrix unavailable"));
-    when(caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            CaseHandoverRequest.Status.GRANTED,
-            CaseHandoverRequest.AccessType.CO_ACCESS,
-            LocalDateTime.of(2026, 8, 16, 10, 0)))
-        .thenReturn(List.of(failingRequest));
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+        .thenReturn(List.of(expiring(failingRequest)));
 
     assertEquals(0, caseHandoverService.expireCoAccess());
 
-    assertEquals(CaseHandoverRequest.Status.GRANTED, failingRequest.getStatus());
-    verify(caseHandoverRequestRepository).saveAll(List.of());
+    verify(coAccessExpiryStore, never()).markExpired(any(), any(), anyString());
+  }
+
+  @Test
+  void expireCoAccess_stopsInsteadOfLoopingWhenAFullBatchKeepsFailing() {
+    // A row whose Matrix removal cannot be confirmed stays GRANTED, so a naive loop would re-read
+    // the same full page until the batch cap. The sweep must notice it has already tried them.
+    CaseHandoverRequest request = grantedAdviceRequest();
+    session.setMatrixRoomId("!room:matrix");
+    requester.setMatrixUserId("@requester:matrix");
+    when(matrixSynapseService.getRoomMembers("!room:matrix"))
+        .thenThrow(new IllegalStateException("Matrix unavailable"));
+    ReflectionTestUtils.setField(caseHandoverService, "coAccessSweepBatchSize", 1);
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+        .thenReturn(List.of(expiring(request)));
+
+    assertEquals(0, caseHandoverService.expireCoAccess());
+
+    verify(coAccessExpiryStore, times(2)).findExpiredBatch(eq(SWEEP_NOW), anyInt());
   }
 
   @Test
@@ -862,8 +882,8 @@ class CaseHandoverServiceTest {
         .thenReturn(false);
     try {
       caseHandoverService.expireCoAccessSchedule();
-      verify(caseHandoverRequestRepository, never())
-          .findByStatusAndAccessTypeAndExpiresAtLessThanEqual(any(), any(), any());
+      verify(coAccessExpiryStore, never()).findExpiredBatch(any(), anyInt());
+      verify(tenantContextProvider, never()).setTechnicalContextIfMultiTenancyIsEnabled();
       assertEquals(77L, TenantContext.getCurrentTenant());
     } finally {
       TenantContext.clear();
@@ -871,18 +891,16 @@ class CaseHandoverServiceTest {
   }
 
   @Test
-  void expiryScheduler_usesSharedLeaseAndTechnicalTenantContext() {
-    when(caseHandoverRequestRepository.findByStatusAndAccessTypeAndExpiresAtLessThanEqual(
-            any(), any(), any()))
-        .thenAnswer(
-            invocation -> {
-              assertEquals(TenantContext.TECHNICAL_TENANT_ID, TenantContext.getCurrentTenant());
-              return List.of();
-            });
+  void expiryScheduler_usesSharedLeaseAndTheTenantContextProvider() {
+    // Setting TECHNICAL_TENANT_ID unconditionally gave a single-tenant deployment a tenant context
+    // it has nowhere else; the provider is the no-op-when-disabled entry point the sibling offer
+    // scheduler already uses.
+    when(coAccessExpiryStore.findExpiredBatch(any(), anyInt())).thenReturn(List.of());
 
     caseHandoverService.expireCoAccessSchedule();
 
     verify(scheduledTaskClaimService).tryClaim(eq("case-handover-co-access-expiry"), any());
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
     assertNull(TenantContext.getCurrentTenant());
   }
 
@@ -929,9 +947,7 @@ class CaseHandoverServiceTest {
 
   @Test
   void searchCandidates_returnsMetadataOnlySameAgencyMatches() {
-    when(sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            List.of(10L), requester, List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE)))
-        .thenReturn(List.of(session));
+    givenCandidates(session);
 
     var response = caseHandoverService.searchCandidates("asker", 0, 15, false);
 
@@ -951,9 +967,7 @@ class CaseHandoverServiceTest {
     // display name stays a valid search term as well.
     previous.setDisplayName("Anna B.");
     previous.setInternalDisplayName("Standort Nord Team 7");
-    when(sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            List.of(10L), requester, List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE)))
-        .thenReturn(List.of(session));
+    givenCandidates(session);
 
     var internalNameResponse = caseHandoverService.searchCandidates("standort nord", 0, 15, false);
     var publicNameResponse = caseHandoverService.searchCandidates("anna b", 0, 15, false);
@@ -971,9 +985,7 @@ class CaseHandoverServiceTest {
     asker.setUsername(usernameTranscoder.encodeUsername("codexasker1782348153159"));
     previous.setUsername(usernameTranscoder.encodeUsername("codexcounselor20260625023940"));
     previous.setDisplayName(usernameTranscoder.encodeUsername("Codex Counselor"));
-    when(sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            List.of(10L), requester, List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE)))
-        .thenReturn(List.of(session));
+    givenCandidates(session);
 
     var askerResponse = caseHandoverService.searchCandidates("codexasker", 0, 15, false);
     var consultantResponse = caseHandoverService.searchCandidates("codexcounselor", 0, 15, false);
@@ -1061,11 +1073,36 @@ class CaseHandoverServiceTest {
     assertEquals("COUNSELLOR_ASKED_FOR_ADVICE", request.getReasonCode());
     assertEquals("Historical unchanged label", request.getReasonLabel());
     assertEquals("Historical unchanged authority", request.getPolicyAuthority());
-    verify(caseHandoverPolicyCacheService).getEffective(7L);
+    // Read twice now: once to resolve the effective reason, once to resolve the tenant-configured
+    // client wording, which this grant path previously ignored.
+    verify(caseHandoverPolicyCacheService, atLeastOnce()).getEffective(7L);
     verify(sessionRepository, never()).save(session);
     verify(caseHandoverEmailNotification, never())
         .ownershipGranted(any(), any(), any(), any(), any());
     verify(caseHandoverEmailNotification, never()).takeoverConsentRequested(any(), any(), any());
+  }
+
+  @Test
+  void grantingCoAccessUsesTheTenantConfiguredClientWordingNotTheBuiltInDefault() {
+    // The tenant template was loaded into the reason and stored, and
+    // resolveClientNotificationDescription existed to prefer it - but the grant path read the
+    // built-in defaults directly, so a Traeger that configured its own co-access wording never saw
+    // it. The fixture template is the one tenantPolicies() carries.
+    CaseHandoverRequest request = pendingConsentRequest();
+    when(caseHandoverRequestRepository.findByIdAndSessionId(88L, 123L))
+        .thenReturn(Optional.of(request));
+    when(caseHandoverPolicyCacheService.getEffective(7L))
+        .thenReturn(tenantPolicies("Rat benötigt", 180));
+
+    caseHandoverService.resolveClientConsent(123L, 88L, true);
+
+    ArgumentCaptor<String> text = ArgumentCaptor.forClass(String.class);
+    verify(eventNotificationService, atLeastOnce())
+        .createEvent(any(), any(), any(), any(), text.capture(), any(), any(), any(), any());
+    assertTrue(
+        text.getAllValues().stream()
+            .anyMatch(value -> value != null && value.contains("zeitlich begrenzt mitlesen")),
+        "the tenant-configured client wording must reach the notification");
   }
 
   @Test
@@ -1311,9 +1348,17 @@ class CaseHandoverServiceTest {
     return candidate;
   }
 
+  /**
+   * The database now narrows by agency and topic and the service loads that window by id. The
+   * department predicate still runs in the service, so these tests deliberately hand back rows the
+   * query might have over-fetched and assert the service drops them.
+   */
   private void givenCandidates(Session... candidates) {
-    when(sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            List.of(10L), requester, List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE)))
+    List<Long> ids = java.util.Arrays.stream(candidates).map(Session::getId).toList();
+    when(sessionRepository.findCaseHandoverCandidateIds(
+            any(), eq(requester), any(), anyBoolean(), any(), any()))
+        .thenReturn(ids);
+    when(sessionRepository.findCaseHandoverCandidatesWithTopics(ids))
         .thenReturn(List.of(candidates));
   }
 
@@ -1442,13 +1487,10 @@ class CaseHandoverServiceTest {
     secondAgency.setConsultant(requester);
     requester.setConsultantAgencies(Set.of(firstAgency, secondAgency));
     givenRequesterTopics(5L, 6L);
-    when(sessionRepository.findByAgencyIdInAndConsultantNotAndStatusInOrderByUpdateDateDesc(
-            any(), eq(requester), eq(List.of(SessionStatus.IN_PROGRESS, SessionStatus.DONE))))
-        .thenReturn(
-            List.of(
-                candidateSession(213L, 10L, 5L, false),
-                candidateSession(214L, 20L, 6L, true),
-                candidateSession(215L, 20L, 99L, false)));
+    givenCandidates(
+        candidateSession(213L, 10L, 5L, false),
+        candidateSession(214L, 20L, 6L, true),
+        candidateSession(215L, 20L, 99L, false));
 
     var response = caseHandoverService.searchCandidates("asker", 0, 15, false);
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/CaseHandoverServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -757,6 +756,7 @@ class CaseHandoverServiceTest {
   private CaseHandoverCoAccessExpiryStore.ExpiringCoAccess expiring(CaseHandoverRequest request) {
     return new CaseHandoverCoAccessExpiryStore.ExpiringCoAccess(
         request.getId(),
+        request.getExpiresAt(),
         session.getId(),
         session.getMatrixRoomId(),
         requester.getId(),
@@ -781,7 +781,7 @@ class CaseHandoverServiceTest {
     when(matrixSynapseService.removeUserFromRoom(
             "!room:matrix", "@requester:matrix", "previous-token"))
         .thenReturn(true);
-    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), any(), any(), anyInt()))
         .thenReturn(List.of(expiring(request)))
         .thenReturn(List.of());
     when(coAccessExpiryStore.markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED"))
@@ -801,7 +801,7 @@ class CaseHandoverServiceTest {
     requester.setMatrixUserId("@requester:matrix");
     previous.setMatrixUserId("@previous:matrix");
     session.setConsultant(requester);
-    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), any(), any(), anyInt()))
         .thenReturn(List.of(expiring(request)))
         .thenReturn(List.of());
     when(coAccessExpiryStore.markExpired(request.getId(), SWEEP_NOW, "ACCESS_EXPIRED"))
@@ -824,7 +824,7 @@ class CaseHandoverServiceTest {
         .thenReturn(Optional.of(List.of("@requester:matrix")));
     when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
         .thenReturn("previous-token");
-    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), any(), any(), anyInt()))
         .thenReturn(List.of(expiring(request)));
 
     assertEquals(0, caseHandoverService.expireCoAccess());
@@ -840,7 +840,7 @@ class CaseHandoverServiceTest {
     requester.setMatrixUserId("@requester:matrix");
     when(matrixSynapseService.getRoomMembers("!room:matrix"))
         .thenThrow(new IllegalStateException("Matrix unavailable"));
-    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), any(), any(), anyInt()))
         .thenReturn(List.of(expiring(failingRequest)));
 
     assertEquals(0, caseHandoverService.expireCoAccess());
@@ -849,21 +849,64 @@ class CaseHandoverServiceTest {
   }
 
   @Test
-  void expireCoAccess_stopsInsteadOfLoopingWhenAFullBatchKeepsFailing() {
-    // A row whose Matrix removal cannot be confirmed stays GRANTED, so a naive loop would re-read
-    // the same full page until the batch cap. The sweep must notice it has already tried them.
-    CaseHandoverRequest request = grantedAdviceRequest();
+  void expireCoAccess_reachesLaterGrantsWhenTheOldestBatchCannotBeReconciled() {
+    // The failure this guards: a row whose Matrix removal cannot be confirmed stays GRANTED. With
+    // page-zero paging it comes back at the head of every following read and starves the grants
+    // behind it. The cursor must step past it and still reconcile the later one.
+    CaseHandoverRequest failing = grantedAdviceRequest();
+    failing.setId(100L);
+    failing.setExpiresAt(SWEEP_NOW.minusMinutes(30));
     session.setMatrixRoomId("!room:matrix");
     requester.setMatrixUserId("@requester:matrix");
+    previous.setMatrixUserId("@previous:matrix");
+    ReflectionTestUtils.setField(caseHandoverService, "coAccessSweepBatchSize", 1);
+
+    var laterExpiring =
+        new CaseHandoverCoAccessExpiryStore.ExpiringCoAccess(
+            101L,
+            SWEEP_NOW.minusMinutes(10),
+            session.getId(),
+            "!later:matrix",
+            requester.getId(),
+            "@requester:matrix",
+            null,
+            null,
+            "@previous:matrix");
+
     when(matrixSynapseService.getRoomMembers("!room:matrix"))
         .thenThrow(new IllegalStateException("Matrix unavailable"));
-    ReflectionTestUtils.setField(caseHandoverService, "coAccessSweepBatchSize", 1);
-    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), anyInt()))
-        .thenReturn(List.of(expiring(request)));
+    when(matrixSynapseService.getRoomMembers("!later:matrix"))
+        .thenReturn(Optional.of(List.of("@requester:matrix")));
+    when(matrixSynapseService.loginAsUserAccessToken("@previous:matrix"))
+        .thenReturn("previous-token");
+    when(matrixSynapseService.removeUserFromRoom(
+            "!later:matrix", "@requester:matrix", "previous-token"))
+        .thenReturn(true);
+    when(coAccessExpiryStore.markExpired(101L, SWEEP_NOW, "ACCESS_EXPIRED")).thenReturn(true);
 
-    assertEquals(0, caseHandoverService.expireCoAccess());
+    when(coAccessExpiryStore.findExpiredBatch(eq(SWEEP_NOW), isNull(), isNull(), anyInt()))
+        .thenReturn(List.of(expiring(failing)));
+    when(coAccessExpiryStore.findExpiredBatch(
+            eq(SWEEP_NOW), eq(SWEEP_NOW.minusMinutes(30)), eq(100L), anyInt()))
+        .thenReturn(List.of(laterExpiring));
+    when(coAccessExpiryStore.findExpiredBatch(
+            eq(SWEEP_NOW), eq(SWEEP_NOW.minusMinutes(10)), eq(101L), anyInt()))
+        .thenReturn(List.of());
 
-    verify(coAccessExpiryStore, times(2)).findExpiredBatch(eq(SWEEP_NOW), anyInt());
+    assertEquals(1, caseHandoverService.expireCoAccess());
+
+    verify(coAccessExpiryStore, never()).markExpired(eq(100L), any(), anyString());
+    verify(coAccessExpiryStore).markExpired(101L, SWEEP_NOW, "ACCESS_EXPIRED");
+  }
+
+  @Test
+  void expirySchedulerEntrypointIsNotTransactional() throws Exception {
+    // A transaction opened here would be the one the store methods join, and its connection and
+    // row locks would stay held across every Matrix call.
+    var method = CaseHandoverService.class.getMethod("expireCoAccessSchedule");
+
+    assertNull(
+        method.getAnnotation(org.springframework.transaction.annotation.Transactional.class));
   }
 
   @Test
@@ -882,7 +925,7 @@ class CaseHandoverServiceTest {
         .thenReturn(false);
     try {
       caseHandoverService.expireCoAccessSchedule();
-      verify(coAccessExpiryStore, never()).findExpiredBatch(any(), anyInt());
+      verify(coAccessExpiryStore, never()).findExpiredBatch(any(), any(), any(), anyInt());
       verify(tenantContextProvider, never()).setTechnicalContextIfMultiTenancyIsEnabled();
       assertEquals(77L, TenantContext.getCurrentTenant());
     } finally {
@@ -895,7 +938,7 @@ class CaseHandoverServiceTest {
     // Setting TECHNICAL_TENANT_ID unconditionally gave a single-tenant deployment a tenant context
     // it has nowhere else; the provider is the no-op-when-disabled entry point the sibling offer
     // scheduler already uses.
-    when(coAccessExpiryStore.findExpiredBatch(any(), anyInt())).thenReturn(List.of());
+    when(coAccessExpiryStore.findExpiredBatch(any(), any(), any(), anyInt())).thenReturn(List.of());
 
     caseHandoverService.expireCoAccessSchedule();
 
@@ -1357,7 +1400,7 @@ class CaseHandoverServiceTest {
     List<Long> ids = java.util.Arrays.stream(candidates).map(Session::getId).toList();
     when(sessionRepository.findCaseHandoverCandidateIds(
             any(), eq(requester), any(), anyBoolean(), any(), any()))
-        .thenReturn(ids);
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(ids));
     when(sessionRepository.findCaseHandoverCandidatesWithTopics(ids))
         .thenReturn(List.of(candidates));
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/email/layout/EmailBrandingResolverTest.java
@@ -370,4 +370,25 @@ class EmailBrandingResolverTest {
     assertThat(cached.resolve(8L).brandName()).isEqualTo("Sued");
     assertThat(cached.resolve(7L).brandName()).isEqualTo("Nord");
   }
+
+  @Test
+  void anOverlargeTtlIsClampedInsteadOfOverflowingIntoNoCacheAtAll() {
+    // 9_223_372_037 seconds x 1e9 overflows a long and lands negative, which read as "TTL <= 0" and
+    // silently disabled the cache despite a positive configured value.
+    givenNoTemplateAttributes();
+    when(tenantService.getRestrictedTenantDataFresh(7L)).thenReturn(tenant("Nord", new Theming()));
+    var resolver =
+        new EmailBrandingResolver(
+            tenantService,
+            tenantTemplateSupplier,
+            "ORISO",
+            "",
+            "https://app.oriso.org",
+            9_223_372_037L);
+
+    resolver.resolve(7L);
+    resolver.resolve(7L);
+
+    verify(tenantService, times(1)).getRestrictedTenantDataFresh(7L);
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/notification/TenantSystemEmailDeliveryClientTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/notification/TenantSystemEmailDeliveryClientTest.java
@@ -150,4 +150,37 @@ class TenantSystemEmailDeliveryClientTest {
     verifyNoInteractions(identity);
     server.verify();
   }
+
+  @Test
+  void aFailedDeliveryRecordsTheFailureShapeWithoutTheDownstreamBody() {
+    // Discarding the cause entirely made a TenantService outage, an expired technical user and a
+    // serialization bug indistinguishable in production. The type and status must survive; the
+    // response body, which can quote the recipient address, must not.
+    server
+        .expect(requestTo("https://tenant.example.org/tenant/7/internal/system-email-deliveries"))
+        .andRespond(
+            withServerError()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body("synthetic-body-quoting advice.seeker@example.org"));
+
+    try (var logs =
+        de.caritas.cob.userservice.testutils.LogbackCaptor.forClass(
+            TenantSystemEmailDeliveryClient.class)) {
+      assertThatThrownBy(
+              () ->
+                  client.send(
+                      7L,
+                      TenantSystemEmailDeliveryClient.Purpose.SUPERVISOR_ADDED,
+                      "advice.seeker@example.org",
+                      email))
+          .isInstanceOf(IllegalStateException.class)
+          .hasNoCause();
+
+      assertThat(logs.messages(ch.qos.logback.classic.Level.ERROR)).hasSize(1);
+      var message = logs.messages(ch.qos.logback.classic.Level.ERROR).get(0);
+      assertThat(message).contains("HTTP 500").contains("SUPERVISOR_ADDED");
+      assertThat(message).doesNotContain("synthetic-body-quoting");
+      assertThat(logs.events()).allSatisfy(event -> assertThat(event.getThrowableProxy()).isNull());
+    }
+  }
 }


### PR DESCRIPTION
Targets `emails-v2` so the fixes land inside PR #1124. Follows #1132, which closed the first three.

Closes the **10 remaining Major findings** from the first CodeRabbit review plus the **1 Minor** from the re-review. #1124's `CHANGES_REQUESTED` should clear once this is merged and the bot re-runs there.

## Findings closed

| Finding | Where | What was wrong |
|---|---|---|
| Minor, Functional Correctness | `EmailBrandingResolver:85` | TTL overflowed above 9,223,372,036s and silently disabled the cache |
| Major, Stability | `TenantSystemEmailDeliveryClient:61` | cause discarded at both layers; outage, expired user and serialization bug indistinguishable |
| Major, Maintainability | `CaseHandoverService:1566` | scheduled sweep set `TECHNICAL_TENANT_ID` unconditionally |
| Major, Stability | `CaseHandoverEmailNotification:48` | null `Session.tenantId` threw *after* the Matrix join, failing a handover that had already happened |
| Major, Functional Correctness | `CaseHandoverService:1681` | tenant-configured client wording resolved, then discarded for the built-in default |
| Major, Data Integrity | `CaseHandoverService:675` | one-open-offer rule was an unlocked read-then-write |
| Major, Stability + Performance | `CaseHandoverService:1584`, `CaseHandoverRequestRepository:56` | Matrix round trips inside the expiry transaction, unbounded and locked |
| Major, Performance x2 | `CaseHandoverService:444`, `SessionRepository:110` | unbounded candidate read plus a lazy `sessionTopics` load per candidate |

## The three worth reading closely

**Expiry sweep.** Was one `@Transactional` method over an unbounded result set doing `getRoomMembers` + operator login + `removeUserFromRoom` per row — a hanging Synapse pinned a pooled connection and the row locks for the whole backlog. Now: bounded batch read in a short transaction, Matrix reconciliation with **no transaction open**, then each outcome persisted in its own short locked transaction that re-checks the row is still `GRANTED`. Confirmed removal still precedes `EXPIRED`.

The boundaries live in a new `CaseHandoverCoAccessExpiryStore` rather than extra methods on the service: a self-invocation would bypass the Spring proxy and run with no transaction at all, which is the same trap in a different shape. The reconciliation takes plain values, not entities, because reading an association off a detached entity is the failure that passes every mock-based test and then throws in production.

**Tenant client wording.** The template was loaded into the reason and stored, `resolveClientNotificationDescription` existed to prefer it, and the grant path read the defaults directly anyway. PMD reporting that method as unused was the tell. Now asserted end to end against the fixture template already in `tenantPolicies()`.

**Offer race.** No unique index was available — "an open PUSH offer" is a status predicate, not a column value — so the session row is locked for the transaction instead. Contention is scoped to the one case being offered.

## Two deliberate departures from the review

Both are about not trading correctness for tidiness. Happy to be overruled, but I'd want the reasoning addressed rather than the diff reshaped.

**`isInRequesterDepartment` stays in Java.** The review asked for the complete filter in the repository. That predicate is the least-privilege boundary (#202) and is covered by ten unit tests; moving it into JPQL would leave it verifiable only by an integration test. It is now a narrowing-then-enforcing pair — the query narrows by agency and topic, the Java predicate still decides — so a mistake in the JPQL can only over-fetch, never over-share.

**The free-text filter cannot move to SQL at all.** It matches decoded usernames and the internal display name with fallback (#996). Those values do not exist in the columns the database would have to search, because usernames are stored encoded. Moving the text search into SQL means changing how usernames are stored, which is a different change than this one. A bounded scan window replaces the unbounded read, and a filled window is logged rather than silently trimmed.

## Verification

```
mvn -o test                          4444 passing, 0 failures, 0 errors, 0 skipped
python3 -m unittest tests/ci          100 passing
```

Spotless passes. **Testcontainers ITs were not run locally** — no Docker on this machine — so the new JPQL is covered by CI's `required integration tests` and `mariadb-contract` jobs, not by anything I ran myself. That is the part of this change I would most want a reviewer's eyes on.

`replica-safety-components.json` is updated: the sweep's decision text described the old locking model.

## Reviewer test plan

- [ ] Expire several co-access grants with Synapse slow; confirm no long-held DB transaction and that each row is written individually.
- [ ] Kill Synapse mid-sweep; confirm unconfirmed rows stay `GRANTED` and the sweep terminates instead of re-reading the same page.
- [ ] Two concurrent `POST /users/case-handover/offers` for one session; confirm exactly one offer is created.
- [ ] Candidate search as a consultant with several departments; confirm the same results as before and no per-candidate topic queries in the SQL log.
- [ ] Configure a tenant co-access template; confirm the client notification uses it.

## Still open, and not code

`case_handover_reason_policy` on Dev holds the five legacy codes with `client_consent_required = 0` for all of them. Four of the five map to `TAKEOVER`. Someone should confirm that is the intended product state before handover is exercised in a real environment — no patch in this PR changes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved case-handover candidate search with bounded, paginated results and agency/topic filtering.
  * Added reliable processing for expired co-access grants, including retries and status validation.
  * Added tenant-specific notification wording.

* **Bug Fixes**
  * Prevented concurrent handover offers and unsafe cache-TTL overflow.
  * Improved email-delivery failure logging while protecting downstream response details.
  * Handover notifications no longer fail when tenant information is unavailable.

* **Tests**
  * Expanded coverage for expiry handling, tenant configuration, filtering, retries, caching, and email failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->