### PR TITLE
feat(live-chat): carry the department coordinate on the waiting payload

### DIFF
--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -346,6 +346,22 @@ components:
           type: integer
           minimum: 0
           description: Number of visible live-chat enquiries created before this one in the same consulting type and topic, still waiting (status NEW, privacy confirmed, no consultant assigned).
+        agencyId:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            The counselling centre bound to this enquiry, so the entry room can resolve its
+            data-protection declaration (agency x topic) once the case has been accepted and show
+            the advice seeker the wording that actually governs them, rather than the platform
+            fallback. Null while no agency is bound. Additive - older clients ignore it.
+        mainTopicId:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            The enquiry's main topic. Second half of the department coordinate the legal text is
+            resolved by; see agencyId. Null when the enquiry carries no topic.
         status:
           type: string
           enum:

--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -352,9 +352,10 @@ components:
           example: 17
           description: >-
             The counselling centre bound to this enquiry, so the entry room can resolve its
-            data-protection declaration (agency x topic) once the case has been accepted and show
-            the advice seeker the wording that actually governs them, rather than the platform
-            fallback; null while no agency is bound. Additive - older clients can ignore it.
+            data-protection declaration (agency x topic) once the case has been accepted. When no
+            usable declaration exists, the client uses this coordinate to show the non-blocking
+            missing-policy warning; null while no agency is bound. Additive - older clients can
+            ignore it.
         mainTopicId:
           type: integer
           format: int64

--- a/api/conversationservice.yaml
+++ b/api/conversationservice.yaml
@@ -349,19 +349,20 @@ components:
         agencyId:
           type: integer
           format: int64
-          nullable: true
+          example: 17
           description: >-
             The counselling centre bound to this enquiry, so the entry room can resolve its
             data-protection declaration (agency x topic) once the case has been accepted and show
             the advice seeker the wording that actually governs them, rather than the platform
-            fallback. Null while no agency is bound. Additive - older clients ignore it.
+            fallback; null while no agency is bound. Additive - older clients can ignore it.
         mainTopicId:
           type: integer
           format: int64
-          nullable: true
+          example: 3
           description: >-
-            The enquiry's main topic. Second half of the department coordinate the legal text is
-            resolved by; see agencyId. Null when the enquiry carries no topic.
+            The enquiry's main topic - second half of the department coordinate the legal text is
+            resolved by; see agencyId. Null when the enquiry carries no topic. Additive - older
+            clients can ignore it.
         status:
           type: string
           enum:

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
@@ -21,8 +21,8 @@ public class ConversationDtoMapper {
     anonymousEnquiry.setStatus(StatusEnum.fromValue(statusString));
     /* The department coordinate (agency x topic). The entry room needs both to resolve
     the accepting counselling centre's data-protection declaration once the case reads
-    IN_PROGRESS; without them it can only show the platform fallback, which is not the
-    wording that governs the advice seeker. Either may legitimately be null — an enquiry
+    IN_PROGRESS, or show the explicit non-blocking warning when none is usable. Either may
+    legitimately be null — an enquiry
     with no agency bound yet, or none carrying a topic — and the client falls back. */
     anonymousEnquiry.setAgencyId(agencyIdOf(sessionMap));
     anonymousEnquiry.setMainTopicId(mainTopicIdOf(sessionMap));

--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapper.java
@@ -19,6 +19,13 @@ public class ConversationDtoMapper {
     anonymousEnquiry.setNumAvailableConsultants(numAvailableConsultants);
     anonymousEnquiry.setPeopleAhead((int) Math.min(Integer.MAX_VALUE, peopleAhead));
     anonymousEnquiry.setStatus(StatusEnum.fromValue(statusString));
+    /* The department coordinate (agency x topic). The entry room needs both to resolve
+    the accepting counselling centre's data-protection declaration once the case reads
+    IN_PROGRESS; without them it can only show the platform fallback, which is not the
+    wording that governs the advice seeker. Either may legitimately be null — an enquiry
+    with no agency bound yet, or none carrying a topic — and the client falls back. */
+    anonymousEnquiry.setAgencyId(agencyIdOf(sessionMap));
+    anonymousEnquiry.setMainTopicId(mainTopicIdOf(sessionMap));
 
     return anonymousEnquiry;
   }

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapperTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Why it is pinned: the entry room resolves the accepting counselling centre's data-protection
  * declaration from (agencyId, topicId) once the case reads IN_PROGRESS. Drop either half and the
- * consent screen silently falls back to the platform wording — which is not the text that governs
- * the advice seeker, and the failure is invisible because the fallback renders perfectly.
+ * consent screen cannot distinguish a configured policy from the non-blocking missing-policy
+ * warning, and that failure is invisible because both states render successfully.
  */
 class ConversationDtoMapperTest {
 
@@ -48,8 +48,8 @@ class ConversationDtoMapperTest {
 
   @Test
   void anonymousEnquiryOf_should_tolerateAMissingCoordinate() {
-    // No agency bound yet, or an enquiry without a topic. The client falls back to the
-    // platform wording; the payload must not fail to build.
+    // No agency bound yet, or an enquiry without a topic. The client keeps its legacy platform
+    // wording because it cannot attribute a missing policy to an agency; the payload must build.
     var enquiry = mapper.anonymousEnquiryOf(sessionMap(null, null), 0, 0L);
 
     assertThat(enquiry.getAgencyId()).isNull();

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapperTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/mapping/ConversationDtoMapperTest.java
@@ -1,0 +1,58 @@
+package de.caritas.cob.userservice.api.adapters.web.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The department coordinate on the live-chat waiting payload.
+ *
+ * <p>Why it is pinned: the entry room resolves the accepting counselling centre's data-protection
+ * declaration from (agencyId, topicId) once the case reads IN_PROGRESS. Drop either half and the
+ * consent screen silently falls back to the platform wording — which is not the text that governs
+ * the advice seeker, and the failure is invisible because the fallback renders perfectly.
+ */
+class ConversationDtoMapperTest {
+
+  private final ConversationDtoMapper mapper = new ConversationDtoMapper();
+
+  private static Map<String, Object> sessionMap(Object agencyId, Object mainTopicId) {
+    Map<String, Object> map = new HashMap<>();
+    map.put("status", "NEW");
+    map.put("agencyId", agencyId);
+    map.put("mainTopicId", mainTopicId);
+    return map;
+  }
+
+  @Test
+  void anonymousEnquiryOf_should_carryTheDepartmentCoordinate() {
+    var enquiry = mapper.anonymousEnquiryOf(sessionMap(17L, 3L), 2, 4L);
+
+    assertThat(enquiry.getAgencyId()).isEqualTo(17L);
+    assertThat(enquiry.getMainTopicId()).isEqualTo(3L);
+    assertThat(enquiry.getNumAvailableConsultants()).isEqualTo(2);
+    assertThat(enquiry.getPeopleAhead()).isEqualTo(4);
+  }
+
+  @Test
+  void anonymousEnquiryOf_should_widenIntegerIds() {
+    // The session map is untyped; JSON and JPA both hand these back as Integer often enough
+    // that reading them as Long directly would ClassCastException in production only.
+    var enquiry = mapper.anonymousEnquiryOf(sessionMap(17, 3), 0, 0L);
+
+    assertThat(enquiry.getAgencyId()).isEqualTo(17L);
+    assertThat(enquiry.getMainTopicId()).isEqualTo(3L);
+  }
+
+  @Test
+  void anonymousEnquiryOf_should_tolerateAMissingCoordinate() {
+    // No agency bound yet, or an enquiry without a topic. The client falls back to the
+    // platform wording; the payload must not fail to build.
+    var enquiry = mapper.anonymousEnquiryOf(sessionMap(null, null), 0, 0L);
+
+    assertThat(enquiry.getAgencyId()).isNull();
+    assertThat(enquiry.getMainTopicId()).isNull();
+  }
+}


### PR DESCRIPTION
Backend half of the follow-up noted in #1140. Draft on purpose — opened to let CI check it.

## Problem

The live-chat consent screen shows the **platform** legal text, not the data-protection declaration of the counselling centre that accepted the case. The advice seeker agrees to wording that does not govern them — and it renders perfectly, so nothing about it looks wrong.

Everything else already exists: AgencyService serves the declaration per department at `GET /service/agencies/{agencyId}/topics/{topicId}/legal` (`dpp.consentText` + `versionId`, ADR-021 decision 4), and Gate 2 pins a recorded consent to that version via `PUT /users/sessions/{sessionId}/consent` (ADR-022 decision 2). The entry room can call neither, because the payload it polls while waiting does not say which department the enquiry belongs to.

## What changed

- `AnonymousEnquiry` gains `agencyId` and `mainTopicId`, both nullable.
- `ConversationDtoMapper` fills them from the session map, widening `Integer` ids the way the existing accessors already do.
- A mapper test pins the coordinate: drop either half and the consent screen degrades silently to the platform wording.

Additive and backwards compatible in both directions — an older client ignores the two fields, and a client paired with an older backend reads them as absent and keeps today's platform fallback.

## Verification

- `ConversationDtoMapperTest` covers the coordinate, `Integer` widening, and a missing coordinate.
- Not built locally: `mvn` is blocked in the session this was written in, which is the main reason this is a draft. CI on this PR is the check.

Frontend half: ORISO-Frontend#1360. Neither blocks #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASK7rc5HuHJK7HB5FkMKqd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASK7rc5HuHJK7HB5FkMKqd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymous enquiries now retain associated agency and main topic information when available.

* **Bug Fixes**
  * Improved handling of missing agency or topic information without causing errors.

* **Tests**
  * Added coverage for session-based department details, consultant and queue counts, ID conversion, and null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->