### PR TITLE
fix(security): permit anonymous reads on the service-prefixed consultant-languages route

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/UserController.java
@@ -331,8 +331,22 @@ public class UserController implements UsersApi {
     return userAccountControllerDelegate.updateConsultantData(updateConsultantDTO);
   }
 
+  /**
+   * Returns the languages of all consultants working for the given agency.
+   *
+   * <p>Public by design: anonymous registration reads this list before an account exists. Mapped to
+   * both the direct path and the /service/ prefix because the API gateway forwards /service
+   * unchanged and the deployed frontend calls the prefixed route.
+   *
+   * @param agencyId (required) the agency to read the consultant languages of
+   * @return {@link ResponseEntity} containing {@link LanguageResponseDTO}
+   */
+  @GetMapping(
+      value = {"/users/consultants/languages", "/service/users/consultants/languages"},
+      produces = MediaType.APPLICATION_JSON_VALUE)
   @Override
-  public ResponseEntity<LanguageResponseDTO> getLanguages(Long agencyId) {
+  public ResponseEntity<LanguageResponseDTO> getLanguages(
+      @RequestParam(value = "agencyId", required = true) Long agencyId) {
     return userConsultantControllerDelegate.getLanguages(agencyId);
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/userservice/api/config/auth/SecurityConfig.java
@@ -136,6 +136,7 @@ public class SecurityConfig {
                     "/service/conversations/anonymous/availability",
                     "/users/consultants/{consultantId:" + PUBLIC_CONSULTANT_ID_PATTERN + "}",
                     "/users/consultants/languages",
+                    "/service/users/consultants/languages",
                     "/error-reports",
                     "/service/error-reports",
                     "/users/magic-link/request",

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/UserControllerAuthorizationIT.java
@@ -46,6 +46,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -852,6 +853,41 @@ class UserControllerAuthorizationIT {
         .andExpect(status().isForbidden());
 
     verifyNoMoreInteractions(consultantAgencyService);
+  }
+
+  @Test
+  void getLanguages_Should_ReturnOkForAnonymousCaller_WhenPathIsServicePrefixed() throws Exception {
+    when(consultantAgencyService.getLanguageCodesOfAgency(1L)).thenReturn(Set.of("de"));
+
+    mvc.perform(
+            get("/service/users/consultants/languages")
+                .param("agencyId", "1")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.languages[0]").value("de"));
+
+    verify(consultantAgencyService).getLanguageCodesOfAgency(1L);
+  }
+
+  @Test
+  void getLanguages_Should_ReturnOkForAnonymousCaller_WhenPathIsUnprefixed() throws Exception {
+    when(consultantAgencyService.getLanguageCodesOfAgency(1L)).thenReturn(Set.of("de"));
+
+    mvc.perform(
+            get("/users/consultants/languages")
+                .param("agencyId", "1")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.languages[0]").value("de"));
+
+    verify(consultantAgencyService).getLanguageCodesOfAgency(1L);
+  }
+
+  @Test
+  void getSessionForId_Should_StillRejectAnonymousCaller_WhenPathIsServicePrefixed()
+      throws Exception {
+    mvc.perform(get("/service/users/sessions/room/1").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test


### PR DESCRIPTION
Closes #1119

## Problem

Anonymous registration calls `GET /service/users/consultants/languages?agencyId=<id>` and the API gateway forwards `/service` unchanged. `SecurityConfig` permitted only `/users/consultants/languages`, so the request fell through to the authenticated matcher and returned **401**. Registration cards then rendered an empty language list even for agencies that do have consultant languages.

There are two gaps, not one. Permitting the matcher alone would have turned the 401 into a **404**, because the generated mapping on `UserController.getLanguages` only carries the unprefixed path.

## Change

- `SecurityConfig` — `/service/users/consultants/languages` added to the public allow-list, next to the existing unprefixed entry.
- `UserController.getLanguages` — dual `@GetMapping` over both paths, with `@RequestParam` re-declared because a method-level mapping does not inherit the interface's parameter annotations. Same shape as `registerUser` and `getSessionForId`, which already handle the gateway prefix this way.

No OpenAPI change: the spec never lists `/service` variants, so the generated-diff check is unaffected.

## Tests

Three cases in `UserControllerAuthorizationIT`:

- anonymous `GET /service/users/consultants/languages?agencyId=1` → 200, payload asserted, delegation verified;
- anonymous `GET /users/consultants/languages?agencyId=1` → 200, existing behaviour unchanged;
- anonymous `GET /service/users/sessions/room/1` → 401, so the `/service` prefix does not become blanket-public.

## Notes for review

- `StatelessCsrfFilter` exempts GET, so the anonymous reads need no CSRF token.
- `multitenancy.enabled` is `false` in every environment, so `HttpTenantFilter` is not registered. Were it enabled, its whitelist matches on `requestUri.contains(...)`, which already covers `/service` prefixes.
- The three existing `getLanguages` E2E cases are untouched: they use the unprefixed path with `@WithMockUser`, and the missing-`agencyId` case still returns 400 through `required = true`.

## Reviewer test plan

- [ ] `mvn -Dtest=UserControllerAuthorizationIT test`
- [ ] UserService quality gate for the changed module
- [ ] On Dev, in a fresh browser session, open registration for an agency with consultant languages and confirm the request returns 200 with the languages rendered
- [ ] Confirm another protected UserService endpoint still rejects an anonymous request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving consultant languages through both standard and service-prefixed API paths.
  * Consultant language requests now accept a required agency identifier and return JSON results.
  * These language endpoints are accessible without authentication.

* **Bug Fixes**
  * Preserved authentication requirements for user session room endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->