### PR TITLE
fix(invites): release the tenant-ID reservation when an invite dies

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -368,15 +368,15 @@ public class AccountInviteService {
    * Returns the tenant ID an invite reserved to the free pool once the invite that justified the
    * reservation is durably dead (#1052).
    *
-   * <p>Tenant IDs are short, admin-visible and deliberately chosen — the Admin panel offers a
-   * "next free ID" picker — so a reservation outliving its invite silently degrades the ID space
-   * and makes that suggestion drift away from reality. {@code createInvite} already compensates
-   * this way on its failure path; revoke and expiry are the same orphan.
+   * <p>Tenant IDs are short, admin-visible and deliberately chosen — the Admin panel offers a "next
+   * free ID" picker — so a reservation outliving its invite silently degrades the ID space and
+   * makes that suggestion drift away from reality. {@code createInvite} already compensates this
+   * way on its failure path; revoke and expiry are the same orphan.
    *
    * <p>After commit, not inline: the reservation may only be freed once the terminal status is
-   * durable. Releasing inside the transaction would hand the ID back and then, on a rollback,
-   * leave a live invite pointing at an ID somebody else can now take. Outside a transaction it
-   * runs inline, which carries the same guarantee because {@code release} never throws.
+   * durable. Releasing inside the transaction would hand the ID back and then, on a rollback, leave
+   * a live invite pointing at an ID somebody else can now take. Outside a transaction it runs
+   * inline, which carries the same guarantee because {@code release} never throws.
    *
    * <p>Agency IDs are deliberately left alone. {@code agencyId} carries either a reserved ID or a
    * pre-existing agency's ID and the row does not record which, so releasing it here could free an

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -43,6 +43,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
@@ -347,12 +349,72 @@ public class AccountInviteService {
     if (invite.getStatus() == AccountInviteStatus.ACCEPTED) {
       throw new BadRequestException("Accepted invites cannot be revoked");
     }
+    // A second revoke of an already-REVOKED invite must not release a second time: the ID may
+    // have been re-reserved by someone else in the meantime.
+    boolean alreadyRevoked = invite.getStatus() == AccountInviteStatus.REVOKED;
     LocalDateTime now = LocalDateTime.now();
     invite.setStatus(AccountInviteStatus.REVOKED);
     invite.setRevokedAt(now);
     invite.setRevokedByUserId(authenticatedUser.getUserId());
     invite.setUpdateDate(now);
-    return accountInviteRepository.save(invite);
+    AccountInvite revoked = accountInviteRepository.save(invite);
+    if (!alreadyRevoked) {
+      releaseTenantIdReservationAfterCommit(revoked);
+    }
+    return revoked;
+  }
+
+  /**
+   * Returns the tenant ID an invite reserved to the free pool once the invite that justified the
+   * reservation is durably dead (#1052).
+   *
+   * <p>Tenant IDs are short, admin-visible and deliberately chosen — the Admin panel offers a
+   * "next free ID" picker — so a reservation outliving its invite silently degrades the ID space
+   * and makes that suggestion drift away from reality. {@code createInvite} already compensates
+   * this way on its failure path; revoke and expiry are the same orphan.
+   *
+   * <p>After commit, not inline: the reservation may only be freed once the terminal status is
+   * durable. Releasing inside the transaction would hand the ID back and then, on a rollback,
+   * leave a live invite pointing at an ID somebody else can now take. Outside a transaction it
+   * runs inline, which carries the same guarantee because {@code release} never throws.
+   *
+   * <p>Agency IDs are deliberately left alone. {@code agencyId} carries either a reserved ID or a
+   * pre-existing agency's ID and the row does not record which, so releasing it here could free an
+   * ID that belongs to a live agency. Closing that half needs the allocation mode persisted first.
+   */
+  public void releaseTenantIdReservationAfterCommit(AccountInvite invite) {
+    if (invite.getTenantIdReservationToken() == null || invite.getTenantId() == null) {
+      return;
+    }
+    // resendInvite hands the very same reservation to the replacement invite and only marks this
+    // row SUPERSEDED. Releasing here would pull the ID out from under that live replacement.
+    if (invite.getSupersededByInviteId() != null) {
+      return;
+    }
+    long tenantId = invite.getTenantId();
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      tenantIdAllocationClient.release(tenantId);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            try {
+              tenantIdAllocationClient.release(tenantId);
+            } catch (RuntimeException releaseFailure) {
+              // Nothing may escape afterCommit: the invite is already durably dead and an escaping
+              // exception would surface as a 500 on a revoke that has in fact succeeded. The
+              // client swallows its own transport errors; this guards the rest (header supply,
+              // client construction). The reservation ledger stays the source of truth for the
+              // manual cleanup an orphan then needs.
+              log.error(
+                  "Failed to release tenant ID reservation {} after the invite died",
+                  tenantId,
+                  releaseFailure);
+            }
+          }
+        });
   }
 
   @Transactional

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
@@ -629,6 +629,7 @@ public class TenantAdminOnboardingService {
       invite.setStatus(AccountInviteStatus.EXPIRED);
       invite.setUpdateDate(now);
       accountInviteRepository.save(invite);
+      accountInviteService.releaseTenantIdReservationAfterCommit(invite);
       return new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
     }
     return null;

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
@@ -175,6 +176,34 @@ class AccountInviteReservationOrchestrationIT {
     verify(tenantIdAllocationClient).release(21L);
     assertThat(accountInviteRepository.count()).isZero();
     assertThat(tenantIdLedger).isEmpty();
+  }
+
+  @Test
+  void revokedInvite_Should_LeaveNoReservationBehind() {
+    AccountInvite invite =
+        createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "owner@example.org");
+    assertThat(tenantIdLedger).containsExactly(21L);
+
+    service.revokeInvite(invite.getId());
+
+    verify(tenantIdAllocationClient).release(21L);
+    assertThat(tenantIdLedger).isEmpty();
+    assertThat(accountInviteRepository.findById(invite.getId()))
+        .get()
+        .extracting(AccountInvite::getStatus)
+        .isEqualTo(AccountInviteStatus.REVOKED);
+  }
+
+  @Test
+  void revokedInvite_Should_LeaveAgencyIdReservationsAlone() {
+    AccountInvite invite =
+        createTenantAdminInvite(22L, IdAllocationMode.MANUAL, "owner-2@example.org");
+
+    service.revokeInvite(invite.getId());
+
+    // agencyId carries either a reserved ID or a pre-existing agency's ID and the row does not
+    // record which, so revoke must not touch that ledger (#1052).
+    verifyNoInteractions(agencyIdAllocationClient);
   }
 
   private AccountInvite createTenantAdminInvite(

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -747,6 +747,88 @@ class AccountInviteServiceTest {
   }
 
   @Test
+  void revokeInvite_Should_releaseTenantIdReservation_When_inviteStillHoldsOne() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .tenantId(17L)
+            .tenantIdReservationToken("token-17")
+            .build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.revokeInvite(1L);
+
+    verify(tenantIdAllocationClient).release(17L);
+  }
+
+  @Test
+  void revokeInvite_Should_notReleaseTenantId_When_inviteHoldsNoReservation() {
+    AccountInvite invite =
+        AccountInvite.builder().id(1L).status(AccountInviteStatus.EMAIL_SENT).tenantId(17L).build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.revokeInvite(1L);
+
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void revokeInvite_Should_notReleaseTenantId_When_replacementInheritedTheReservation() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.SUPERSEDED)
+            .tenantId(17L)
+            .tenantIdReservationToken("token-17")
+            .supersededByInviteId(2L)
+            .build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.revokeInvite(1L);
+
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void revokeInvite_Should_notReleaseTenantIdTwice_When_inviteAlreadyRevoked() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.REVOKED)
+            .tenantId(17L)
+            .tenantIdReservationToken("token-17")
+            .build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.revokeInvite(1L);
+
+    verify(tenantIdAllocationClient, never()).release(anyLong());
+  }
+
+  @Test
+  void revokeInvite_Should_leaveAgencyIdReservationsAlone() {
+    AccountInvite invite =
+        AccountInvite.builder()
+            .id(1L)
+            .status(AccountInviteStatus.EMAIL_SENT)
+            .tenantId(17L)
+            .tenantIdReservationToken("token-17")
+            .agencyId(42L)
+            .build();
+    when(accountInviteRepository.findById(1L)).thenReturn(Optional.of(invite));
+    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.revokeInvite(1L);
+
+    verifyNoInteractions(agencyIdAllocationClient);
+  }
+
+  @Test
   void revokeInvite_Should_throwNotFound_When_inviteMissing() {
     when(accountInviteRepository.findById(99L)).thenReturn(Optional.empty());
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OnboardingInviteExpiryCommitIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/OnboardingInviteExpiryCommitIT.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.service.accountinvite.onboarding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
@@ -11,6 +12,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteTargetRole;
 import de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.TwoFactorGateStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.onboarding.CounsellorOnboardingService.RegisterCounsellorCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.onboarding.TenantAdminOnboardingService.RegisterTenantAdminCommand;
 import java.time.LocalDateTime;
@@ -21,6 +23,7 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -51,6 +54,8 @@ class OnboardingInviteExpiryCommitIT {
 
   @Autowired private PlatformTransactionManager transactionManager;
 
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+
   @Test
   void tenantAdminResolve_expiredInvite_commitsTheExpiredTransitionDespiteTheLinkDeathAnswer() {
     String token = "expiry-commit-tenant-resolve-" + java.util.UUID.randomUUID();
@@ -62,6 +67,8 @@ class OnboardingInviteExpiryCommitIT {
         .isEqualTo(AccountInviteLinkException.Reason.EXPIRED);
 
     assertThat(committedStatusOf(inviteId)).isEqualTo(AccountInviteStatus.EXPIRED);
+    // #1052: the reservation dies with the invite, once the EXPIRED write is durable.
+    verify(tenantIdAllocationClient).release(79L);
   }
 
   @Test
@@ -78,6 +85,7 @@ class OnboardingInviteExpiryCommitIT {
         .isEqualTo(AccountInviteLinkException.Reason.EXPIRED);
 
     assertThat(committedStatusOf(inviteId)).isEqualTo(AccountInviteStatus.EXPIRED);
+    verify(tenantIdAllocationClient).release(79L);
   }
 
   @Test


### PR DESCRIPTION
Closes #1052

## Problem

Revoking a tenant-admin invite did not release the tenant ID it reserved. The reservation stayed `RESERVED` in TenantService forever, so every revoked — and every expired — invite permanently burned one ID from a small, human-meaningful ID space. Because the Admin panel offers a "next free ID" picker, that suggestion drifts away from reality as the space degrades.

`createInvite` already carries exactly this compensation on its failure path. Revoke and expiry are the same orphan.

## Change

`AccountInviteService` gains `releaseTenantIdReservationAfterCommit`, called from `revokeInvite` and from the tenant-admin expiry transition in `TenantAdminOnboardingService`.

**After commit, not inline.** The reservation may only be freed once the terminal status is durable — releasing inside the transaction would hand the ID back and then, on a rollback, leave a live invite pointing at an ID somebody else can already take. This uses the same `TransactionSynchronization` idiom as `CaseHandoverService.attachStandingSupervisorAfterCommit`. Outside a transaction it runs inline, which carries the same guarantee because `release` never throws.

**Nothing escapes `afterCommit`.** The invite is durably dead by then, and an escaping exception would surface as a 500 on a revoke that has in fact succeeded. The client swallows its own transport errors; the guard covers the rest (header supply, client construction).

## Three cases that must not release

| Case | Why |
|---|---|
| No reservation held (`tenantIdReservationToken == null`) | Nothing to give back |
| `SUPERSEDED` invite | `resendInvite` hands the very same reservation to the replacement; releasing would pull the ID out from under a live invite |
| Second revoke of an already-`REVOKED` invite | The ID may have been re-reserved by someone else in the meantime |

## Deliberately out of scope

**Agency IDs.** The issue asks whether the identical gap exists there. It does not have a safe fix yet: `AccountInvite.agencyId` carries either a reserved ID or a pre-existing agency's ID, and the row does not record which, so releasing it here could free an ID belonging to a live agency. Closing that half needs the allocation mode persisted on the invite first. Pinned by a test so the boundary is explicit rather than accidental.

**The expiry transition in `AccountInviteService.acceptInvite`.** Not wired, because it cannot fire: `AccountInviteLinkException extends RuntimeException` and the method is `@Transactional` without `noRollbackFor`, so the `save(EXPIRED)` immediately before the throw is rolled back with it. `TenantAdminOnboardingService.expireIfPastExpiry` returns the link-death answer instead of throwing precisely so its write commits, which is why the release is wired there and only there. Worth a separate look — the `EXPIRED` write in `acceptInvite` appears to be lost today.

## Tests

`AccountInviteServiceTest` — releases when a reservation is held; does not release without a token, for a superseded invite, or on a second revoke; never touches the agency ledger.

`AccountInviteReservationOrchestrationIT` — `revokedInvite_Should_LeaveNoReservationBehind` mirrors the PreDev evidence in the issue: the in-memory ledger is empty again and the row is `REVOKED`. A sibling pins the agency-ledger boundary.

`OnboardingInviteExpiryCommitIT` — asserts the release on both tenant-admin expiry paths. This IT previously did not mock `TenantIdAllocationClient` while seeding an invite with `tenantId=79` and a reservation token, so the new call would have reached the real client; it is now a `@MockitoBean`.

## Reviewer test plan

- [ ] `mvn -Dtest='AccountInviteServiceTest,AccountInviteReservationOrchestrationIT,OnboardingInviteExpiryCommitIT' test`
- [ ] UserService quality gate for the changed module
- [ ] On PreDev, repeat the issue's steps: create an AUTO-mode tenant-admin invite, revoke it, then `GET /service/tenantadmin/tenant-ids/{id}/availability` and expect `FREE`
- [ ] Resend an invite, then revoke the superseded original, and confirm the replacement keeps its reserved ID
