### PR TITLE
fix(calls): restore group tenant ownership and participant membership

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSessionRoomGateway.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSessionRoomGateway.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateRoomException
 import de.caritas.cob.userservice.api.exception.matrix.MatrixCreateUserException;
 import de.caritas.cob.userservice.api.exception.matrix.MatrixInviteUserException;
 import de.caritas.cob.userservice.api.port.out.SessionRoomGateway;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +44,8 @@ public class MatrixSessionRoomGateway implements SessionRoomGateway {
   @Override
   public String createUser(String username, String password, String displayName)
       throws MatrixCreateUserException {
-    var response = matrixSynapseService.createUser(username, password, displayName);
+    var response =
+        matrixSynapseService.createUser(encodeLocalpart(username), password, displayName);
     return response == null || response.getBody() == null ? null : response.getBody().getUserId();
   }
 
@@ -76,6 +78,27 @@ public class MatrixSessionRoomGateway implements SessionRoomGateway {
 
   @Override
   public String userIdFor(String localpart) {
-    return "@" + localpart + ":" + matrixConfig.getServerName();
+    return "@" + encodeLocalpart(localpart) + ":" + matrixConfig.getServerName();
+  }
+
+  /** Maps application usernames using the Matrix UTF-8 escaping convention. */
+  private static String encodeLocalpart(String username) {
+    var result = new StringBuilder();
+    for (byte value : username.getBytes(StandardCharsets.UTF_8)) {
+      int character = Byte.toUnsignedInt(value);
+      if (character >= 'A' && character <= 'Z') {
+        character += 'a' - 'A';
+      }
+      if ((character >= 'a' && character <= 'z')
+          || (character >= '0' && character <= '9')
+          || "_-./+".indexOf(character) >= 0) {
+        result.append((char) character);
+      } else {
+        result.append('=');
+        result.append(Character.forDigit(character >>> 4, 16));
+        result.append(Character.forDigit(character & 15, 16));
+      }
+    }
+    return result.toString();
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -21,6 +21,7 @@ import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -43,6 +44,7 @@ public class CreateChatFacade {
   private final @NonNull ConsultantRepository consultantRepository;
   private final @NonNull GroupChatParticipantRepository groupChatParticipantRepository;
   private final @NonNull de.caritas.cob.userservice.api.port.out.UserRepository userRepository;
+  private final @NonNull AgencySilentMembershipService consultantMembership;
 
   /**
    * Creates a group chat in MariaDB and Matrix.
@@ -140,13 +142,13 @@ public class CreateChatFacade {
       String roomName = chatDTO.getTopic();
       String roomAlias = "group_chat_" + sessionId;
 
-      if (consultant.getMatrixUserId() == null || consultant.getMatrixUserId().isBlank()) {
+      String ownerMatrixUserId = consultantMembership.ensureMatrixAccount(consultant);
+      if (ownerMatrixUserId == null || ownerMatrixUserId.isBlank()) {
         throw new InternalServerErrorException("Consultant does not have Matrix credentials");
       }
 
       var matrixResponse =
-          matrixSynapseService.createRoomAsMatrixUser(
-              roomName, roomAlias, consultant.getMatrixUserId());
+          matrixSynapseService.createRoomAsMatrixUser(roomName, roomAlias, ownerMatrixUserId);
 
       matrixRoomId = matrixResponse.getBody().getRoomId();
       log.info("Created Matrix room: {} for group chat session: {}", matrixRoomId, sessionId);
@@ -160,8 +162,7 @@ public class CreateChatFacade {
       createChatAgencyRelation(chat, agencyId);
 
       // Get consultant token for inviting others
-      String consultantToken =
-          matrixSynapseService.loginAsUserAccessToken(consultant.getMatrixUserId());
+      String consultantToken = matrixSynapseService.loginAsUserAccessToken(ownerMatrixUserId);
       if (consultantToken == null) {
         throw new InternalServerErrorException("Could not create Matrix token for consultant");
       }
@@ -175,6 +176,7 @@ public class CreateChatFacade {
       groupChatParticipantRepository.save(creatorParticipant);
       log.info("Added creator consultant {} to group_chat_participant", consultant.getId());
 
+      int joinedParticipants = 1;
       // Invite and auto-join all selected consultants
       for (String participantId : participantIds) {
         try {
@@ -184,16 +186,10 @@ public class CreateChatFacade {
             continue;
           }
 
-          // Invite to Matrix room
-          matrixSynapseService.inviteUserToRoom(
-              matrixRoomId, participant.getMatrixUserId(), consultantToken);
-
-          // Auto-join the participant
-          String participantToken =
-              matrixSynapseService.loginAsUserAccessToken(participant.getMatrixUserId());
-          if (participantToken != null) {
-            matrixSynapseService.joinRoom(matrixRoomId, participantToken);
-            log.info("Consultant {} joined group chat room: {}", participantId, matrixRoomId);
+          if (!consultantMembership.joinConsultantIntoRoom(
+              participant, matrixRoomId, consultantToken)) {
+            log.warn("Consultant {} did not join group chat {}", participantId, matrixRoomId);
+            continue;
           }
 
           // Save participant in group_chat_participant table (for querying who's in the group)
@@ -203,6 +199,7 @@ public class CreateChatFacade {
           gcp.setRole(GroupChatParticipant.ParticipantRole.CO_MODERATOR);
           gcp.setConsultantId(participantId);
           groupChatParticipantRepository.save(gcp);
+          joinedParticipants++;
 
         } catch (Exception e) {
           log.error(
@@ -217,7 +214,7 @@ public class CreateChatFacade {
           sessionId,
           chatId,
           matrixRoomId,
-          participantIds.size() + 1); // +1 for creator
+          joinedParticipants);
 
       return new CreateChatResponseDTO()
           .matrixRoomId(matrixRoomId)

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -89,6 +89,7 @@ public class CreateChatFacade {
     // Create a session for the group (needed for backend logic)
     Session session = new Session();
     session.setConsultant(consultant);
+    session.setTenantId(consultant.getTenantId());
 
     // Use a tenant-scoped system user for group chats (user_id is NOT NULL in database).
     var systemUser = resolveOrCreateGroupChatSystemUser(consultant);

--- a/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/CreateChatFacade.java
@@ -7,6 +7,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.web.dto.AgencyDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateChatResponseDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.ChatAgency;
@@ -25,6 +26,7 @@ import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipServ
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +89,27 @@ public class CreateChatFacade {
     List<String> participantIds =
         chatDTO.getConsultantIds() == null ? List.of() : chatDTO.getConsultantIds();
     Long agencyId = resolveAgencyId(chatDTO, consultant);
+    List<Consultant> participants =
+        participantIds.stream()
+            .distinct()
+            .filter(id -> !Objects.equals(id, consultant.getId()))
+            .map(
+                id -> {
+                  if (id == null || id.isBlank()) {
+                    throw new BadRequestException("Invalid selected consultant");
+                  }
+                  Consultant participant =
+                      consultantRepository
+                          .findByIdAndDeleteDateIsNull(id)
+                          .orElseThrow(
+                              () -> new BadRequestException("Selected consultant is not active"));
+                  if (consultant.getTenantId() == null
+                      || !Objects.equals(consultant.getTenantId(), participant.getTenantId())) {
+                    throw new BadRequestException("Selected consultant belongs to another tenant");
+                  }
+                  return participant;
+                })
+            .toList();
 
     // Create a session for the group (needed for backend logic)
     Session session = new Session();
@@ -178,34 +201,19 @@ public class CreateChatFacade {
 
       int joinedParticipants = 1;
       // Invite and auto-join all selected consultants
-      for (String participantId : participantIds) {
-        try {
-          Consultant participant = consultantRepository.findById(participantId).orElse(null);
-          if (participant == null) {
-            log.warn("Consultant {} not found, skipping", participantId);
-            continue;
-          }
-
-          if (!consultantMembership.joinConsultantIntoRoom(
-              participant, matrixRoomId, consultantToken)) {
-            log.warn("Consultant {} did not join group chat {}", participantId, matrixRoomId);
-            continue;
-          }
-
-          // Save participant in group_chat_participant table (for querying who's in the group)
-          GroupChatParticipant gcp = new GroupChatParticipant();
-          gcp.setChatId(sessionId); // Link to session ID
-          gcp.setSeriesId(chatId);
-          gcp.setRole(GroupChatParticipant.ParticipantRole.CO_MODERATOR);
-          gcp.setConsultantId(participantId);
-          groupChatParticipantRepository.save(gcp);
-          joinedParticipants++;
-
-        } catch (Exception e) {
-          log.error(
-              "Failed to invite consultant {} to group chat: {}", participantId, e.getMessage());
-          // Continue with other participants
+      for (Consultant participant : participants) {
+        if (!consultantMembership.joinConsultantIntoRoom(
+            participant, matrixRoomId, consultantToken)) {
+          throw new InternalServerErrorException(
+              "Selected consultant could not join the group chat");
         }
+        GroupChatParticipant gcp = new GroupChatParticipant();
+        gcp.setChatId(sessionId);
+        gcp.setSeriesId(chatId);
+        gcp.setRole(GroupChatParticipant.ParticipantRole.CO_MODERATOR);
+        gcp.setConsultantId(participant.getId());
+        groupChatParticipantRepository.save(gcp);
+        joinedParticipants++;
       }
 
       log.info(

--- a/src/main/java/de/caritas/cob/userservice/api/service/TenantHibernateInterceptor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/TenantHibernateInterceptor.java
@@ -8,10 +8,12 @@ import org.hibernate.type.Type;
 /** Stamps newly persisted records without reassigning existing tenant ownership. */
 public class TenantHibernateInterceptor implements Interceptor {
   @Override
-  public boolean onPersist(Object entity, Object id, Object[] state,
-      String[] propertyNames, Type[] types) {
-    if (!(entity instanceof TenantAware owned) || owned.getTenantId() != null
-        || !TenantContext.contextIsSet() || TenantContext.isTechnicalOrSuperAdminContext()) {
+  public boolean onPersist(
+      Object entity, Object id, Object[] state, String[] propertyNames, Type[] types) {
+    if (!(entity instanceof TenantAware owned)
+        || owned.getTenantId() != null
+        || !TenantContext.contextIsSet()
+        || TenantContext.isTechnicalOrSuperAdminContext()) {
       return false;
     }
     for (int index = 0; index < propertyNames.length; index++) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/TenantHibernateInterceptor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/TenantHibernateInterceptor.java
@@ -2,30 +2,26 @@ package de.caritas.cob.userservice.api.service;
 
 import de.caritas.cob.userservice.api.model.TenantAware;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
-import java.util.Iterator;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.hibernate.EmptyInterceptor;
-import org.springframework.stereotype.Service;
+import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class TenantHibernateInterceptor extends EmptyInterceptor {
-
+/** Stamps newly persisted records without reassigning existing tenant ownership. */
+public class TenantHibernateInterceptor implements Interceptor {
   @Override
-  public void preFlush(Iterator entities) {
-    Object entity;
-    while (entities.hasNext()) {
-      entity = entities.next();
-      if (entity instanceof TenantAware) {
-        var tenantAware = (TenantAware) entity;
-        if (tenantAware.getTenantId() == null && !TenantContext.isTechnicalOrSuperAdminContext()) {
-          ((TenantAware) entity).setTenantId(TenantContext.getCurrentTenant());
-        }
+  public boolean onPersist(Object entity, Object id, Object[] state,
+      String[] propertyNames, Type[] types) {
+    if (!(entity instanceof TenantAware owned) || owned.getTenantId() != null
+        || !TenantContext.contextIsSet() || TenantContext.isTechnicalOrSuperAdminContext()) {
+      return false;
+    }
+    for (int index = 0; index < propertyNames.length; index++) {
+      if ("tenantId".equals(propertyNames[index])) {
+        Long tenantId = TenantContext.getCurrentTenant();
+        owned.setTenantId(tenantId);
+        state[index] = tenantId;
+        return true;
       }
     }
-
-    super.preFlush(entities);
+    return false;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
@@ -4,15 +4,15 @@ import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestExceptio
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.model.Chat;
+import de.caritas.cob.userservice.api.model.Consultant;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant;
 import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole;
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
-import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
-import de.caritas.cob.userservice.api.model.Consultant;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -92,7 +92,6 @@ public class GroupChatParticipantReconciliationService {
         throw new InternalServerErrorException(
             "Consultant " + consultantId + " could not join the Matrix room");
       }
-
     }
 
     for (var consultantId : desiredIds) {
@@ -124,6 +123,5 @@ public class GroupChatParticipantReconciliationService {
         participantRepository.delete(existing);
       }
     }
-
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
@@ -9,6 +9,7 @@ import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -26,6 +27,7 @@ public class GroupChatParticipantReconciliationService {
   private final GroupChatParticipantRepository participantRepository;
   private final ConsultantRepository consultantRepository;
   private final GroupChatMembershipService membershipService;
+  private final AgencySilentMembershipService consultantMembership;
 
   /**
    * Reconciles co-moderators only when the client explicitly supplies {@code consultantIds}. A null
@@ -91,7 +93,13 @@ public class GroupChatParticipantReconciliationService {
       if (!Objects.equals(series.getChatOwner().getTenantId(), consultant.getTenantId())) {
         throw new BadRequestException("Consultant does not belong to the chat owner's tenant");
       }
-      if (!membershipService.addMemberToRoom(series, consultant.getMatrixUserId())) {
+      var matrixUserId = consultant.getMatrixUserId();
+      if (matrixUserId == null || matrixUserId.isBlank()) {
+        matrixUserId = consultantMembership.ensureMatrixAccount(consultant);
+      }
+      if (matrixUserId == null
+          || matrixUserId.isBlank()
+          || !membershipService.addMemberToRoom(series, matrixUserId)) {
         throw new InternalServerErrorException(
             "Consultant " + consultantId + " could not join the Matrix room");
       }

--- a/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationService.java
@@ -11,6 +11,8 @@ import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
 import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
+import de.caritas.cob.userservice.api.model.Consultant;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -53,6 +55,63 @@ public class GroupChatParticipantReconciliationService {
                     Function.identity(),
                     (left, right) -> left));
 
+    var sessionId =
+        participants.stream()
+            .map(GroupChatParticipant::getChatId)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new ConflictException(
+                        "Chat Series has no owner participation and cannot be updated"));
+
+    // Validate the whole selection before changing any external room membership.
+    var selectedConsultants = new LinkedHashMap<String, Consultant>();
+    for (var consultantId : desiredIds) {
+      var consultant =
+          consultantRepository
+              .findByIdAndDeleteDateIsNull(consultantId)
+              .orElseThrow(
+                  () -> new BadRequestException("Consultant " + consultantId + " does not exist"));
+      if (!Objects.equals(series.getChatOwner().getTenantId(), consultant.getTenantId())) {
+        throw new BadRequestException("Consultant does not belong to the chat owner's tenant");
+      }
+      selectedConsultants.put(consultantId, consultant);
+    }
+
+    // Existing database rows do not prove Matrix membership: retry the join too.
+    // Complete joins before removing anyone, so a failed replacement keeps existing access.
+    for (var consultant : selectedConsultants.values()) {
+      var consultantId = consultant.getId();
+      var matrixUserId = consultant.getMatrixUserId();
+      if (matrixUserId == null || matrixUserId.isBlank()) {
+        matrixUserId = consultantMembership.ensureMatrixAccount(consultant);
+      }
+      if (matrixUserId == null
+          || matrixUserId.isBlank()
+          || !membershipService.addMemberToRoom(series, matrixUserId)) {
+        throw new InternalServerErrorException(
+            "Consultant " + consultantId + " could not join the Matrix room");
+      }
+
+    }
+
+    for (var consultantId : desiredIds) {
+      var existing = participantsByConsultantId.get(consultantId);
+      if (existing != null) {
+        if (existing.getRole() == ParticipantRole.PARTICIPANT) {
+          existing.setRole(ParticipantRole.CO_MODERATOR);
+          participantRepository.save(existing);
+        }
+        continue;
+      }
+      participantRepository.save(
+          GroupChatParticipant.builder()
+              .chatId(sessionId)
+              .seriesId(series.getId())
+              .consultantId(consultantId)
+              .role(ParticipantRole.CO_MODERATOR)
+              .build());
+    }
     for (var existing : participants) {
       if (existing.getRole() == ParticipantRole.CO_MODERATOR
           && !desiredIds.contains(existing.getConsultantId())) {
@@ -66,51 +125,5 @@ public class GroupChatParticipantReconciliationService {
       }
     }
 
-    var sessionId =
-        participants.stream()
-            .map(GroupChatParticipant::getChatId)
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new ConflictException(
-                        "Chat Series has no owner participation and cannot be updated"));
-
-    for (var consultantId : desiredIds) {
-      var existing = participantsByConsultantId.get(consultantId);
-      if (existing != null) {
-        if (existing.getRole() == ParticipantRole.PARTICIPANT) {
-          existing.setRole(ParticipantRole.CO_MODERATOR);
-          participantRepository.save(existing);
-        }
-        continue;
-      }
-
-      var consultant =
-          consultantRepository
-              .findByIdAndDeleteDateIsNull(consultantId)
-              .orElseThrow(
-                  () -> new BadRequestException("Consultant " + consultantId + " does not exist"));
-      if (!Objects.equals(series.getChatOwner().getTenantId(), consultant.getTenantId())) {
-        throw new BadRequestException("Consultant does not belong to the chat owner's tenant");
-      }
-      var matrixUserId = consultant.getMatrixUserId();
-      if (matrixUserId == null || matrixUserId.isBlank()) {
-        matrixUserId = consultantMembership.ensureMatrixAccount(consultant);
-      }
-      if (matrixUserId == null
-          || matrixUserId.isBlank()
-          || !membershipService.addMemberToRoom(series, matrixUserId)) {
-        throw new InternalServerErrorException(
-            "Consultant " + consultantId + " could not join the Matrix room");
-      }
-
-      participantRepository.save(
-          GroupChatParticipant.builder()
-              .chatId(sessionId)
-              .seriesId(series.getId())
-              .consultantId(consultantId)
-              .role(ParticipantRole.CO_MODERATOR)
-              .build());
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContextResolver.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcPolicyContextResolver.java
@@ -57,7 +57,8 @@ class MatrixRtcPolicyContextResolver {
         || (conversationType == null
             && session.getRegistrationType() == Session.RegistrationType.ANONYMOUS)) {
       chatType = MatrixRtcPolicyContext.ChatType.ANONYMOUS;
-    } else if (conversationType == ConversationType.INTERNAL_GROUP) {
+    } else if (conversationType == ConversationType.INTERNAL_GROUP
+        || conversationType == ConversationType.SELF_HELP) {
       chatType = MatrixRtcPolicyContext.ChatType.GROUP;
     } else {
       chatType = MatrixRtcPolicyContext.ChatType.ONE_ON_ONE;

--- a/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/session/AgencySilentMembershipService.java
@@ -140,9 +140,9 @@ public class AgencySilentMembershipService {
    * Counsellor Matrix accounts are provisioned lazily elsewhere (on accept, or on direct-session
    * creation), so a counsellor who has never handled a case yet has none. Without one they cannot
    * be a room member and the enquiry stays invisible to them, which is the very bug being fixed —
-   * so provision here too.
+   * so provision here too. Group-room creators use this before their first room exists.
    */
-  private String ensureMatrixAccount(Consultant consultant) {
+  public String ensureMatrixAccount(Consultant consultant) {
     if (!isBlank(consultant.getMatrixUserId())) {
       return consultant.getMatrixUserId();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -303,7 +303,7 @@ keycloak.cors=false
 
 # ---------------- Multitenancy ----------------
 multitenancy.enabled=false
-spring.jpa.properties.hibernate.ejb.interceptor=de.caritas.cob.userservice.api.service.TenantHibernateInterceptor
+spring.jpa.properties.hibernate.session_factory.interceptor=de.caritas.cob.userservice.api.service.TenantHibernateInterceptor
 hibernate.current_session_context_class=org.hibernate.context.internal.ThreadLocalSessionContext
 
 # ---------------- Appointments & Features ----------------

--- a/src/main/resources/db/changelog/changeset/0091_group_session_tenant/0091_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0091_group_session_tenant/0091_changeSet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+ <changeSet id="0091-group-session-tenant" author="frank">
+  <sqlFile path="db/changelog/changeset/0091_group_session_tenant/migrate.sql"
+   relativeToChangelogFile="false" splitStatements="true" stripComments="true"/>
+  <!-- Forward-only data repair: resetting legitimate ownership would reintroduce denied calls. -->
+ </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0091_group_session_tenant/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0091_group_session_tenant/migrate.sql
@@ -1,0 +1,13 @@
+-- Only synthetic group sessions with an unambiguous consultant owner are repaired.
+-- Existing ownership and human-owned sessions must never be reassigned.
+UPDATE session
+SET tenant_id = (SELECT c.tenant_id FROM consultant c WHERE c.consultant_id = session.consultant_id)
+WHERE tenant_id IS NULL
+  AND conversation_type IN ('SELF_HELP', 'INTERNAL_GROUP')
+  AND EXISTS (
+    SELECT 1 FROM consultant c
+    WHERE c.consultant_id = session.consultant_id
+      AND c.tenant_id > 0
+      AND (session.user_id = 'group-chat-system'
+        OR session.user_id = CONCAT('group-chat-system-', c.tenant_id))
+  );

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -168,6 +168,8 @@
   <include
     file="db/changelog/changeset/0090_session_consented_legal_version/0090_changeSet.xml" />
 
+  <include file="db/changelog/changeset/0091_group_session_tenant/0091_changeSet.xml" />
+
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->
   <include

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSessionRoomGatewayTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/matrix/MatrixSessionRoomGatewayTest.java
@@ -8,6 +8,8 @@ import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomRespon
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateUserResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -62,6 +64,27 @@ class MatrixSessionRoomGatewayTest {
     when(matrixConfig.getServerName()).thenReturn("matrix.example.org");
 
     assertThat(gateway.userIdFor("consultant")).isEqualTo("@consultant:matrix.example.org");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "bart.simpson@dreambau.com,bart.simpson=40dreambau.com",
+    "Bart.Simpson@Dreambau.com,bart.simpson=40dreambau.com",
+    "bart.simpson=40dreambau.com,bart.simpson=3d40dreambau.com",
+    "jürgen@example.org,j=c3=bcrgen=40example.org",
+    "ordinary_user-1.2/+,ordinary_user-1.2/+"
+  })
+  void shouldUseTheSameSafeIdentityForProvisioningAndExistingAccountLookup(
+      String username, String expectedLocalpart) throws Exception {
+    when(matrixConfig.getServerName()).thenReturn("matrix.example.org");
+    var expectedId = "@" + expectedLocalpart + ":matrix.example.org";
+    var body = new MatrixCreateUserResponseDTO();
+    body.setUserId(expectedId);
+    when(matrixSynapseService.createUser(expectedLocalpart, "password", "Consultant"))
+        .thenReturn(ResponseEntity.ok(body));
+
+    assertThat(gateway.createUser(username, "password", "Consultant")).isEqualTo(expectedId);
+    assertThat(gateway.userIdFor(username)).isEqualTo(expectedId);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatMatrixMembershipTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatMatrixMembershipTest.java
@@ -77,7 +77,7 @@ class CreateChatMatrixMembershipTest {
     when(agencies.getAgency(12L)).thenReturn(AGENCY_DTO_KREUZBUND);
     when(converter.convertToEntity(any(), any(), any())).thenReturn(chat);
     when(users.findByUserIdAndDeleteDateIsNull(any())).thenReturn(Optional.of(new User()));
-    when(consultants.findById("colleague")).thenReturn(Optional.of(colleague));
+    when(consultants.findByIdAndDeleteDateIsNull("colleague")).thenReturn(Optional.of(colleague));
     var room = new MatrixCreateRoomResponseDTO();
     room.setRoomId("!group:matrix.org");
     when(matrix.createRoomAsMatrixUser(any(), any(), any())).thenReturn(ResponseEntity.ok(room));

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatMatrixMembershipTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatMatrixMembershipTest.java
@@ -1,0 +1,113 @@
+package de.caritas.cob.userservice.api.facade;
+
+import static de.caritas.cob.userservice.api.testHelper.TestConstants.AGENCY_DTO_KREUZBUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
+import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
+import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
+import de.caritas.cob.userservice.api.helper.ConsultantDisplayNameResolver;
+import de.caritas.cob.userservice.api.helper.UserHelper;
+import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
+import de.caritas.cob.userservice.api.model.*;
+import de.caritas.cob.userservice.api.port.out.*;
+import de.caritas.cob.userservice.api.service.ChatService;
+import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
+import de.caritas.cob.userservice.api.service.session.SessionService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.ResponseEntity;
+
+class CreateChatMatrixMembershipTest {
+  @ParameterizedTest
+  @CsvSource({"SELF_HELP,false", "INTERNAL_GROUP,false", "SELF_HELP,true", "INTERNAL_GROUP,true"})
+  void selectedColleagueWithoutMatrixMappingIsProvisionedAndJoined(
+      ConversationType type, boolean newOwner) throws Exception {
+    var chats = mock(ChatService.class);
+    var sessions = mock(SessionService.class);
+    var agencies = mock(AgencyService.class);
+    var converter = mock(ChatConverter.class);
+    var matrix = mock(MatrixSynapseService.class);
+    var consultants = mock(ConsultantRepository.class);
+    var participants = mock(GroupChatParticipantRepository.class);
+    var users = mock(UserRepository.class);
+    var gateway = mock(SessionRoomGateway.class);
+    var helper = mock(UserHelper.class);
+    var transcoder = mock(UsernameTranscoder.class);
+    var names = mock(ConsultantDisplayNameResolver.class);
+    var membership =
+        new AgencySilentMembershipService(consultants, gateway, helper, transcoder, names);
+    var facade =
+        new CreateChatFacade(
+            chats,
+            sessions,
+            agencies,
+            converter,
+            matrix,
+            consultants,
+            participants,
+            users,
+            membership);
+    var owner = new Consultant();
+    owner.setId("owner");
+    owner.setTenantId(40L);
+    owner.setUsername("encoded-owner");
+    owner.setMatrixUserId(newOwner ? null : "@owner:matrix.org");
+    var colleague = new Consultant();
+    colleague.setId("colleague");
+    colleague.setTenantId(40L);
+    colleague.setUsername("encoded-colleague");
+    var chat = new Chat();
+    chat.setId(300L);
+    chat.setConversationType(type);
+    var session = new Session();
+    session.setId(200L);
+    session.setCreateDate(java.time.LocalDateTime.of(2026, 9, 9, 12, 0));
+    var dto = mock(ChatDTO.class);
+    when(dto.getConsultantIds()).thenReturn(List.of("colleague"));
+    when(dto.getAgencyId()).thenReturn(12L);
+    when(dto.getTopic()).thenReturn("Call membership regression");
+    when(chats.saveChat(any())).thenReturn(chat);
+    when(sessions.saveSession(any())).thenReturn(session);
+    when(agencies.getAgency(12L)).thenReturn(AGENCY_DTO_KREUZBUND);
+    when(converter.convertToEntity(any(), any(), any())).thenReturn(chat);
+    when(users.findByUserIdAndDeleteDateIsNull(any())).thenReturn(Optional.of(new User()));
+    when(consultants.findById("colleague")).thenReturn(Optional.of(colleague));
+    var room = new MatrixCreateRoomResponseDTO();
+    room.setRoomId("!group:matrix.org");
+    when(matrix.createRoomAsMatrixUser(any(), any(), any())).thenReturn(ResponseEntity.ok(room));
+    when(matrix.loginAsUserAccessToken("@owner:matrix.org")).thenReturn("owner-test-token");
+    when(transcoder.decodeUsername("encoded-colleague")).thenReturn("colleague");
+    when(names.resolveMatrixDisplayName(colleague)).thenReturn("Colleague");
+    when(helper.getRandomPassword()).thenReturn("generated-test-password");
+    when(transcoder.decodeUsername("encoded-owner")).thenReturn("owner");
+    when(names.resolveMatrixDisplayName(owner)).thenReturn("Owner");
+    when(gateway.createUser("owner", "generated-test-password", "Owner"))
+        .thenReturn("@owner:matrix.org");
+    when(gateway.createUser("colleague", "generated-test-password", "Colleague"))
+        .thenReturn("@colleague:matrix.org");
+    when(gateway.loginAsUser("@colleague:matrix.org")).thenReturn("colleague-test-token");
+    when(gateway.joinRoom("!group:matrix.org", "colleague-test-token")).thenReturn(true);
+
+    facade.createChatV2(dto, owner);
+
+    assertThat(colleague.getMatrixUserId()).isEqualTo("@colleague:matrix.org");
+    verify(consultants).save(colleague);
+    assertThat(owner.getMatrixUserId()).isEqualTo("@owner:matrix.org");
+    if (newOwner) verify(consultants).save(owner);
+    else verify(consultants, never()).save(owner);
+    verify(gateway).inviteUser("!group:matrix.org", "@colleague:matrix.org", "owner-test-token");
+    verify(gateway).joinRoom("!group:matrix.org", "colleague-test-token");
+    verify(participants)
+        .save(
+            argThat(
+                p ->
+                    "colleague".equals(p.getConsultantId())
+                        && p.getRole() == GroupChatParticipant.ParticipantRole.CO_MODERATOR));
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -16,6 +16,7 @@ import de.caritas.cob.userservice.api.adapters.matrix.MatrixSynapseService;
 import de.caritas.cob.userservice.api.adapters.matrix.dto.MatrixCreateRoomResponseDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.ChatDTO;
 import de.caritas.cob.userservice.api.adapters.web.dto.CreateChatResponseDTO;
+import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.model.Chat;
 import de.caritas.cob.userservice.api.model.Consultant;
@@ -94,7 +95,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     when(userRepository.findByUserIdAndDeleteDateIsNull(any())).thenReturn(Optional.of(systemUser));
 
     when(agencyService.getAgency(any())).thenReturn(AGENCY_DTO_KREUZBUND);
-    when(consultantRepository.findById(any())).thenReturn(Optional.empty());
+    when(consultantRepository.findByIdAndDeleteDateIsNull(any())).thenReturn(Optional.empty());
   }
 
   @org.junit.jupiter.params.ParameterizedTest
@@ -134,12 +135,13 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void createChatV1_Should_UseMatrixFlow_When_ConsultantIdsArePresent() throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
+  void createChatV1_Should_UseMatrixFlow_When_SelectionIsEmpty() throws Exception {
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room-id:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("token-123");
-    when(consultantRepository.findById("participant-1")).thenReturn(Optional.empty());
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-1"))
+        .thenReturn(Optional.empty());
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     createChatFacade.createChatV1(chatDto, consultant);
@@ -148,12 +150,13 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
-  void createChatV2_Should_UseMatrixFlow_When_ConsultantIdsArePresent() throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
+  void createChatV2_Should_UseMatrixFlow_When_SelectionIsEmpty() throws Exception {
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room-id:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("token-123");
-    when(consultantRepository.findById("participant-1")).thenReturn(Optional.empty());
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-1"))
+        .thenReturn(Optional.empty());
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     createChatFacade.createChatV2(chatDto, consultant);
@@ -173,8 +176,11 @@ class CreateChatSimplifiedGroupChatFacadeTest {
         .thenReturn(matrixRoomResponse(matrixRoomId));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
     Consultant participant = mock(Consultant.class);
+    when(participant.getId()).thenReturn("participant-1");
+    when(participant.getTenantId()).thenReturn(1L);
     when(participant.getMatrixUserId()).thenReturn("@participant:matrix.org");
-    when(consultantRepository.findById("participant-1")).thenReturn(Optional.of(participant));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-1"))
+        .thenReturn(Optional.of(participant));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     CreateChatResponseDTO result = createChatFacade.createChatV1(chatDto, consultant);
@@ -185,7 +191,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChat_Should_PersistCreatorInGroupChatParticipantTable()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
@@ -199,7 +205,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
 
   @Test
   void createSimplifiedGroupChat_Should_SaveSessionAndChatWithMatrixRoomId() throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
@@ -216,7 +222,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChat_Should_RemainInactiveUntilCounsellorOpensOccurrence()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
@@ -233,7 +239,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   void createSimplifiedGroupChatShouldOpenAnInternalTeamChatOnCreation() throws Exception {
     // #979: a team chat has no occurrence to open, so leaving it inactive dropped colleagues
     // into the askers' Waiting Area with a countdown to a start time nobody had chosen.
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
@@ -249,7 +255,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChatShouldStampBothRowsAsSelfHelpForOneOccurrenceSeries()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(chatDto.getRepeatCount()).thenReturn(1);
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
@@ -275,7 +281,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   void
       createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantMatrixProvisioningFails() {
     when(consultant.getMatrixUserId()).thenReturn(null);
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     assertThrows(
@@ -291,7 +297,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
       createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantMatrixProvisioningReturnsBlank()
           throws Exception {
     when(consultant.getMatrixUserId()).thenReturn("  ");
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     assertThrows(
@@ -305,7 +311,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_MatrixRoomCreationFails()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenThrow(new RuntimeException("Matrix unavailable"));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
@@ -321,7 +327,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantTokenIsNull()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn(null);
@@ -339,22 +345,58 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   // createSimplifiedGroupChat — per-participant edge cases
   // ---------------------------------------------------------------------------
 
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.CsvSource({
+    "foreign,84,false",
+    "deleted,1,true",
+    "missing,1,false"
+  })
+  void creationRejectsInvalidSelectionBeforeAnyMatrixOrPersistenceSideEffect(
+      String participantId, long tenantId, boolean deleted) throws Exception {
+    var selected = new Consultant();
+    selected.setId(participantId);
+    selected.setTenantId(tenantId);
+    if (deleted) selected.setDeleteDate(LocalDateTime.now());
+    when(consultantRepository.findByIdAndDeleteDateIsNull(participantId))
+        .thenReturn("missing".equals(participantId) ? Optional.empty() : Optional.of(selected));
+    when(consultantRepository.findByIdAndDeleteDateIsNull(participantId))
+        .thenReturn(
+            deleted || "missing".equals(participantId) ? Optional.empty() : Optional.of(selected));
+    when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
+        .thenReturn(matrixRoomResponse("!room:matrix.org"));
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
+    doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            createChatFacade.createChatV2(
+                chatDtoWithConsultantIds(List.of(participantId)), consultant));
+
+    org.mockito.Mockito.verifyNoInteractions(
+        matrixSynapseService,
+        consultantMembership,
+        sessionService,
+        chatService,
+        userRepository,
+        groupChatParticipantRepository);
+  }
+
   @Test
-  void createSimplifiedGroupChat_Should_SkipParticipant_When_NotFoundInConsultantRepository()
+  void createSimplifiedGroupChat_Should_RejectParticipant_When_NotFoundInConsultantRepository()
       throws Exception {
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("unknown-participant"));
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");
-    when(consultantRepository.findById("unknown-participant")).thenReturn(Optional.empty());
+    when(consultantRepository.findByIdAndDeleteDateIsNull("unknown-participant"))
+        .thenReturn(Optional.empty());
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
-    createChatFacade.createChatV1(chatDto, consultant);
-
-    // Only creator save; unknown participant skipped → no invite call
-    verify(matrixSynapseService, never()).inviteUserToRoom(any(), any(), any());
-    // Only creator saved in participant table
-    verify(groupChatParticipantRepository, times(1)).save(any());
+    assertThrows(
+        BadRequestException.class, () -> createChatFacade.createChatV1(chatDto, consultant));
+    org.mockito.Mockito.verifyNoInteractions(
+        matrixSynapseService, consultantMembership, groupChatParticipantRepository);
   }
 
   @Test
@@ -367,14 +409,19 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     when(matrixSynapseService.loginAsUserAccessToken("@creator:matrix.org"))
         .thenReturn("creator-token");
     Consultant participant = mock(Consultant.class);
+    when(participant.getId()).thenReturn("participant-1");
+    when(participant.getTenantId()).thenReturn(1L);
     when(participant.getMatrixUserId()).thenReturn("@participant:matrix.org");
     when(consultantMembership.joinConsultantIntoRoom(
             org.mockito.ArgumentMatchers.eq(participant), any(), any()))
         .thenReturn(false);
-    when(consultantRepository.findById("participant-1")).thenReturn(Optional.of(participant));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-1"))
+        .thenReturn(Optional.of(participant));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
-    createChatFacade.createChatV1(chatDto, consultant);
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> createChatFacade.createChatV1(chatDto, consultant));
 
     verify(consultantMembership)
         .joinConsultantIntoRoom(org.mockito.ArgumentMatchers.eq(participant), any(), any());
@@ -383,7 +430,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
-  void createSimplifiedGroupChat_Should_ContinueWithOtherParticipants_When_OneInviteFails()
+  void createSimplifiedGroupChat_Should_ReportFailureAndRollback_When_OneInviteFails()
       throws Exception {
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1", "participant-2"));
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
@@ -392,11 +439,17 @@ class CreateChatSimplifiedGroupChatFacadeTest {
         .thenReturn("creator-token");
 
     Consultant p1 = mock(Consultant.class);
+    when(p1.getId()).thenReturn("participant-1");
+    when(p1.getTenantId()).thenReturn(1L);
     when(p1.getMatrixUserId()).thenReturn("@p1:matrix.org");
     Consultant p2 = mock(Consultant.class);
+    when(p2.getId()).thenReturn("participant-2");
+    when(p2.getTenantId()).thenReturn(1L);
     when(p2.getMatrixUserId()).thenReturn("@p2:matrix.org");
-    when(consultantRepository.findById("participant-1")).thenReturn(Optional.of(p1));
-    when(consultantRepository.findById("participant-2")).thenReturn(Optional.of(p2));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-1"))
+        .thenReturn(Optional.of(p1));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("participant-2"))
+        .thenReturn(Optional.of(p2));
 
     // p1 invite fails, p2 invite succeeds
     when(consultantMembership.joinConsultantIntoRoom(
@@ -406,10 +459,11 @@ class CreateChatSimplifiedGroupChatFacadeTest {
 
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
-    // Must not throw — exceptions per participant are swallowed
-    CreateChatResponseDTO result = createChatFacade.createChatV1(chatDto, consultant);
-
-    assertThat(result).isNotNull();
+    assertThrows(
+        InternalServerErrorException.class,
+        () -> createChatFacade.createChatV1(chatDto, consultant));
+    verify(sessionService).deleteSession(savedSession);
+    verify(chatService).deleteChat(savedChat);
   }
 
   // ---------------------------------------------------------------------------
@@ -418,7 +472,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
 
   @Test
   void resolveOrCreateGroupChatSystemUser_Should_UseTenantScopedUser_When_Found() throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("token");
@@ -438,7 +492,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void resolveOrCreateGroupChatSystemUser_Should_FallBackToGenericUser_When_TenantUserNotFound()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("token");
@@ -458,7 +512,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void resolveOrCreateGroupChatSystemUser_Should_CreateFallbackUser_When_NeitherFound()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("token");
@@ -479,7 +533,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Test
   void createSimplifiedGroupChatShouldPersistCreatorAsSeriesOwnerAndKeepLegacySessionId()
       throws Exception {
-    ChatDTO chatDto = chatDtoWithConsultantIds(List.of("dummy-participant"));
+    ChatDTO chatDto = chatDtoWithConsultantIds(List.of());
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
     when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("creator-token");

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -92,6 +92,23 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     when(consultantRepository.findById(any())).thenReturn(Optional.empty());
   }
 
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.EnumSource(value = ConversationType.class,
+      names = {"SELF_HELP", "INTERNAL_GROUP"})
+  void groupSessionCarriesItsOwnerTenantBeforeTheFirstSave(ConversationType type) throws Exception {
+    ChatDTO dto = chatDtoWithConsultantIds(List.of());
+    Chat chat = new Chat();
+    chat.setConversationType(type);
+    doReturn(chat).when(chatConverter).convertToEntity(any(), any(), any());
+    when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
+        .thenReturn(matrixRoomResponse("!tenant-regression:matrix.org"));
+    when(matrixSynapseService.loginAsUserAccessToken(any())).thenReturn("test-token");
+    createChatFacade.createChatV2(dto, consultant);
+    var captured = ArgumentCaptor.forClass(Session.class);
+    verify(sessionService, times(2)).saveSession(captured.capture());
+    assertThat(captured.getAllValues().getFirst().getTenantId()).isEqualTo(1L);
+  }
+
   private ChatDTO chatDtoWithConsultantIds(List<String> consultantIds) {
     ChatDTO dto = mock(ChatDTO.class);
     when(dto.getConsultantIds()).thenReturn(consultantIds);

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -29,6 +29,7 @@ import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.port.out.UserRepository;
 import de.caritas.cob.userservice.api.service.ChatService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
+import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
 import de.caritas.cob.userservice.api.service.session.SessionService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -59,6 +60,7 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   @Mock private ConsultantRepository consultantRepository;
   @Mock private GroupChatParticipantRepository groupChatParticipantRepository;
   @Mock private UserRepository userRepository;
+  @Mock private AgencySilentMembershipService consultantMembership;
 
   @SuppressWarnings("unused")
   @Spy
@@ -70,6 +72,9 @@ class CreateChatSimplifiedGroupChatFacadeTest {
 
   @BeforeEach
   void setup() {
+    when(consultantMembership.ensureMatrixAccount(any()))
+        .thenAnswer(invocation -> ((Consultant) invocation.getArgument(0)).getMatrixUserId());
+    when(consultantMembership.joinConsultantIntoRoom(any(), any(), any())).thenReturn(true);
     consultant = mock(Consultant.class);
     when(consultant.getId()).thenReturn("creator-consultant-id");
     when(consultant.getMatrixUserId()).thenReturn("@creator:matrix.org");
@@ -267,7 +272,8 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantHasNoMatrixUserId() {
+  void
+      createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantMatrixProvisioningFails() {
     when(consultant.getMatrixUserId()).thenReturn(null);
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
@@ -281,8 +287,9 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
-  void createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantMatrixUserIdIsBlank()
-      throws Exception {
+  void
+      createSimplifiedGroupChat_Should_ThrowISE_And_Rollback_When_ConsultantMatrixProvisioningReturnsBlank()
+          throws Exception {
     when(consultant.getMatrixUserId()).thenReturn("  ");
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
@@ -351,9 +358,8 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @Test
-  void
-      createSimplifiedGroupChat_Should_SkipJoinAndStillSaveParticipant_When_ParticipantTokenIsNull()
-          throws Exception {
+  void createSimplifiedGroupChat_Should_NotRecordParticipant_When_MembershipFails()
+      throws Exception {
     ChatDTO chatDto = chatDtoWithConsultantIds(List.of("participant-1"));
     when(matrixSynapseService.createRoomAsMatrixUser(any(), any(), any()))
         .thenReturn(matrixRoomResponse("!room:matrix.org"));
@@ -362,16 +368,18 @@ class CreateChatSimplifiedGroupChatFacadeTest {
         .thenReturn("creator-token");
     Consultant participant = mock(Consultant.class);
     when(participant.getMatrixUserId()).thenReturn("@participant:matrix.org");
-    when(matrixSynapseService.loginAsUserAccessToken("@participant:matrix.org")).thenReturn(null);
+    when(consultantMembership.joinConsultantIntoRoom(
+            org.mockito.ArgumentMatchers.eq(participant), any(), any()))
+        .thenReturn(false);
     when(consultantRepository.findById("participant-1")).thenReturn(Optional.of(participant));
     doReturn(mock(Chat.class)).when(chatConverter).convertToEntity(any(), any(), any());
 
     createChatFacade.createChatV1(chatDto, consultant);
 
-    verify(matrixSynapseService).inviteUserToRoom(any(), any(), any());
-    verify(matrixSynapseService, never()).joinRoom(any(), any());
-    // creator + participant both saved to participant table
-    verify(groupChatParticipantRepository, times(2)).save(any());
+    verify(consultantMembership)
+        .joinConsultantIntoRoom(org.mockito.ArgumentMatchers.eq(participant), any(), any());
+    // Only confirmed members are persisted.
+    verify(groupChatParticipantRepository, times(1)).save(any());
   }
 
   @Test
@@ -391,7 +399,8 @@ class CreateChatSimplifiedGroupChatFacadeTest {
     when(consultantRepository.findById("participant-2")).thenReturn(Optional.of(p2));
 
     // p1 invite fails, p2 invite succeeds
-    when(matrixSynapseService.loginAsUserAccessToken("@p1:matrix.org"))
+    when(consultantMembership.joinConsultantIntoRoom(
+            org.mockito.ArgumentMatchers.eq(p1), any(), any()))
         .thenThrow(new RuntimeException("Matrix error for p1"));
     when(matrixSynapseService.loginAsUserAccessToken("@p2:matrix.org")).thenReturn("p2-token");
 

--- a/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/facade/CreateChatSimplifiedGroupChatFacadeTest.java
@@ -93,7 +93,8 @@ class CreateChatSimplifiedGroupChatFacadeTest {
   }
 
   @org.junit.jupiter.params.ParameterizedTest
-  @org.junit.jupiter.params.provider.EnumSource(value = ConversationType.class,
+  @org.junit.jupiter.params.provider.EnumSource(
+      value = ConversationType.class,
       names = {"SELF_HELP", "INTERNAL_GROUP"})
   void groupSessionCarriesItsOwnerTenantBeforeTheFirstSave(ConversationType type) throws Exception {
     ChatDTO dto = chatDtoWithConsultantIds(List.of());

--- a/src/test/java/de/caritas/cob/userservice/api/service/GroupSessionTenantMigrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/GroupSessionTenantMigrationTest.java
@@ -12,15 +12,21 @@ class GroupSessionTenantMigrationTest {
   void repairsOnlyUnambiguousGroupOwnershipAndIsIdempotent() throws Exception {
     try (var connection = DriverManager.getConnection("jdbc:h2:mem:group-backfill;MODE=MariaDB");
         var sql = connection.createStatement()) {
-      sql.execute("CREATE TABLE consultant (consultant_id VARCHAR(64) PRIMARY KEY, tenant_id BIGINT)");
-      sql.execute("CREATE TABLE session (id BIGINT PRIMARY KEY, consultant_id VARCHAR(64), user_id VARCHAR(64), tenant_id BIGINT, conversation_type VARCHAR(64))");
+      sql.execute(
+          "CREATE TABLE consultant (consultant_id VARCHAR(64) PRIMARY KEY, tenant_id BIGINT)");
+      sql.execute(
+          "CREATE TABLE session (id BIGINT PRIMARY KEY, consultant_id VARCHAR(64), user_id VARCHAR(64), tenant_id BIGINT, conversation_type VARCHAR(64))");
       sql.execute("INSERT INTO consultant VALUES ('owner',2),('technical',0),('unknown',NULL)");
-      sql.execute("INSERT INTO session VALUES (1,'owner','group-chat-system-2',NULL,'SELF_HELP'),(2,'owner','group-chat-system',NULL,'INTERNAL_GROUP'),(3,'owner','group-chat-system-2',7,'SELF_HELP'),(4,'owner','person',NULL,'AGENCY_COUNSELLING'),(5,'technical','group-chat-system',NULL,'SELF_HELP'),(6,'unknown','group-chat-system',NULL,'SELF_HELP'),(7,NULL,'group-chat-system',NULL,'SELF_HELP'),(8,'owner','group-chat-system-7',NULL,'SELF_HELP'),(9,'owner','person',NULL,'SELF_HELP')");
-      var migration = Files.readString(Path.of("src/main/resources/db/changelog/changeset/0091_group_session_tenant/migrate.sql"));
+      sql.execute(
+          "INSERT INTO session VALUES (1,'owner','group-chat-system-2',NULL,'SELF_HELP'),(2,'owner','group-chat-system',NULL,'INTERNAL_GROUP'),(3,'owner','group-chat-system-2',7,'SELF_HELP'),(4,'owner','person',NULL,'AGENCY_COUNSELLING'),(5,'technical','group-chat-system',NULL,'SELF_HELP'),(6,'unknown','group-chat-system',NULL,'SELF_HELP'),(7,NULL,'group-chat-system',NULL,'SELF_HELP'),(8,'owner','group-chat-system-7',NULL,'SELF_HELP'),(9,'owner','person',NULL,'SELF_HELP')");
+      var migration =
+          Files.readString(
+              Path.of(
+                  "src/main/resources/db/changelog/changeset/0091_group_session_tenant/migrate.sql"));
       for (int run = 0; run < 2; run++) {
         sql.execute(migration);
         try (var rows = sql.executeQuery("SELECT tenant_id FROM session ORDER BY id")) {
-          Long[] expected = {2L,2L,7L,null,null,null,null,null,null};
+          Long[] expected = {2L, 2L, 7L, null, null, null, null, null, null};
           for (var tenant : expected) {
             assertThat(rows.next()).isTrue();
             assertThat(rows.getObject(1, Long.class)).isEqualTo(tenant);

--- a/src/test/java/de/caritas/cob/userservice/api/service/GroupSessionTenantMigrationTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/GroupSessionTenantMigrationTest.java
@@ -1,0 +1,33 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import org.junit.jupiter.api.Test;
+
+class GroupSessionTenantMigrationTest {
+  @Test
+  void repairsOnlyUnambiguousGroupOwnershipAndIsIdempotent() throws Exception {
+    try (var connection = DriverManager.getConnection("jdbc:h2:mem:group-backfill;MODE=MariaDB");
+        var sql = connection.createStatement()) {
+      sql.execute("CREATE TABLE consultant (consultant_id VARCHAR(64) PRIMARY KEY, tenant_id BIGINT)");
+      sql.execute("CREATE TABLE session (id BIGINT PRIMARY KEY, consultant_id VARCHAR(64), user_id VARCHAR(64), tenant_id BIGINT, conversation_type VARCHAR(64))");
+      sql.execute("INSERT INTO consultant VALUES ('owner',2),('technical',0),('unknown',NULL)");
+      sql.execute("INSERT INTO session VALUES (1,'owner','group-chat-system-2',NULL,'SELF_HELP'),(2,'owner','group-chat-system',NULL,'INTERNAL_GROUP'),(3,'owner','group-chat-system-2',7,'SELF_HELP'),(4,'owner','person',NULL,'AGENCY_COUNSELLING'),(5,'technical','group-chat-system',NULL,'SELF_HELP'),(6,'unknown','group-chat-system',NULL,'SELF_HELP'),(7,NULL,'group-chat-system',NULL,'SELF_HELP'),(8,'owner','group-chat-system-7',NULL,'SELF_HELP'),(9,'owner','person',NULL,'SELF_HELP')");
+      var migration = Files.readString(Path.of("src/main/resources/db/changelog/changeset/0091_group_session_tenant/migrate.sql"));
+      for (int run = 0; run < 2; run++) {
+        sql.execute(migration);
+        try (var rows = sql.executeQuery("SELECT tenant_id FROM session ORDER BY id")) {
+          Long[] expected = {2L,2L,7L,null,null,null,null,null,null};
+          for (var tenant : expected) {
+            assertThat(rows.next()).isTrue();
+            assertThat(rows.getObject(1, Long.class)).isEqualTo(tenant);
+          }
+          assertThat(rows.next()).isFalse();
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/TenantStampingPersistenceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/TenantStampingPersistenceTest.java
@@ -1,0 +1,79 @@
+package de.caritas.cob.userservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.userservice.api.model.TenantAware;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.util.Properties;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TenantStampingPersistenceTest {
+  @AfterEach
+  void clearContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void applicationConfigurationPersistsTheCurrentTenantOnAnUnstampedEntity() throws Exception {
+    assertPersistedTenant(2L, null, 2L);
+  }
+
+  @Test
+  void preservesAnExplicitTenant() throws Exception {
+    assertPersistedTenant(2L, 7L, 7L);
+  }
+
+  @Test
+  void technicalContextDoesNotInventAnOwner() throws Exception {
+    assertPersistedTenant(0L, null, null);
+  }
+
+  private void assertPersistedTenant(Long context, Long initial, Long expected) throws Exception {
+    var properties = new Properties();
+    try (var stream = getClass().getResourceAsStream("/application.properties")) {
+      properties.load(stream);
+    }
+    var builder = new StandardServiceRegistryBuilder();
+    properties.forEach((key, value) -> {
+      String name = key.toString();
+      if (name.startsWith("spring.jpa.properties.hibernate.") && name.contains("interceptor")) {
+        builder.applySetting(name.substring("spring.jpa.properties.".length()), value);
+      }
+    });
+    var registry = builder
+        .applySetting("hibernate.connection.url", "jdbc:h2:mem:tenant-stamping;DB_CLOSE_DELAY=-1")
+        .applySetting("hibernate.connection.driver_class", "org.h2.Driver")
+        .applySetting("hibernate.hbm2ddl.auto", "create-drop")
+        .build();
+    try (var factory = new MetadataSources(registry).addAnnotatedClass(OwnedRecord.class)
+        .buildMetadata().buildSessionFactory()) {
+      TenantContext.setCurrentTenant(context);
+      try (var session = factory.openSession()) {
+        var transaction = session.beginTransaction();
+        var record = new OwnedRecord();
+        record.id = 1L;
+        record.tenantId = initial;
+        session.persist(record);
+        transaction.commit();
+      }
+      try (var session = factory.openSession()) {
+        assertThat(session.find(OwnedRecord.class, 1L).getTenantId()).isEqualTo(expected);
+      }
+    } finally {
+      StandardServiceRegistryBuilder.destroy(registry);
+    }
+  }
+
+  @Entity(name = "TenantStampingRecord")
+  public static class OwnedRecord implements TenantAware {
+    @Id private Long id;
+    private Long tenantId;
+    public Long getTenantId() { return tenantId; }
+    public void setTenantId(Long tenantId) { this.tenantId = tenantId; }
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/TenantStampingPersistenceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/TenantStampingPersistenceTest.java
@@ -39,19 +39,25 @@ class TenantStampingPersistenceTest {
       properties.load(stream);
     }
     var builder = new StandardServiceRegistryBuilder();
-    properties.forEach((key, value) -> {
-      String name = key.toString();
-      if (name.startsWith("spring.jpa.properties.hibernate.") && name.contains("interceptor")) {
-        builder.applySetting(name.substring("spring.jpa.properties.".length()), value);
-      }
-    });
-    var registry = builder
-        .applySetting("hibernate.connection.url", "jdbc:h2:mem:tenant-stamping;DB_CLOSE_DELAY=-1")
-        .applySetting("hibernate.connection.driver_class", "org.h2.Driver")
-        .applySetting("hibernate.hbm2ddl.auto", "create-drop")
-        .build();
-    try (var factory = new MetadataSources(registry).addAnnotatedClass(OwnedRecord.class)
-        .buildMetadata().buildSessionFactory()) {
+    properties.forEach(
+        (key, value) -> {
+          String name = key.toString();
+          if (name.startsWith("spring.jpa.properties.hibernate.") && name.contains("interceptor")) {
+            builder.applySetting(name.substring("spring.jpa.properties.".length()), value);
+          }
+        });
+    var registry =
+        builder
+            .applySetting(
+                "hibernate.connection.url", "jdbc:h2:mem:tenant-stamping;DB_CLOSE_DELAY=-1")
+            .applySetting("hibernate.connection.driver_class", "org.h2.Driver")
+            .applySetting("hibernate.hbm2ddl.auto", "create-drop")
+            .build();
+    try (var factory =
+        new MetadataSources(registry)
+            .addAnnotatedClass(OwnedRecord.class)
+            .buildMetadata()
+            .buildSessionFactory()) {
       TenantContext.setCurrentTenant(context);
       try (var session = factory.openSession()) {
         var transaction = session.beginTransaction();
@@ -73,7 +79,13 @@ class TenantStampingPersistenceTest {
   public static class OwnedRecord implements TenantAware {
     @Id private Long id;
     private Long tenantId;
-    public Long getTenantId() { return tenantId; }
-    public void setTenantId(Long tenantId) { this.tenantId = tenantId; }
+
+    public Long getTenantId() {
+      return tenantId;
+    }
+
+    public void setTenantId(Long tenantId) {
+      this.tenantId = tenantId;
+    }
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
@@ -191,14 +191,17 @@ class GroupChatParticipantReconciliationServiceTest {
     var valid = consultant("valid", "@valid:matrix");
     when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, removed));
     var removedConsultant = consultant("removed", "@removed:matrix");
-    Mockito.lenient().when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
+    Mockito.lenient()
+        .when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
         .thenReturn(Optional.of(removedConsultant));
     when(consultantRepository.findByIdAndDeleteDateIsNull("valid")).thenReturn(Optional.of(valid));
-    Mockito.lenient().when(membershipService.addMemberToRoom(series, "@valid:matrix")).thenReturn(true);
+    Mockito.lenient()
+        .when(membershipService.addMemberToRoom(series, "@valid:matrix"))
+        .thenReturn(true);
     when(consultantRepository.findByIdAndDeleteDateIsNull("deleted")).thenReturn(Optional.empty());
 
-    assertThrows(BadRequestException.class,
-        () -> service.reconcile(series, List.of("valid", "deleted")));
+    assertThrows(
+        BadRequestException.class, () -> service.reconcile(series, List.of("valid", "deleted")));
 
     verifyNoInteractions(membershipService, consultantMembership);
     verify(participantRepository, never()).delete(Mockito.any());
@@ -225,13 +228,14 @@ class GroupChatParticipantReconciliationServiceTest {
     var newcomer = consultant("newcomer", "@newcomer:matrix");
     when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, removed));
     var removedConsultant = consultant("removed", "@removed:matrix");
-    Mockito.lenient().when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
+    Mockito.lenient()
+        .when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
         .thenReturn(Optional.of(removedConsultant));
     when(consultantRepository.findByIdAndDeleteDateIsNull("newcomer"))
         .thenReturn(Optional.of(newcomer));
 
-    assertThrows(InternalServerErrorException.class,
-        () -> service.reconcile(series, List.of("newcomer")));
+    assertThrows(
+        InternalServerErrorException.class, () -> service.reconcile(series, List.of("newcomer")));
 
     verify(membershipService, never()).removeLeavingMemberFromRoom(Mockito.any(), Mockito.any());
     verify(participantRepository, never()).delete(Mockito.any());

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
@@ -168,6 +168,75 @@ class GroupChatParticipantReconciliationServiceTest {
     verify(participantRepository, never()).save(org.mockito.ArgumentMatchers.any());
   }
 
+  @Test
+  void reconcile_ShouldRepairAnExistingSelectedCoModeratorWithoutMatrixAccount() {
+    var existing = participant(7L, "existing", ParticipantRole.CO_MODERATOR);
+    var consultant = consultant("existing", null);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, existing));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("existing"))
+        .thenReturn(Optional.of(consultant));
+    when(consultantMembership.ensureMatrixAccount(consultant)).thenReturn("@existing:matrix");
+    when(membershipService.addMemberToRoom(series, "@existing:matrix")).thenReturn(true);
+
+    service.reconcile(series, List.of("existing"));
+
+    verify(consultantMembership).ensureMatrixAccount(consultant);
+    verify(membershipService).addMemberToRoom(series, "@existing:matrix");
+    verify(participantRepository, never()).save(Mockito.any());
+  }
+
+  @Test
+  void reconcile_ShouldValidateWholeSelectionBeforeAnyMembershipSideEffects() {
+    var removed = participant(7L, "removed", ParticipantRole.CO_MODERATOR);
+    var valid = consultant("valid", "@valid:matrix");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, removed));
+    var removedConsultant = consultant("removed", "@removed:matrix");
+    Mockito.lenient().when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
+        .thenReturn(Optional.of(removedConsultant));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("valid")).thenReturn(Optional.of(valid));
+    Mockito.lenient().when(membershipService.addMemberToRoom(series, "@valid:matrix")).thenReturn(true);
+    when(consultantRepository.findByIdAndDeleteDateIsNull("deleted")).thenReturn(Optional.empty());
+
+    assertThrows(BadRequestException.class,
+        () -> service.reconcile(series, List.of("valid", "deleted")));
+
+    verifyNoInteractions(membershipService, consultantMembership);
+    verify(participantRepository, never()).delete(Mockito.any());
+    verify(participantRepository, never()).save(Mockito.any());
+  }
+
+  @Test
+  void reconcile_ShouldRevalidateExistingSelectionTenantBeforeJoining() {
+    var existing = participant(7L, "existing", ParticipantRole.CO_MODERATOR);
+    var consultant = consultant("existing", "@existing:matrix");
+    when(consultant.getTenantId()).thenReturn(99L);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, existing));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("existing"))
+        .thenReturn(Optional.of(consultant));
+
+    assertThrows(BadRequestException.class, () -> service.reconcile(series, List.of("existing")));
+
+    verifyNoInteractions(membershipService, consultantMembership);
+  }
+
+  @Test
+  void reconcile_ShouldKeepDeselectedMembersWhenReplacementJoinFails() {
+    var removed = participant(7L, "removed", ParticipantRole.CO_MODERATOR);
+    var newcomer = consultant("newcomer", "@newcomer:matrix");
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner, removed));
+    var removedConsultant = consultant("removed", "@removed:matrix");
+    Mockito.lenient().when(consultantRepository.findByIdAndDeleteDateIsNull("removed"))
+        .thenReturn(Optional.of(removedConsultant));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("newcomer"))
+        .thenReturn(Optional.of(newcomer));
+
+    assertThrows(InternalServerErrorException.class,
+        () -> service.reconcile(series, List.of("newcomer")));
+
+    verify(membershipService, never()).removeLeavingMemberFromRoom(Mockito.any(), Mockito.any());
+    verify(participantRepository, never()).delete(Mockito.any());
+  }
+
   private GroupChatParticipant participant(
       Long sessionId, String consultantId, ParticipantRole role) {
     return GroupChatParticipant.builder()

--- a/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/chat/GroupChatParticipantReconciliationServiceTest.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.model.GroupChatParticipant.ParticipantRole
 import de.caritas.cob.userservice.api.port.out.ConsultantRepository;
 import de.caritas.cob.userservice.api.port.out.GroupChatParticipantRepository;
 import de.caritas.cob.userservice.api.service.matrix.GroupChatMembershipService;
+import de.caritas.cob.userservice.api.service.session.AgencySilentMembershipService;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ class GroupChatParticipantReconciliationServiceTest {
   @Mock private GroupChatParticipantRepository participantRepository;
   @Mock private ConsultantRepository consultantRepository;
   @Mock private GroupChatMembershipService membershipService;
+  @Mock private AgencySilentMembershipService consultantMembership;
 
   private GroupChatParticipantReconciliationService service;
   private Chat series;
@@ -40,7 +42,7 @@ class GroupChatParticipantReconciliationServiceTest {
   void setUp() {
     service =
         new GroupChatParticipantReconciliationService(
-            participantRepository, consultantRepository, membershipService);
+            participantRepository, consultantRepository, membershipService, consultantMembership);
     var ownerConsultant = consultant("owner", "@owner:matrix");
     series = Mockito.mock(Chat.class);
     Mockito.lenient().when(series.getId()).thenReturn(42L);
@@ -52,7 +54,8 @@ class GroupChatParticipantReconciliationServiceTest {
   void reconcile_ShouldPreserveParticipants_WhenIdsAreOmitted() {
     service.reconcile(series, null);
 
-    verifyNoInteractions(participantRepository, consultantRepository, membershipService);
+    verifyNoInteractions(
+        participantRepository, consultantRepository, membershipService, consultantMembership);
   }
 
   @Test
@@ -74,6 +77,38 @@ class GroupChatParticipantReconciliationServiceTest {
     org.junit.jupiter.api.Assertions.assertEquals("co-moderator", participant.getConsultantId());
     org.junit.jupiter.api.Assertions.assertEquals(
         ParticipantRole.CO_MODERATOR, participant.getRole());
+  }
+
+  @Test
+  void reconcile_ShouldProvisionNewCoModeratorBeforeInvitingToExistingGroup() {
+    var newcomer = consultant("newcomer", null);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("newcomer"))
+        .thenReturn(Optional.of(newcomer));
+    when(consultantMembership.ensureMatrixAccount(newcomer))
+        .thenReturn("@newcomer=40example.org:matrix");
+    when(membershipService.addMemberToRoom(series, "@newcomer=40example.org:matrix"))
+        .thenReturn(true);
+
+    service.reconcile(series, List.of("newcomer"));
+
+    verify(consultantMembership).ensureMatrixAccount(newcomer);
+    verify(membershipService).addMemberToRoom(series, "@newcomer=40example.org:matrix");
+    verify(participantRepository).save(Mockito.any(GroupChatParticipant.class));
+  }
+
+  @Test
+  void reconcile_ShouldNotInviteOrPersistWhenAccountProvisioningFails() {
+    var newcomer = consultant("newcomer", null);
+    when(participantRepository.findBySeriesIdForUpdate(42L)).thenReturn(List.of(owner));
+    when(consultantRepository.findByIdAndDeleteDateIsNull("newcomer"))
+        .thenReturn(Optional.of(newcomer));
+
+    assertThrows(
+        InternalServerErrorException.class, () -> service.reconcile(series, List.of("newcomer")));
+
+    verifyNoInteractions(membershipService);
+    verify(participantRepository, never()).save(Mockito.any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -136,15 +136,22 @@ class MatrixRtcCallPolicyServiceTest {
   }
 
   @org.junit.jupiter.params.ParameterizedTest
-  @org.junit.jupiter.params.provider.EnumSource(value = ConversationType.class,
+  @org.junit.jupiter.params.provider.EnumSource(
+      value = ConversationType.class,
       names = {"SELF_HELP", "INTERNAL_GROUP"})
   void groupSessionsUseGroupFlagsEvenWhenTheSessionLookupWins(ConversationType type) {
     var groupSession = session(type);
     when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(groupSession));
-    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID)).thenReturn(tenant(enabledSettings()
-        .featureAudioCallsGroupChatsEnabled(true).featureVideoCallsGroupChatsEnabled(false)
-        .featureAudioCallsOneOnOneChatsEnabled(false).featureVideoCallsOneOnOneChatsEnabled(true)));
-    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(new CallMediaPolicy(true, false));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID))
+        .thenReturn(
+            tenant(
+                enabledSettings()
+                    .featureAudioCallsGroupChatsEnabled(true)
+                    .featureVideoCallsGroupChatsEnabled(false)
+                    .featureAudioCallsOneOnOneChatsEnabled(false)
+                    .featureVideoCallsOneOnOneChatsEnabled(true)));
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID))
+        .isEqualTo(new CallMediaPolicy(true, false));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/matrixrtc/MatrixRtcCallPolicyServiceTest.java
@@ -135,6 +135,18 @@ class MatrixRtcCallPolicyServiceTest {
         .isEqualTo(new CallMediaPolicy(true, false));
   }
 
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.EnumSource(value = ConversationType.class,
+      names = {"SELF_HELP", "INTERNAL_GROUP"})
+  void groupSessionsUseGroupFlagsEvenWhenTheSessionLookupWins(ConversationType type) {
+    var groupSession = session(type);
+    when(sessionRepository.findByMatrixRoomId(ROOM_ID)).thenReturn(Optional.of(groupSession));
+    when(tenantService.getRestrictedTenantDataFresh(TENANT_ID)).thenReturn(tenant(enabledSettings()
+        .featureAudioCallsGroupChatsEnabled(true).featureVideoCallsGroupChatsEnabled(false)
+        .featureAudioCallsOneOnOneChatsEnabled(false).featureVideoCallsOneOnOneChatsEnabled(true)));
+    assertThat(service.resolve(ROOM_ID, MATRIX_USER_ID)).isEqualTo(new CallMediaPolicy(true, false));
+  }
+
   @Test
   void resolvesSupervisionRoomAgainstSupervisionFlags() {
     var supervision = mock(SessionSupervisor.class);

--- a/src/test/java/tenantstamping/TenantStampingPersistenceTest.java
+++ b/src/test/java/tenantstamping/TenantStampingPersistenceTest.java
@@ -1,4 +1,4 @@
-package de.caritas.cob.userservice.api.service;
+package tenantstamping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Group audio/video calls can fail with SFU403 after a caller joins the Matrix room because the source Session has no tenant. Self-help Sessions also select the wrong media-policy category. Independently, selected colleagues without a stored Matrix identity are silently omitted from the group, so they cannot participate in calls.

Restore Hibernate7 insert-time tenant stamping, explicitly assign group Sessions their consultant tenant, apply group flags to SELF_HELP, and backfill only unambiguous synthetic group Sessions with null tenant. Reuse the existing Matrix account and membership service for group creators and selected colleagues; record and count a participant only after joining succeeds. Existing identities and tenant ownership remain intact.

Refs #1130
Refs #1135
Frontend companion: https://github.com/OpenResilienceInitiative/ORISO-Frontend/pull/1350

Validation:
- Red–Green regressions: actual Hibernate persistence/readback, both group types, group versus one-to-one policy flags, guarded idempotent backfill, and first-time creator/colleague Matrix provisioning.
- Latest commit47ae7287: 32 focused membership/creation tests and all4,307 current unit tests passed; Java21 package, Spotless and diff check passed.
- Real MariaDB11 migration/schema validation previously passed; PreDev successfully executed0091 and repaired the22 captured eligible group rows.
- Same-room PreDev comparison: internal Chat21/Session98 audio start returned SFU403/NO_TENANT_CONTEXT before; tenant40, SFU200 and a running audio-call UI after baab64e0 with Frontendd4125df2. Normal hangup removed the iframe.
- Fresh normal-UI proof for#1135: selected Bart's correct consultantId reached POST/v2/new; response201 but server invitation used null. This exposed the remaining membership bug;47ae7287 has not yet passed browser acceptance.

PreDev is temporarily running the earlier tenant fix and companion frontend under owned four-hour pins. The new membership image and the full independent-participant audio/video matrix are in progress. No Dev deployment or merge. At completion restore the captured regular images and Always policies, remove only this run's frontend/userservice pins, and restore tenant40's temporary group feature flag.

Reviewer test plan:
- [ ] Start audio/video in existing backfilled and newly created self-help/internal groups: correct tenant, SFU acceptance and media exchange.
- [ ] Select a colleague without a Matrix mapping, and create a group as a first-time consultant: identities are persisted and participants actually join.
- [ ] Make a participant join fail: no false joined-participant record is saved.
- [ ] Repeat calls with independent participants for registered/team counselling, anonymous/live, supervision and team discussions, including end/rejoin.
- [ ] Confirm disabled media and nonmember requests remain denied.

Migration0091 is a forward-only ownership repair limited to matching tenant system users or the legacy synthetic group user; it does not alter existing tenant values, human Sessions, technical tenants or conflicting synthetic identities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Matrix username handling for Unicode, capitalization, and special characters.
  - Group chats now validate participants, provision required Matrix accounts, and manage invitations reliably.
  - Self-help sessions now use group-call settings.
  - Added tenant assignment repair for eligible group sessions.

- **Bug Fixes**
  - Prevented invalid or cross-tenant consultants from being added to chats.
  - Improved rollback when membership or room operations fail.
  - Preserved existing tenant assignments during persistence and migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->