### PR TITLE
fix: make direct invite sending retry-safe

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
+++ b/src/main/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteController.java
@@ -61,29 +61,27 @@ public class AccountInviteController {
       @RequestBody(required = false) CreateAccountInviteRequestDTO request) {
     CreateAccountInviteRequestDTO safe =
         request == null ? new CreateAccountInviteRequestDTO() : request;
-    AccountInvite invite =
-        accountInviteService.createInvite(
-            new CreateAccountInviteCommand(
-                parseEnum(AccountInviteTargetRole.class, safe.targetRole, "targetRole"),
-                safe.tenantId,
-                safe.recipientEmail,
-                safe.firstName,
-                safe.lastName,
-                safe.agencyId,
-                safe.departmentId,
-                safe.expiresInDays,
-                parseOptionalEnum(
-                    IdAllocationMode.class, safe.tenantIdAllocationMode, "tenantIdAllocationMode"),
-                parseOptionalEnum(
-                    IdAllocationMode.class,
-                    safe.agencyIdAllocationMode,
-                    "agencyIdAllocationMode")));
+    CreateAccountInviteCommand command =
+        new CreateAccountInviteCommand(
+            parseEnum(AccountInviteTargetRole.class, safe.targetRole, "targetRole"),
+            safe.tenantId,
+            safe.recipientEmail,
+            safe.firstName,
+            safe.lastName,
+            safe.agencyId,
+            safe.departmentId,
+            safe.expiresInDays,
+            parseOptionalEnum(
+                IdAllocationMode.class, safe.tenantIdAllocationMode, "tenantIdAllocationMode"),
+            parseOptionalEnum(
+                IdAllocationMode.class, safe.agencyIdAllocationMode, "agencyIdAllocationMode"));
 
     if (safe.templateId != null) {
-      InviteSendResult result =
-          accountInviteService.sendInvite(new SendInviteCommand(invite.getId(), safe.templateId));
+      InviteSendResult result = accountInviteService.createAndSendInvite(command, safe.templateId);
       return new ResponseEntity<>(AccountInviteResponseDTO.from(result), HttpStatus.CREATED);
     }
+
+    AccountInvite invite = accountInviteService.createInvite(command);
 
     return new ResponseEntity<>(
         AccountInviteResponseDTO.from(

--- a/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
+++ b/src/main/java/de/caritas/cob/userservice/api/exception/SmtpSendException.java
@@ -3,12 +3,14 @@ package de.caritas.cob.userservice.api.exception;
 /**
  * Signals that an email could not be handed over to the SMTP server (or that the global SMTP
  * configuration required to do so is unavailable). Mirrors the strict contract established in
- * ConsultingTypeService (TEN-INV-U5): callers must never report success — and never persist a SENT
- * state — when this is thrown. Mapped to 502 Bad Gateway.
+ * ConsultingTypeService (TEN-INV-U5): callers must never report success when this is thrown. A
+ * caller with a committed deduplication claim may need to retain it when delivery is uncertain.
+ * Mapped to 502 Bad Gateway.
  *
  * <p>#1006: each instance carries a coarse {@link Category}. Only the category reaches the API
  * response body (information-poor per the repository error contract); the detailed message stays in
- * the server log.
+ * the server log. {@link DeliveryDisposition} is an internal retry-safety signal: callers may only
+ * release a committed deduplication claim when the message is confirmed not to have been sent.
  */
 public class SmtpSendException extends RuntimeException {
 
@@ -26,7 +28,16 @@ public class SmtpSendException extends RuntimeException {
     SMTP_TRANSPORT_FAILED
   }
 
+  /** What is known about delivery when the failure surfaced. */
+  public enum DeliveryDisposition {
+    /** The failure happened before dispatch, or SMTP explicitly rejected every recipient. */
+    CONFIRMED_NOT_SENT,
+    /** SMTP may have accepted the message before the client observed the failure. */
+    DELIVERY_UNCERTAIN
+  }
+
   private final Category category;
+  private final DeliveryDisposition deliveryDisposition;
 
   public SmtpSendException(String message) {
     this(Category.SMTP_TRANSPORT_FAILED, message);
@@ -37,16 +48,42 @@ public class SmtpSendException extends RuntimeException {
   }
 
   public SmtpSendException(Category category, String message) {
-    super(message);
-    this.category = category;
+    this(category, defaultDisposition(category), message);
   }
 
   public SmtpSendException(Category category, String message, Throwable cause) {
+    this(category, defaultDisposition(category), message, cause);
+  }
+
+  public SmtpSendException(
+      Category category, DeliveryDisposition deliveryDisposition, String message) {
+    super(message);
+    this.category = category;
+    this.deliveryDisposition = deliveryDisposition;
+  }
+
+  public SmtpSendException(
+      Category category, DeliveryDisposition deliveryDisposition, String message, Throwable cause) {
     super(message, cause);
     this.category = category;
+    this.deliveryDisposition = deliveryDisposition;
   }
 
   public Category getCategory() {
     return category;
+  }
+
+  public DeliveryDisposition getDeliveryDisposition() {
+    return deliveryDisposition;
+  }
+
+  public boolean isConfirmedNotSent() {
+    return deliveryDisposition == DeliveryDisposition.CONFIRMED_NOT_SENT;
+  }
+
+  private static DeliveryDisposition defaultDisposition(Category category) {
+    return category == Category.SMTP_TRANSPORT_FAILED
+        ? DeliveryDisposition.DELIVERY_UNCERTAIN
+        : DeliveryDisposition.CONFIRMED_NOT_SENT;
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/AccountInvite.java
@@ -28,7 +28,11 @@ import lombok.ToString;
     indexes = {
       @Index(name = "idx_account_invite_tenant_status", columnList = "tenant_id,status"),
       @Index(name = "idx_account_invite_target_role", columnList = "target_role"),
-      @Index(name = "idx_account_invite_token_hash", columnList = "token_hash", unique = true)
+      @Index(name = "idx_account_invite_token_hash", columnList = "token_hash", unique = true),
+      @Index(
+          name = "idx_account_invite_active_recipient",
+          columnList = "active_recipient_key",
+          unique = true)
     })
 @Getter
 @Setter
@@ -52,6 +56,14 @@ public class AccountInvite {
 
   @Column(name = "recipient_email", nullable = false)
   private String recipientEmail;
+
+  /**
+   * Normalized recipient while this invite holds the address. Null for terminal and legacy rows.
+   * The unique index is the cross-replica concurrency guard; the service-side count remains the
+   * user-friendly validation for ordinary requests.
+   */
+  @Column(name = "active_recipient_key")
+  private String activeRecipientKey;
 
   @Column(name = "first_name")
   private String firstName;

--- a/src/main/java/de/caritas/cob/userservice/api/model/IdReservationReleaseTask.java
+++ b/src/main/java/de/caritas/cob/userservice/api/model/IdReservationReleaseTask.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.userservice.api.model;
+
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/** Durable retry record for releasing an external tenant or agency ID reservation. */
+@Entity
+@Table(
+    name = "id_reservation_release_task",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "idx_id_reservation_release_task_type_id",
+            columnNames = {"allocation_type", "reserved_id"}))
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class IdReservationReleaseTask {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "allocation_type", nullable = false, length = 16)
+  private IdReservationReleaseType allocationType;
+
+  @Column(name = "reserved_id", nullable = false)
+  private Long reservedId;
+
+  /** Tenant header needed when retrying an AgencyService release outside the request thread. */
+  @Column(name = "tenant_context_id")
+  private Long tenantContextId;
+
+  @Column(name = "attempt_count", nullable = false)
+  @Builder.Default
+  private int attemptCount = 0;
+
+  @Column(name = "last_attempt_at", columnDefinition = "datetime(6)")
+  private LocalDateTime lastAttemptAt;
+
+  @Column(name = "create_date", nullable = false, columnDefinition = "datetime(6)")
+  private LocalDateTime createDate;
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -99,6 +99,27 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
       @Param("statuses") Collection<AccountInviteStatus> statuses,
       @Param("now") LocalDateTime now);
 
+  /**
+   * Materializes elapsed address-holding rows before a new claim is inserted. Without this update,
+   * the date-aware availability query would allow a retry while the unique recipient key still
+   * rejects it.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE AccountInvite i"
+          + " SET i.status ="
+          + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.EXPIRED,"
+          + " i.activeRecipientKey = NULL,"
+          + " i.updateDate = :now"
+          + " WHERE i.activeRecipientKey = :recipientEmail"
+          + " AND i.status IN :statuses"
+          + " AND i.expiresAt IS NOT NULL"
+          + " AND i.expiresAt <= :now")
+  int expireElapsedRecipientClaims(
+      @Param("recipientEmail") String recipientEmail,
+      @Param("statuses") Collection<AccountInviteStatus> statuses,
+      @Param("now") LocalDateTime now);
+
   @Query(
       "SELECT i FROM AccountInvite i"
           + " WHERE (:tenantId IS NULL OR i.tenantId = :tenantId)"

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -50,6 +50,7 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
           + " i.acceptedByUserId = :acceptedByUserId,"
           + " i.emailVerificationStatus ="
           + " de.caritas.cob.userservice.api.service.accountinvite.EmailVerificationStatus.VERIFIED,"
+          + " i.activeRecipientKey = NULL,"
           + " i.updateDate = :now"
           + " WHERE i.id = :id AND i.status ="
           + " de.caritas.cob.userservice.api.service.accountinvite.AccountInviteStatus.EMAIL_SENT")
@@ -82,17 +83,11 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
    * <p>The caller passes the non-terminal statuses; terminal ones ({@code ACCEPTED}, {@code
    * EXPIRED}, {@code REVOKED}, {@code SUPERSEDED}) must never block a fresh invite.
    *
-   * <p><b>Why this stays advisory instead of becoming a unique constraint.</b> The rule above is
-   * not expressible as one. MariaDB has no partial indexes, so it would have to become a persisted
-   * generated column plus a unique index — and that column cannot contain {@code NOW()}, so it
-   * could not carry the expiry clause. The resulting constraint would be strictly harsher than the
-   * rule it is meant to enforce and would reject the legitimate re-invite after a lapsed invite,
-   * with no way for an admin to recover as long as expiry stays lazily materialized. On top of
-   * that, rows violating it already exist in the wild (two Pre-Dev addresses each hold two
-   * unaccepted invites), so the changeset would need a destructive data migration before it could
-   * even apply, and Liquibase does not run in the test profile — the migration would ship with no
-   * test coverage at all. A constraint becomes worth revisiting once invite expiry is swept
-   * eagerly; until then the service-side guard is the enforcement point.
+   * <p>The date-aware rule is not itself expressible as a MariaDB unique constraint. New active
+   * rows therefore also hold a nullable normalized key whose unique index closes the concurrent
+   * create race; terminal transitions clear that key. Legacy rows remain null so existing
+   * duplicates do not require a destructive migration. This query stays authoritative for expiry
+   * and for those legacy rows, while the key is the final cross-replica concurrency guard.
    */
   @Query(
       "SELECT COUNT(i) FROM AccountInvite i"

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/AccountInviteRepository.java
@@ -99,6 +99,18 @@ public interface AccountInviteRepository extends JpaRepository<AccountInvite, Lo
       @Param("statuses") Collection<AccountInviteStatus> statuses,
       @Param("now") LocalDateTime now);
 
+  @Query(
+      "SELECT COUNT(i) FROM AccountInvite i"
+          + " WHERE LOWER(i.recipientEmail) = :recipientEmail"
+          + " AND i.id <> :excludedInviteId"
+          + " AND i.status IN :statuses"
+          + " AND (i.expiresAt IS NULL OR i.expiresAt > :now)")
+  long countNonTerminalInvitesForRecipientEmailExcludingId(
+      @Param("recipientEmail") String recipientEmail,
+      @Param("excludedInviteId") Long excludedInviteId,
+      @Param("statuses") Collection<AccountInviteStatus> statuses,
+      @Param("now") LocalDateTime now);
+
   /**
    * Materializes elapsed address-holding rows before a new claim is inserted. Without this update,
    * the date-aware availability query would allow a retry while the unique recipient key still

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdReservationReleaseTaskRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdReservationReleaseTaskRepository.java
@@ -1,0 +1,19 @@
+package de.caritas.cob.userservice.api.port.out;
+
+import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+public interface IdReservationReleaseTaskRepository
+    extends JpaRepository<IdReservationReleaseTask, Long> {
+
+  List<IdReservationReleaseTask> findTop100ByOrderByCreateDateAsc();
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select task from IdReservationReleaseTask task where task.id = :id")
+  Optional<IdReservationReleaseTask> findByIdForUpdate(Long id);
+}

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/IdReservationReleaseTaskRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/IdReservationReleaseTaskRepository.java
@@ -1,17 +1,32 @@
 package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseType;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IdReservationReleaseTaskRepository
     extends JpaRepository<IdReservationReleaseTask, Long> {
 
-  List<IdReservationReleaseTask> findTop100ByOrderByCreateDateAsc();
+  boolean existsByAllocationTypeAndReservedId(
+      IdReservationReleaseType allocationType, Long reservedId);
+
+  @Query(
+      "SELECT task FROM IdReservationReleaseTask task"
+          + " WHERE task.attemptCount < :maxAttempts"
+          + " AND (task.lastAttemptAt IS NULL OR task.lastAttemptAt < :retryBefore)"
+          + " ORDER BY task.createDate ASC")
+  List<IdReservationReleaseTask> findRetryable(
+      @Param("maxAttempts") int maxAttempts,
+      @Param("retryBefore") LocalDateTime retryBefore,
+      Pageable pageable);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select task from IdReservationReleaseTask task where task.id = :id")

--- a/src/main/java/de/caritas/cob/userservice/api/port/out/ScheduledTaskClaimRepository.java
+++ b/src/main/java/de/caritas/cob/userservice/api/port/out/ScheduledTaskClaimRepository.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.port.out;
 
 import de.caritas.cob.userservice.api.model.ScheduledTaskClaim;
 import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ScheduledTaskClaimRepository extends JpaRepository<ScheduledTaskClaim, String> {
+
+  int deleteByTaskNameAndClaimedUntil(String taskName, LocalDateTime claimedUntil);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT claim FROM ScheduledTaskClaim claim WHERE claim.taskName = :taskName")

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -271,7 +271,6 @@ public class AccountInviteService {
                 accountInviteRepository.deleteById(invite.getId());
                 accountInviteRepository.flush();
               });
-      releaseDirectInviteReservations(invite, command);
     } catch (RuntimeException compensationFailure) {
       log.error(
           "Direct invite {} failed before dispatch and its committed claim could not be released",
@@ -279,6 +278,7 @@ public class AccountInviteService {
           compensationFailure);
       sendFailure.addSuppressed(compensationFailure);
     }
+    releaseDirectInviteReservations(invite, command);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -221,7 +221,8 @@ public class AccountInviteService {
 
     return deliverPreparedInvite(
         dispatch,
-        null,
+        dispatch.invite().getId(),
+        false,
         sendFailure -> releaseDirectInviteClaim(dispatch.invite(), command, sendFailure));
   }
 
@@ -444,6 +445,18 @@ public class AccountInviteService {
   private void revalidateReservations(
       TenantIdReservation tenantReservation, Long reservedAgencyId) {
     if (tenantReservation != null
+        && reservationReleaseTaskRepository.existsByAllocationTypeAndReservedId(
+            IdReservationReleaseType.TENANT, tenantReservation.tenantId())) {
+      throw new ConflictException(
+          "tenantId " + tenantReservation.tenantId() + " still has a pending reservation cleanup");
+    }
+    if (reservedAgencyId != null
+        && reservationReleaseTaskRepository.existsByAllocationTypeAndReservedId(
+            IdReservationReleaseType.AGENCY, reservedAgencyId)) {
+      throw new ConflictException(
+          "agencyId " + reservedAgencyId + " still has a pending reservation cleanup");
+    }
+    if (tenantReservation != null
         && tenantIdAllocationClient.getAvailability(tenantReservation.tenantId())
             != IdAllocationStatus.RESERVED) {
       throw new ConflictException(
@@ -482,6 +495,7 @@ public class AccountInviteService {
     return deliverPreparedInvite(
         resend.dispatch(),
         resend.oldInviteId(),
+        true,
         sendFailure -> restoreResendAfterConfirmedFailure(resend, sendFailure));
   }
 
@@ -582,6 +596,7 @@ public class AccountInviteService {
   private InviteSendResult deliverPreparedInvite(
       DirectInviteDispatch dispatch,
       Long failureAuditInviteId,
+      boolean auditConfirmedNotSent,
       ConfirmedSendFailureHandler confirmedFailureHandler) {
     InviteMailSendReceipt receipt;
     try {
@@ -595,7 +610,7 @@ public class AccountInviteService {
               dispatch.template().getLanguage());
     } catch (SmtpSendException sendFailure) {
       recordDeliveryFailureSafely(
-          failureAuditInviteId,
+          sendFailure.isConfirmedNotSent() && !auditConfirmedNotSent ? null : failureAuditInviteId,
           dispatch.template(),
           dispatch.invite(),
           dispatch.subject(),

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -54,6 +54,8 @@ import org.springframework.web.client.HttpClientErrorException;
 @RequiredArgsConstructor
 public class AccountInviteService {
 
+  private static final String ACTIVE_RECIPIENT_CONSTRAINT = "idx_account_invite_active_recipient";
+
   private static final int TOKEN_BYTES = 32;
   private static final long DEFAULT_EXPIRY_DAYS = 30L;
   private static final SecureRandom RANDOM = new SecureRandom();
@@ -161,9 +163,8 @@ public class AccountInviteService {
       if (tenantReservation != null) {
         tenantIdAllocationClient.release(tenantReservation.tenantId());
       }
-      if (exception instanceof DataIntegrityViolationException) {
-        throw new CustomValidationHttpStatusException(
-            HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      if (isActiveRecipientConflict(exception)) {
+        throw emailNotAvailable(exception);
       }
       throw exception;
     }
@@ -206,9 +207,8 @@ public class AccountInviteService {
       if (claimedInvite[0] != null) {
         releaseDirectInviteReservations(claimedInvite[0], command);
       }
-      if (claimFailure instanceof DataIntegrityViolationException) {
-        throw new CustomValidationHttpStatusException(
-            HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      if (isActiveRecipientConflict(claimFailure)) {
+        throw emailNotAvailable(claimFailure);
       }
       throw claimFailure;
     }
@@ -273,6 +273,7 @@ public class AccountInviteService {
 
   private void releaseDirectInviteClaim(
       AccountInvite invite, CreateAccountInviteCommand command, RuntimeException sendFailure) {
+    boolean claimReleased = false;
     try {
       requiresNewTransaction()
           .executeWithoutResult(
@@ -280,6 +281,7 @@ public class AccountInviteService {
                 accountInviteRepository.deleteById(invite.getId());
                 accountInviteRepository.flush();
               });
+      claimReleased = true;
     } catch (RuntimeException compensationFailure) {
       log.error(
           "Direct invite {} failed before dispatch and its committed claim could not be released",
@@ -287,7 +289,9 @@ public class AccountInviteService {
           compensationFailure);
       sendFailure.addSuppressed(compensationFailure);
     }
-    releaseDirectInviteReservations(invite, command);
+    if (claimReleased) {
+      releaseDirectInviteReservations(invite, command);
+    }
   }
 
   /**
@@ -298,18 +302,27 @@ public class AccountInviteService {
    */
   private void releaseDirectInviteReservations(
       AccountInvite invite, CreateAccountInviteCommand command) {
-    try {
-      if (invite.getTenantIdReservationToken() != null && invite.getTenantId() != null) {
+    if (invite.getTenantIdReservationToken() != null && invite.getTenantId() != null) {
+      try {
         tenantIdAllocationClient.release(invite.getTenantId());
+      } catch (RuntimeException releaseException) {
+        logReservationReleaseFailure("tenant", releaseException);
       }
-      if (command.agencyIdAllocationMode() != null && invite.getAgencyId() != null) {
-        agencyIdAllocationClient.release(invite.getAgencyId());
-      }
-    } catch (RuntimeException releaseException) {
-      log.warn(
-          "Could not release direct-invite ID reservation after failed send ({})",
-          releaseException.getClass().getSimpleName());
     }
+    if (command.agencyIdAllocationMode() != null && invite.getAgencyId() != null) {
+      try {
+        agencyIdAllocationClient.release(invite.getAgencyId());
+      } catch (RuntimeException releaseException) {
+        logReservationReleaseFailure("agency", releaseException);
+      }
+    }
+  }
+
+  private void logReservationReleaseFailure(String allocationType, RuntimeException exception) {
+    log.warn(
+        "Could not release direct-invite {} ID reservation after failed send ({})",
+        allocationType,
+        exception.getClass().getSimpleName());
   }
 
   /**
@@ -347,16 +360,20 @@ public class AccountInviteService {
    */
   private void verifyRecipientEmailAvailable(String recipientEmail) {
     String normalized = normalizeEmail(recipientEmail);
-    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()
-        || accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
-                normalized, ADDRESS_HOLDING_INVITE_STATUSES, LocalDateTime.now())
-            > 0) {
+    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()) {
+      throw emailNotAvailable(null);
+    }
+    LocalDateTime now = LocalDateTime.now();
+    accountInviteRepository.expireElapsedRecipientClaims(
+        normalized, ADDRESS_HOLDING_INVITE_STATUSES, now);
+    if (accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
+            normalized, ADDRESS_HOLDING_INVITE_STATUSES, now)
+        > 0) {
       // 409 + X-Reason: EMAIL_NOT_AVAILABLE — distinguishable from the bare 400 of a malformed
       // address and from the reason-less 409 of a taken tenant ID. Both sources answer with the
       // SAME reason on purpose: the admin renders one inline field error for it, and a second
       // code would degrade to a generic toast.
-      throw new CustomValidationHttpStatusException(
-          HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      throw emailNotAvailable(null);
     }
   }
 
@@ -466,6 +483,7 @@ public class AccountInviteService {
             // tenant ID, so it must also keep the token that consumes the reservation.
             .tenantIdReservationToken(oldInvite.getTenantIdReservationToken())
             .recipientEmail(oldInvite.getRecipientEmail())
+            .activeRecipientKey(normalizeEmail(oldInvite.getRecipientEmail()))
             .firstName(oldInvite.getFirstName())
             .lastName(oldInvite.getLastName())
             .agencyId(oldInvite.getAgencyId())
@@ -480,21 +498,31 @@ public class AccountInviteService {
             .updateDate(now)
             .build();
 
-    // Transport first (TEN-INV-U6): the old invite is only superseded and the replacement only
-    // persisted after the SMTP server accepted the replacement mail. A failed handover leaves
-    // the previous invite fully intact and resendable. The FAILED audit row anchors on the old
-    // invite because the replacement does not exist outside this transaction.
+    // Transfer the unique recipient claim before SMTP. Both writes belong to this transaction, so
+    // a rejected send restores the old claim; a competing invite fails this flush before mail.
+    oldInvite.setActiveRecipientKey(null);
+    accountInviteRepository.saveAndFlush(oldInvite);
+    try {
+      replacement = accountInviteRepository.saveAndFlush(replacement);
+    } catch (DataIntegrityViolationException conflict) {
+      if (isActiveRecipientConflict(conflict)) {
+        throw emailNotAvailable(conflict);
+      }
+      throw conflict;
+    }
+
+    // Transport first (TEN-INV-U6): the old invite is only superseded after the SMTP server
+    // accepted the replacement mail. A failed handover rolls this transaction back, restoring
+    // the old claim and removing the replacement. The FAILED audit row anchors on the committed
+    // old invite because the replacement does not exist outside this transaction.
     InviteSendResult result = sendInvite(replacement, template, oldInvite.getId());
 
     oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
-    oldInvite.setActiveRecipientKey(null);
     oldInvite.setSupersededAt(now);
     oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
     oldInvite.setSupersededByInviteId(result.invite().getId());
     oldInvite.setUpdateDate(now);
-    accountInviteRepository.saveAndFlush(oldInvite);
-    result.invite().setActiveRecipientKey(normalizeEmail(result.invite().getRecipientEmail()));
-    accountInviteRepository.save(result.invite());
+    accountInviteRepository.save(oldInvite);
     return result;
   }
 
@@ -513,7 +541,7 @@ public class AccountInviteService {
     return accountInviteRepository.save(invite);
   }
 
-  @Transactional
+  @Transactional(noRollbackFor = AccountInviteLinkException.class)
   public AccountInvite acceptInvite(String rawToken, String acceptedByUserId) {
     if (isBlank(rawToken)) {
       throw new BadRequestException("Invite token is required");
@@ -970,6 +998,29 @@ public class AccountInviteService {
 
   private static String normalizeEmail(String value) {
     return value.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static boolean isActiveRecipientConflict(Throwable exception) {
+    Throwable current = exception;
+    while (current != null) {
+      String message = current.getMessage();
+      if (message != null
+          && message.toLowerCase(Locale.ROOT).contains(ACTIVE_RECIPIENT_CONSTRAINT)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static CustomValidationHttpStatusException emailNotAvailable(Throwable cause) {
+    CustomValidationHttpStatusException conflict =
+        new CustomValidationHttpStatusException(
+            HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+    if (cause != null) {
+      conflict.initCause(cause);
+    }
+    return conflict;
   }
 
   private static String trimToNull(String value) {

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -10,15 +10,19 @@ import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.userservice.api.exception.httpresponses.customheader.HttpStatusExceptionReason;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
 import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseType;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
@@ -84,6 +88,8 @@ public class AccountInviteService {
   private final @NonNull InviteMailDispatchService inviteMailDispatchService;
   private final @NonNull InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
   private final @NonNull IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final @NonNull IdReservationReleaseTaskRepository reservationReleaseTaskRepository;
+  private final @NonNull IdReservationReleaseProcessor reservationReleaseProcessor;
   private final @NonNull PlatformTransactionManager transactionManager;
 
   @Transactional
@@ -213,56 +219,10 @@ public class AccountInviteService {
       throw claimFailure;
     }
 
-    InviteMailSendReceipt receipt;
-    try {
-      receipt =
-          inviteMailDispatchService.send(
-              dispatch.invite().getRecipientEmail(),
-              dispatch.subject(),
-              dispatch.body(),
-              dispatch.acceptUrl(),
-              dispatch.invite().getTenantId(),
-              dispatch.template().getLanguage());
-    } catch (SmtpSendException sendFailure) {
-      if (sendFailure.isConfirmedNotSent()) {
-        releaseDirectInviteClaim(dispatch.invite(), command, sendFailure);
-      } else {
-        log.warn(
-            "Direct invite {} has an uncertain SMTP delivery outcome; keeping the claim to prevent"
-                + " a duplicate send",
-            dispatch.invite().getId(),
-            sendFailure);
-      }
-      throw sendFailure;
-    }
-
-    InviteEmailDelivery pendingDelivery =
-        InviteEmailDelivery.builder()
-            .accountInviteId(dispatch.invite().getId())
-            .templateId(dispatch.template().getId())
-            .templateKind(dispatch.template().getKind())
-            .recipientSnapshot(dispatch.invite().getRecipientEmail())
-            .subjectSnapshot(dispatch.subject())
-            .bodySnapshot(dispatch.body())
-            .status(InviteEmailDeliveryStatus.SENT)
-            .sentAt(LocalDateTime.ofInstant(receipt.sentAt(), ZoneId.systemDefault()))
-            .createDate(dispatch.createdAt())
-            .build();
-    InviteEmailDelivery delivery = pendingDelivery;
-    try {
-      delivery =
-          requiresNewTransaction()
-              .execute(transaction -> deliveryRepository.saveAndFlush(pendingDelivery));
-    } catch (RuntimeException auditFailure) {
-      // The committed invite remains the durable deduplication claim. Releasing it after SMTP
-      // would make the next click send a duplicate merely because audit bookkeeping failed.
-      log.error(
-          "Direct invite {} was sent but its delivery audit could not be recorded",
-          dispatch.invite().getId(),
-          auditFailure);
-    }
-    return new InviteSendResult(
-        dispatch.invite(), delivery, dispatch.rawToken(), dispatch.acceptUrl());
+    return deliverPreparedInvite(
+        dispatch,
+        null,
+        sendFailure -> releaseDirectInviteClaim(dispatch.invite(), command, sendFailure));
   }
 
   private TransactionTemplate requiresNewTransaction() {
@@ -273,24 +233,59 @@ public class AccountInviteService {
 
   private void releaseDirectInviteClaim(
       AccountInvite invite, CreateAccountInviteCommand command, RuntimeException sendFailure) {
-    boolean claimReleased = false;
+    List<Long> releaseTaskIds;
     try {
-      requiresNewTransaction()
-          .executeWithoutResult(
-              transaction -> {
-                accountInviteRepository.deleteById(invite.getId());
-                accountInviteRepository.flush();
-              });
-      claimReleased = true;
+      releaseTaskIds =
+          requiresNewTransaction()
+              .execute(
+                  transaction -> {
+                    List<Long> taskIds = new java.util.ArrayList<>();
+                    LocalDateTime now = LocalDateTime.now();
+                    if (invite.getTenantIdReservationToken() != null
+                        && invite.getTenantId() != null) {
+                      taskIds.add(
+                          reservationReleaseTaskRepository
+                              .saveAndFlush(
+                                  IdReservationReleaseTask.builder()
+                                      .allocationType(IdReservationReleaseType.TENANT)
+                                      .reservedId(invite.getTenantId())
+                                      .tenantContextId(invite.getTenantId())
+                                      .createDate(now)
+                                      .build())
+                              .getId());
+                    }
+                    if (command.agencyIdAllocationMode() != null && invite.getAgencyId() != null) {
+                      taskIds.add(
+                          reservationReleaseTaskRepository
+                              .saveAndFlush(
+                                  IdReservationReleaseTask.builder()
+                                      .allocationType(IdReservationReleaseType.AGENCY)
+                                      .reservedId(invite.getAgencyId())
+                                      .tenantContextId(invite.getTenantId())
+                                      .createDate(now)
+                                      .build())
+                              .getId());
+                    }
+                    accountInviteRepository.deleteById(invite.getId());
+                    accountInviteRepository.flush();
+                    return List.copyOf(taskIds);
+                  });
     } catch (RuntimeException compensationFailure) {
       log.error(
-          "Direct invite {} failed before dispatch and its committed claim could not be released",
+          "Direct invite {} failed before dispatch and its claim cleanup could not be recorded",
           invite.getId(),
           compensationFailure);
       sendFailure.addSuppressed(compensationFailure);
+      return;
     }
-    if (claimReleased) {
-      releaseDirectInviteReservations(invite, command);
+
+    for (Long taskId : releaseTaskIds) {
+      try {
+        reservationReleaseProcessor.process(taskId);
+      } catch (RuntimeException releaseFailure) {
+        // The durable task remains for the scheduler. Keep the SMTP exception primary.
+        logReservationReleaseFailure("scheduled", releaseFailure);
+      }
     }
   }
 
@@ -304,14 +299,18 @@ public class AccountInviteService {
       AccountInvite invite, CreateAccountInviteCommand command) {
     if (invite.getTenantIdReservationToken() != null && invite.getTenantId() != null) {
       try {
-        tenantIdAllocationClient.release(invite.getTenantId());
+        if (!tenantIdAllocationClient.release(invite.getTenantId())) {
+          logReservationReleaseFailure("tenant", new IllegalStateException("release pending"));
+        }
       } catch (RuntimeException releaseException) {
         logReservationReleaseFailure("tenant", releaseException);
       }
     }
     if (command.agencyIdAllocationMode() != null && invite.getAgencyId() != null) {
       try {
-        agencyIdAllocationClient.release(invite.getAgencyId());
+        if (!agencyIdAllocationClient.release(invite.getAgencyId())) {
+          logReservationReleaseFailure("agency", new IllegalStateException("release pending"));
+        }
       } catch (RuntimeException releaseException) {
         logReservationReleaseFailure("agency", releaseException);
       }
@@ -373,6 +372,21 @@ public class AccountInviteService {
       // address and from the reason-less 409 of a taken tenant ID. Both sources answer with the
       // SAME reason on purpose: the admin renders one inline field error for it, and a second
       // code would degrade to a generic toast.
+      throw emailNotAvailable(null);
+    }
+  }
+
+  private void verifyRecipientEmailAvailableExcluding(
+      String recipientEmail, Long excludedInviteId, LocalDateTime now) {
+    String normalized = normalizeEmail(recipientEmail);
+    if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()) {
+      throw emailNotAvailable(null);
+    }
+    accountInviteRepository.expireElapsedRecipientClaims(
+        normalized, ADDRESS_HOLDING_INVITE_STATUSES, now);
+    if (accountInviteRepository.countNonTerminalInvitesForRecipientEmailExcludingId(
+            normalized, excludedInviteId, ADDRESS_HOLDING_INVITE_STATUSES, now)
+        > 0) {
       throw emailNotAvailable(null);
     }
   }
@@ -463,67 +477,168 @@ public class AccountInviteService {
     return sendInvite(invite, template, invite.getId());
   }
 
-  @Transactional
   public InviteSendResult resendInvite(SendInviteCommand command) {
-    AccountInvite oldInvite = findInvite(command.inviteId());
-    if (oldInvite.getStatus() == AccountInviteStatus.ACCEPTED) {
-      throw new BadRequestException("Accepted invites cannot be resent");
-    }
-    if (oldInvite.getStatus() == AccountInviteStatus.REVOKED) {
-      throw new BadRequestException("Revoked invites cannot be resent");
-    }
-    InviteEmailTemplate template = findTemplate(command.templateId());
+    ResendDispatch resend = prepareResend(command);
+    return deliverPreparedInvite(
+        resend.dispatch(),
+        resend.oldInviteId(),
+        sendFailure -> restoreResendAfterConfirmedFailure(resend, sendFailure));
+  }
 
-    LocalDateTime now = LocalDateTime.now();
-    AccountInvite replacement =
-        AccountInvite.builder()
-            .targetRole(oldInvite.getTargetRole())
-            .tenantId(oldInvite.getTenantId())
-            // The reservation follows the invite chain: the replacement keeps the reserved
-            // tenant ID, so it must also keep the token that consumes the reservation.
-            .tenantIdReservationToken(oldInvite.getTenantIdReservationToken())
-            .recipientEmail(oldInvite.getRecipientEmail())
-            .activeRecipientKey(normalizeEmail(oldInvite.getRecipientEmail()))
-            .firstName(oldInvite.getFirstName())
-            .lastName(oldInvite.getLastName())
-            .agencyId(oldInvite.getAgencyId())
-            .departmentId(oldInvite.getDepartmentId())
-            .expiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS))
-            .status(AccountInviteStatus.DRAFT)
-            .emailVerificationStatus(oldInvite.getEmailVerificationStatus())
-            .twoFactorStatus(oldInvite.getTwoFactorStatus())
-            .createdByUserId(authenticatedUser.getUserId())
-            .createdByUsername(authenticatedUser.getUsername())
-            .createDate(now)
-            .updateDate(now)
-            .build();
+  private ResendDispatch prepareResend(SendInviteCommand command) {
+    return requiresNewTransaction()
+        .execute(
+            transaction -> {
+              AccountInvite initialOldInvite = findInvite(command.inviteId());
+              if (initialOldInvite.getStatus() == AccountInviteStatus.ACCEPTED) {
+                throw new BadRequestException("Accepted invites cannot be resent");
+              }
+              if (initialOldInvite.getStatus() == AccountInviteStatus.REVOKED) {
+                throw new BadRequestException("Revoked invites cannot be resent");
+              }
 
-    // Transfer the unique recipient claim before SMTP. Both writes belong to this transaction, so
-    // a rejected send restores the old claim; a competing invite fails this flush before mail.
-    oldInvite.setActiveRecipientKey(null);
-    accountInviteRepository.saveAndFlush(oldInvite);
+              LocalDateTime now = LocalDateTime.now();
+              verifyRecipientEmailAvailableExcluding(
+                  initialOldInvite.getRecipientEmail(), initialOldInvite.getId(), now);
+              // The expiry cleanup is a clearing bulk update, so reload the old row before the
+              // durable handover.
+              AccountInvite oldInvite = findInvite(command.inviteId());
+              InviteEmailTemplate template = findTemplate(command.templateId());
+              String rawToken = generateToken();
+              String acceptUrl =
+                  inviteAcceptUrlBuilder.buildAcceptUrl(oldInvite.getTargetRole(), rawToken);
+              String subject = render(template.getSubject(), oldInvite, acceptUrl);
+              String body = renderBody(template.getBody(), oldInvite, acceptUrl);
+
+              ResendState oldState = ResendState.from(oldInvite);
+              AccountInvite replacement =
+                  AccountInvite.builder()
+                      .targetRole(oldInvite.getTargetRole())
+                      .tenantId(oldInvite.getTenantId())
+                      .tenantIdReservationToken(oldInvite.getTenantIdReservationToken())
+                      .recipientEmail(oldInvite.getRecipientEmail())
+                      .activeRecipientKey(normalizeEmail(oldInvite.getRecipientEmail()))
+                      .firstName(oldInvite.getFirstName())
+                      .lastName(oldInvite.getLastName())
+                      .agencyId(oldInvite.getAgencyId())
+                      .departmentId(oldInvite.getDepartmentId())
+                      .tokenHash(hash(rawToken))
+                      .expiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS))
+                      .status(AccountInviteStatus.EMAIL_SENT)
+                      .emailVerificationStatus(oldInvite.getEmailVerificationStatus())
+                      .twoFactorStatus(oldInvite.getTwoFactorStatus())
+                      .createdByUserId(authenticatedUser.getUserId())
+                      .createdByUsername(authenticatedUser.getUsername())
+                      .createDate(now)
+                      .updateDate(now)
+                      .build();
+
+              oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
+              oldInvite.setActiveRecipientKey(null);
+              oldInvite.setSupersededAt(now);
+              oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
+              oldInvite.setUpdateDate(now);
+              accountInviteRepository.saveAndFlush(oldInvite);
+              try {
+                replacement = accountInviteRepository.saveAndFlush(replacement);
+              } catch (DataIntegrityViolationException conflict) {
+                if (isActiveRecipientConflict(conflict)) {
+                  throw emailNotAvailable(conflict);
+                }
+                throw conflict;
+              }
+              oldInvite.setSupersededByInviteId(replacement.getId());
+              accountInviteRepository.saveAndFlush(oldInvite);
+
+              return new ResendDispatch(
+                  new DirectInviteDispatch(
+                      replacement, template, rawToken, acceptUrl, subject, body, now),
+                  oldInvite.getId(),
+                  oldState);
+            });
+  }
+
+  private void restoreResendAfterConfirmedFailure(
+      ResendDispatch resend, SmtpSendException sendFailure) {
     try {
-      replacement = accountInviteRepository.saveAndFlush(replacement);
-    } catch (DataIntegrityViolationException conflict) {
-      if (isActiveRecipientConflict(conflict)) {
-        throw emailNotAvailable(conflict);
+      requiresNewTransaction()
+          .executeWithoutResult(
+              transaction -> {
+                accountInviteRepository.deleteById(resend.dispatch().invite().getId());
+                accountInviteRepository.flush();
+                AccountInvite oldInvite = findInvite(resend.oldInviteId());
+                resend.oldState().restore(oldInvite);
+                accountInviteRepository.saveAndFlush(oldInvite);
+              });
+    } catch (RuntimeException compensationFailure) {
+      log.error(
+          "Resend {} failed before dispatch and its committed claim handover could not be restored",
+          resend.dispatch().invite().getId(),
+          compensationFailure);
+      sendFailure.addSuppressed(compensationFailure);
+    }
+  }
+
+  private InviteSendResult deliverPreparedInvite(
+      DirectInviteDispatch dispatch,
+      Long failureAuditInviteId,
+      ConfirmedSendFailureHandler confirmedFailureHandler) {
+    InviteMailSendReceipt receipt;
+    try {
+      receipt =
+          inviteMailDispatchService.send(
+              dispatch.invite().getRecipientEmail(),
+              dispatch.subject(),
+              dispatch.body(),
+              dispatch.acceptUrl(),
+              dispatch.invite().getTenantId(),
+              dispatch.template().getLanguage());
+    } catch (SmtpSendException sendFailure) {
+      recordDeliveryFailureSafely(
+          failureAuditInviteId,
+          dispatch.template(),
+          dispatch.invite(),
+          dispatch.subject(),
+          dispatch.body(),
+          sendFailure);
+      if (sendFailure.isConfirmedNotSent()) {
+        confirmedFailureHandler.compensate(sendFailure);
+      } else {
+        log.warn(
+            "Prepared invite {} has an uncertain SMTP delivery outcome; keeping the claim to"
+                + " prevent"
+                + " a duplicate send",
+            dispatch.invite().getId(),
+            sendFailure);
       }
-      throw conflict;
+      throw sendFailure;
     }
 
-    // Transport first (TEN-INV-U6): the old invite is only superseded after the SMTP server
-    // accepted the replacement mail. A failed handover rolls this transaction back, restoring
-    // the old claim and removing the replacement. The FAILED audit row anchors on the committed
-    // old invite because the replacement does not exist outside this transaction.
-    InviteSendResult result = sendInvite(replacement, template, oldInvite.getId());
-
-    oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
-    oldInvite.setSupersededAt(now);
-    oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
-    oldInvite.setSupersededByInviteId(result.invite().getId());
-    oldInvite.setUpdateDate(now);
-    accountInviteRepository.save(oldInvite);
-    return result;
+    InviteEmailDelivery pendingDelivery =
+        InviteEmailDelivery.builder()
+            .accountInviteId(dispatch.invite().getId())
+            .templateId(dispatch.template().getId())
+            .templateKind(dispatch.template().getKind())
+            .recipientSnapshot(dispatch.invite().getRecipientEmail())
+            .subjectSnapshot(dispatch.subject())
+            .bodySnapshot(dispatch.body())
+            .status(InviteEmailDeliveryStatus.SENT)
+            .sentAt(LocalDateTime.ofInstant(receipt.sentAt(), ZoneId.systemDefault()))
+            .createDate(dispatch.createdAt())
+            .build();
+    InviteEmailDelivery delivery = pendingDelivery;
+    try {
+      delivery =
+          requiresNewTransaction()
+              .execute(transaction -> deliveryRepository.saveAndFlush(pendingDelivery));
+    } catch (RuntimeException auditFailure) {
+      log.error(
+          "Prepared invite {} was sent but its delivery audit could not be recorded",
+          dispatch.invite().getId(),
+          auditFailure);
+    }
+    return new InviteSendResult(
+        dispatch.invite(), delivery, dispatch.rawToken(), dispatch.acceptUrl());
   }
 
   @Transactional
@@ -744,8 +859,7 @@ public class AccountInviteService {
    * audit row behind.
    *
    * @param failureAuditInviteId id of an already-committed invite the FAILED audit row may
-   *     reference; for resends this is the old invite because the replacement only exists inside
-   *     the still-open transaction.
+   *     reference
    */
   private InviteSendResult sendInvite(
       AccountInvite invite, InviteEmailTemplate template, Long failureAuditInviteId) {
@@ -1084,6 +1198,42 @@ public class AccountInviteService {
       String subject,
       String body,
       LocalDateTime createdAt) {}
+
+  private record ResendDispatch(
+      DirectInviteDispatch dispatch, Long oldInviteId, ResendState oldState) {}
+
+  private record ResendState(
+      AccountInviteStatus status,
+      String activeRecipientKey,
+      LocalDateTime supersededAt,
+      String supersededByUserId,
+      Long supersededByInviteId,
+      LocalDateTime updateDate) {
+
+    private static ResendState from(AccountInvite invite) {
+      return new ResendState(
+          invite.getStatus(),
+          invite.getActiveRecipientKey(),
+          invite.getSupersededAt(),
+          invite.getSupersededByUserId(),
+          invite.getSupersededByInviteId(),
+          invite.getUpdateDate());
+    }
+
+    private void restore(AccountInvite invite) {
+      invite.setStatus(status);
+      invite.setActiveRecipientKey(activeRecipientKey);
+      invite.setSupersededAt(supersededAt);
+      invite.setSupersededByUserId(supersededByUserId);
+      invite.setSupersededByInviteId(supersededByInviteId);
+      invite.setUpdateDate(updateDate);
+    }
+  }
+
+  @FunctionalInterface
+  private interface ConfirmedSendFailureHandler {
+    void compensate(SmtpSendException sendFailure);
+  }
 
   public record WaiveTwoFactorCommand(String reason) {}
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -38,11 +38,15 @@ import java.util.regex.Pattern;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
@@ -78,6 +82,7 @@ public class AccountInviteService {
   private final @NonNull InviteMailDispatchService inviteMailDispatchService;
   private final @NonNull InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
   private final @NonNull IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  private final @NonNull PlatformTransactionManager transactionManager;
 
   @Transactional
   public AccountInvite createInvite(CreateAccountInviteCommand command) {
@@ -130,6 +135,7 @@ public class AccountInviteService {
               .tenantIdReservationToken(
                   tenantReservation != null ? tenantReservation.token() : null)
               .recipientEmail(command.recipientEmail().trim())
+              .activeRecipientKey(normalizeEmail(command.recipientEmail()))
               .firstName(trimToNull(command.firstName()))
               .lastName(trimToNull(command.lastName()))
               .agencyId(reservedAgencyId != null ? reservedAgencyId : command.agencyId())
@@ -144,7 +150,9 @@ public class AccountInviteService {
               .createDate(now)
               .updateDate(now)
               .build();
-      return accountInviteRepository.save(invite);
+      AccountInvite saved = accountInviteRepository.save(invite);
+      accountInviteRepository.flush();
+      return saved;
     } catch (RuntimeException exception) {
       // Compensation: a failed creation must not leave orphaned reservations behind.
       if (reservedAgencyId != null) {
@@ -153,31 +161,123 @@ public class AccountInviteService {
       if (tenantReservation != null) {
         tenantIdAllocationClient.release(tenantReservation.tenantId());
       }
+      if (exception instanceof DataIntegrityViolationException) {
+        throw new CustomValidationHttpStatusException(
+            HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      }
       throw exception;
     }
   }
 
   /**
-   * Creates and directly sends an invite as one database operation.
-   *
-   * <p>A direct-send request is not allowed to leave a {@code DRAFT} invite behind when the SMTP
-   * handover fails: such a draft holds both the recipient address and, for tenant admins, the
-   * tenant-ID reservation, while the admin only saw a failed send. The caller can therefore retry
-   * the same request after a transport failure without first finding and cleaning up hidden state.
-   *
-   * <p>A failed delivery has no committed invite row to attach an independent delivery audit row
-   * to. The transport failure remains logged and is returned to the caller; persisting a dangling
-   * delivery row would violate the delivery foreign-key contract.
+   * Commits the address claim and usable token before SMTP, then compensates pre-dispatch errors.
    */
-  @Transactional
   public InviteSendResult createAndSendInvite(CreateAccountInviteCommand command, Long templateId) {
-    AccountInvite invite = createInvite(command);
+    DirectInviteDispatch dispatch;
+    AccountInvite[] claimedInvite = new AccountInvite[1];
     try {
-      InviteEmailTemplate template = findTemplate(templateId);
-      return sendInvite(invite, template, null);
-    } catch (RuntimeException exception) {
+      dispatch =
+          requiresNewTransaction()
+              .execute(
+                  transaction -> {
+                    AccountInvite invite = createInvite(command);
+                    claimedInvite[0] = invite;
+                    InviteEmailTemplate template = findTemplate(templateId);
+                    LocalDateTime now = LocalDateTime.now();
+                    String rawToken = generateToken();
+                    String acceptUrl =
+                        inviteAcceptUrlBuilder.buildAcceptUrl(invite.getTargetRole(), rawToken);
+                    String subject = render(template.getSubject(), invite, acceptUrl);
+                    String body = renderBody(template.getBody(), invite, acceptUrl);
+
+                    invite.setTokenHash(hash(rawToken));
+                    if (invite.getExpiresAt() == null || invite.getExpiresAt().isBefore(now)) {
+                      invite.setExpiresAt(resolveExpiry(now, DEFAULT_EXPIRY_DAYS));
+                    }
+                    invite.setStatus(AccountInviteStatus.EMAIL_SENT);
+                    invite.setUpdateDate(now);
+                    invite = accountInviteRepository.saveAndFlush(invite);
+                    claimedInvite[0] = invite;
+                    return new DirectInviteDispatch(
+                        invite, template, rawToken, acceptUrl, subject, body, now);
+                  });
+    } catch (RuntimeException claimFailure) {
+      if (claimedInvite[0] != null) {
+        releaseDirectInviteReservations(claimedInvite[0], command);
+      }
+      if (claimFailure instanceof DataIntegrityViolationException) {
+        throw new CustomValidationHttpStatusException(
+            HttpStatusExceptionReason.EMAIL_NOT_AVAILABLE, HttpStatus.CONFLICT);
+      }
+      throw claimFailure;
+    }
+
+    InviteMailSendReceipt receipt;
+    try {
+      receipt =
+          inviteMailDispatchService.send(
+              dispatch.invite().getRecipientEmail(),
+              dispatch.subject(),
+              dispatch.body(),
+              dispatch.acceptUrl(),
+              dispatch.invite().getTenantId(),
+              dispatch.template().getLanguage());
+    } catch (SmtpSendException beforeDispatch) {
+      releaseDirectInviteClaim(dispatch.invite(), command, beforeDispatch);
+      throw beforeDispatch;
+    }
+
+    InviteEmailDelivery pendingDelivery =
+        InviteEmailDelivery.builder()
+            .accountInviteId(dispatch.invite().getId())
+            .templateId(dispatch.template().getId())
+            .templateKind(dispatch.template().getKind())
+            .recipientSnapshot(dispatch.invite().getRecipientEmail())
+            .subjectSnapshot(dispatch.subject())
+            .bodySnapshot(dispatch.body())
+            .status(InviteEmailDeliveryStatus.SENT)
+            .sentAt(LocalDateTime.ofInstant(receipt.sentAt(), ZoneId.systemDefault()))
+            .createDate(dispatch.createdAt())
+            .build();
+    InviteEmailDelivery delivery = pendingDelivery;
+    try {
+      delivery =
+          requiresNewTransaction()
+              .execute(transaction -> deliveryRepository.saveAndFlush(pendingDelivery));
+    } catch (RuntimeException auditFailure) {
+      // The committed invite remains the durable deduplication claim. Releasing it after SMTP
+      // would make the next click send a duplicate merely because audit bookkeeping failed.
+      log.error(
+          "Direct invite {} was sent but its delivery audit could not be recorded",
+          dispatch.invite().getId(),
+          auditFailure);
+    }
+    return new InviteSendResult(
+        dispatch.invite(), delivery, dispatch.rawToken(), dispatch.acceptUrl());
+  }
+
+  private TransactionTemplate requiresNewTransaction() {
+    TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+    transaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    return transaction;
+  }
+
+  private void releaseDirectInviteClaim(
+      AccountInvite invite, CreateAccountInviteCommand command, RuntimeException sendFailure) {
+    try {
+      requiresNewTransaction()
+          .executeWithoutResult(
+              transaction -> {
+                accountInviteRepository.deleteById(invite.getId());
+                accountInviteRepository.flush();
+              });
       releaseDirectInviteReservations(invite, command);
-      throw exception;
+    } catch (RuntimeException compensationFailure) {
+      log.error(
+          "Direct invite {} failed before dispatch and its committed claim could not be released",
+          invite.getId(),
+          compensationFailure);
+      sendFailure.addSuppressed(compensationFailure);
     }
   }
 
@@ -233,12 +333,11 @@ public class AccountInviteService {
    *       wording of the rule, such an address is just as "already there" as a registered one.
    * </ol>
    *
-   * <p>Deliberately not backed by a database constraint — see {@link
-   * AccountInviteRepository#countNonTerminalInvitesForRecipientEmail} for why the rule is not
-   * expressible as one.
+   * <p>The count provides the user-friendly conflict. New active rows additionally carry a unique
+   * normalized claim so concurrent requests on different replicas cannot both pass this read.
    */
   private void verifyRecipientEmailAvailable(String recipientEmail) {
-    String normalized = recipientEmail.trim().toLowerCase(Locale.ROOT);
+    String normalized = normalizeEmail(recipientEmail);
     if (identityEmailOwnerLookup.findByEmail(normalized).isPresent()
         || accountInviteRepository.countNonTerminalInvitesForRecipientEmail(
                 normalized, ADDRESS_HOLDING_INVITE_STATUSES, LocalDateTime.now())
@@ -379,11 +478,14 @@ public class AccountInviteService {
     InviteSendResult result = sendInvite(replacement, template, oldInvite.getId());
 
     oldInvite.setStatus(AccountInviteStatus.SUPERSEDED);
+    oldInvite.setActiveRecipientKey(null);
     oldInvite.setSupersededAt(now);
     oldInvite.setSupersededByUserId(authenticatedUser.getUserId());
     oldInvite.setSupersededByInviteId(result.invite().getId());
     oldInvite.setUpdateDate(now);
-    accountInviteRepository.save(oldInvite);
+    accountInviteRepository.saveAndFlush(oldInvite);
+    result.invite().setActiveRecipientKey(normalizeEmail(result.invite().getRecipientEmail()));
+    accountInviteRepository.save(result.invite());
     return result;
   }
 
@@ -395,6 +497,7 @@ public class AccountInviteService {
     }
     LocalDateTime now = LocalDateTime.now();
     invite.setStatus(AccountInviteStatus.REVOKED);
+    invite.setActiveRecipientKey(null);
     invite.setRevokedAt(now);
     invite.setRevokedByUserId(authenticatedUser.getUserId());
     invite.setUpdateDate(now);
@@ -417,6 +520,7 @@ public class AccountInviteService {
     }
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
+      invite.setActiveRecipientKey(null);
       invite.setUpdateDate(now);
       accountInviteRepository.save(invite);
       throw new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);
@@ -439,6 +543,7 @@ public class AccountInviteService {
     // Mirror exactly the columns the guarded UPDATE wrote onto the (now detached) entity so the
     // caller sees the persisted state without an extra round trip.
     invite.setStatus(AccountInviteStatus.ACCEPTED);
+    invite.setActiveRecipientKey(null);
     invite.setAcceptedAt(now);
     invite.setAcceptedByUserId(acceptedByUserId);
     invite.setEmailVerificationStatus(EmailVerificationStatus.VERIFIED);
@@ -854,6 +959,10 @@ public class AccountInviteService {
     return value == null || value.trim().isEmpty();
   }
 
+  private static String normalizeEmail(String value) {
+    return value.trim().toLowerCase(Locale.ROOT);
+  }
+
   private static String trimToNull(String value) {
     return isBlank(value) ? null : value.trim();
   }
@@ -906,6 +1015,15 @@ public class AccountInviteService {
 
   public record InviteSendResult(
       AccountInvite invite, InviteEmailDelivery delivery, String rawToken, String acceptUrl) {}
+
+  private record DirectInviteDispatch(
+      AccountInvite invite,
+      InviteEmailTemplate template,
+      String rawToken,
+      String acceptUrl,
+      String subject,
+      String body,
+      LocalDateTime createdAt) {}
 
   public record WaiveTwoFactorCommand(String reason) {}
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -170,7 +170,8 @@ public class AccountInviteService {
   }
 
   /**
-   * Commits the address claim and usable token before SMTP, then compensates pre-dispatch errors.
+   * Commits the address claim and usable token before SMTP. Confirmed pre-dispatch failures are
+   * compensated; ambiguous transport failures retain the claim so a retry cannot duplicate mail.
    */
   public InviteSendResult createAndSendInvite(CreateAccountInviteCommand command, Long templateId) {
     DirectInviteDispatch dispatch;
@@ -222,9 +223,17 @@ public class AccountInviteService {
               dispatch.acceptUrl(),
               dispatch.invite().getTenantId(),
               dispatch.template().getLanguage());
-    } catch (SmtpSendException beforeDispatch) {
-      releaseDirectInviteClaim(dispatch.invite(), command, beforeDispatch);
-      throw beforeDispatch;
+    } catch (SmtpSendException sendFailure) {
+      if (sendFailure.isConfirmedNotSent()) {
+        releaseDirectInviteClaim(dispatch.invite(), command, sendFailure);
+      } else {
+        log.warn(
+            "Direct invite {} has an uncertain SMTP delivery outcome; keeping the claim to prevent"
+                + " a duplicate send",
+            dispatch.invite().getId(),
+            sendFailure);
+      }
+      throw sendFailure;
     }
 
     InviteEmailDelivery pendingDelivery =

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteService.java
@@ -158,6 +158,52 @@ public class AccountInviteService {
   }
 
   /**
+   * Creates and directly sends an invite as one database operation.
+   *
+   * <p>A direct-send request is not allowed to leave a {@code DRAFT} invite behind when the SMTP
+   * handover fails: such a draft holds both the recipient address and, for tenant admins, the
+   * tenant-ID reservation, while the admin only saw a failed send. The caller can therefore retry
+   * the same request after a transport failure without first finding and cleaning up hidden state.
+   *
+   * <p>A failed delivery has no committed invite row to attach an independent delivery audit row
+   * to. The transport failure remains logged and is returned to the caller; persisting a dangling
+   * delivery row would violate the delivery foreign-key contract.
+   */
+  @Transactional
+  public InviteSendResult createAndSendInvite(CreateAccountInviteCommand command, Long templateId) {
+    AccountInvite invite = createInvite(command);
+    try {
+      InviteEmailTemplate template = findTemplate(templateId);
+      return sendInvite(invite, template, null);
+    } catch (RuntimeException exception) {
+      releaseDirectInviteReservations(invite, command);
+      throw exception;
+    }
+  }
+
+  /**
+   * External ID reservations do not participate in the database transaction. A failed direct send
+   * must release the holds that {@link #createInvite(CreateAccountInviteCommand)} acquired before
+   * the transaction rolls its database row back. A failed compensation is logged but never masks
+   * the original request failure.
+   */
+  private void releaseDirectInviteReservations(
+      AccountInvite invite, CreateAccountInviteCommand command) {
+    try {
+      if (invite.getTenantIdReservationToken() != null && invite.getTenantId() != null) {
+        tenantIdAllocationClient.release(invite.getTenantId());
+      }
+      if (command.agencyIdAllocationMode() != null && invite.getAgencyId() != null) {
+        agencyIdAllocationClient.release(invite.getAgencyId());
+      }
+    } catch (RuntimeException releaseException) {
+      log.warn(
+          "Could not release direct-invite ID reservation after failed send ({})",
+          releaseException.getClass().getSimpleName());
+    }
+  }
+
+  /**
    * P3: refuses an invite whose recipient address already belongs to a registered identity.
    *
    * <p>Before this guard the collision only surfaced at redemption time — the invitee filled in the

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/AgencyIdAllocationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/AgencyIdAllocationClient.java
@@ -57,21 +57,25 @@ public class AgencyIdAllocationClient {
   }
 
   /**
-   * Best-effort compensation: releases an unconsumed reservation so the ID becomes assignable
-   * again. Never throws — a failed release must not mask the original creation failure; the
-   * upstream reservation ledger stays the single source of truth for manual cleanup.
+   * Releases an unconsumed reservation so the ID becomes assignable again.
+   *
+   * @return whether the reservation is now confirmed released; transient failures return false so
+   *     callers can retain a durable retry task without masking the original creation failure
    */
-  public void release(long agencyId) {
+  public boolean release(long agencyId) {
     try {
       createControllerApi().releaseAgencyIdReservation(agencyId);
+      return true;
     } catch (HttpClientErrorException.NotFound exception) {
       log.info("Agency ID reservation {} was already released", agencyId);
+      return true;
     } catch (RestClientException exception) {
       log.error(
           "Failed to release agency ID reservation {} — possible orphaned reservation in"
               + " AgencyService",
           agencyId,
           exception);
+      return false;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessor.java
@@ -1,0 +1,81 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantData;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Executes idempotent external reservation releases and retains failures for later retry. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IdReservationReleaseProcessor {
+
+  private final @NonNull IdReservationReleaseTaskRepository taskRepository;
+  private final @NonNull TenantIdAllocationClient tenantIdAllocationClient;
+  private final @NonNull AgencyIdAllocationClient agencyIdAllocationClient;
+
+  @Transactional(readOnly = true)
+  public List<Long> pendingTaskIds() {
+    return taskRepository.findTop100ByOrderByCreateDateAsc().stream()
+        .map(IdReservationReleaseTask::getId)
+        .toList();
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public boolean process(Long taskId) {
+    var task = taskRepository.findByIdForUpdate(taskId);
+    if (task.isEmpty()) {
+      return true;
+    }
+
+    IdReservationReleaseTask pending = task.get();
+    boolean released = attemptRelease(pending);
+    if (released) {
+      taskRepository.delete(pending);
+    } else {
+      pending.setAttemptCount(pending.getAttemptCount() + 1);
+      pending.setLastAttemptAt(LocalDateTime.now());
+      taskRepository.save(pending);
+    }
+    return released;
+  }
+
+  private boolean attemptRelease(IdReservationReleaseTask task) {
+    TenantData currentTenant = TenantContext.getCurrentTenantData();
+    TenantData previousTenant =
+        currentTenant == null
+            ? null
+            : new TenantData(currentTenant.getTenantId(), currentTenant.getSubdomain());
+    try {
+      if (task.getTenantContextId() != null) {
+        TenantContext.setCurrentTenant(task.getTenantContextId());
+      }
+      return switch (task.getAllocationType()) {
+        case TENANT -> tenantIdAllocationClient.release(task.getReservedId());
+        case AGENCY -> agencyIdAllocationClient.release(task.getReservedId());
+      };
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Reservation release task {} could not reach {} allocation ledger",
+          task.getId(),
+          task.getAllocationType(),
+          exception);
+      return false;
+    } finally {
+      if (previousTenant == null) {
+        TenantContext.clear();
+      } else {
+        TenantContext.setCurrentTenantData(previousTenant);
+      }
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessor.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessor.java
@@ -4,11 +4,14 @@ import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
 import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
 import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantData;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,9 +26,17 @@ public class IdReservationReleaseProcessor {
   private final @NonNull TenantIdAllocationClient tenantIdAllocationClient;
   private final @NonNull AgencyIdAllocationClient agencyIdAllocationClient;
 
+  @Value("${account-invite.reservation-release.max-attempts:10}")
+  private int maxAttempts;
+
+  @Value("${account-invite.reservation-release.retry-backoff:PT5M}")
+  private Duration retryBackoff;
+
   @Transactional(readOnly = true)
   public List<Long> pendingTaskIds() {
-    return taskRepository.findTop100ByOrderByCreateDateAsc().stream()
+    return taskRepository
+        .findRetryable(maxAttempts, LocalDateTime.now().minus(retryBackoff), PageRequest.of(0, 100))
+        .stream()
         .map(IdReservationReleaseTask::getId)
         .toList();
   }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
@@ -11,11 +11,13 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /** Replica-safe retry worker for reservation releases left pending by failed direct sends. */
 @Component
+@Profile("!testing")
 @RequiredArgsConstructor
 @Slf4j
 public class IdReservationReleaseScheduler {

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
@@ -1,0 +1,59 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.service.httpheader.TechnicalAccessTokenContext;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Replica-safe retry worker for reservation releases left pending by failed direct sends. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IdReservationReleaseScheduler {
+
+  static final String TASK_NAME = "account-invite-reservation-release";
+
+  private final @NonNull IdReservationReleaseProcessor processor;
+  private final @NonNull ScheduledTaskClaimService taskClaimService;
+  private final @NonNull TenantContextProvider tenantContextProvider;
+  private final @NonNull IdentityClientConfig identityClientConfig;
+  private final @NonNull IdentityAuthentication identityAuthentication;
+
+  @Value("${account-invite.reservation-release.claim-duration:PT5M}")
+  private Duration claimDuration;
+
+  @Scheduled(fixedDelayString = "${account-invite.reservation-release.retry-delay-ms:60000}")
+  public void retryPendingReleases() {
+    try {
+      if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+        return;
+      }
+      tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
+      var technicalUser = identityClientConfig.getTechnicalUser();
+      var login =
+          identityAuthentication.login(technicalUser.getUsername(), technicalUser.getPassword());
+      TechnicalAccessTokenContext.set(login.accessToken());
+      for (Long taskId : processor.pendingTaskIds()) {
+        try {
+          processor.process(taskId);
+        } catch (RuntimeException exception) {
+          log.warn("Could not process reservation release task {}", taskId, exception);
+        }
+      }
+    } catch (RuntimeException exception) {
+      log.warn("Could not process pending account-invite reservation releases", exception);
+    } finally {
+      TechnicalAccessTokenContext.clear();
+      TenantContext.clear();
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java
@@ -35,10 +35,13 @@ public class IdReservationReleaseScheduler {
 
   @Scheduled(fixedDelayString = "${account-invite.reservation-release.retry-delay-ms:60000}")
   public void retryPendingReleases() {
+    ScheduledTaskClaimService.ClaimLease lease = null;
     try {
-      if (!taskClaimService.tryClaim(TASK_NAME, claimDuration)) {
+      var acquiredLease = taskClaimService.tryClaimLease(TASK_NAME, claimDuration);
+      if (acquiredLease.isEmpty()) {
         return;
       }
+      lease = acquiredLease.get();
       tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
       var technicalUser = identityClientConfig.getTechnicalUser();
       var login =
@@ -56,6 +59,13 @@ public class IdReservationReleaseScheduler {
     } finally {
       TechnicalAccessTokenContext.clear();
       TenantContext.clear();
+      if (lease != null) {
+        try {
+          taskClaimService.release(lease);
+        } catch (RuntimeException exception) {
+          log.warn("Could not release account-invite reservation scheduler claim", exception);
+        }
+      }
     }
   }
 }

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseType.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseType.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+/** External allocation ledger that owns an ID reservation awaiting release. */
+public enum IdReservationReleaseType {
+  TENANT,
+  AGENCY
+}

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdAllocationClient.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/TenantIdAllocationClient.java
@@ -52,21 +52,25 @@ public class TenantIdAllocationClient {
   }
 
   /**
-   * Best-effort compensation: releases an unconsumed reservation so the ID becomes assignable
-   * again. Never throws — a failed release must not mask the original creation failure; the
-   * upstream reservation ledger stays the single source of truth for manual cleanup.
+   * Releases an unconsumed reservation so the ID becomes assignable again.
+   *
+   * @return whether the reservation is now confirmed released; transient failures return false so
+   *     callers can retain a durable retry task without masking the original creation failure
    */
-  public void release(long tenantId) {
+  public boolean release(long tenantId) {
     try {
       createControllerApi().releaseTenantIdReservation(tenantId);
+      return true;
     } catch (HttpClientErrorException.NotFound exception) {
       log.info("Tenant ID reservation {} was already released", tenantId);
+      return true;
     } catch (RestClientException exception) {
       log.error(
           "Failed to release tenant ID reservation {} — possible orphaned reservation in"
               + " TenantService",
           tenantId,
           exception);
+      return false;
     }
   }
 

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchService.java
@@ -22,7 +22,8 @@ import org.springframework.web.client.RestTemplate;
  * Sends account-invite mails via the platform's global SMTP settings with a strict
  * receipt-after-send contract (TEN-INV-U6, #890): either the SMTP server accepted the message and
  * an {@link InviteMailSendReceipt} is returned, or an {@link SmtpSendException} propagates. There
- * is no silent-failure path — a caller that does not receive a receipt must never persist SENT.
+ * is no silent-failure path. Failures additionally say whether non-delivery is confirmed or the
+ * SMTP outcome is uncertain, allowing callers with an existing deduplication claim to retry safely.
  *
  * <p>Settings resolution mirrors {@link
  * de.caritas.cob.userservice.api.service.auth.PasswordResetService}: connection settings come from
@@ -103,10 +104,34 @@ public class InviteMailDispatchService {
       String primaryActionUrl,
       Long tenantId,
       String language) {
-    InviteSmtpSettings smtp = resolveGlobalSmtpSettings();
-    BrandedEmail mail =
-        renderBrandedMail(subject, bodyContent, primaryActionUrl, tenantId, language);
-    return inviteMailTransport.send(smtp, recipient, subject, mail.html(), mail.plainText());
+    InviteSmtpSettings smtp;
+    BrandedEmail mail;
+    try {
+      smtp = resolveGlobalSmtpSettings();
+      mail = renderBrandedMail(subject, bodyContent, primaryActionUrl, tenantId, language);
+    } catch (SmtpSendException exception) {
+      throw exception;
+    } catch (RuntimeException exception) {
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+          SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT,
+          "Invite mail could not be prepared before SMTP dispatch",
+          exception);
+    }
+
+    try {
+      return inviteMailTransport.send(smtp, recipient, subject, mail.html(), mail.plainText());
+    } catch (SmtpSendException exception) {
+      throw exception;
+    } catch (RuntimeException exception) {
+      // A transport implementation that violates the checked contract can still fail after the
+      // SMTP server accepted the message. Treat that as ambiguous so callers keep their claim.
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+          SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN,
+          "Invite mail transport failed without a confirmed delivery outcome",
+          exception);
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailTransport.java
@@ -5,7 +5,8 @@ import de.caritas.cob.userservice.api.exception.SmtpSendException;
 /**
  * Strict SMTP send contract for account-invite mails: implementations either return an {@link
  * InviteMailSendReceipt} after the SMTP server accepted the message, or throw {@link
- * SmtpSendException}. Silent success is not allowed (TEN-INV-U6, mirrors the ConsultingTypeService
+ * SmtpSendException}. Failures distinguish confirmed non-delivery from an uncertain outcome after
+ * handover began. Silent success is not allowed (TEN-INV-U6, mirrors the ConsultingTypeService
  * DpaMailTransport contract from U5).
  */
 public interface InviteMailTransport {

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import jakarta.mail.Address;
+import jakarta.mail.AuthenticationFailedException;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -75,14 +76,10 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
     try {
       Transport.send(message);
       return new InviteMailSendReceipt(recipient, Instant.now());
-    } catch (SendFailedException exception) {
-      SmtpSendException.DeliveryDisposition disposition =
-          allRecipientsConfirmedUnsent(recipients, exception)
-              ? SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT
-              : SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN;
+    } catch (MessagingException exception) {
       throw new SmtpSendException(
           SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
-          disposition,
+          deliveryDisposition(recipients, exception),
           "Account invite email could not be sent",
           exception);
     } catch (Exception exception) {
@@ -94,6 +91,18 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
           "Account invite email delivery outcome is uncertain",
           exception);
     }
+  }
+
+  static SmtpSendException.DeliveryDisposition deliveryDisposition(
+      Address[] intendedRecipients, MessagingException exception) {
+    if (exception instanceof AuthenticationFailedException) {
+      return SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT;
+    }
+    if (exception instanceof SendFailedException sendFailure
+        && allRecipientsConfirmedUnsent(intendedRecipients, sendFailure)) {
+      return SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT;
+    }
+    return SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN;
   }
 
   static boolean allRecipientsConfirmedUnsent(

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransport.java
@@ -3,10 +3,12 @@ package de.caritas.cob.userservice.api.service.accountinvite.mail;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import jakarta.mail.Address;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.SendFailedException;
 import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
@@ -14,7 +16,10 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,6 +42,8 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
       String subject,
       String htmlBody,
       String plainTextBody) {
+    Message message;
+    Address[] recipients;
     try {
       Session session =
           Session.getInstance(
@@ -47,20 +54,79 @@ public class JakartaInviteMailTransport implements InviteMailTransport {
                   return new PasswordAuthentication(settings.username(), settings.password());
                 }
               });
-      Message message = new MimeMessage(session);
+      message = new MimeMessage(session);
       message.setFrom(new InternetAddress(settings.from()));
-      message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(recipient, true));
+      recipients = InternetAddress.parse(recipient, true);
+      message.setRecipients(Message.RecipientType.TO, recipients);
       message.setSubject(subject);
       if (isBlank(plainTextBody)) {
         message.setContent(htmlBody, "text/html; charset=UTF-8");
       } else {
         message.setContent(buildAlternativeContent(htmlBody, plainTextBody));
       }
+    } catch (Exception exception) {
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+          SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT,
+          "Account invite email could not be prepared for SMTP dispatch",
+          exception);
+    }
+
+    try {
       Transport.send(message);
       return new InviteMailSendReceipt(recipient, Instant.now());
+    } catch (SendFailedException exception) {
+      SmtpSendException.DeliveryDisposition disposition =
+          allRecipientsConfirmedUnsent(recipients, exception)
+              ? SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT
+              : SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN;
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+          disposition,
+          "Account invite email could not be sent",
+          exception);
     } catch (Exception exception) {
-      throw new SmtpSendException("Account invite email could not be sent", exception);
+      // Jakarta Mail can report a connection failure after the SMTP DATA command was accepted.
+      // Without per-recipient evidence that nothing was sent, retrying risks a duplicate mail.
+      throw new SmtpSendException(
+          SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+          SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN,
+          "Account invite email delivery outcome is uncertain",
+          exception);
     }
+  }
+
+  static boolean allRecipientsConfirmedUnsent(
+      Address[] intendedRecipients, SendFailedException exception) {
+    if (intendedRecipients == null
+        || intendedRecipients.length == 0
+        || hasAddresses(exception.getValidSentAddresses())) {
+      return false;
+    }
+
+    Set<String> confirmedUnsent = addressKeys(exception.getValidUnsentAddresses());
+    confirmedUnsent.addAll(addressKeys(exception.getInvalidAddresses()));
+    Set<String> intended = addressKeys(intendedRecipients);
+    return !intended.isEmpty() && confirmedUnsent.containsAll(intended);
+  }
+
+  private static boolean hasAddresses(Address[] addresses) {
+    return addresses != null && addresses.length > 0;
+  }
+
+  private static Set<String> addressKeys(Address[] addresses) {
+    Set<String> keys = new HashSet<>();
+    if (addresses == null) {
+      return keys;
+    }
+    for (Address address : addresses) {
+      if (address instanceof InternetAddress internetAddress) {
+        keys.add(internetAddress.getAddress().toLowerCase(Locale.ROOT));
+      } else if (address != null) {
+        keys.add(address.toString().toLowerCase(Locale.ROOT));
+      }
+    }
+    return keys;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/CounsellorOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/CounsellorOnboardingService.java
@@ -418,6 +418,7 @@ public class CounsellorOnboardingService {
   private AccountInviteLinkException expireIfPastExpiry(AccountInvite invite, LocalDateTime now) {
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
+      invite.setActiveRecipientKey(null);
       invite.setUpdateDate(now);
       accountInviteRepository.save(invite);
       return new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);

--- a/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/accountinvite/onboarding/TenantAdminOnboardingService.java
@@ -627,6 +627,7 @@ public class TenantAdminOnboardingService {
   private AccountInviteLinkException expireIfPastExpiry(AccountInvite invite, LocalDateTime now) {
     if (invite.getExpiresAt() != null && invite.getExpiresAt().isBefore(now)) {
       invite.setStatus(AccountInviteStatus.EXPIRED);
+      invite.setActiveRecipientKey(null);
       invite.setUpdateDate(now);
       accountInviteRepository.save(invite);
       return new AccountInviteLinkException(AccountInviteLinkException.Reason.EXPIRED);

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimService.java
@@ -1,6 +1,8 @@
 package de.caritas.cob.userservice.api.workflow.scheduling;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
@@ -14,12 +16,7 @@ public class ScheduledTaskClaimService {
   private final @NonNull ScheduledTaskClaimWriter claimWriter;
 
   public boolean tryClaim(String taskName, Duration claimDuration) {
-    if (taskName == null || taskName.isBlank()) {
-      throw new IllegalArgumentException("taskName must not be blank");
-    }
-    if (claimDuration == null || claimDuration.isZero() || claimDuration.isNegative()) {
-      throw new IllegalArgumentException("claimDuration must be positive");
-    }
+    validate(taskName, claimDuration);
     try {
       return claimWriter.claim(taskName, claimDuration);
     } catch (DataAccessException claimConflict) {
@@ -29,4 +26,33 @@ public class ScheduledTaskClaimService {
       throw claimConflict;
     }
   }
+
+  public Optional<ClaimLease> tryClaimLease(String taskName, Duration claimDuration) {
+    validate(taskName, claimDuration);
+    try {
+      return claimWriter
+          .claimUntil(taskName, claimDuration)
+          .map(claimedUntil -> new ClaimLease(taskName, claimedUntil));
+    } catch (DataAccessException claimConflict) {
+      if (claimWriter.hasActiveClaim(taskName)) {
+        return Optional.empty();
+      }
+      throw claimConflict;
+    }
+  }
+
+  public boolean release(ClaimLease lease) {
+    return claimWriter.release(lease.taskName(), lease.claimedUntil());
+  }
+
+  private void validate(String taskName, Duration claimDuration) {
+    if (taskName == null || taskName.isBlank()) {
+      throw new IllegalArgumentException("taskName must not be blank");
+    }
+    if (claimDuration == null || claimDuration.isZero() || claimDuration.isNegative()) {
+      throw new IllegalArgumentException("claimDuration must be positive");
+    }
+  }
+
+  public record ClaimLease(String taskName, LocalDateTime claimedUntil) {}
 }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimWriter.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimWriter.java
@@ -5,6 +5,7 @@ import de.caritas.cob.userservice.api.port.out.ScheduledTaskClaimRepository;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,17 +22,22 @@ public class ScheduledTaskClaimWriter {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public boolean claim(String taskName, Duration claimDuration) {
+    return claimUntil(taskName, claimDuration).isPresent();
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public Optional<LocalDateTime> claimUntil(String taskName, Duration claimDuration) {
     LocalDateTime now = LocalDateTime.now(clock);
     var existingClaim = claimRepository.findByTaskNameForUpdate(taskName);
     if (existingClaim.isPresent()) {
       var claim = existingClaim.get();
       if (claim.getClaimedUntil().isAfter(now)) {
-        return false;
+        return Optional.empty();
       }
       claim.setClaimedAt(now);
       claim.setClaimedUntil(now.plus(claimDuration));
       claimRepository.saveAndFlush(claim);
-      return true;
+      return Optional.of(claim.getClaimedUntil());
     }
 
     claimRepository.saveAndFlush(
@@ -40,7 +46,13 @@ public class ScheduledTaskClaimWriter {
             .claimedAt(now)
             .claimedUntil(now.plus(claimDuration))
             .build());
-    return true;
+    return Optional.of(now.plus(claimDuration));
+  }
+
+  /** Deletes only the exact lease version acquired by this execution. */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public boolean release(String taskName, LocalDateTime claimedUntil) {
+    return claimRepository.deleteByTaskNameAndClaimedUntil(taskName, claimedUntil) == 1;
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)

--- a/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/0091_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/0091_changeSet.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+  <changeSet id="0091_account_invite_active_recipient" author="oriso">
+    <sqlFile
+      path="db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient.sql"
+      relativeToChangelogFile="false"
+      splitStatements="true"
+      stripComments="true"/>
+    <rollback>
+      <sqlFile
+        path="db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient-rollback.sql"
+        relativeToChangelogFile="false"
+        splitStatements="true"
+        stripComments="true"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient-rollback.sql
@@ -1,3 +1,5 @@
 ALTER TABLE account_invite
-  DROP INDEX idx_account_invite_active_recipient,
-  DROP COLUMN active_recipient_key;
+  DROP INDEX IF EXISTS idx_account_invite_active_recipient;
+
+ALTER TABLE account_invite
+  DROP COLUMN IF EXISTS active_recipient_key;

--- a/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient-rollback.sql
@@ -1,0 +1,3 @@
+ALTER TABLE account_invite
+  DROP INDEX idx_account_invite_active_recipient,
+  DROP COLUMN active_recipient_key;

--- a/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient.sql
+++ b/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient.sql
@@ -1,0 +1,5 @@
+-- New rows claim their normalized recipient in this nullable column. Existing duplicate rows stay
+-- NULL, so the migration is non-destructive; the existing service guard still covers them.
+ALTER TABLE account_invite
+  ADD COLUMN active_recipient_key VARCHAR(255) NULL AFTER recipient_email,
+  ADD UNIQUE KEY idx_account_invite_active_recipient (active_recipient_key);

--- a/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient.sql
+++ b/src/main/resources/db/changelog/changeset/0091_account_invite_active_recipient/account-invite-active-recipient.sql
@@ -1,5 +1,7 @@
 -- New rows claim their normalized recipient in this nullable column. Existing duplicate rows stay
 -- NULL, so the migration is non-destructive; the existing service guard still covers them.
 ALTER TABLE account_invite
-  ADD COLUMN active_recipient_key VARCHAR(255) NULL AFTER recipient_email,
-  ADD UNIQUE KEY idx_account_invite_active_recipient (active_recipient_key);
+  ADD COLUMN IF NOT EXISTS active_recipient_key VARCHAR(255) NULL AFTER recipient_email;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_account_invite_active_recipient
+  ON account_invite (active_recipient_key);

--- a/src/main/resources/db/changelog/changeset/0092_id_reservation_release_task/0092_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0092_id_reservation_release_task/0092_changeSet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+  <changeSet id="0092-id-reservation-release-task" author="oriso">
+    <sqlFile
+      path="db/changelog/changeset/0092_id_reservation_release_task/migrate.sql"
+      relativeToChangelogFile="false" splitStatements="true" stripComments="true" endDelimiter=";"/>
+    <rollback><sql>DROP TABLE IF EXISTS id_reservation_release_task;</sql></rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0092_id_reservation_release_task/migrate.sql
+++ b/src/main/resources/db/changelog/changeset/0092_id_reservation_release_task/migrate.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS id_reservation_release_task (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  allocation_type VARCHAR(16) NOT NULL,
+  reserved_id BIGINT NOT NULL,
+  tenant_context_id BIGINT NULL,
+  attempt_count INT NOT NULL DEFAULT 0,
+  last_attempt_at DATETIME(6) NULL,
+  create_date DATETIME(6) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_id_reservation_release_task_type_id (allocation_type, reserved_id)
+);

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -169,6 +169,8 @@
     file="db/changelog/changeset/0090_session_consented_legal_version/0090_changeSet.xml" />
   <include
     file="db/changelog/changeset/0091_account_invite_active_recipient/0091_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0092_id_reservation_release_task/0092_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/main/resources/db/changelog/userservice-master.xml
+++ b/src/main/resources/db/changelog/userservice-master.xml
@@ -167,6 +167,8 @@
     file="db/changelog/changeset/0089_account_invite_dpa_signed_at/0089_changeSet.xml" />
   <include
     file="db/changelog/changeset/0090_session_consented_legal_version/0090_changeSet.xml" />
+  <include
+    file="db/changelog/changeset/0091_account_invite_active_recipient/0091_changeSet.xml" />
 
   <!-- Seed/demo data (context="seed"): append future seed changesets below this
        line and tag every changeset with context="seed". -->

--- a/src/main/resources/replica-safety-components.json
+++ b/src/main/resources/replica-safety-components.json
@@ -301,6 +301,22 @@
       "status": "blocker"
     },
     {
+      "id": "account-invite-reservation-release-scheduler",
+      "source": "src/main/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseScheduler.java",
+      "kind": "scheduler",
+      "owner": "agency-tenant",
+      "risk": "duplicate-side-effect",
+      "components": [
+        "retryPendingReleases"
+      ],
+      "decision": "Lease each batch and use idempotent release endpoints plus row locks for safe replay.",
+      "signals": [
+        "userservice.scheduler.executions",
+        "userservice.scheduler.duration"
+      ],
+      "status": "safe"
+    },
+    {
       "id": "enquiry-notification-scheduler",
       "source": "src/main/java/de/caritas/cob/userservice/api/workflow/enquirynotification/scheduler/EnquiryNotificationScheduler.java",
       "kind": "scheduler",

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -125,9 +125,8 @@ class AccountInviteControllerTest {
   }
 
   @Test
-  void createInvite_withTemplateId_sendsInviteAndReturnsCreated() {
-    // Business reason: template-triggered invitation must send immediately and return accept URL
-    // metadata.
+  void createInvite_withTemplateId_createsAndSendsAtomicallyAndReturnsCreated() {
+    // Business reason: a direct-send request must not leave an invisible draft if SMTP rejects it.
     var request = new AccountInviteController.CreateAccountInviteRequestDTO();
     request.targetRole = AccountInviteTargetRole.COUNSELLOR.name();
     request.recipientEmail = "invitee@example.org";
@@ -137,16 +136,13 @@ class AccountInviteControllerTest {
     var invite = sampleInvite();
     var delivery = InviteEmailDelivery.builder().status(InviteEmailDeliveryStatus.SENT).build();
     var sendResult = new InviteSendResult(invite, delivery, "raw-token", "accept-url");
-    when(accountInviteService.createInvite(any())).thenReturn(invite);
-    when(accountInviteService.sendInvite(any())).thenReturn(sendResult);
+    when(accountInviteService.createAndSendInvite(any(), eq(12L))).thenReturn(sendResult);
 
     var response = controller.createInvite(request);
 
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     assertEquals("raw-token", response.getBody().rawToken);
-    var sendCaptor = ArgumentCaptor.forClass(AccountInviteService.SendInviteCommand.class);
-    verify(accountInviteService).sendInvite(sendCaptor.capture());
-    assertEquals(12L, sendCaptor.getValue().templateId());
+    verify(accountInviteService).createAndSendInvite(any(), eq(12L));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/adapters/web/controller/AccountInviteControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import de.caritas.cob.userservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.exception.httpresponses.NotFoundException;
@@ -129,7 +130,15 @@ class AccountInviteControllerTest {
     // Business reason: a direct-send request must not leave an invisible draft if SMTP rejects it.
     var request = new AccountInviteController.CreateAccountInviteRequestDTO();
     request.targetRole = AccountInviteTargetRole.COUNSELLOR.name();
+    request.tenantId = 7L;
     request.recipientEmail = "invitee@example.org";
+    request.firstName = "Ada";
+    request.lastName = "Lovelace";
+    request.agencyId = 9L;
+    request.departmentId = 11L;
+    request.expiresInDays = 14L;
+    request.tenantIdAllocationMode = "AUTO";
+    request.agencyIdAllocationMode = "MANUAL";
     request.templateId = 12L;
     request.acceptBaseUrl = "https://example.org/invite";
 
@@ -142,7 +151,36 @@ class AccountInviteControllerTest {
 
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     assertEquals("raw-token", response.getBody().rawToken);
-    verify(accountInviteService).createAndSendInvite(any(), eq(12L));
+    var commandCaptor =
+        ArgumentCaptor.forClass(AccountInviteService.CreateAccountInviteCommand.class);
+    verify(accountInviteService).createAndSendInvite(commandCaptor.capture(), eq(12L));
+    var command = commandCaptor.getValue();
+    assertEquals(AccountInviteTargetRole.COUNSELLOR, command.targetRole());
+    assertEquals(7L, command.tenantId());
+    assertEquals("invitee@example.org", command.recipientEmail());
+    assertEquals("Ada", command.firstName());
+    assertEquals("Lovelace", command.lastName());
+    assertEquals(9L, command.agencyId());
+    assertEquals(11L, command.departmentId());
+    assertEquals(14L, command.expiresInDays());
+    assertEquals(IdAllocationMode.AUTO, command.tenantIdAllocationMode());
+    assertEquals(IdAllocationMode.MANUAL, command.agencyIdAllocationMode());
+  }
+
+  @Test
+  void createInvite_withTemplateId_propagatesSmtpFailure() {
+    // Business reason: the controller must preserve the service's 502 error contract when a
+    // direct-send attempt cannot be confirmed.
+    var request = new AccountInviteController.CreateAccountInviteRequestDTO();
+    request.targetRole = AccountInviteTargetRole.COUNSELLOR.name();
+    request.recipientEmail = "invitee@example.org";
+    request.templateId = 12L;
+    var failure = new SmtpSendException("SMTP refused the message");
+    when(accountInviteService.createAndSendInvite(any(), eq(12L))).thenThrow(failure);
+
+    var thrown = assertThrows(SmtpSendException.class, () -> controller.createInvite(request));
+
+    assertEquals(failure, thrown);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/config/observability/ReplicaSafetyInventoryContractTest.java
@@ -33,6 +33,7 @@ class ReplicaSafetyInventoryContractTest {
           "tenant-admin-cache",
           "topics-cache",
           "operator-dpa-content-cache",
+          "account-invite-reservation-release-scheduler",
           "appointment-cleanup-scheduler",
           "enquiry-notification-scheduler",
           "group-chat-deactivation-scheduler",

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteAcceptRaceIT.java
@@ -8,6 +8,7 @@ import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ class AccountInviteAcceptRaceIT {
   @MockitoBean private TenantService tenantService;
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private IdReservationReleaseProcessor reservationReleaseProcessor;
   @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
 
   @MockitoBean

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -96,6 +96,7 @@ class AccountInviteDirectSendAtomicIT {
 
   @AfterEach
   void cleanUp() {
+    deliveryRepository.deleteAll();
     accountInviteRepository.deleteAll();
     templateRepository.deleteAll();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -1,0 +1,136 @@
+package de.caritas.cob.userservice.api.service.accountinvite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
+import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
+import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Public direct-send seam: an SMTP rejection is a failed operation, not a silently persisted draft
+ * that blocks the recipient from trying again.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(AccountInviteService.class)
+class AccountInviteDirectSendAtomicIT {
+
+  private static final String RECIPIENT = "owner@example.org";
+
+  @Autowired private AccountInviteService service;
+  @Autowired private AccountInviteRepository accountInviteRepository;
+  @Autowired private InviteEmailTemplateRepository templateRepository;
+
+  @MockitoBean private AuthenticatedUser authenticatedUser;
+  @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @MockitoBean private TenantService tenantService;
+  @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
+  @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
+  @MockitoBean private InviteMailDispatchService inviteMailDispatchService;
+  @MockitoBean private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
+
+  private Long templateId;
+
+  @BeforeEach
+  void setUp() {
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.getUsername()).thenReturn("admin@example.org");
+    when(identityEmailOwnerLookup.findByEmail(RECIPIENT)).thenReturn(Optional.empty());
+    when(tenantIdAllocationClient.reserve(null))
+        .thenReturn(new TenantIdReservation(17L, "reservation-17"));
+    when(tenantIdAllocationClient.getAvailability(17L)).thenReturn(IdAllocationStatus.RESERVED);
+    templateId =
+        templateRepository
+            .save(
+                InviteEmailTemplate.builder()
+                    .kind(InviteEmailTemplateKind.TENANT_INVITE)
+                    .name("Tenant welcome")
+                    .subject("Welcome")
+                    .body("Open {{inviteLink}}")
+                    .active(true)
+                    .createDate(LocalDateTime.now())
+                    .build())
+            .getId();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    accountInviteRepository.deleteAll();
+    templateRepository.deleteAll();
+  }
+
+  @Test
+  void directSend_ShouldRollbackInviteWhenSmtpRejects_AndPermitExactlyOneRetry() {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    doThrow(new SmtpSendException("SMTP refused the message"))
+        .doReturn(
+            new de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt(
+                RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z")))
+        .when(inviteMailDispatchService)
+        .send(any(), any(), any(), any(), any(), any());
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
+        .isInstanceOf(SmtpSendException.class);
+
+    assertThat(accountInviteRepository.count()).isZero();
+    verify(tenantIdAllocationClient).release(17L);
+
+    service.createAndSendInvite(tenantAdminInvite(), templateId);
+
+    assertThat(accountInviteRepository.findAll())
+        .singleElement()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getRecipientEmail()).isEqualTo(RECIPIENT);
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+            });
+  }
+
+  private CreateAccountInviteCommand tenantAdminInvite() {
+    return new CreateAccountInviteCommand(
+        AccountInviteTargetRole.TENANT_ADMIN,
+        null,
+        RECIPIENT,
+        "Ada",
+        "Lovelace",
+        null,
+        null,
+        30L,
+        IdAllocationMode.AUTO,
+        null);
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -15,6 +15,7 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
@@ -23,6 +24,8 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseType;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
@@ -56,7 +59,7 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
-@Import(AccountInviteService.class)
+@Import({AccountInviteService.class, IdReservationReleaseProcessor.class})
 class AccountInviteDirectSendAtomicIT {
 
   private static final String RECIPIENT = "owner@example.org";
@@ -64,6 +67,7 @@ class AccountInviteDirectSendAtomicIT {
   @Autowired private AccountInviteService service;
   @MockitoSpyBean private AccountInviteRepository accountInviteRepository;
   @Autowired private InviteEmailTemplateRepository templateRepository;
+  @Autowired private IdReservationReleaseTaskRepository reservationReleaseTaskRepository;
   @MockitoSpyBean private InviteEmailDeliveryRepository deliveryRepository;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;
@@ -85,6 +89,8 @@ class AccountInviteDirectSendAtomicIT {
     when(tenantIdAllocationClient.reserve(null))
         .thenReturn(new TenantIdReservation(17L, "reservation-17"));
     when(tenantIdAllocationClient.getAvailability(17L)).thenReturn(IdAllocationStatus.RESERVED);
+    when(tenantIdAllocationClient.release(17L)).thenReturn(true);
+    when(agencyIdAllocationClient.release(23L)).thenReturn(true);
     templateId =
         templateRepository
             .save(
@@ -101,6 +107,7 @@ class AccountInviteDirectSendAtomicIT {
 
   @AfterEach
   void cleanUp() {
+    reservationReleaseTaskRepository.deleteAll();
     deliveryRepository.deleteAll();
     accountInviteRepository.deleteAll();
     templateRepository.deleteAll();
@@ -140,12 +147,11 @@ class AccountInviteDirectSendAtomicIT {
     when(agencyIdAllocationClient.getAvailability(23L)).thenReturn(IdAllocationStatus.RESERVED);
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
         .thenReturn("https://example.org/invite/token");
-    doThrow(confirmedRejection())
-        .when(inviteMailDispatchService)
-        .send(any(), any(), any(), any(), any(), any());
+    SmtpSendException failure = confirmedRejection();
+    doThrow(failure).when(inviteMailDispatchService).send(any(), any(), any(), any(), any(), any());
 
     assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminAgencyInvite(), templateId))
-        .isInstanceOf(SmtpSendException.class);
+        .isSameAs(failure);
 
     assertThat(accountInviteRepository.count()).isZero();
     verify(tenantIdAllocationClient).release(17L);
@@ -156,15 +162,14 @@ class AccountInviteDirectSendAtomicIT {
   void directSend_ShouldKeepReservationsWhenCommittedClaimCannotBeDeleted() {
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
         .thenReturn("https://example.org/invite/token");
-    doThrow(confirmedRejection())
-        .when(inviteMailDispatchService)
-        .send(any(), any(), any(), any(), any(), any());
+    SmtpSendException failure = confirmedRejection();
+    doThrow(failure).when(inviteMailDispatchService).send(any(), any(), any(), any(), any(), any());
     doThrow(new DataAccessResourceFailureException("database unavailable"))
         .when(accountInviteRepository)
         .deleteById(any());
 
     assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
-        .isInstanceOf(SmtpSendException.class)
+        .isSameAs(failure)
         .satisfies(exception -> assertThat(exception.getSuppressed()).hasSize(1));
 
     assertThat(accountInviteRepository.findAll()).hasSize(1);
@@ -172,22 +177,28 @@ class AccountInviteDirectSendAtomicIT {
   }
 
   @Test
-  void directSend_ShouldAttemptAgencyReleaseWhenTenantReleaseFails() {
+  void directSend_ShouldPersistTenantReleaseRetryAndStillReleaseAgency() {
     when(agencyIdAllocationClient.reserve(null, 17L)).thenReturn(23L);
     when(agencyIdAllocationClient.getAvailability(23L)).thenReturn(IdAllocationStatus.RESERVED);
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
         .thenReturn("https://example.org/invite/token");
-    doThrow(confirmedRejection())
-        .when(inviteMailDispatchService)
-        .send(any(), any(), any(), any(), any(), any());
-    doThrow(new IllegalStateException("tenant allocator unavailable"))
-        .when(tenantIdAllocationClient)
-        .release(17L);
+    SmtpSendException failure = confirmedRejection();
+    doThrow(failure).when(inviteMailDispatchService).send(any(), any(), any(), any(), any(), any());
+    when(tenantIdAllocationClient.release(17L)).thenReturn(false);
 
     assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminAgencyInvite(), templateId))
-        .isInstanceOf(SmtpSendException.class);
+        .isSameAs(failure);
 
     verify(agencyIdAllocationClient).release(23L);
+    assertThat(reservationReleaseTaskRepository.findAll())
+        .singleElement()
+        .satisfies(
+            task -> {
+              assertThat(task.getAllocationType()).isEqualTo(IdReservationReleaseType.TENANT);
+              assertThat(task.getReservedId()).isEqualTo(17L);
+              assertThat(task.getAttemptCount()).isEqualTo(1);
+              assertThat(task.getLastAttemptAt()).isNotNull();
+            });
   }
 
   @Test
@@ -333,8 +344,9 @@ class AccountInviteDirectSendAtomicIT {
     AccountInvite oldInvite = persistedInvite(AccountInviteStatus.EXPIRED, RECIPIENT);
     oldInvite.setActiveRecipientKey(null);
     oldInvite = accountInviteRepository.saveAndFlush(oldInvite);
-    accountInviteRepository.saveAndFlush(
-        persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT));
+    AccountInvite legacyConflict = persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT);
+    legacyConflict.setActiveRecipientKey(null);
+    accountInviteRepository.saveAndFlush(legacyConflict);
 
     Long oldInviteId = oldInvite.getId();
     assertThatThrownBy(
@@ -344,6 +356,117 @@ class AccountInviteDirectSendAtomicIT {
         .isInstanceOf(CustomValidationHttpStatusException.class);
 
     verify(inviteMailDispatchService, never()).send(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void resendInvite_ShouldCommitClaimHandoverBeforeMailDispatch() throws Exception {
+    AccountInvite oldInvite =
+        accountInviteRepository.saveAndFlush(
+            persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/replacement");
+    CountDownLatch mailStarted = new CountDownLatch(1);
+    CountDownLatch releaseMail = new CountDownLatch(1);
+    when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              mailStarted.countDown();
+              if (!releaseMail.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("test timed out waiting to release mail");
+              }
+              return new de.caritas.cob.userservice.api.service.accountinvite.mail
+                  .InviteMailSendReceipt(
+                  RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z"));
+            });
+
+    CompletableFuture<Void> resend =
+        CompletableFuture.runAsync(
+            () ->
+                service.resendInvite(
+                    new AccountInviteService.SendInviteCommand(oldInvite.getId(), templateId)));
+    assertThat(mailStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    try {
+      assertThat(accountInviteRepository.findById(oldInvite.getId()))
+          .get()
+          .satisfies(
+              committedOld -> {
+                assertThat(committedOld.getStatus()).isEqualTo(AccountInviteStatus.SUPERSEDED);
+                assertThat(committedOld.getActiveRecipientKey()).isNull();
+              });
+      assertThat(accountInviteRepository.findAll())
+          .filteredOn(invite -> !invite.getId().equals(oldInvite.getId()))
+          .singleElement()
+          .satisfies(
+              replacement -> {
+                assertThat(replacement.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+                assertThat(replacement.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+                assertThat(replacement.getTokenHash()).isNotBlank();
+              });
+    } finally {
+      releaseMail.countDown();
+      resend.get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void resendInvite_ShouldRestoreOldInviteWhenSmtpConfirmedNotSent() {
+    AccountInvite oldInvite =
+        accountInviteRepository.saveAndFlush(
+            persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/replacement");
+    SmtpSendException failure = confirmedRejection();
+    doThrow(failure).when(inviteMailDispatchService).send(any(), any(), any(), any(), any(), any());
+
+    assertThatThrownBy(
+            () ->
+                service.resendInvite(
+                    new AccountInviteService.SendInviteCommand(oldInvite.getId(), templateId)))
+        .isSameAs(failure);
+
+    assertThat(accountInviteRepository.findAll())
+        .singleElement()
+        .satisfies(
+            restored -> {
+              assertThat(restored.getId()).isEqualTo(oldInvite.getId());
+              assertThat(restored.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+              assertThat(restored.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+              assertThat(restored.getSupersededByInviteId()).isNull();
+            });
+  }
+
+  @Test
+  void resendInvite_ShouldKeepCommittedReplacementWhenDeliveryAuditFails() {
+    AccountInvite oldInvite =
+        accountInviteRepository.saveAndFlush(
+            persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT));
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/replacement");
+    when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt(
+                RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z")));
+    doThrow(new DataAccessResourceFailureException("audit unavailable"))
+        .when(deliveryRepository)
+        .saveAndFlush(any());
+
+    InviteSendResult result =
+        service.resendInvite(
+            new AccountInviteService.SendInviteCommand(oldInvite.getId(), templateId));
+
+    assertThat(result.rawToken()).isNotBlank();
+    assertThat(accountInviteRepository.findById(oldInvite.getId()))
+        .get()
+        .extracting(AccountInvite::getStatus)
+        .isEqualTo(AccountInviteStatus.SUPERSEDED);
+    assertThat(accountInviteRepository.findById(result.invite().getId()))
+        .get()
+        .satisfies(
+            replacement -> {
+              assertThat(replacement.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+              assertThat(replacement.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+            });
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
@@ -129,6 +130,7 @@ class AccountInviteDirectSendAtomicIT {
 
     assertThat(accountInviteRepository.count()).isZero();
     verify(tenantIdAllocationClient).release(17L);
+    verifyNoInteractions(deliveryFailureRecorder);
 
     service.createAndSendInvite(tenantAdminInvite(), templateId);
 
@@ -216,14 +218,22 @@ class AccountInviteDirectSendAtomicIT {
     assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
         .isInstanceOf(SmtpSendException.class);
 
-    assertThat(accountInviteRepository.findAll())
-        .singleElement()
+    AccountInvite retained = accountInviteRepository.findAll().getFirst();
+    assertThat(retained)
         .satisfies(
             invite -> {
               assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
               assertThat(invite.getTokenHash()).isNotBlank();
               assertThat(invite.getActiveRecipientKey()).isEqualTo(RECIPIENT);
             });
+    verify(deliveryFailureRecorder)
+        .recordFailure(
+            org.mockito.ArgumentMatchers.eq(retained.getId()),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
     verify(tenantIdAllocationClient, never()).release(17L);
 
     assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.SmtpSendException;
+import de.caritas.cob.userservice.api.exception.httpresponses.CustomValidationHttpStatusException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
+import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
@@ -38,6 +40,8 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -58,7 +62,7 @@ class AccountInviteDirectSendAtomicIT {
   private static final String RECIPIENT = "owner@example.org";
 
   @Autowired private AccountInviteService service;
-  @Autowired private AccountInviteRepository accountInviteRepository;
+  @MockitoSpyBean private AccountInviteRepository accountInviteRepository;
   @Autowired private InviteEmailTemplateRepository templateRepository;
   @MockitoSpyBean private InviteEmailDeliveryRepository deliveryRepository;
 
@@ -145,6 +149,44 @@ class AccountInviteDirectSendAtomicIT {
 
     assertThat(accountInviteRepository.count()).isZero();
     verify(tenantIdAllocationClient).release(17L);
+    verify(agencyIdAllocationClient).release(23L);
+  }
+
+  @Test
+  void directSend_ShouldKeepReservationsWhenCommittedClaimCannotBeDeleted() {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    doThrow(confirmedRejection())
+        .when(inviteMailDispatchService)
+        .send(any(), any(), any(), any(), any(), any());
+    doThrow(new DataAccessResourceFailureException("database unavailable"))
+        .when(accountInviteRepository)
+        .deleteById(any());
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
+        .isInstanceOf(SmtpSendException.class)
+        .satisfies(exception -> assertThat(exception.getSuppressed()).hasSize(1));
+
+    assertThat(accountInviteRepository.findAll()).hasSize(1);
+    verify(tenantIdAllocationClient, never()).release(17L);
+  }
+
+  @Test
+  void directSend_ShouldAttemptAgencyReleaseWhenTenantReleaseFails() {
+    when(agencyIdAllocationClient.reserve(null, 17L)).thenReturn(23L);
+    when(agencyIdAllocationClient.getAvailability(23L)).thenReturn(IdAllocationStatus.RESERVED);
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    doThrow(confirmedRejection())
+        .when(inviteMailDispatchService)
+        .send(any(), any(), any(), any(), any(), any());
+    doThrow(new IllegalStateException("tenant allocator unavailable"))
+        .when(tenantIdAllocationClient)
+        .release(17L);
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminAgencyInvite(), templateId))
+        .isInstanceOf(SmtpSendException.class);
+
     verify(agencyIdAllocationClient).release(23L);
   }
 
@@ -246,6 +288,73 @@ class AccountInviteDirectSendAtomicIT {
     assertThat(mailCalls).hasValue(1);
   }
 
+  @Test
+  void createInvite_ShouldExpireElapsedClaimAndPermitReinvite() {
+    AccountInvite expired = persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT);
+    expired.setExpiresAt(LocalDateTime.now().minusMinutes(1));
+    expired.setActiveRecipientKey(RECIPIENT);
+    expired = accountInviteRepository.saveAndFlush(expired);
+
+    AccountInvite replacement = service.createInvite(counsellorInvite("Ada"));
+
+    assertThat(accountInviteRepository.findById(expired.getId()))
+        .get()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EXPIRED);
+              assertThat(invite.getActiveRecipientKey()).isNull();
+            });
+    assertThat(replacement.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+  }
+
+  @Test
+  void acceptInvite_ShouldCommitExpiredStateAndReleaseRecipientClaim() {
+    String rawToken = "expired-invite-token";
+    AccountInvite expired = persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT);
+    expired.setTokenHash(AccountInviteService.hash(rawToken));
+    expired.setExpiresAt(LocalDateTime.now().minusMinutes(1));
+    expired.setActiveRecipientKey(RECIPIENT);
+    expired = accountInviteRepository.saveAndFlush(expired);
+
+    assertThatThrownBy(() -> service.acceptInvite(rawToken, "user-1"))
+        .isInstanceOf(AccountInviteLinkException.class);
+
+    assertThat(accountInviteRepository.findById(expired.getId()))
+        .get()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EXPIRED);
+              assertThat(invite.getActiveRecipientKey()).isNull();
+            });
+  }
+
+  @Test
+  void resendInvite_ShouldRejectExistingRecipientClaimBeforeMailDispatch() {
+    AccountInvite oldInvite = persistedInvite(AccountInviteStatus.EXPIRED, RECIPIENT);
+    oldInvite.setActiveRecipientKey(null);
+    oldInvite = accountInviteRepository.saveAndFlush(oldInvite);
+    accountInviteRepository.saveAndFlush(
+        persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT));
+
+    Long oldInviteId = oldInvite.getId();
+    assertThatThrownBy(
+            () ->
+                service.resendInvite(
+                    new AccountInviteService.SendInviteCommand(oldInviteId, templateId)))
+        .isInstanceOf(CustomValidationHttpStatusException.class);
+
+    verify(inviteMailDispatchService, never()).send(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void createInvite_ShouldNotMisreportUnrelatedIntegrityFailureAsEmailConflict() {
+    CreateAccountInviteCommand command = counsellorInvite("x".repeat(300));
+
+    assertThatThrownBy(() -> service.createInvite(command))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .isNotInstanceOf(CustomValidationHttpStatusException.class);
+  }
+
   private CreateAccountInviteCommand tenantAdminInvite() {
     return new CreateAccountInviteCommand(
         AccountInviteTargetRole.TENANT_ADMIN,
@@ -279,5 +388,39 @@ class AccountInviteDirectSendAtomicIT {
         30L,
         IdAllocationMode.AUTO,
         IdAllocationMode.AUTO);
+  }
+
+  private static CreateAccountInviteCommand counsellorInvite(String firstName) {
+    return new CreateAccountInviteCommand(
+        AccountInviteTargetRole.COUNSELLOR,
+        null,
+        RECIPIENT,
+        firstName,
+        "Lovelace",
+        null,
+        null,
+        30L,
+        null,
+        null);
+  }
+
+  private static AccountInvite persistedInvite(AccountInviteStatus status, String recipient) {
+    LocalDateTime now = LocalDateTime.now();
+    return AccountInvite.builder()
+        .targetRole(AccountInviteTargetRole.TENANT_ADMIN)
+        .tenantId(17L)
+        .tenantIdReservationToken("reservation-17")
+        .recipientEmail(recipient)
+        .activeRecipientKey(recipient)
+        .expiresAt(now.plusDays(30))
+        .status(status)
+        .provisioningStatus(AccountInviteProvisioningStatus.PENDING)
+        .emailVerificationStatus(EmailVerificationStatus.PENDING)
+        .twoFactorStatus(TwoFactorGateStatus.PENDING_SETUP)
+        .createdByUserId("admin-1")
+        .createdByUsername("admin@example.org")
+        .createDate(now)
+        .updateDate(now)
+        .build();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -329,6 +329,25 @@ class AccountInviteDirectSendAtomicIT {
   }
 
   @Test
+  void createInvite_ShouldExpireClaimedDraftThatWasNeverOpenedAndPermitReinvite() {
+    AccountInvite expiredDraft = persistedInvite(AccountInviteStatus.DRAFT, RECIPIENT);
+    expiredDraft.setExpiresAt(LocalDateTime.now().minusMinutes(1));
+    expiredDraft.setActiveRecipientKey(RECIPIENT);
+    expiredDraft = accountInviteRepository.saveAndFlush(expiredDraft);
+
+    AccountInvite replacement = service.createInvite(counsellorInvite("Ada"));
+
+    assertThat(accountInviteRepository.findById(expiredDraft.getId()))
+        .get()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EXPIRED);
+              assertThat(invite.getActiveRecipientKey()).isNull();
+            });
+    assertThat(replacement.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+  }
+
+  @Test
   void acceptInvite_ShouldCommitExpiredStateAndReleaseRecipientClaim() {
     String rawToken = "expired-invite-token";
     AccountInvite expired = persistedInvite(AccountInviteStatus.EMAIL_SENT, RECIPIENT);

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -13,8 +13,10 @@ import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
+import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
 import de.caritas.cob.userservice.api.port.out.InviteEmailTemplateRepository;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
+import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.InviteSendResult;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
@@ -37,6 +39,7 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +59,7 @@ class AccountInviteDirectSendAtomicIT {
   @Autowired private AccountInviteService service;
   @Autowired private AccountInviteRepository accountInviteRepository;
   @Autowired private InviteEmailTemplateRepository templateRepository;
+  @MockitoSpyBean private InviteEmailDeliveryRepository deliveryRepository;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;
   @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
@@ -125,6 +129,49 @@ class AccountInviteDirectSendAtomicIT {
   }
 
   @Test
+  void directSend_ShouldReleaseTenantAndAgencyReservationsWhenSmtpRejects() {
+    when(agencyIdAllocationClient.reserve(null, 17L)).thenReturn(23L);
+    when(agencyIdAllocationClient.getAvailability(23L)).thenReturn(IdAllocationStatus.RESERVED);
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    doThrow(new SmtpSendException("SMTP refused the message"))
+        .when(inviteMailDispatchService)
+        .send(any(), any(), any(), any(), any(), any());
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminAgencyInvite(), templateId))
+        .isInstanceOf(SmtpSendException.class);
+
+    assertThat(accountInviteRepository.count()).isZero();
+    verify(tenantIdAllocationClient).release(17L);
+    verify(agencyIdAllocationClient).release(23L);
+  }
+
+  @Test
+  void directSend_ShouldKeepUsableClaimWhenDeliveryAuditFailsAfterSmtp() {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt(
+                RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z")));
+    doThrow(new org.springframework.dao.DataAccessResourceFailureException("audit unavailable"))
+        .when(deliveryRepository)
+        .saveAndFlush(any());
+
+    InviteSendResult result = service.createAndSendInvite(tenantAdminInvite(), templateId);
+
+    assertThat(result.rawToken()).isNotBlank();
+    assertThat(accountInviteRepository.findById(result.invite().getId()))
+        .get()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+              assertThat(invite.getTokenHash()).isNotBlank();
+              assertThat(invite.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+            });
+  }
+
+  @Test
   void directSend_ShouldCommitRecipientClaimBeforeSmtp_AndRejectRapidSecondClick()
       throws Exception {
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
@@ -154,13 +201,15 @@ class AccountInviteDirectSendAtomicIT {
     try {
       assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
           .isInstanceOf(
-              de.caritas.cob.userservice.api.exception.httpresponses.ConflictException.class);
+              de.caritas.cob.userservice.api.exception.httpresponses
+                  .CustomValidationHttpStatusException.class);
     } finally {
       releaseFirstMail.countDown();
       firstRequest.get(5, TimeUnit.SECONDS);
     }
 
     assertThat(accountInviteRepository.findAll()).hasSize(1);
+    assertThat(mailCalls).hasValue(1);
   }
 
   private CreateAccountInviteCommand tenantAdminInvite() {
@@ -175,5 +224,19 @@ class AccountInviteDirectSendAtomicIT {
         30L,
         IdAllocationMode.AUTO,
         null);
+  }
+
+  private CreateAccountInviteCommand tenantAdminAgencyInvite() {
+    return new CreateAccountInviteCommand(
+        AccountInviteTargetRole.TENANT_ADMIN,
+        null,
+        RECIPIENT,
+        "Ada",
+        "Lovelace",
+        null,
+        null,
+        30L,
+        IdAllocationMode.AUTO,
+        IdAllocationMode.AUTO);
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -23,6 +23,10 @@ import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdR
 import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,6 +122,45 @@ class AccountInviteDirectSendAtomicIT {
               assertThat(invite.getRecipientEmail()).isEqualTo(RECIPIENT);
               assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
             });
+  }
+
+  @Test
+  void directSend_ShouldCommitRecipientClaimBeforeSmtp_AndRejectRapidSecondClick()
+      throws Exception {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    CountDownLatch firstMailStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstMail = new CountDownLatch(1);
+    AtomicInteger mailCalls = new AtomicInteger();
+    when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              if (mailCalls.incrementAndGet() == 1) {
+                firstMailStarted.countDown();
+                if (!releaseFirstMail.await(5, TimeUnit.SECONDS)) {
+                  throw new IllegalStateException("test timed out waiting to release first mail");
+                }
+              }
+              return new de.caritas.cob.userservice.api.service.accountinvite.mail
+                  .InviteMailSendReceipt(
+                  RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z"));
+            });
+
+    CompletableFuture<Void> firstRequest =
+        CompletableFuture.runAsync(
+            () -> service.createAndSendInvite(tenantAdminInvite(), templateId));
+    assertThat(firstMailStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    try {
+      assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
+          .isInstanceOf(
+              de.caritas.cob.userservice.api.exception.httpresponses.ConflictException.class);
+    } finally {
+      releaseFirstMail.countDown();
+      firstRequest.get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(accountInviteRepository.findAll()).hasSize(1);
   }
 
   private CreateAccountInviteCommand tenantAdminInvite() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteDirectSendAtomicIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,7 +106,7 @@ class AccountInviteDirectSendAtomicIT {
   void directSend_ShouldRollbackInviteWhenSmtpRejects_AndPermitExactlyOneRetry() {
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
         .thenReturn("https://example.org/invite/token");
-    doThrow(new SmtpSendException("SMTP refused the message"))
+    doThrow(confirmedRejection())
         .doReturn(
             new de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailSendReceipt(
                 RECIPIENT, java.time.Instant.parse("2026-09-10T10:00:00Z")))
@@ -135,7 +136,7 @@ class AccountInviteDirectSendAtomicIT {
     when(agencyIdAllocationClient.getAvailability(23L)).thenReturn(IdAllocationStatus.RESERVED);
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
         .thenReturn("https://example.org/invite/token");
-    doThrow(new SmtpSendException("SMTP refused the message"))
+    doThrow(confirmedRejection())
         .when(inviteMailDispatchService)
         .send(any(), any(), any(), any(), any(), any());
 
@@ -145,6 +146,38 @@ class AccountInviteDirectSendAtomicIT {
     assertThat(accountInviteRepository.count()).isZero();
     verify(tenantIdAllocationClient).release(17L);
     verify(agencyIdAllocationClient).release(23L);
+  }
+
+  @Test
+  void directSend_ShouldKeepClaimWhenSmtpDeliveryIsUncertain_AndBlockRetry() {
+    when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any()))
+        .thenReturn("https://example.org/invite/token");
+    doThrow(
+            new SmtpSendException(
+                SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+                SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN,
+                "SMTP connection closed after DATA"))
+        .when(inviteMailDispatchService)
+        .send(any(), any(), any(), any(), any(), any());
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
+        .isInstanceOf(SmtpSendException.class);
+
+    assertThat(accountInviteRepository.findAll())
+        .singleElement()
+        .satisfies(
+            invite -> {
+              assertThat(invite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
+              assertThat(invite.getTokenHash()).isNotBlank();
+              assertThat(invite.getActiveRecipientKey()).isEqualTo(RECIPIENT);
+            });
+    verify(tenantIdAllocationClient, never()).release(17L);
+
+    assertThatThrownBy(() -> service.createAndSendInvite(tenantAdminInvite(), templateId))
+        .isInstanceOf(
+            de.caritas.cob.userservice.api.exception.httpresponses
+                .CustomValidationHttpStatusException.class);
+    verify(inviteMailDispatchService).send(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -225,6 +258,13 @@ class AccountInviteDirectSendAtomicIT {
         30L,
         IdAllocationMode.AUTO,
         null);
+  }
+
+  private static SmtpSendException confirmedRejection() {
+    return new SmtpSendException(
+        SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+        SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT,
+        "SMTP refused the message");
   }
 
   private CreateAccountInviteCommand tenantAdminAgencyInvite() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteRecipientEmailGuardIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteRecipientEmailGuardIT.java
@@ -12,6 +12,7 @@ import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -55,6 +56,7 @@ class AccountInviteRecipientEmailGuardIT {
   @MockitoBean private TenantService tenantService;
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private IdReservationReleaseProcessor reservationReleaseProcessor;
   @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;
 
   @MockitoBean

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -11,15 +11,19 @@ import de.caritas.cob.userservice.api.admin.service.tenant.TenantService;
 import de.caritas.cob.userservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.userservice.api.helper.AuthenticatedUser;
 import de.caritas.cob.userservice.api.model.AccountInvite;
+import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService.CreateAccountInviteCommand;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseType;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -60,6 +64,7 @@ class AccountInviteReservationOrchestrationIT {
 
   @Autowired private AccountInviteService service;
   @Autowired private AccountInviteRepository accountInviteRepository;
+  @Autowired private IdReservationReleaseTaskRepository reservationReleaseTaskRepository;
 
   @MockitoBean private AuthenticatedUser authenticatedUser;
   @MockitoBean private IdentityEmailOwnerLookup identityEmailOwnerLookup;
@@ -115,7 +120,7 @@ class AccountInviteReservationOrchestrationIT {
     org.mockito.Mockito.doAnswer(
             invocation -> {
               tenantIdLedger.remove((long) invocation.getArgument(0));
-              return null;
+              return true;
             })
         .when(tenantIdAllocationClient)
         .release(anyLong());
@@ -124,6 +129,7 @@ class AccountInviteReservationOrchestrationIT {
   @AfterEach
   void cleanUp() {
     accountInviteRepository.deleteAll();
+    reservationReleaseTaskRepository.deleteAll();
     tenantIdLedger.clear();
   }
 
@@ -173,6 +179,26 @@ class AccountInviteReservationOrchestrationIT {
     assertThatThrownBy(
             () -> createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "owner@example.org"))
         .isInstanceOf(ConflictException.class);
+
+    verify(tenantIdAllocationClient).release(21L);
+    assertThat(accountInviteRepository.count()).isZero();
+    assertThat(tenantIdLedger).isEmpty();
+  }
+
+  @Test
+  void staleReleaseTask_ShouldBlockAReissuedReservationUntilCleanupCompletes() {
+    reservationReleaseTaskRepository.saveAndFlush(
+        IdReservationReleaseTask.builder()
+            .allocationType(IdReservationReleaseType.TENANT)
+            .reservedId(21L)
+            .tenantContextId(21L)
+            .createDate(LocalDateTime.now())
+            .build());
+
+    assertThatThrownBy(
+            () -> createTenantAdminInvite(21L, IdAllocationMode.MANUAL, "owner@example.org"))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("pending reservation cleanup");
 
     verify(tenantIdAllocationClient).release(21L);
     assertThat(accountInviteRepository.count()).isZero();

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteReservationOrchestrationIT.java
@@ -17,6 +17,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ class AccountInviteReservationOrchestrationIT {
   @MockitoBean private TenantService tenantService;
   @MockitoBean private TenantIdAllocationClient tenantIdAllocationClient;
   @MockitoBean private AgencyIdAllocationClient agencyIdAllocationClient;
+  @MockitoBean private IdReservationReleaseProcessor reservationReleaseProcessor;
 
   // TEN-INV-U6 collaborators of the send path — not exercised by these creation-focused tests.
   @MockitoBean private InviteAcceptUrlBuilder inviteAcceptUrlBuilder;

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -145,6 +145,8 @@ class AccountInviteServiceTest {
             .build();
     when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.saveAndFlush(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     givenSuccessfulDispatch();
@@ -292,6 +294,8 @@ class AccountInviteServiceTest {
             .build();
     when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.saveAndFlush(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any())).thenReturn("https://x/y");
     when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
         .thenThrow(new SmtpSendException("SMTP refused the message"));
@@ -299,7 +303,8 @@ class AccountInviteServiceTest {
     assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(10L, 20L)))
         .isInstanceOf(SmtpSendException.class);
 
-    // The previous invite must stay valid and resendable — no supersede, no replacement.
+    // The transaction boundary (covered by AccountInviteDirectSendAtomicIT) rolls the claim
+    // transfer back. At this unit seam, prove that the failure never supersedes the old invite.
     assertThat(oldInvite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
     assertThat(oldInvite.getSupersededByInviteId()).isNull();
     verify(accountInviteRepository, never()).save(any());
@@ -1957,6 +1962,8 @@ class AccountInviteServiceTest {
             .build();
     when(accountInviteRepository.findById(10L)).thenReturn(Optional.of(oldInvite));
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
+    when(accountInviteRepository.saveAndFlush(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +68,7 @@ class AccountInviteServiceTest {
   @Mock private InviteMailDispatchService inviteMailDispatchService;
   @Mock private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private PlatformTransactionManager transactionManager;
 
   @InjectMocks private AccountInviteService service;
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/AccountInviteServiceTest.java
@@ -23,6 +23,7 @@ import de.caritas.cob.userservice.api.model.AccountInvite;
 import de.caritas.cob.userservice.api.model.InviteEmailDelivery;
 import de.caritas.cob.userservice.api.model.InviteEmailTemplate;
 import de.caritas.cob.userservice.api.port.out.AccountInviteRepository;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwner;
 import de.caritas.cob.userservice.api.port.out.IdentityEmailOwnerLookup;
 import de.caritas.cob.userservice.api.port.out.InviteEmailDeliveryRepository;
@@ -33,6 +34,7 @@ import de.caritas.cob.userservice.api.service.accountinvite.AccountInviteService
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.AgencyIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationMode;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdAllocationStatus;
+import de.caritas.cob.userservice.api.service.accountinvite.allocation.IdReservationReleaseProcessor;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdAllocationClient;
 import de.caritas.cob.userservice.api.service.accountinvite.allocation.TenantIdReservation;
 import de.caritas.cob.userservice.api.service.accountinvite.mail.InviteMailDispatchService;
@@ -68,6 +70,8 @@ class AccountInviteServiceTest {
   @Mock private InviteMailDispatchService inviteMailDispatchService;
   @Mock private InviteEmailDeliveryFailureRecorder deliveryFailureRecorder;
   @Mock private IdentityEmailOwnerLookup identityEmailOwnerLookup;
+  @Mock private IdReservationReleaseTaskRepository reservationReleaseTaskRepository;
+  @Mock private IdReservationReleaseProcessor reservationReleaseProcessor;
   @Mock private PlatformTransactionManager transactionManager;
 
   @InjectMocks private AccountInviteService service;
@@ -147,8 +151,6 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.saveAndFlush(any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
-    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     givenSuccessfulDispatch();
 
     var result = service.resendInvite(new SendInviteCommand(10L, 20L));
@@ -298,13 +300,16 @@ class AccountInviteServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(inviteAcceptUrlBuilder.buildAcceptUrl(any(), any())).thenReturn("https://x/y");
     when(inviteMailDispatchService.send(any(), any(), any(), any(), any(), any()))
-        .thenThrow(new SmtpSendException("SMTP refused the message"));
+        .thenThrow(
+            new SmtpSendException(
+                SmtpSendException.Category.SMTP_TRANSPORT_FAILED,
+                SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT,
+                "SMTP refused the message"));
 
     assertThatThrownBy(() -> service.resendInvite(new SendInviteCommand(10L, 20L)))
         .isInstanceOf(SmtpSendException.class);
 
-    // The transaction boundary (covered by AccountInviteDirectSendAtomicIT) rolls the claim
-    // transfer back. At this unit seam, prove that the failure never supersedes the old invite.
+    // The confirmed failure compensation restores the old claim after the committed handover.
     assertThat(oldInvite.getStatus()).isEqualTo(AccountInviteStatus.EMAIL_SENT);
     assertThat(oldInvite.getSupersededByInviteId()).isNull();
     verify(accountInviteRepository, never()).save(any());
@@ -335,7 +340,6 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-
     givenSuccessfulDispatch();
     service.sendInvite(new SendInviteCommand(10L, 20L));
     template.setSubject("Changed");
@@ -1106,7 +1110,6 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-
     givenSuccessfulDispatch();
     service.sendInvite(new SendInviteCommand(1L, 20L));
 
@@ -1964,8 +1967,6 @@ class AccountInviteServiceTest {
     when(templateRepository.findById(20L)).thenReturn(Optional.of(template));
     when(accountInviteRepository.saveAndFlush(any()))
         .thenAnswer(invocation -> invocation.getArgument(0));
-    when(accountInviteRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-    when(deliveryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
     givenSuccessfulDispatch();
     var result = service.resendInvite(new SendInviteCommand(10L, 20L));

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessorTest.java
@@ -1,0 +1,78 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
+import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantData;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdReservationReleaseProcessorTest {
+
+  @InjectMocks private IdReservationReleaseProcessor processor;
+
+  @Mock private IdReservationReleaseTaskRepository taskRepository;
+  @Mock private TenantIdAllocationClient tenantIdAllocationClient;
+  @Mock private AgencyIdAllocationClient agencyIdAllocationClient;
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void process_ShouldDeleteTask_WhenReleaseSucceeds() {
+    IdReservationReleaseTask task = task(IdReservationReleaseType.TENANT, 41L, null);
+    when(taskRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(task));
+    when(tenantIdAllocationClient.release(41L)).thenReturn(true);
+
+    assertThat(processor.process(1L)).isTrue();
+
+    verify(taskRepository).delete(task);
+    verify(taskRepository, never()).save(task);
+  }
+
+  @Test
+  void process_ShouldRetainTaskAndRestoreTenantContext_WhenReleaseFails() {
+    IdReservationReleaseTask task = task(IdReservationReleaseType.AGENCY, 73L, 12L);
+    TenantContext.setCurrentTenantData(new TenantData(99L, "original"));
+    when(taskRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(task));
+    when(agencyIdAllocationClient.release(73L))
+        .thenAnswer(
+            invocation -> {
+              assertThat(TenantContext.getCurrentTenant()).isEqualTo(12L);
+              return false;
+            });
+
+    assertThat(processor.process(1L)).isFalse();
+
+    assertThat(task.getAttemptCount()).isEqualTo(1);
+    assertThat(task.getLastAttemptAt()).isNotNull();
+    assertThat(TenantContext.getCurrentTenantData()).isEqualTo(new TenantData(99L, "original"));
+    verify(taskRepository).save(task);
+    verify(taskRepository, never()).delete(task);
+  }
+
+  private IdReservationReleaseTask task(
+      IdReservationReleaseType type, Long reservedId, Long tenantContextId) {
+    return IdReservationReleaseTask.builder()
+        .id(1L)
+        .allocationType(type)
+        .reservedId(reservedId)
+        .tenantContextId(tenantContextId)
+        .createDate(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessorTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseProcessorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import de.caritas.cob.userservice.api.model.IdReservationReleaseTask;
 import de.caritas.cob.userservice.api.port.out.IdReservationReleaseTaskRepository;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class IdReservationReleaseProcessorTest {
@@ -30,6 +32,20 @@ class IdReservationReleaseProcessorTest {
   @AfterEach
   void clearTenantContext() {
     TenantContext.clear();
+  }
+
+  @Test
+  void pendingTaskIds_ShouldSelectOnlyBoundedBackedOffAttempts() {
+    setField(processor, "maxAttempts", 8);
+    setField(processor, "retryBackoff", java.time.Duration.ofMinutes(3));
+    IdReservationReleaseTask task = task(IdReservationReleaseType.TENANT, 41L, null);
+    when(taskRepository.findRetryable(
+            org.mockito.ArgumentMatchers.eq(8),
+            org.mockito.ArgumentMatchers.any(LocalDateTime.class),
+            org.mockito.ArgumentMatchers.eq(PageRequest.of(0, 100))))
+        .thenReturn(java.util.List.of(task));
+
+    assertThat(processor.pendingTaskIds()).containsExactly(1L);
   }
 
   @Test
@@ -63,6 +79,31 @@ class IdReservationReleaseProcessorTest {
     assertThat(TenantContext.getCurrentTenantData()).isEqualTo(new TenantData(99L, "original"));
     verify(taskRepository).save(task);
     verify(taskRepository, never()).delete(task);
+  }
+
+  @Test
+  void process_ShouldSucceedWithoutWrites_WhenTaskIsAlreadyGone() {
+    when(taskRepository.findByIdForUpdate(1L)).thenReturn(Optional.empty());
+
+    assertThat(processor.process(1L)).isTrue();
+
+    verify(taskRepository, never()).delete(org.mockito.ArgumentMatchers.any());
+    verify(taskRepository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void process_ShouldRetainTaskAndClearTenantContext_WhenClientThrows() {
+    IdReservationReleaseTask task = task(IdReservationReleaseType.TENANT, 41L, 12L);
+    when(taskRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(task));
+    when(tenantIdAllocationClient.release(41L))
+        .thenThrow(new IllegalStateException("ledger unreachable"));
+
+    assertThat(processor.process(1L)).isFalse();
+
+    assertThat(task.getAttemptCount()).isEqualTo(1);
+    assertThat(task.getLastAttemptAt()).isNotNull();
+    assertThat(TenantContext.contextIsSet()).isFalse();
+    verify(taskRepository).save(task);
   }
 
   private IdReservationReleaseTask task(

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseSchedulerTest.java
@@ -1,0 +1,84 @@
+package de.caritas.cob.userservice.api.service.accountinvite.allocation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.userservice.api.config.auth.TechnicalUserConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityAuthentication;
+import de.caritas.cob.userservice.api.port.out.IdentityClientConfig;
+import de.caritas.cob.userservice.api.port.out.IdentityLogin;
+import de.caritas.cob.userservice.api.service.httpheader.TechnicalAccessTokenContext;
+import de.caritas.cob.userservice.api.tenant.TenantContext;
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
+import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdReservationReleaseSchedulerTest {
+
+  @InjectMocks private IdReservationReleaseScheduler scheduler;
+
+  @Mock private IdReservationReleaseProcessor processor;
+  @Mock private ScheduledTaskClaimService taskClaimService;
+  @Mock private TenantContextProvider tenantContextProvider;
+  @Mock private IdentityClientConfig identityClientConfig;
+  @Mock private IdentityAuthentication identityAuthentication;
+
+  private final Duration claimDuration = Duration.ofMinutes(5);
+
+  @BeforeEach
+  void setUp() {
+    setField(scheduler, "claimDuration", claimDuration);
+  }
+
+  @AfterEach
+  void clearContexts() {
+    TechnicalAccessTokenContext.clear();
+    TenantContext.clear();
+  }
+
+  @Test
+  void retryPendingReleases_ShouldSkipWork_WhenClaimIsLost() {
+    when(taskClaimService.tryClaim(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
+        .thenReturn(false);
+
+    scheduler.retryPendingReleases();
+
+    verifyNoInteractions(
+        processor, tenantContextProvider, identityClientConfig, identityAuthentication);
+  }
+
+  @Test
+  void retryPendingReleases_ShouldAuthenticateAndContinueAfterOneTaskFails() {
+    TechnicalUserConfig technicalUser = new TechnicalUserConfig();
+    technicalUser.setUsername("technical");
+    technicalUser.setPassword("secret");
+    when(taskClaimService.tryClaim(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
+        .thenReturn(true);
+    when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
+    when(identityAuthentication.login("technical", "secret"))
+        .thenReturn(new IdentityLogin("token", 60, 60, "refresh"));
+    when(processor.pendingTaskIds()).thenReturn(List.of(1L, 2L));
+    doThrow(new IllegalStateException("database unavailable")).when(processor).process(1L);
+
+    scheduler.retryPendingReleases();
+
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
+    verify(processor).process(1L);
+    verify(processor).process(2L);
+    assertThat(TechnicalAccessTokenContext.get()).isEmpty();
+    assertThat(TenantContext.contextIsSet()).isFalse();
+  }
+}

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/allocation/IdReservationReleaseSchedulerTest.java
@@ -16,7 +16,9 @@ import de.caritas.cob.userservice.api.tenant.TenantContext;
 import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.scheduling.ScheduledTaskClaimService;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,9 @@ class IdReservationReleaseSchedulerTest {
   @Mock private IdentityAuthentication identityAuthentication;
 
   private final Duration claimDuration = Duration.ofMinutes(5);
+  private final ScheduledTaskClaimService.ClaimLease lease =
+      new ScheduledTaskClaimService.ClaimLease(
+          IdReservationReleaseScheduler.TASK_NAME, LocalDateTime.of(2026, 9, 11, 18, 0));
 
   @BeforeEach
   void setUp() {
@@ -51,8 +56,8 @@ class IdReservationReleaseSchedulerTest {
 
   @Test
   void retryPendingReleases_ShouldSkipWork_WhenClaimIsLost() {
-    when(taskClaimService.tryClaim(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
-        .thenReturn(false);
+    when(taskClaimService.tryClaimLease(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
+        .thenReturn(Optional.empty());
 
     scheduler.retryPendingReleases();
 
@@ -65,19 +70,26 @@ class IdReservationReleaseSchedulerTest {
     TechnicalUserConfig technicalUser = new TechnicalUserConfig();
     technicalUser.setUsername("technical");
     technicalUser.setPassword("secret");
-    when(taskClaimService.tryClaim(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
-        .thenReturn(true);
+    when(taskClaimService.tryClaimLease(IdReservationReleaseScheduler.TASK_NAME, claimDuration))
+        .thenReturn(Optional.of(lease));
     when(identityClientConfig.getTechnicalUser()).thenReturn(technicalUser);
     when(identityAuthentication.login("technical", "secret"))
         .thenReturn(new IdentityLogin("token", 60, 60, "refresh"));
     when(processor.pendingTaskIds()).thenReturn(List.of(1L, 2L));
     doThrow(new IllegalStateException("database unavailable")).when(processor).process(1L);
+    when(processor.process(2L))
+        .thenAnswer(
+            invocation -> {
+              assertThat(TechnicalAccessTokenContext.get()).contains("token");
+              return true;
+            });
 
     scheduler.retryPendingReleases();
 
     verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
     verify(processor).process(1L);
     verify(processor).process(2L);
+    verify(taskClaimService).release(lease);
     assertThat(TechnicalAccessTokenContext.get()).isEmpty();
     assertThat(TenantContext.contextIsSet()).isFalse();
   }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/InviteMailDispatchServiceTest.java
@@ -444,4 +444,38 @@ class InviteMailDispatchServiceTest {
                 assertThat(e.getCategory())
                     .isEqualTo(SmtpSendException.Category.SMTP_TRANSPORT_FAILED));
   }
+
+  @Test
+  void send_Should_markUnexpectedRenderingFailureAsConfirmedNotSent() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    when(emailBrandingResolver.resolve(any()))
+        .thenThrow(new IllegalStateException("branding unavailable"));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            exception -> {
+              assertThat(exception.getDeliveryDisposition())
+                  .isEqualTo(SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT);
+              assertThat(exception).hasCauseInstanceOf(IllegalStateException.class);
+            });
+    verifyNoInteractions(inviteMailTransport);
+  }
+
+  @Test
+  void send_Should_markUnexpectedTransportRuntimeFailureAsDeliveryUncertain() {
+    when(restTemplate.getForObject(anyString(), any())).thenReturn(completeSettingsPayload());
+    givenNeutralBranding();
+    when(inviteMailTransport.send(any(), any(), any(), any(), any()))
+        .thenThrow(new IllegalStateException("connection disappeared"));
+
+    assertThatThrownBy(() -> service("u", "p").send("to@example.org", "s", "b"))
+        .isInstanceOfSatisfying(
+            SmtpSendException.class,
+            exception -> {
+              assertThat(exception.getDeliveryDisposition())
+                  .isEqualTo(SmtpSendException.DeliveryDisposition.DELIVERY_UNCERTAIN);
+              assertThat(exception).hasCauseInstanceOf(IllegalStateException.class);
+            });
+  }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
@@ -2,6 +2,9 @@ package de.caritas.cob.userservice.api.service.accountinvite.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.mail.Address;
+import jakarta.mail.SendFailedException;
+import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMultipart;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -74,6 +77,44 @@ class JakartaInviteMailTransportTest {
 
     assertThat(multipart.getBodyPart(0).getContentType()).containsIgnoringCase("utf-8");
     assertThat(multipart.getBodyPart(1).getContentType()).containsIgnoringCase("utf-8");
+  }
+
+  @Test
+  void allRecipientsConfirmedUnsent_Should_returnTrue_WhenSmtpExplicitlyRejectsRecipient()
+      throws Exception {
+    Address recipient = new InternetAddress("owner@example.org");
+    SendFailedException rejection =
+        new SendFailedException("550 rejected", null, null, new Address[] {recipient}, null);
+
+    assertThat(
+            JakartaInviteMailTransport.allRecipientsConfirmedUnsent(
+                new Address[] {recipient}, rejection))
+        .isTrue();
+  }
+
+  @Test
+  void allRecipientsConfirmedUnsent_Should_returnFalse_WhenAnyRecipientMayHaveBeenSent()
+      throws Exception {
+    Address recipient = new InternetAddress("owner@example.org");
+    SendFailedException ambiguousFailure =
+        new SendFailedException("connection lost", null, new Address[] {recipient}, null, null);
+
+    assertThat(
+            JakartaInviteMailTransport.allRecipientsConfirmedUnsent(
+                new Address[] {recipient}, ambiguousFailure))
+        .isFalse();
+  }
+
+  @Test
+  void allRecipientsConfirmedUnsent_Should_returnFalse_WhenFailureHasNoRecipientEvidence()
+      throws Exception {
+    Address recipient = new InternetAddress("owner@example.org");
+    SendFailedException ambiguousFailure = new SendFailedException("connection lost");
+
+    assertThat(
+            JakartaInviteMailTransport.allRecipientsConfirmedUnsent(
+                new Address[] {recipient}, ambiguousFailure))
+        .isFalse();
   }
 
   private static InviteSmtpSettings insecureSettings() {

--- a/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/accountinvite/mail/JakartaInviteMailTransportTest.java
@@ -2,7 +2,9 @@ package de.caritas.cob.userservice.api.service.accountinvite.mail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.caritas.cob.userservice.api.exception.SmtpSendException;
 import jakarta.mail.Address;
+import jakarta.mail.AuthenticationFailedException;
 import jakarta.mail.SendFailedException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMultipart;
@@ -115,6 +117,16 @@ class JakartaInviteMailTransportTest {
             JakartaInviteMailTransport.allRecipientsConfirmedUnsent(
                 new Address[] {recipient}, ambiguousFailure))
         .isFalse();
+  }
+
+  @Test
+  void deliveryDisposition_Should_confirmAuthenticationFailureWasNotSent() throws Exception {
+    Address recipient = new InternetAddress("owner@example.org");
+
+    assertThat(
+            JakartaInviteMailTransport.deliveryDisposition(
+                new Address[] {recipient}, new AuthenticationFailedException("535 rejected")))
+        .isEqualTo(SmtpSendException.DeliveryDisposition.CONFIRMED_NOT_SENT);
   }
 
   private static InviteSmtpSettings insecureSettings() {

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -50,5 +52,18 @@ class ScheduledTaskClaimServiceTest {
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> service.tryClaim("task", null))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void claimLeaseShouldBeReleasedWithItsExactVersion() {
+    var service = new ScheduledTaskClaimService(claimWriter);
+    var duration = Duration.ofMinutes(30);
+    var claimedUntil = LocalDateTime.of(2026, 9, 11, 18, 30);
+    when(claimWriter.claimUntil("task", duration)).thenReturn(Optional.of(claimedUntil));
+    when(claimWriter.release("task", claimedUntil)).thenReturn(true);
+
+    var lease = service.tryClaimLease("task", duration).orElseThrow();
+
+    assertThat(service.release(lease)).isTrue();
   }
 }

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimWriterTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/scheduling/ScheduledTaskClaimWriterTest.java
@@ -103,4 +103,12 @@ class ScheduledTaskClaimWriterTest {
     activeClaim.setClaimedUntil(NOW);
     assertThat(claimWriter.hasActiveClaim(TASK_NAME)).isFalse();
   }
+
+  @Test
+  void releaseShouldDeleteOnlyTheAcquiredLeaseVersion() {
+    LocalDateTime claimedUntil = NOW.plusMinutes(30);
+    when(claimRepository.deleteByTaskNameAndClaimedUntil(TASK_NAME, claimedUntil)).thenReturn(1);
+
+    assertThat(claimWriter.release(TASK_NAME, claimedUntil)).isTrue();
+  }
 }


### PR DESCRIPTION
## What happened

Repeated clicks on Direct send could race across concurrent requests. Depending on timing, an invite could fail silently, return an error, or create more than one active send attempt. SMTP rejection also left reservations in an inconsistent state.

## What changed

- Claims each active recipient with a database uniqueness constraint before SMTP dispatch.
- Maps concurrent duplicate attempts to the existing EMAIL_NOT_AVAILABLE conflict.
- Releases tenant and agency reservations when SMTP rejects the message.
- Keeps a valid invite and token when only the post-send audit write fails.
- Clears the active recipient claim on acceptance, revocation, expiry, and supersession.
- Adds a forward and rollback Liquibase migration.

## How tested

- TDD: the new rapid-double-click test reproduced two mail paths before the fix.
- 131 focused Java 21 tests green: controller 33, direct-send integration 4, service 94.
- Spotless and compile green.
- Database changelog drift test compiles but is skipped locally because Docker is unavailable.
- Full verify ran 939 tests; it remains baseline-red in unrelated UserControllerE2EIT AvailabilityStore infrastructure tests: 3 failures and 19 errors.
- Independent sub-agent review reran the direct-send suite and confirmed the duplicate, SMTP rollback, and recovery paths.

## How to test it quickly

- [ ] Submit Direct send twice rapidly for the same address.
- [ ] Verify only one active invite and one mail dispatch are created.
- [ ] Force SMTP rejection, retry, and verify the second attempt can proceed.
- [ ] Force only the delivery-audit write to fail and verify the received link remains usable.
- [ ] Accept or revoke the invite and verify the address can be invited again.

## Evidence boundary

This is verified locally on the branch. It has not been deployed to Pre-Dev, and the migration has not run against a local Docker MariaDB instance.

Closes #1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic account-invite creation and delivery when an email template is provided.
  * Prevented duplicate active invites for the same normalized recipient.
  * Improved invite lifecycle handling during acceptance, expiry, revocation, and resend.
  * Added clearer handling of confirmed versus uncertain email delivery outcomes.
  * Added automatic retry handling for failed tenant and agency ID reservation releases.

* **Bug Fixes**
  * Improved recovery when email delivery or delivery auditing fails.
  * Ensured invite creation and resource reservations remain consistent during delivery failures.

* **Tests**
  * Added coverage for delivery failures, retries, concurrent submissions, and atomic invite processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->